### PR TITLE
Fix XML error deserializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - More efficiently and correctly remove scheme from `Region::Custom` endpoints
 - Prevent reactor from hanging indefinitely when using the new tokio release
 - Fixed bug in query services where lists had incorrect parent item in request
+- Improve deserializer of XML error responses
 
 ## [0.32.0] - 2018-03-03
 

--- a/rusoto/services/autoscaling/src/generated.rs
+++ b/rusoto/services/autoscaling/src/generated.rs
@@ -8583,7 +8583,7 @@ impl AttachInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => AttachInstancesError::ResourceContentionFault(
                     String::from(parsed_error.message),
@@ -8592,6 +8592,14 @@ impl AttachInstancesError {
             },
             Err(_) => AttachInstancesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -8652,7 +8660,7 @@ impl AttachLoadBalancerTargetGroupsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => {
                     AttachLoadBalancerTargetGroupsError::ResourceContentionFault(String::from(
@@ -8663,6 +8671,14 @@ impl AttachLoadBalancerTargetGroupsError {
             },
             Err(_) => AttachLoadBalancerTargetGroupsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -8725,7 +8741,7 @@ impl AttachLoadBalancersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => AttachLoadBalancersError::ResourceContentionFault(
                     String::from(parsed_error.message),
@@ -8734,6 +8750,14 @@ impl AttachLoadBalancersError {
             },
             Err(_) => AttachLoadBalancersError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -8796,7 +8820,7 @@ impl CompleteLifecycleActionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => {
                     CompleteLifecycleActionError::ResourceContentionFault(String::from(
@@ -8807,6 +8831,14 @@ impl CompleteLifecycleActionError {
             },
             Err(_) => CompleteLifecycleActionError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -8873,7 +8905,7 @@ impl CreateAutoScalingGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AlreadyExistsFault" => CreateAutoScalingGroupError::AlreadyExistsFault(
                     String::from(parsed_error.message),
@@ -8888,6 +8920,14 @@ impl CreateAutoScalingGroupError {
             },
             Err(_) => CreateAutoScalingGroupError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -8956,7 +8996,7 @@ impl CreateLaunchConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AlreadyExistsFault" => CreateLaunchConfigurationError::AlreadyExistsFault(
                     String::from(parsed_error.message),
@@ -8973,6 +9013,14 @@ impl CreateLaunchConfigurationError {
             },
             Err(_) => CreateLaunchConfigurationError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -9043,7 +9091,7 @@ impl CreateOrUpdateTagsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AlreadyExistsFault" => {
                     CreateOrUpdateTagsError::AlreadyExistsFault(String::from(parsed_error.message))
@@ -9061,6 +9109,14 @@ impl CreateOrUpdateTagsError {
             },
             Err(_) => CreateOrUpdateTagsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -9130,7 +9186,7 @@ impl DeleteAutoScalingGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => DeleteAutoScalingGroupError::ResourceContentionFault(
                     String::from(parsed_error.message),
@@ -9147,6 +9203,14 @@ impl DeleteAutoScalingGroupError {
             },
             Err(_) => DeleteAutoScalingGroupError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -9213,7 +9277,7 @@ impl DeleteLaunchConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => {
                     DeleteLaunchConfigurationError::ResourceContentionFault(String::from(
@@ -9227,6 +9291,14 @@ impl DeleteLaunchConfigurationError {
             },
             Err(_) => DeleteLaunchConfigurationError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -9290,7 +9362,7 @@ impl DeleteLifecycleHookError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => DeleteLifecycleHookError::ResourceContentionFault(
                     String::from(parsed_error.message),
@@ -9299,6 +9371,14 @@ impl DeleteLifecycleHookError {
             },
             Err(_) => DeleteLifecycleHookError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -9361,7 +9441,7 @@ impl DeleteNotificationConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => {
                     DeleteNotificationConfigurationError::ResourceContentionFault(String::from(
@@ -9372,6 +9452,14 @@ impl DeleteNotificationConfigurationError {
             },
             Err(_) => DeleteNotificationConfigurationError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -9434,7 +9522,7 @@ impl DeletePolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => {
                     DeletePolicyError::ResourceContentionFault(String::from(parsed_error.message))
@@ -9443,6 +9531,14 @@ impl DeletePolicyError {
             },
             Err(_) => DeletePolicyError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -9503,7 +9599,7 @@ impl DeleteScheduledActionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => DeleteScheduledActionError::ResourceContentionFault(
                     String::from(parsed_error.message),
@@ -9512,6 +9608,14 @@ impl DeleteScheduledActionError {
             },
             Err(_) => DeleteScheduledActionError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -9576,7 +9680,7 @@ impl DeleteTagsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => {
                     DeleteTagsError::ResourceContentionFault(String::from(parsed_error.message))
@@ -9588,6 +9692,14 @@ impl DeleteTagsError {
             },
             Err(_) => DeleteTagsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -9649,7 +9761,7 @@ impl DescribeAccountLimitsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => DescribeAccountLimitsError::ResourceContentionFault(
                     String::from(parsed_error.message),
@@ -9658,6 +9770,14 @@ impl DescribeAccountLimitsError {
             },
             Err(_) => DescribeAccountLimitsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -9720,7 +9840,7 @@ impl DescribeAdjustmentTypesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => {
                     DescribeAdjustmentTypesError::ResourceContentionFault(String::from(
@@ -9731,6 +9851,14 @@ impl DescribeAdjustmentTypesError {
             },
             Err(_) => DescribeAdjustmentTypesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -9795,7 +9923,7 @@ impl DescribeAutoScalingGroupsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidNextToken" => DescribeAutoScalingGroupsError::InvalidNextToken(
                     String::from(parsed_error.message),
@@ -9809,6 +9937,14 @@ impl DescribeAutoScalingGroupsError {
             },
             Err(_) => DescribeAutoScalingGroupsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -9874,7 +10010,7 @@ impl DescribeAutoScalingInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidNextToken" => DescribeAutoScalingInstancesError::InvalidNextToken(
                     String::from(parsed_error.message),
@@ -9888,6 +10024,14 @@ impl DescribeAutoScalingInstancesError {
             },
             Err(_) => DescribeAutoScalingInstancesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -9951,7 +10095,7 @@ impl DescribeAutoScalingNotificationTypesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => {
                     DescribeAutoScalingNotificationTypesError::ResourceContentionFault(
@@ -9962,6 +10106,14 @@ impl DescribeAutoScalingNotificationTypesError {
             },
             Err(_) => DescribeAutoScalingNotificationTypesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10026,7 +10178,7 @@ impl DescribeLaunchConfigurationsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidNextToken" => DescribeLaunchConfigurationsError::InvalidNextToken(
                     String::from(parsed_error.message),
@@ -10040,6 +10192,14 @@ impl DescribeLaunchConfigurationsError {
             },
             Err(_) => DescribeLaunchConfigurationsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10103,7 +10263,7 @@ impl DescribeLifecycleHookTypesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => {
                     DescribeLifecycleHookTypesError::ResourceContentionFault(String::from(
@@ -10114,6 +10274,14 @@ impl DescribeLifecycleHookTypesError {
             },
             Err(_) => DescribeLifecycleHookTypesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10176,7 +10344,7 @@ impl DescribeLifecycleHooksError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => DescribeLifecycleHooksError::ResourceContentionFault(
                     String::from(parsed_error.message),
@@ -10185,6 +10353,14 @@ impl DescribeLifecycleHooksError {
             },
             Err(_) => DescribeLifecycleHooksError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10247,7 +10423,7 @@ impl DescribeLoadBalancerTargetGroupsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => {
                     DescribeLoadBalancerTargetGroupsError::ResourceContentionFault(String::from(
@@ -10258,6 +10434,14 @@ impl DescribeLoadBalancerTargetGroupsError {
             },
             Err(_) => DescribeLoadBalancerTargetGroupsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10320,7 +10504,7 @@ impl DescribeLoadBalancersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => DescribeLoadBalancersError::ResourceContentionFault(
                     String::from(parsed_error.message),
@@ -10329,6 +10513,14 @@ impl DescribeLoadBalancersError {
             },
             Err(_) => DescribeLoadBalancersError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10391,7 +10583,7 @@ impl DescribeMetricCollectionTypesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => {
                     DescribeMetricCollectionTypesError::ResourceContentionFault(String::from(
@@ -10402,6 +10594,14 @@ impl DescribeMetricCollectionTypesError {
             },
             Err(_) => DescribeMetricCollectionTypesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10466,7 +10666,7 @@ impl DescribeNotificationConfigurationsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidNextToken" => DescribeNotificationConfigurationsError::InvalidNextToken(
                     String::from(parsed_error.message),
@@ -10480,6 +10680,14 @@ impl DescribeNotificationConfigurationsError {
             },
             Err(_) => DescribeNotificationConfigurationsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10545,7 +10753,7 @@ impl DescribePoliciesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidNextToken" => {
                     DescribePoliciesError::InvalidNextToken(String::from(parsed_error.message))
@@ -10557,6 +10765,14 @@ impl DescribePoliciesError {
             },
             Err(_) => DescribePoliciesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10620,7 +10836,7 @@ impl DescribeScalingActivitiesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidNextToken" => DescribeScalingActivitiesError::InvalidNextToken(
                     String::from(parsed_error.message),
@@ -10634,6 +10850,14 @@ impl DescribeScalingActivitiesError {
             },
             Err(_) => DescribeScalingActivitiesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10697,7 +10921,7 @@ impl DescribeScalingProcessTypesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => {
                     DescribeScalingProcessTypesError::ResourceContentionFault(String::from(
@@ -10708,6 +10932,14 @@ impl DescribeScalingProcessTypesError {
             },
             Err(_) => DescribeScalingProcessTypesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10772,7 +11004,7 @@ impl DescribeScheduledActionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidNextToken" => DescribeScheduledActionsError::InvalidNextToken(
                     String::from(parsed_error.message),
@@ -10786,6 +11018,14 @@ impl DescribeScheduledActionsError {
             },
             Err(_) => DescribeScheduledActionsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10851,7 +11091,7 @@ impl DescribeTagsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidNextToken" => {
                     DescribeTagsError::InvalidNextToken(String::from(parsed_error.message))
@@ -10863,6 +11103,14 @@ impl DescribeTagsError {
             },
             Err(_) => DescribeTagsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10924,7 +11172,7 @@ impl DescribeTerminationPolicyTypesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => {
                     DescribeTerminationPolicyTypesError::ResourceContentionFault(String::from(
@@ -10935,6 +11183,14 @@ impl DescribeTerminationPolicyTypesError {
             },
             Err(_) => DescribeTerminationPolicyTypesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10997,7 +11253,7 @@ impl DetachInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => DetachInstancesError::ResourceContentionFault(
                     String::from(parsed_error.message),
@@ -11006,6 +11262,14 @@ impl DetachInstancesError {
             },
             Err(_) => DetachInstancesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11066,7 +11330,7 @@ impl DetachLoadBalancerTargetGroupsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => {
                     DetachLoadBalancerTargetGroupsError::ResourceContentionFault(String::from(
@@ -11077,6 +11341,14 @@ impl DetachLoadBalancerTargetGroupsError {
             },
             Err(_) => DetachLoadBalancerTargetGroupsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11139,7 +11411,7 @@ impl DetachLoadBalancersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => DetachLoadBalancersError::ResourceContentionFault(
                     String::from(parsed_error.message),
@@ -11148,6 +11420,14 @@ impl DetachLoadBalancersError {
             },
             Err(_) => DetachLoadBalancersError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11210,7 +11490,7 @@ impl DisableMetricsCollectionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => {
                     DisableMetricsCollectionError::ResourceContentionFault(String::from(
@@ -11221,6 +11501,14 @@ impl DisableMetricsCollectionError {
             },
             Err(_) => DisableMetricsCollectionError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11283,7 +11571,7 @@ impl EnableMetricsCollectionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => {
                     EnableMetricsCollectionError::ResourceContentionFault(String::from(
@@ -11294,6 +11582,14 @@ impl EnableMetricsCollectionError {
             },
             Err(_) => EnableMetricsCollectionError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11356,7 +11652,7 @@ impl EnterStandbyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => {
                     EnterStandbyError::ResourceContentionFault(String::from(parsed_error.message))
@@ -11365,6 +11661,14 @@ impl EnterStandbyError {
             },
             Err(_) => EnterStandbyError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11427,7 +11731,7 @@ impl ExecutePolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => {
                     ExecutePolicyError::ResourceContentionFault(String::from(parsed_error.message))
@@ -11441,6 +11745,14 @@ impl ExecutePolicyError {
             },
             Err(_) => ExecutePolicyError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11502,7 +11814,7 @@ impl ExitStandbyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => {
                     ExitStandbyError::ResourceContentionFault(String::from(parsed_error.message))
@@ -11511,6 +11823,14 @@ impl ExitStandbyError {
             },
             Err(_) => ExitStandbyError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11573,7 +11893,7 @@ impl PutLifecycleHookError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "LimitExceededFault" => {
                     PutLifecycleHookError::LimitExceededFault(String::from(parsed_error.message))
@@ -11585,6 +11905,14 @@ impl PutLifecycleHookError {
             },
             Err(_) => PutLifecycleHookError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11648,7 +11976,7 @@ impl PutNotificationConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "LimitExceededFault" => PutNotificationConfigurationError::LimitExceededFault(
                     String::from(parsed_error.message),
@@ -11662,6 +11990,14 @@ impl PutNotificationConfigurationError {
             },
             Err(_) => PutNotificationConfigurationError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11727,7 +12063,7 @@ impl PutScalingPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "LimitExceededFault" => {
                     PutScalingPolicyError::LimitExceededFault(String::from(parsed_error.message))
@@ -11739,6 +12075,14 @@ impl PutScalingPolicyError {
             },
             Err(_) => PutScalingPolicyError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11804,7 +12148,7 @@ impl PutScheduledUpdateGroupActionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AlreadyExistsFault" => PutScheduledUpdateGroupActionError::AlreadyExistsFault(
                     String::from(parsed_error.message),
@@ -11821,6 +12165,14 @@ impl PutScheduledUpdateGroupActionError {
             },
             Err(_) => PutScheduledUpdateGroupActionError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11885,7 +12237,7 @@ impl RecordLifecycleActionHeartbeatError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => {
                     RecordLifecycleActionHeartbeatError::ResourceContentionFault(String::from(
@@ -11896,6 +12248,14 @@ impl RecordLifecycleActionHeartbeatError {
             },
             Err(_) => RecordLifecycleActionHeartbeatError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11960,7 +12320,7 @@ impl ResumeProcessesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => ResumeProcessesError::ResourceContentionFault(
                     String::from(parsed_error.message),
@@ -11972,6 +12332,14 @@ impl ResumeProcessesError {
             },
             Err(_) => ResumeProcessesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -12035,7 +12403,7 @@ impl SetDesiredCapacityError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => SetDesiredCapacityError::ResourceContentionFault(
                     String::from(parsed_error.message),
@@ -12049,6 +12417,14 @@ impl SetDesiredCapacityError {
             },
             Err(_) => SetDesiredCapacityError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -12112,7 +12488,7 @@ impl SetInstanceHealthError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => SetInstanceHealthError::ResourceContentionFault(
                     String::from(parsed_error.message),
@@ -12121,6 +12497,14 @@ impl SetInstanceHealthError {
             },
             Err(_) => SetInstanceHealthError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -12185,7 +12569,7 @@ impl SetInstanceProtectionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "LimitExceededFault" => SetInstanceProtectionError::LimitExceededFault(
                     String::from(parsed_error.message),
@@ -12197,6 +12581,14 @@ impl SetInstanceProtectionError {
             },
             Err(_) => SetInstanceProtectionError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -12262,7 +12654,7 @@ impl SuspendProcessesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => SuspendProcessesError::ResourceContentionFault(
                     String::from(parsed_error.message),
@@ -12274,6 +12666,14 @@ impl SuspendProcessesError {
             },
             Err(_) => SuspendProcessesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -12337,7 +12737,7 @@ impl TerminateInstanceInAutoScalingGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => {
                     TerminateInstanceInAutoScalingGroupError::ResourceContentionFault(
@@ -12353,6 +12753,14 @@ impl TerminateInstanceInAutoScalingGroupError {
             },
             Err(_) => TerminateInstanceInAutoScalingGroupError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -12420,7 +12828,7 @@ impl UpdateAutoScalingGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceContentionFault" => UpdateAutoScalingGroupError::ResourceContentionFault(
                     String::from(parsed_error.message),
@@ -12434,6 +12842,14 @@ impl UpdateAutoScalingGroupError {
             },
             Err(_) => UpdateAutoScalingGroupError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 

--- a/rusoto/services/autoscaling/src/generated.rs
+++ b/rusoto/services/autoscaling/src/generated.rs
@@ -8585,7 +8585,7 @@ impl AttachInstancesError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ResourceContentionFault" => AttachInstancesError::ResourceContentionFault(
+                "ResourceContention" => AttachInstancesError::ResourceContentionFault(
                     String::from(parsed_error.message),
                 ),
                 _ => AttachInstancesError::Unknown(String::from(body)),
@@ -8662,7 +8662,7 @@ impl AttachLoadBalancerTargetGroupsError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ResourceContentionFault" => {
+                "ResourceContention" => {
                     AttachLoadBalancerTargetGroupsError::ResourceContentionFault(String::from(
                         parsed_error.message,
                     ))
@@ -8743,7 +8743,7 @@ impl AttachLoadBalancersError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ResourceContentionFault" => AttachLoadBalancersError::ResourceContentionFault(
+                "ResourceContention" => AttachLoadBalancersError::ResourceContentionFault(
                     String::from(parsed_error.message),
                 ),
                 _ => AttachLoadBalancersError::Unknown(String::from(body)),
@@ -8822,11 +8822,9 @@ impl CompleteLifecycleActionError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ResourceContentionFault" => {
-                    CompleteLifecycleActionError::ResourceContentionFault(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "ResourceContention" => CompleteLifecycleActionError::ResourceContentionFault(
+                    String::from(parsed_error.message),
+                ),
                 _ => CompleteLifecycleActionError::Unknown(String::from(body)),
             },
             Err(_) => CompleteLifecycleActionError::Unknown(body.to_string()),
@@ -8907,13 +8905,13 @@ impl CreateAutoScalingGroupError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AlreadyExistsFault" => CreateAutoScalingGroupError::AlreadyExistsFault(
-                    String::from(parsed_error.message),
-                ),
-                "LimitExceededFault" => CreateAutoScalingGroupError::LimitExceededFault(
-                    String::from(parsed_error.message),
-                ),
-                "ResourceContentionFault" => CreateAutoScalingGroupError::ResourceContentionFault(
+                "AlreadyExists" => CreateAutoScalingGroupError::AlreadyExistsFault(String::from(
+                    parsed_error.message,
+                )),
+                "LimitExceeded" => CreateAutoScalingGroupError::LimitExceededFault(String::from(
+                    parsed_error.message,
+                )),
+                "ResourceContention" => CreateAutoScalingGroupError::ResourceContentionFault(
                     String::from(parsed_error.message),
                 ),
                 _ => CreateAutoScalingGroupError::Unknown(String::from(body)),
@@ -8998,17 +8996,15 @@ impl CreateLaunchConfigurationError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AlreadyExistsFault" => CreateLaunchConfigurationError::AlreadyExistsFault(
+                "AlreadyExists" => CreateLaunchConfigurationError::AlreadyExistsFault(
                     String::from(parsed_error.message),
                 ),
-                "LimitExceededFault" => CreateLaunchConfigurationError::LimitExceededFault(
+                "LimitExceeded" => CreateLaunchConfigurationError::LimitExceededFault(
                     String::from(parsed_error.message),
                 ),
-                "ResourceContentionFault" => {
-                    CreateLaunchConfigurationError::ResourceContentionFault(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "ResourceContention" => CreateLaunchConfigurationError::ResourceContentionFault(
+                    String::from(parsed_error.message),
+                ),
                 _ => CreateLaunchConfigurationError::Unknown(String::from(body)),
             },
             Err(_) => CreateLaunchConfigurationError::Unknown(body.to_string()),
@@ -9093,16 +9089,16 @@ impl CreateOrUpdateTagsError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AlreadyExistsFault" => {
+                "AlreadyExists" => {
                     CreateOrUpdateTagsError::AlreadyExistsFault(String::from(parsed_error.message))
                 }
-                "LimitExceededFault" => {
+                "LimitExceeded" => {
                     CreateOrUpdateTagsError::LimitExceededFault(String::from(parsed_error.message))
                 }
-                "ResourceContentionFault" => CreateOrUpdateTagsError::ResourceContentionFault(
+                "ResourceContention" => CreateOrUpdateTagsError::ResourceContentionFault(
                     String::from(parsed_error.message),
                 ),
-                "ResourceInUseFault" => {
+                "ResourceInUse" => {
                     CreateOrUpdateTagsError::ResourceInUseFault(String::from(parsed_error.message))
                 }
                 _ => CreateOrUpdateTagsError::Unknown(String::from(body)),
@@ -9188,13 +9184,13 @@ impl DeleteAutoScalingGroupError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ResourceContentionFault" => DeleteAutoScalingGroupError::ResourceContentionFault(
+                "ResourceContention" => DeleteAutoScalingGroupError::ResourceContentionFault(
                     String::from(parsed_error.message),
                 ),
-                "ResourceInUseFault" => DeleteAutoScalingGroupError::ResourceInUseFault(
-                    String::from(parsed_error.message),
-                ),
-                "ScalingActivityInProgressFault" => {
+                "ResourceInUse" => DeleteAutoScalingGroupError::ResourceInUseFault(String::from(
+                    parsed_error.message,
+                )),
+                "ScalingActivityInProgress" => {
                     DeleteAutoScalingGroupError::ScalingActivityInProgressFault(String::from(
                         parsed_error.message,
                     ))
@@ -9279,12 +9275,10 @@ impl DeleteLaunchConfigurationError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ResourceContentionFault" => {
-                    DeleteLaunchConfigurationError::ResourceContentionFault(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "ResourceInUseFault" => DeleteLaunchConfigurationError::ResourceInUseFault(
+                "ResourceContention" => DeleteLaunchConfigurationError::ResourceContentionFault(
+                    String::from(parsed_error.message),
+                ),
+                "ResourceInUse" => DeleteLaunchConfigurationError::ResourceInUseFault(
                     String::from(parsed_error.message),
                 ),
                 _ => DeleteLaunchConfigurationError::Unknown(String::from(body)),
@@ -9364,7 +9358,7 @@ impl DeleteLifecycleHookError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ResourceContentionFault" => DeleteLifecycleHookError::ResourceContentionFault(
+                "ResourceContention" => DeleteLifecycleHookError::ResourceContentionFault(
                     String::from(parsed_error.message),
                 ),
                 _ => DeleteLifecycleHookError::Unknown(String::from(body)),
@@ -9443,7 +9437,7 @@ impl DeleteNotificationConfigurationError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ResourceContentionFault" => {
+                "ResourceContention" => {
                     DeleteNotificationConfigurationError::ResourceContentionFault(String::from(
                         parsed_error.message,
                     ))
@@ -9524,7 +9518,7 @@ impl DeletePolicyError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ResourceContentionFault" => {
+                "ResourceContention" => {
                     DeletePolicyError::ResourceContentionFault(String::from(parsed_error.message))
                 }
                 _ => DeletePolicyError::Unknown(String::from(body)),
@@ -9601,7 +9595,7 @@ impl DeleteScheduledActionError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ResourceContentionFault" => DeleteScheduledActionError::ResourceContentionFault(
+                "ResourceContention" => DeleteScheduledActionError::ResourceContentionFault(
                     String::from(parsed_error.message),
                 ),
                 _ => DeleteScheduledActionError::Unknown(String::from(body)),
@@ -9682,10 +9676,10 @@ impl DeleteTagsError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ResourceContentionFault" => {
+                "ResourceContention" => {
                     DeleteTagsError::ResourceContentionFault(String::from(parsed_error.message))
                 }
-                "ResourceInUseFault" => {
+                "ResourceInUse" => {
                     DeleteTagsError::ResourceInUseFault(String::from(parsed_error.message))
                 }
                 _ => DeleteTagsError::Unknown(String::from(body)),
@@ -9763,7 +9757,7 @@ impl DescribeAccountLimitsError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ResourceContentionFault" => DescribeAccountLimitsError::ResourceContentionFault(
+                "ResourceContention" => DescribeAccountLimitsError::ResourceContentionFault(
                     String::from(parsed_error.message),
                 ),
                 _ => DescribeAccountLimitsError::Unknown(String::from(body)),
@@ -9842,11 +9836,9 @@ impl DescribeAdjustmentTypesError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ResourceContentionFault" => {
-                    DescribeAdjustmentTypesError::ResourceContentionFault(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "ResourceContention" => DescribeAdjustmentTypesError::ResourceContentionFault(
+                    String::from(parsed_error.message),
+                ),
                 _ => DescribeAdjustmentTypesError::Unknown(String::from(body)),
             },
             Err(_) => DescribeAdjustmentTypesError::Unknown(body.to_string()),
@@ -9928,11 +9920,9 @@ impl DescribeAutoScalingGroupsError {
                 "InvalidNextToken" => DescribeAutoScalingGroupsError::InvalidNextToken(
                     String::from(parsed_error.message),
                 ),
-                "ResourceContentionFault" => {
-                    DescribeAutoScalingGroupsError::ResourceContentionFault(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "ResourceContention" => DescribeAutoScalingGroupsError::ResourceContentionFault(
+                    String::from(parsed_error.message),
+                ),
                 _ => DescribeAutoScalingGroupsError::Unknown(String::from(body)),
             },
             Err(_) => DescribeAutoScalingGroupsError::Unknown(body.to_string()),
@@ -10015,7 +10005,7 @@ impl DescribeAutoScalingInstancesError {
                 "InvalidNextToken" => DescribeAutoScalingInstancesError::InvalidNextToken(
                     String::from(parsed_error.message),
                 ),
-                "ResourceContentionFault" => {
+                "ResourceContention" => {
                     DescribeAutoScalingInstancesError::ResourceContentionFault(String::from(
                         parsed_error.message,
                     ))
@@ -10097,7 +10087,7 @@ impl DescribeAutoScalingNotificationTypesError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ResourceContentionFault" => {
+                "ResourceContention" => {
                     DescribeAutoScalingNotificationTypesError::ResourceContentionFault(
                         String::from(parsed_error.message),
                     )
@@ -10183,7 +10173,7 @@ impl DescribeLaunchConfigurationsError {
                 "InvalidNextToken" => DescribeLaunchConfigurationsError::InvalidNextToken(
                     String::from(parsed_error.message),
                 ),
-                "ResourceContentionFault" => {
+                "ResourceContention" => {
                     DescribeLaunchConfigurationsError::ResourceContentionFault(String::from(
                         parsed_error.message,
                     ))
@@ -10265,11 +10255,9 @@ impl DescribeLifecycleHookTypesError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ResourceContentionFault" => {
-                    DescribeLifecycleHookTypesError::ResourceContentionFault(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "ResourceContention" => DescribeLifecycleHookTypesError::ResourceContentionFault(
+                    String::from(parsed_error.message),
+                ),
                 _ => DescribeLifecycleHookTypesError::Unknown(String::from(body)),
             },
             Err(_) => DescribeLifecycleHookTypesError::Unknown(body.to_string()),
@@ -10346,7 +10334,7 @@ impl DescribeLifecycleHooksError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ResourceContentionFault" => DescribeLifecycleHooksError::ResourceContentionFault(
+                "ResourceContention" => DescribeLifecycleHooksError::ResourceContentionFault(
                     String::from(parsed_error.message),
                 ),
                 _ => DescribeLifecycleHooksError::Unknown(String::from(body)),
@@ -10425,7 +10413,7 @@ impl DescribeLoadBalancerTargetGroupsError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ResourceContentionFault" => {
+                "ResourceContention" => {
                     DescribeLoadBalancerTargetGroupsError::ResourceContentionFault(String::from(
                         parsed_error.message,
                     ))
@@ -10506,7 +10494,7 @@ impl DescribeLoadBalancersError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ResourceContentionFault" => DescribeLoadBalancersError::ResourceContentionFault(
+                "ResourceContention" => DescribeLoadBalancersError::ResourceContentionFault(
                     String::from(parsed_error.message),
                 ),
                 _ => DescribeLoadBalancersError::Unknown(String::from(body)),
@@ -10585,7 +10573,7 @@ impl DescribeMetricCollectionTypesError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ResourceContentionFault" => {
+                "ResourceContention" => {
                     DescribeMetricCollectionTypesError::ResourceContentionFault(String::from(
                         parsed_error.message,
                     ))
@@ -10671,7 +10659,7 @@ impl DescribeNotificationConfigurationsError {
                 "InvalidNextToken" => DescribeNotificationConfigurationsError::InvalidNextToken(
                     String::from(parsed_error.message),
                 ),
-                "ResourceContentionFault" => {
+                "ResourceContention" => {
                     DescribeNotificationConfigurationsError::ResourceContentionFault(String::from(
                         parsed_error.message,
                     ))
@@ -10758,7 +10746,7 @@ impl DescribePoliciesError {
                 "InvalidNextToken" => {
                     DescribePoliciesError::InvalidNextToken(String::from(parsed_error.message))
                 }
-                "ResourceContentionFault" => DescribePoliciesError::ResourceContentionFault(
+                "ResourceContention" => DescribePoliciesError::ResourceContentionFault(
                     String::from(parsed_error.message),
                 ),
                 _ => DescribePoliciesError::Unknown(String::from(body)),
@@ -10841,11 +10829,9 @@ impl DescribeScalingActivitiesError {
                 "InvalidNextToken" => DescribeScalingActivitiesError::InvalidNextToken(
                     String::from(parsed_error.message),
                 ),
-                "ResourceContentionFault" => {
-                    DescribeScalingActivitiesError::ResourceContentionFault(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "ResourceContention" => DescribeScalingActivitiesError::ResourceContentionFault(
+                    String::from(parsed_error.message),
+                ),
                 _ => DescribeScalingActivitiesError::Unknown(String::from(body)),
             },
             Err(_) => DescribeScalingActivitiesError::Unknown(body.to_string()),
@@ -10923,11 +10909,9 @@ impl DescribeScalingProcessTypesError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ResourceContentionFault" => {
-                    DescribeScalingProcessTypesError::ResourceContentionFault(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "ResourceContention" => DescribeScalingProcessTypesError::ResourceContentionFault(
+                    String::from(parsed_error.message),
+                ),
                 _ => DescribeScalingProcessTypesError::Unknown(String::from(body)),
             },
             Err(_) => DescribeScalingProcessTypesError::Unknown(body.to_string()),
@@ -11009,11 +10993,9 @@ impl DescribeScheduledActionsError {
                 "InvalidNextToken" => DescribeScheduledActionsError::InvalidNextToken(
                     String::from(parsed_error.message),
                 ),
-                "ResourceContentionFault" => {
-                    DescribeScheduledActionsError::ResourceContentionFault(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "ResourceContention" => DescribeScheduledActionsError::ResourceContentionFault(
+                    String::from(parsed_error.message),
+                ),
                 _ => DescribeScheduledActionsError::Unknown(String::from(body)),
             },
             Err(_) => DescribeScheduledActionsError::Unknown(body.to_string()),
@@ -11096,7 +11078,7 @@ impl DescribeTagsError {
                 "InvalidNextToken" => {
                     DescribeTagsError::InvalidNextToken(String::from(parsed_error.message))
                 }
-                "ResourceContentionFault" => {
+                "ResourceContention" => {
                     DescribeTagsError::ResourceContentionFault(String::from(parsed_error.message))
                 }
                 _ => DescribeTagsError::Unknown(String::from(body)),
@@ -11174,7 +11156,7 @@ impl DescribeTerminationPolicyTypesError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ResourceContentionFault" => {
+                "ResourceContention" => {
                     DescribeTerminationPolicyTypesError::ResourceContentionFault(String::from(
                         parsed_error.message,
                     ))
@@ -11255,7 +11237,7 @@ impl DetachInstancesError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ResourceContentionFault" => DetachInstancesError::ResourceContentionFault(
+                "ResourceContention" => DetachInstancesError::ResourceContentionFault(
                     String::from(parsed_error.message),
                 ),
                 _ => DetachInstancesError::Unknown(String::from(body)),
@@ -11332,7 +11314,7 @@ impl DetachLoadBalancerTargetGroupsError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ResourceContentionFault" => {
+                "ResourceContention" => {
                     DetachLoadBalancerTargetGroupsError::ResourceContentionFault(String::from(
                         parsed_error.message,
                     ))
@@ -11413,7 +11395,7 @@ impl DetachLoadBalancersError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ResourceContentionFault" => DetachLoadBalancersError::ResourceContentionFault(
+                "ResourceContention" => DetachLoadBalancersError::ResourceContentionFault(
                     String::from(parsed_error.message),
                 ),
                 _ => DetachLoadBalancersError::Unknown(String::from(body)),
@@ -11492,11 +11474,9 @@ impl DisableMetricsCollectionError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ResourceContentionFault" => {
-                    DisableMetricsCollectionError::ResourceContentionFault(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "ResourceContention" => DisableMetricsCollectionError::ResourceContentionFault(
+                    String::from(parsed_error.message),
+                ),
                 _ => DisableMetricsCollectionError::Unknown(String::from(body)),
             },
             Err(_) => DisableMetricsCollectionError::Unknown(body.to_string()),
@@ -11573,11 +11553,9 @@ impl EnableMetricsCollectionError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ResourceContentionFault" => {
-                    EnableMetricsCollectionError::ResourceContentionFault(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "ResourceContention" => EnableMetricsCollectionError::ResourceContentionFault(
+                    String::from(parsed_error.message),
+                ),
                 _ => EnableMetricsCollectionError::Unknown(String::from(body)),
             },
             Err(_) => EnableMetricsCollectionError::Unknown(body.to_string()),
@@ -11654,7 +11632,7 @@ impl EnterStandbyError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ResourceContentionFault" => {
+                "ResourceContention" => {
                     EnterStandbyError::ResourceContentionFault(String::from(parsed_error.message))
                 }
                 _ => EnterStandbyError::Unknown(String::from(body)),
@@ -11733,14 +11711,12 @@ impl ExecutePolicyError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ResourceContentionFault" => {
+                "ResourceContention" => {
                     ExecutePolicyError::ResourceContentionFault(String::from(parsed_error.message))
                 }
-                "ScalingActivityInProgressFault" => {
-                    ExecutePolicyError::ScalingActivityInProgressFault(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "ScalingActivityInProgress" => ExecutePolicyError::ScalingActivityInProgressFault(
+                    String::from(parsed_error.message),
+                ),
                 _ => ExecutePolicyError::Unknown(String::from(body)),
             },
             Err(_) => ExecutePolicyError::Unknown(body.to_string()),
@@ -11816,7 +11792,7 @@ impl ExitStandbyError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ResourceContentionFault" => {
+                "ResourceContention" => {
                     ExitStandbyError::ResourceContentionFault(String::from(parsed_error.message))
                 }
                 _ => ExitStandbyError::Unknown(String::from(body)),
@@ -11895,10 +11871,10 @@ impl PutLifecycleHookError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "LimitExceededFault" => {
+                "LimitExceeded" => {
                     PutLifecycleHookError::LimitExceededFault(String::from(parsed_error.message))
                 }
-                "ResourceContentionFault" => PutLifecycleHookError::ResourceContentionFault(
+                "ResourceContention" => PutLifecycleHookError::ResourceContentionFault(
                     String::from(parsed_error.message),
                 ),
                 _ => PutLifecycleHookError::Unknown(String::from(body)),
@@ -11978,10 +11954,10 @@ impl PutNotificationConfigurationError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "LimitExceededFault" => PutNotificationConfigurationError::LimitExceededFault(
+                "LimitExceeded" => PutNotificationConfigurationError::LimitExceededFault(
                     String::from(parsed_error.message),
                 ),
-                "ResourceContentionFault" => {
+                "ResourceContention" => {
                     PutNotificationConfigurationError::ResourceContentionFault(String::from(
                         parsed_error.message,
                     ))
@@ -12065,10 +12041,10 @@ impl PutScalingPolicyError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "LimitExceededFault" => {
+                "LimitExceeded" => {
                     PutScalingPolicyError::LimitExceededFault(String::from(parsed_error.message))
                 }
-                "ResourceContentionFault" => PutScalingPolicyError::ResourceContentionFault(
+                "ResourceContention" => PutScalingPolicyError::ResourceContentionFault(
                     String::from(parsed_error.message),
                 ),
                 _ => PutScalingPolicyError::Unknown(String::from(body)),
@@ -12150,13 +12126,13 @@ impl PutScheduledUpdateGroupActionError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AlreadyExistsFault" => PutScheduledUpdateGroupActionError::AlreadyExistsFault(
+                "AlreadyExists" => PutScheduledUpdateGroupActionError::AlreadyExistsFault(
                     String::from(parsed_error.message),
                 ),
-                "LimitExceededFault" => PutScheduledUpdateGroupActionError::LimitExceededFault(
+                "LimitExceeded" => PutScheduledUpdateGroupActionError::LimitExceededFault(
                     String::from(parsed_error.message),
                 ),
-                "ResourceContentionFault" => {
+                "ResourceContention" => {
                     PutScheduledUpdateGroupActionError::ResourceContentionFault(String::from(
                         parsed_error.message,
                     ))
@@ -12239,7 +12215,7 @@ impl RecordLifecycleActionHeartbeatError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ResourceContentionFault" => {
+                "ResourceContention" => {
                     RecordLifecycleActionHeartbeatError::ResourceContentionFault(String::from(
                         parsed_error.message,
                     ))
@@ -12322,10 +12298,10 @@ impl ResumeProcessesError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ResourceContentionFault" => ResumeProcessesError::ResourceContentionFault(
+                "ResourceContention" => ResumeProcessesError::ResourceContentionFault(
                     String::from(parsed_error.message),
                 ),
-                "ResourceInUseFault" => {
+                "ResourceInUse" => {
                     ResumeProcessesError::ResourceInUseFault(String::from(parsed_error.message))
                 }
                 _ => ResumeProcessesError::Unknown(String::from(body)),
@@ -12405,10 +12381,10 @@ impl SetDesiredCapacityError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ResourceContentionFault" => SetDesiredCapacityError::ResourceContentionFault(
+                "ResourceContention" => SetDesiredCapacityError::ResourceContentionFault(
                     String::from(parsed_error.message),
                 ),
-                "ScalingActivityInProgressFault" => {
+                "ScalingActivityInProgress" => {
                     SetDesiredCapacityError::ScalingActivityInProgressFault(String::from(
                         parsed_error.message,
                     ))
@@ -12490,7 +12466,7 @@ impl SetInstanceHealthError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ResourceContentionFault" => SetInstanceHealthError::ResourceContentionFault(
+                "ResourceContention" => SetInstanceHealthError::ResourceContentionFault(
                     String::from(parsed_error.message),
                 ),
                 _ => SetInstanceHealthError::Unknown(String::from(body)),
@@ -12571,10 +12547,10 @@ impl SetInstanceProtectionError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "LimitExceededFault" => SetInstanceProtectionError::LimitExceededFault(
-                    String::from(parsed_error.message),
-                ),
-                "ResourceContentionFault" => SetInstanceProtectionError::ResourceContentionFault(
+                "LimitExceeded" => SetInstanceProtectionError::LimitExceededFault(String::from(
+                    parsed_error.message,
+                )),
+                "ResourceContention" => SetInstanceProtectionError::ResourceContentionFault(
                     String::from(parsed_error.message),
                 ),
                 _ => SetInstanceProtectionError::Unknown(String::from(body)),
@@ -12656,10 +12632,10 @@ impl SuspendProcessesError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ResourceContentionFault" => SuspendProcessesError::ResourceContentionFault(
+                "ResourceContention" => SuspendProcessesError::ResourceContentionFault(
                     String::from(parsed_error.message),
                 ),
-                "ResourceInUseFault" => {
+                "ResourceInUse" => {
                     SuspendProcessesError::ResourceInUseFault(String::from(parsed_error.message))
                 }
                 _ => SuspendProcessesError::Unknown(String::from(body)),
@@ -12739,12 +12715,12 @@ impl TerminateInstanceInAutoScalingGroupError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ResourceContentionFault" => {
+                "ResourceContention" => {
                     TerminateInstanceInAutoScalingGroupError::ResourceContentionFault(
                         String::from(parsed_error.message),
                     )
                 }
-                "ScalingActivityInProgressFault" => {
+                "ScalingActivityInProgress" => {
                     TerminateInstanceInAutoScalingGroupError::ScalingActivityInProgressFault(
                         String::from(parsed_error.message),
                     )
@@ -12830,10 +12806,10 @@ impl UpdateAutoScalingGroupError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ResourceContentionFault" => UpdateAutoScalingGroupError::ResourceContentionFault(
+                "ResourceContention" => UpdateAutoScalingGroupError::ResourceContentionFault(
                     String::from(parsed_error.message),
                 ),
-                "ScalingActivityInProgressFault" => {
+                "ScalingActivityInProgress" => {
                     UpdateAutoScalingGroupError::ScalingActivityInProgressFault(String::from(
                         parsed_error.message,
                     ))

--- a/rusoto/services/cloudformation/src/generated.rs
+++ b/rusoto/services/cloudformation/src/generated.rs
@@ -9529,7 +9529,7 @@ impl DeleteChangeSetError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "InvalidChangeSetStatusException" => {
+                "InvalidChangeSetStatus" => {
                     DeleteChangeSetError::InvalidChangeSetStatus(String::from(parsed_error.message))
                 }
                 _ => DeleteChangeSetError::Unknown(String::from(body)),
@@ -9944,7 +9944,7 @@ impl DescribeChangeSetError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ChangeSetNotFoundException" => {
+                "ChangeSetNotFound" => {
                     DescribeChangeSetError::ChangeSetNotFound(String::from(parsed_error.message))
                 }
                 _ => DescribeChangeSetError::Unknown(String::from(body)),
@@ -10641,7 +10641,7 @@ impl ExecuteChangeSetError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ChangeSetNotFoundException" => {
+                "ChangeSetNotFound" => {
                     ExecuteChangeSetError::ChangeSetNotFound(String::from(parsed_error.message))
                 }
                 "InsufficientCapabilitiesException" => {
@@ -10649,11 +10649,9 @@ impl ExecuteChangeSetError {
                         parsed_error.message,
                     ))
                 }
-                "InvalidChangeSetStatusException" => {
-                    ExecuteChangeSetError::InvalidChangeSetStatus(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "InvalidChangeSetStatus" => ExecuteChangeSetError::InvalidChangeSetStatus(
+                    String::from(parsed_error.message),
+                ),
                 "TokenAlreadyExistsException" => {
                     ExecuteChangeSetError::TokenAlreadyExists(String::from(parsed_error.message))
                 }
@@ -10805,7 +10803,7 @@ impl GetTemplateError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ChangeSetNotFoundException" => {
+                "ChangeSetNotFound" => {
                     GetTemplateError::ChangeSetNotFound(String::from(parsed_error.message))
                 }
                 _ => GetTemplateError::Unknown(String::from(body)),

--- a/rusoto/services/cloudformation/src/generated.rs
+++ b/rusoto/services/cloudformation/src/generated.rs
@@ -8983,7 +8983,7 @@ impl CancelUpdateStackError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "TokenAlreadyExistsException" => {
                     CancelUpdateStackError::TokenAlreadyExists(String::from(parsed_error.message))
@@ -8992,6 +8992,14 @@ impl CancelUpdateStackError {
             },
             Err(_) => CancelUpdateStackError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -9054,7 +9062,7 @@ impl ContinueUpdateRollbackError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "TokenAlreadyExistsException" => ContinueUpdateRollbackError::TokenAlreadyExists(
                     String::from(parsed_error.message),
@@ -9063,6 +9071,14 @@ impl ContinueUpdateRollbackError {
             },
             Err(_) => ContinueUpdateRollbackError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -9129,7 +9145,7 @@ impl CreateChangeSetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AlreadyExistsException" => {
                     CreateChangeSetError::AlreadyExists(String::from(parsed_error.message))
@@ -9146,6 +9162,14 @@ impl CreateChangeSetError {
             },
             Err(_) => CreateChangeSetError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -9214,7 +9238,7 @@ impl CreateStackError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AlreadyExistsException" => {
                     CreateStackError::AlreadyExists(String::from(parsed_error.message))
@@ -9232,6 +9256,14 @@ impl CreateStackError {
             },
             Err(_) => CreateStackError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -9305,7 +9337,7 @@ impl CreateStackInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidOperationException" => {
                     CreateStackInstancesError::InvalidOperation(String::from(parsed_error.message))
@@ -9331,6 +9363,14 @@ impl CreateStackInstancesError {
             },
             Err(_) => CreateStackInstancesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -9402,7 +9442,7 @@ impl CreateStackSetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CreatedButModifiedException" => {
                     CreateStackSetError::CreatedButModified(String::from(parsed_error.message))
@@ -9417,6 +9457,14 @@ impl CreateStackSetError {
             },
             Err(_) => CreateStackSetError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -9479,7 +9527,7 @@ impl DeleteChangeSetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidChangeSetStatusException" => {
                     DeleteChangeSetError::InvalidChangeSetStatus(String::from(parsed_error.message))
@@ -9488,6 +9536,14 @@ impl DeleteChangeSetError {
             },
             Err(_) => DeleteChangeSetError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -9548,7 +9604,7 @@ impl DeleteStackError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "TokenAlreadyExistsException" => {
                     DeleteStackError::TokenAlreadyExists(String::from(parsed_error.message))
@@ -9557,6 +9613,14 @@ impl DeleteStackError {
             },
             Err(_) => DeleteStackError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -9625,7 +9689,7 @@ impl DeleteStackInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidOperationException" => {
                     DeleteStackInstancesError::InvalidOperation(String::from(parsed_error.message))
@@ -9648,6 +9712,14 @@ impl DeleteStackInstancesError {
             },
             Err(_) => DeleteStackInstancesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -9716,7 +9788,7 @@ impl DeleteStackSetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "OperationInProgressException" => {
                     DeleteStackSetError::OperationInProgress(String::from(parsed_error.message))
@@ -9728,6 +9800,14 @@ impl DeleteStackSetError {
             },
             Err(_) => DeleteStackSetError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -9787,12 +9867,20 @@ impl DescribeAccountLimitsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeAccountLimitsError::Unknown(String::from(body)),
             },
             Err(_) => DescribeAccountLimitsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -9854,7 +9942,7 @@ impl DescribeChangeSetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ChangeSetNotFoundException" => {
                     DescribeChangeSetError::ChangeSetNotFound(String::from(parsed_error.message))
@@ -9863,6 +9951,14 @@ impl DescribeChangeSetError {
             },
             Err(_) => DescribeChangeSetError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -9923,12 +10019,20 @@ impl DescribeStackEventsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeStackEventsError::Unknown(String::from(body)),
             },
             Err(_) => DescribeStackEventsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -9992,7 +10096,7 @@ impl DescribeStackInstanceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "StackInstanceNotFoundException" => {
                     DescribeStackInstanceError::StackInstanceNotFound(String::from(
@@ -10006,6 +10110,14 @@ impl DescribeStackInstanceError {
             },
             Err(_) => DescribeStackInstanceError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10067,12 +10179,20 @@ impl DescribeStackResourceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeStackResourceError::Unknown(String::from(body)),
             },
             Err(_) => DescribeStackResourceError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10132,12 +10252,20 @@ impl DescribeStackResourcesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeStackResourcesError::Unknown(String::from(body)),
             },
             Err(_) => DescribeStackResourcesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10199,7 +10327,7 @@ impl DescribeStackSetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "StackSetNotFoundException" => {
                     DescribeStackSetError::StackSetNotFound(String::from(parsed_error.message))
@@ -10208,6 +10336,14 @@ impl DescribeStackSetError {
             },
             Err(_) => DescribeStackSetError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10270,7 +10406,7 @@ impl DescribeStackSetOperationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "OperationNotFoundException" => DescribeStackSetOperationError::OperationNotFound(
                     String::from(parsed_error.message),
@@ -10282,6 +10418,14 @@ impl DescribeStackSetOperationError {
             },
             Err(_) => DescribeStackSetOperationError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10343,12 +10487,20 @@ impl DescribeStacksError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeStacksError::Unknown(String::from(body)),
             },
             Err(_) => DescribeStacksError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10406,12 +10558,20 @@ impl EstimateTemplateCostError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => EstimateTemplateCostError::Unknown(String::from(body)),
             },
             Err(_) => EstimateTemplateCostError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10479,7 +10639,7 @@ impl ExecuteChangeSetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ChangeSetNotFoundException" => {
                     ExecuteChangeSetError::ChangeSetNotFound(String::from(parsed_error.message))
@@ -10501,6 +10661,14 @@ impl ExecuteChangeSetError {
             },
             Err(_) => ExecuteChangeSetError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10562,12 +10730,20 @@ impl GetStackPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetStackPolicyError::Unknown(String::from(body)),
             },
             Err(_) => GetStackPolicyError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10627,7 +10803,7 @@ impl GetTemplateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ChangeSetNotFoundException" => {
                     GetTemplateError::ChangeSetNotFound(String::from(parsed_error.message))
@@ -10636,6 +10812,14 @@ impl GetTemplateError {
             },
             Err(_) => GetTemplateError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10696,7 +10880,7 @@ impl GetTemplateSummaryError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "StackSetNotFoundException" => {
                     GetTemplateSummaryError::StackSetNotFound(String::from(parsed_error.message))
@@ -10705,6 +10889,14 @@ impl GetTemplateSummaryError {
             },
             Err(_) => GetTemplateSummaryError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10765,12 +10957,20 @@ impl ListChangeSetsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListChangeSetsError::Unknown(String::from(body)),
             },
             Err(_) => ListChangeSetsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10828,12 +11028,20 @@ impl ListExportsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListExportsError::Unknown(String::from(body)),
             },
             Err(_) => ListExportsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10891,12 +11099,20 @@ impl ListImportsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListImportsError::Unknown(String::from(body)),
             },
             Err(_) => ListImportsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10956,7 +11172,7 @@ impl ListStackInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "StackSetNotFoundException" => {
                     ListStackInstancesError::StackSetNotFound(String::from(parsed_error.message))
@@ -10965,6 +11181,14 @@ impl ListStackInstancesError {
             },
             Err(_) => ListStackInstancesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11025,12 +11249,20 @@ impl ListStackResourcesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListStackResourcesError::Unknown(String::from(body)),
             },
             Err(_) => ListStackResourcesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11094,7 +11326,7 @@ impl ListStackSetOperationResultsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "OperationNotFoundException" => {
                     ListStackSetOperationResultsError::OperationNotFound(String::from(
@@ -11110,6 +11342,14 @@ impl ListStackSetOperationResultsError {
             },
             Err(_) => ListStackSetOperationResultsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11173,7 +11413,7 @@ impl ListStackSetOperationsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "StackSetNotFoundException" => ListStackSetOperationsError::StackSetNotFound(
                     String::from(parsed_error.message),
@@ -11182,6 +11422,14 @@ impl ListStackSetOperationsError {
             },
             Err(_) => ListStackSetOperationsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11242,12 +11490,20 @@ impl ListStackSetsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListStackSetsError::Unknown(String::from(body)),
             },
             Err(_) => ListStackSetsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11305,12 +11561,20 @@ impl ListStacksError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListStacksError::Unknown(String::from(body)),
             },
             Err(_) => ListStacksError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11368,12 +11632,20 @@ impl SetStackPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => SetStackPolicyError::Unknown(String::from(body)),
             },
             Err(_) => SetStackPolicyError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11431,12 +11703,20 @@ impl SignalResourceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => SignalResourceError::Unknown(String::from(body)),
             },
             Err(_) => SignalResourceError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11500,7 +11780,7 @@ impl StopStackSetOperationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidOperationException" => {
                     StopStackSetOperationError::InvalidOperation(String::from(parsed_error.message))
@@ -11515,6 +11795,14 @@ impl StopStackSetOperationError {
             },
             Err(_) => StopStackSetOperationError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11581,7 +11869,7 @@ impl UpdateStackError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InsufficientCapabilitiesException" => {
                     UpdateStackError::InsufficientCapabilities(String::from(parsed_error.message))
@@ -11593,6 +11881,14 @@ impl UpdateStackError {
             },
             Err(_) => UpdateStackError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11664,7 +11960,7 @@ impl UpdateStackInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidOperationException" => {
                     UpdateStackInstancesError::InvalidOperation(String::from(parsed_error.message))
@@ -11692,6 +11988,14 @@ impl UpdateStackInstancesError {
             },
             Err(_) => UpdateStackInstancesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11767,7 +12071,7 @@ impl UpdateStackSetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidOperationException" => {
                     UpdateStackSetError::InvalidOperation(String::from(parsed_error.message))
@@ -11790,6 +12094,14 @@ impl UpdateStackSetError {
             },
             Err(_) => UpdateStackSetError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11852,12 +12164,20 @@ impl UpdateTerminationProtectionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => UpdateTerminationProtectionError::Unknown(String::from(body)),
             },
             Err(_) => UpdateTerminationProtectionError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11917,12 +12237,20 @@ impl ValidateTemplateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ValidateTemplateError::Unknown(String::from(body)),
             },
             Err(_) => ValidateTemplateError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 

--- a/rusoto/services/cloudfront/src/generated.rs
+++ b/rusoto/services/cloudfront/src/generated.rs
@@ -8119,7 +8119,7 @@ impl CreateCloudFrontOriginAccessIdentityError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
                             Ok(parsed_error) => {
                                 match &parsed_error.code[..] {
                                     "CloudFrontOriginAccessIdentityAlreadyExists" => CreateCloudFrontOriginAccessIdentityError::CloudFrontOriginAccessIdentityAlreadyExists(String::from(parsed_error.message)),"InconsistentQuantities" => CreateCloudFrontOriginAccessIdentityError::InconsistentQuantities(String::from(parsed_error.message)),"InvalidArgument" => CreateCloudFrontOriginAccessIdentityError::InvalidArgument(String::from(parsed_error.message)),"MissingBody" => CreateCloudFrontOriginAccessIdentityError::MissingBody(String::from(parsed_error.message)),"TooManyCloudFrontOriginAccessIdentities" => CreateCloudFrontOriginAccessIdentityError::TooManyCloudFrontOriginAccessIdentities(String::from(parsed_error.message)),_ => CreateCloudFrontOriginAccessIdentityError::Unknown(String::from(body))
@@ -8127,6 +8127,14 @@ impl CreateCloudFrontOriginAccessIdentityError {
                            },
                            Err(_) => CreateCloudFrontOriginAccessIdentityError::Unknown(body.to_string())
                        }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -8269,7 +8277,7 @@ impl CreateDistributionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessDenied" => {
                     CreateDistributionError::AccessDenied(String::from(parsed_error.message))
@@ -8419,6 +8427,14 @@ impl CreateDistributionError {
             },
             Err(_) => CreateDistributionError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -8600,7 +8616,7 @@ impl CreateDistributionWithTagsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessDenied" => CreateDistributionWithTagsError::AccessDenied(String::from(
                     parsed_error.message,
@@ -8774,6 +8790,14 @@ impl CreateDistributionWithTagsError {
             Err(_) => CreateDistributionWithTagsError::Unknown(body.to_string()),
         }
     }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
+    }
 }
 
 impl From<XmlParseError> for CreateDistributionWithTagsError {
@@ -8889,7 +8913,7 @@ impl CreateInvalidationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessDenied" => {
                     CreateInvalidationError::AccessDenied(String::from(parsed_error.message))
@@ -8918,6 +8942,14 @@ impl CreateInvalidationError {
             },
             Err(_) => CreateInvalidationError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -9008,7 +9040,7 @@ impl CreateStreamingDistributionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessDenied" => CreateStreamingDistributionError::AccessDenied(String::from(
                     parsed_error.message,
@@ -9064,6 +9096,14 @@ impl CreateStreamingDistributionError {
             },
             Err(_) => CreateStreamingDistributionError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -9165,7 +9205,7 @@ impl CreateStreamingDistributionWithTagsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessDenied" => CreateStreamingDistributionWithTagsError::AccessDenied(
                     String::from(parsed_error.message),
@@ -9226,6 +9266,14 @@ impl CreateStreamingDistributionWithTagsError {
             },
             Err(_) => CreateStreamingDistributionWithTagsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -9316,7 +9364,7 @@ impl DeleteCloudFrontOriginAccessIdentityError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
                             Ok(parsed_error) => {
                                 match &parsed_error.code[..] {
                                     "AccessDenied" => DeleteCloudFrontOriginAccessIdentityError::AccessDenied(String::from(parsed_error.message)),"CloudFrontOriginAccessIdentityInUse" => DeleteCloudFrontOriginAccessIdentityError::CloudFrontOriginAccessIdentityInUse(String::from(parsed_error.message)),"InvalidIfMatchVersion" => DeleteCloudFrontOriginAccessIdentityError::InvalidIfMatchVersion(String::from(parsed_error.message)),"NoSuchCloudFrontOriginAccessIdentity" => DeleteCloudFrontOriginAccessIdentityError::NoSuchCloudFrontOriginAccessIdentity(String::from(parsed_error.message)),"PreconditionFailed" => DeleteCloudFrontOriginAccessIdentityError::PreconditionFailed(String::from(parsed_error.message)),_ => DeleteCloudFrontOriginAccessIdentityError::Unknown(String::from(body))
@@ -9324,6 +9372,14 @@ impl DeleteCloudFrontOriginAccessIdentityError {
                            },
                            Err(_) => DeleteCloudFrontOriginAccessIdentityError::Unknown(body.to_string())
                        }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -9402,7 +9458,7 @@ impl DeleteDistributionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessDenied" => {
                     DeleteDistributionError::AccessDenied(String::from(parsed_error.message))
@@ -9423,6 +9479,14 @@ impl DeleteDistributionError {
             },
             Err(_) => DeleteDistributionError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -9495,7 +9559,7 @@ impl DeleteServiceLinkedRoleError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessDenied" => {
                     DeleteServiceLinkedRoleError::AccessDenied(String::from(parsed_error.message))
@@ -9513,6 +9577,14 @@ impl DeleteServiceLinkedRoleError {
             },
             Err(_) => DeleteServiceLinkedRoleError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -9586,7 +9658,7 @@ impl DeleteStreamingDistributionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessDenied" => DeleteStreamingDistributionError::AccessDenied(String::from(
                     parsed_error.message,
@@ -9613,6 +9685,14 @@ impl DeleteStreamingDistributionError {
             },
             Err(_) => DeleteStreamingDistributionError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -9681,7 +9761,7 @@ impl GetCloudFrontOriginAccessIdentityError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessDenied" => GetCloudFrontOriginAccessIdentityError::AccessDenied(
                     String::from(parsed_error.message),
@@ -9695,6 +9775,14 @@ impl GetCloudFrontOriginAccessIdentityError {
             },
             Err(_) => GetCloudFrontOriginAccessIdentityError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -9762,7 +9850,7 @@ impl GetCloudFrontOriginAccessIdentityConfigError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
                             Ok(parsed_error) => {
                                 match &parsed_error.code[..] {
                                     "AccessDenied" => GetCloudFrontOriginAccessIdentityConfigError::AccessDenied(String::from(parsed_error.message)),"NoSuchCloudFrontOriginAccessIdentity" => GetCloudFrontOriginAccessIdentityConfigError::NoSuchCloudFrontOriginAccessIdentity(String::from(parsed_error.message)),_ => GetCloudFrontOriginAccessIdentityConfigError::Unknown(String::from(body))
@@ -9770,6 +9858,14 @@ impl GetCloudFrontOriginAccessIdentityConfigError {
                            },
                            Err(_) => GetCloudFrontOriginAccessIdentityConfigError::Unknown(body.to_string())
                        }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -9833,7 +9929,7 @@ impl GetDistributionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessDenied" => {
                     GetDistributionError::AccessDenied(String::from(parsed_error.message))
@@ -9845,6 +9941,14 @@ impl GetDistributionError {
             },
             Err(_) => GetDistributionError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -9908,7 +10012,7 @@ impl GetDistributionConfigError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessDenied" => {
                     GetDistributionConfigError::AccessDenied(String::from(parsed_error.message))
@@ -9920,6 +10024,14 @@ impl GetDistributionConfigError {
             },
             Err(_) => GetDistributionConfigError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -9987,7 +10099,7 @@ impl GetInvalidationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessDenied" => {
                     GetInvalidationError::AccessDenied(String::from(parsed_error.message))
@@ -10002,6 +10114,14 @@ impl GetInvalidationError {
             },
             Err(_) => GetInvalidationError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10066,7 +10186,7 @@ impl GetStreamingDistributionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessDenied" => {
                     GetStreamingDistributionError::AccessDenied(String::from(parsed_error.message))
@@ -10080,6 +10200,14 @@ impl GetStreamingDistributionError {
             },
             Err(_) => GetStreamingDistributionError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10145,7 +10273,7 @@ impl GetStreamingDistributionConfigError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessDenied" => GetStreamingDistributionConfigError::AccessDenied(String::from(
                     parsed_error.message,
@@ -10159,6 +10287,14 @@ impl GetStreamingDistributionConfigError {
             },
             Err(_) => GetStreamingDistributionConfigError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10222,7 +10358,7 @@ impl ListCloudFrontOriginAccessIdentitiesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidArgument" => ListCloudFrontOriginAccessIdentitiesError::InvalidArgument(
                     String::from(parsed_error.message),
@@ -10231,6 +10367,14 @@ impl ListCloudFrontOriginAccessIdentitiesError {
             },
             Err(_) => ListCloudFrontOriginAccessIdentitiesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10293,7 +10437,7 @@ impl ListDistributionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidArgument" => {
                     ListDistributionsError::InvalidArgument(String::from(parsed_error.message))
@@ -10302,6 +10446,14 @@ impl ListDistributionsError {
             },
             Err(_) => ListDistributionsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10366,7 +10518,7 @@ impl ListDistributionsByWebACLIdError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidArgument" => ListDistributionsByWebACLIdError::InvalidArgument(
                     String::from(parsed_error.message),
@@ -10378,6 +10530,14 @@ impl ListDistributionsByWebACLIdError {
             },
             Err(_) => ListDistributionsByWebACLIdError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10445,7 +10605,7 @@ impl ListInvalidationsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessDenied" => {
                     ListInvalidationsError::AccessDenied(String::from(parsed_error.message))
@@ -10460,6 +10620,14 @@ impl ListInvalidationsError {
             },
             Err(_) => ListInvalidationsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10524,7 +10692,7 @@ impl ListStreamingDistributionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidArgument" => ListStreamingDistributionsError::InvalidArgument(
                     String::from(parsed_error.message),
@@ -10533,6 +10701,14 @@ impl ListStreamingDistributionsError {
             },
             Err(_) => ListStreamingDistributionsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10601,7 +10777,7 @@ impl ListTagsForResourceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessDenied" => {
                     ListTagsForResourceError::AccessDenied(String::from(parsed_error.message))
@@ -10619,6 +10795,14 @@ impl ListTagsForResourceError {
             },
             Err(_) => ListTagsForResourceError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10690,7 +10874,7 @@ impl TagResourceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessDenied" => {
                     TagResourceError::AccessDenied(String::from(parsed_error.message))
@@ -10708,6 +10892,14 @@ impl TagResourceError {
             },
             Err(_) => TagResourceError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10777,7 +10969,7 @@ impl UntagResourceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessDenied" => {
                     UntagResourceError::AccessDenied(String::from(parsed_error.message))
@@ -10795,6 +10987,14 @@ impl UntagResourceError {
             },
             Err(_) => UntagResourceError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10872,7 +11072,7 @@ impl UpdateCloudFrontOriginAccessIdentityError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
                             Ok(parsed_error) => {
                                 match &parsed_error.code[..] {
                                     "AccessDenied" => UpdateCloudFrontOriginAccessIdentityError::AccessDenied(String::from(parsed_error.message)),"IllegalUpdate" => UpdateCloudFrontOriginAccessIdentityError::IllegalUpdate(String::from(parsed_error.message)),"InconsistentQuantities" => UpdateCloudFrontOriginAccessIdentityError::InconsistentQuantities(String::from(parsed_error.message)),"InvalidArgument" => UpdateCloudFrontOriginAccessIdentityError::InvalidArgument(String::from(parsed_error.message)),"InvalidIfMatchVersion" => UpdateCloudFrontOriginAccessIdentityError::InvalidIfMatchVersion(String::from(parsed_error.message)),"MissingBody" => UpdateCloudFrontOriginAccessIdentityError::MissingBody(String::from(parsed_error.message)),"NoSuchCloudFrontOriginAccessIdentity" => UpdateCloudFrontOriginAccessIdentityError::NoSuchCloudFrontOriginAccessIdentity(String::from(parsed_error.message)),"PreconditionFailed" => UpdateCloudFrontOriginAccessIdentityError::PreconditionFailed(String::from(parsed_error.message)),_ => UpdateCloudFrontOriginAccessIdentityError::Unknown(String::from(body))
@@ -10880,6 +11080,14 @@ impl UpdateCloudFrontOriginAccessIdentityError {
                            },
                            Err(_) => UpdateCloudFrontOriginAccessIdentityError::Unknown(body.to_string())
                        }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11029,7 +11237,7 @@ impl UpdateDistributionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessDenied" => {
                     UpdateDistributionError::AccessDenied(String::from(parsed_error.message))
@@ -11180,6 +11388,14 @@ impl UpdateDistributionError {
             Err(_) => UpdateDistributionError::Unknown(body.to_string()),
         }
     }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
+    }
 }
 
 impl From<XmlParseError> for UpdateDistributionError {
@@ -11304,7 +11520,7 @@ impl UpdateStreamingDistributionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessDenied" => UpdateStreamingDistributionError::AccessDenied(String::from(
                     parsed_error.message,
@@ -11363,6 +11579,14 @@ impl UpdateStreamingDistributionError {
             },
             Err(_) => UpdateStreamingDistributionError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 

--- a/rusoto/services/cloudsearch/src/generated.rs
+++ b/rusoto/services/cloudsearch/src/generated.rs
@@ -5495,7 +5495,7 @@ impl BuildSuggestersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "BaseException" => BuildSuggestersError::Base(String::from(parsed_error.message)),
                 "InternalException" => {
@@ -5508,6 +5508,14 @@ impl BuildSuggestersError {
             },
             Err(_) => BuildSuggestersError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -5574,7 +5582,7 @@ impl CreateDomainError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "BaseException" => CreateDomainError::Base(String::from(parsed_error.message)),
                 "InternalException" => {
@@ -5587,6 +5595,14 @@ impl CreateDomainError {
             },
             Err(_) => CreateDomainError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -5657,7 +5673,7 @@ impl DefineAnalysisSchemeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "BaseException" => {
                     DefineAnalysisSchemeError::Base(String::from(parsed_error.message))
@@ -5678,6 +5694,14 @@ impl DefineAnalysisSchemeError {
             },
             Err(_) => DefineAnalysisSchemeError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -5752,7 +5776,7 @@ impl DefineExpressionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "BaseException" => DefineExpressionError::Base(String::from(parsed_error.message)),
                 "InternalException" => {
@@ -5771,6 +5795,14 @@ impl DefineExpressionError {
             },
             Err(_) => DefineExpressionError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -5843,7 +5875,7 @@ impl DefineIndexFieldError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "BaseException" => DefineIndexFieldError::Base(String::from(parsed_error.message)),
                 "InternalException" => {
@@ -5862,6 +5894,14 @@ impl DefineIndexFieldError {
             },
             Err(_) => DefineIndexFieldError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -5934,7 +5974,7 @@ impl DefineSuggesterError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "BaseException" => DefineSuggesterError::Base(String::from(parsed_error.message)),
                 "InternalException" => {
@@ -5953,6 +5993,14 @@ impl DefineSuggesterError {
             },
             Err(_) => DefineSuggesterError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -6023,7 +6071,7 @@ impl DeleteAnalysisSchemeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "BaseException" => {
                     DeleteAnalysisSchemeError::Base(String::from(parsed_error.message))
@@ -6041,6 +6089,14 @@ impl DeleteAnalysisSchemeError {
             },
             Err(_) => DeleteAnalysisSchemeError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -6108,7 +6164,7 @@ impl DeleteDomainError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "BaseException" => DeleteDomainError::Base(String::from(parsed_error.message)),
                 "InternalException" => {
@@ -6118,6 +6174,14 @@ impl DeleteDomainError {
             },
             Err(_) => DeleteDomainError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -6185,7 +6249,7 @@ impl DeleteExpressionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "BaseException" => DeleteExpressionError::Base(String::from(parsed_error.message)),
                 "InternalException" => {
@@ -6201,6 +6265,14 @@ impl DeleteExpressionError {
             },
             Err(_) => DeleteExpressionError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -6270,7 +6342,7 @@ impl DeleteIndexFieldError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "BaseException" => DeleteIndexFieldError::Base(String::from(parsed_error.message)),
                 "InternalException" => {
@@ -6286,6 +6358,14 @@ impl DeleteIndexFieldError {
             },
             Err(_) => DeleteIndexFieldError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -6355,7 +6435,7 @@ impl DeleteSuggesterError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "BaseException" => DeleteSuggesterError::Base(String::from(parsed_error.message)),
                 "InternalException" => {
@@ -6371,6 +6451,14 @@ impl DeleteSuggesterError {
             },
             Err(_) => DeleteSuggesterError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -6438,7 +6526,7 @@ impl DescribeAnalysisSchemesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "BaseException" => {
                     DescribeAnalysisSchemesError::Base(String::from(parsed_error.message))
@@ -6453,6 +6541,14 @@ impl DescribeAnalysisSchemesError {
             },
             Err(_) => DescribeAnalysisSchemesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -6527,7 +6623,7 @@ impl DescribeAvailabilityOptionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "BaseException" => {
                     DescribeAvailabilityOptionsError::Base(String::from(parsed_error.message))
@@ -6553,6 +6649,14 @@ impl DescribeAvailabilityOptionsError {
             },
             Err(_) => DescribeAvailabilityOptionsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -6622,7 +6726,7 @@ impl DescribeDomainsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "BaseException" => DescribeDomainsError::Base(String::from(parsed_error.message)),
                 "InternalException" => {
@@ -6632,6 +6736,14 @@ impl DescribeDomainsError {
             },
             Err(_) => DescribeDomainsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -6697,7 +6809,7 @@ impl DescribeExpressionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "BaseException" => {
                     DescribeExpressionsError::Base(String::from(parsed_error.message))
@@ -6712,6 +6824,14 @@ impl DescribeExpressionsError {
             },
             Err(_) => DescribeExpressionsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -6780,7 +6900,7 @@ impl DescribeIndexFieldsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "BaseException" => {
                     DescribeIndexFieldsError::Base(String::from(parsed_error.message))
@@ -6795,6 +6915,14 @@ impl DescribeIndexFieldsError {
             },
             Err(_) => DescribeIndexFieldsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -6863,7 +6991,7 @@ impl DescribeScalingParametersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "BaseException" => {
                     DescribeScalingParametersError::Base(String::from(parsed_error.message))
@@ -6878,6 +7006,14 @@ impl DescribeScalingParametersError {
             },
             Err(_) => DescribeScalingParametersError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -6946,7 +7082,7 @@ impl DescribeServiceAccessPoliciesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "BaseException" => {
                     DescribeServiceAccessPoliciesError::Base(String::from(parsed_error.message))
@@ -6963,6 +7099,14 @@ impl DescribeServiceAccessPoliciesError {
             },
             Err(_) => DescribeServiceAccessPoliciesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -7031,7 +7175,7 @@ impl DescribeSuggestersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "BaseException" => {
                     DescribeSuggestersError::Base(String::from(parsed_error.message))
@@ -7046,6 +7190,14 @@ impl DescribeSuggestersError {
             },
             Err(_) => DescribeSuggestersError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -7114,7 +7266,7 @@ impl IndexDocumentsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "BaseException" => IndexDocumentsError::Base(String::from(parsed_error.message)),
                 "InternalException" => {
@@ -7127,6 +7279,14 @@ impl IndexDocumentsError {
             },
             Err(_) => IndexDocumentsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -7189,13 +7349,21 @@ impl ListDomainNamesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "BaseException" => ListDomainNamesError::Base(String::from(parsed_error.message)),
                 _ => ListDomainNamesError::Unknown(String::from(body)),
             },
             Err(_) => ListDomainNamesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -7266,7 +7434,7 @@ impl UpdateAvailabilityOptionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "BaseException" => {
                     UpdateAvailabilityOptionsError::Base(String::from(parsed_error.message))
@@ -7290,6 +7458,14 @@ impl UpdateAvailabilityOptionsError {
             },
             Err(_) => UpdateAvailabilityOptionsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -7365,7 +7541,7 @@ impl UpdateScalingParametersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "BaseException" => {
                     UpdateScalingParametersError::Base(String::from(parsed_error.message))
@@ -7386,6 +7562,14 @@ impl UpdateScalingParametersError {
             },
             Err(_) => UpdateScalingParametersError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -7460,7 +7644,7 @@ impl UpdateServiceAccessPoliciesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "BaseException" => {
                     UpdateServiceAccessPoliciesError::Base(String::from(parsed_error.message))
@@ -7481,6 +7665,14 @@ impl UpdateServiceAccessPoliciesError {
             },
             Err(_) => UpdateServiceAccessPoliciesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 

--- a/rusoto/services/cloudsearch/src/generated.rs
+++ b/rusoto/services/cloudsearch/src/generated.rs
@@ -5501,7 +5501,7 @@ impl BuildSuggestersError {
                 "InternalException" => {
                     BuildSuggestersError::Internal(String::from(parsed_error.message))
                 }
-                "ResourceNotFoundException" => {
+                "ResourceNotFound" => {
                     BuildSuggestersError::ResourceNotFound(String::from(parsed_error.message))
                 }
                 _ => BuildSuggestersError::Unknown(String::from(body)),
@@ -5588,7 +5588,7 @@ impl CreateDomainError {
                 "InternalException" => {
                     CreateDomainError::Internal(String::from(parsed_error.message))
                 }
-                "LimitExceededException" => {
+                "LimitExceeded" => {
                     CreateDomainError::LimitExceeded(String::from(parsed_error.message))
                 }
                 _ => CreateDomainError::Unknown(String::from(body)),
@@ -5652,12 +5652,12 @@ pub enum DefineAnalysisSchemeError {
     Base(String),
     /// <p>An internal error occurred while processing the request. If this problem persists, report an issue from the <a href="http://status.aws.amazon.com/" target="_blank">Service Health Dashboard</a>.</p>
     Internal(String),
+    /// <p>The request was rejected because it specified an invalid type definition.</p>
+    InvalidType(String),
     /// <p>The request was rejected because a resource limit has already been met.</p>
     LimitExceeded(String),
     /// <p>The request was rejected because it attempted to reference a resource that does not exist.</p>
     ResourceNotFound(String),
-    /// <p>The request was rejected because it specified an invalid type definition.</p>
-    InvalidType(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -5681,14 +5681,14 @@ impl DefineAnalysisSchemeError {
                 "InternalException" => {
                     DefineAnalysisSchemeError::Internal(String::from(parsed_error.message))
                 }
-                "LimitExceededException" => {
+                "InvalidType" => {
+                    DefineAnalysisSchemeError::InvalidType(String::from(parsed_error.message))
+                }
+                "LimitExceeded" => {
                     DefineAnalysisSchemeError::LimitExceeded(String::from(parsed_error.message))
                 }
-                "ResourceNotFoundException" => {
+                "ResourceNotFound" => {
                     DefineAnalysisSchemeError::ResourceNotFound(String::from(parsed_error.message))
-                }
-                "InvalidTypeException" => {
-                    DefineAnalysisSchemeError::InvalidType(String::from(parsed_error.message))
                 }
                 _ => DefineAnalysisSchemeError::Unknown(String::from(body)),
             },
@@ -5736,9 +5736,9 @@ impl Error for DefineAnalysisSchemeError {
         match *self {
             DefineAnalysisSchemeError::Base(ref cause) => cause,
             DefineAnalysisSchemeError::Internal(ref cause) => cause,
+            DefineAnalysisSchemeError::InvalidType(ref cause) => cause,
             DefineAnalysisSchemeError::LimitExceeded(ref cause) => cause,
             DefineAnalysisSchemeError::ResourceNotFound(ref cause) => cause,
-            DefineAnalysisSchemeError::InvalidType(ref cause) => cause,
             DefineAnalysisSchemeError::Validation(ref cause) => cause,
             DefineAnalysisSchemeError::Credentials(ref err) => err.description(),
             DefineAnalysisSchemeError::HttpDispatch(ref dispatch_error) => {
@@ -5755,12 +5755,12 @@ pub enum DefineExpressionError {
     Base(String),
     /// <p>An internal error occurred while processing the request. If this problem persists, report an issue from the <a href="http://status.aws.amazon.com/" target="_blank">Service Health Dashboard</a>.</p>
     Internal(String),
+    /// <p>The request was rejected because it specified an invalid type definition.</p>
+    InvalidType(String),
     /// <p>The request was rejected because a resource limit has already been met.</p>
     LimitExceeded(String),
     /// <p>The request was rejected because it attempted to reference a resource that does not exist.</p>
     ResourceNotFound(String),
-    /// <p>The request was rejected because it specified an invalid type definition.</p>
-    InvalidType(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -5782,14 +5782,14 @@ impl DefineExpressionError {
                 "InternalException" => {
                     DefineExpressionError::Internal(String::from(parsed_error.message))
                 }
-                "LimitExceededException" => {
+                "InvalidType" => {
+                    DefineExpressionError::InvalidType(String::from(parsed_error.message))
+                }
+                "LimitExceeded" => {
                     DefineExpressionError::LimitExceeded(String::from(parsed_error.message))
                 }
-                "ResourceNotFoundException" => {
+                "ResourceNotFound" => {
                     DefineExpressionError::ResourceNotFound(String::from(parsed_error.message))
-                }
-                "InvalidTypeException" => {
-                    DefineExpressionError::InvalidType(String::from(parsed_error.message))
                 }
                 _ => DefineExpressionError::Unknown(String::from(body)),
             },
@@ -5837,9 +5837,9 @@ impl Error for DefineExpressionError {
         match *self {
             DefineExpressionError::Base(ref cause) => cause,
             DefineExpressionError::Internal(ref cause) => cause,
+            DefineExpressionError::InvalidType(ref cause) => cause,
             DefineExpressionError::LimitExceeded(ref cause) => cause,
             DefineExpressionError::ResourceNotFound(ref cause) => cause,
-            DefineExpressionError::InvalidType(ref cause) => cause,
             DefineExpressionError::Validation(ref cause) => cause,
             DefineExpressionError::Credentials(ref err) => err.description(),
             DefineExpressionError::HttpDispatch(ref dispatch_error) => dispatch_error.description(),
@@ -5854,12 +5854,12 @@ pub enum DefineIndexFieldError {
     Base(String),
     /// <p>An internal error occurred while processing the request. If this problem persists, report an issue from the <a href="http://status.aws.amazon.com/" target="_blank">Service Health Dashboard</a>.</p>
     Internal(String),
+    /// <p>The request was rejected because it specified an invalid type definition.</p>
+    InvalidType(String),
     /// <p>The request was rejected because a resource limit has already been met.</p>
     LimitExceeded(String),
     /// <p>The request was rejected because it attempted to reference a resource that does not exist.</p>
     ResourceNotFound(String),
-    /// <p>The request was rejected because it specified an invalid type definition.</p>
-    InvalidType(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -5881,14 +5881,14 @@ impl DefineIndexFieldError {
                 "InternalException" => {
                     DefineIndexFieldError::Internal(String::from(parsed_error.message))
                 }
-                "LimitExceededException" => {
+                "InvalidType" => {
+                    DefineIndexFieldError::InvalidType(String::from(parsed_error.message))
+                }
+                "LimitExceeded" => {
                     DefineIndexFieldError::LimitExceeded(String::from(parsed_error.message))
                 }
-                "ResourceNotFoundException" => {
+                "ResourceNotFound" => {
                     DefineIndexFieldError::ResourceNotFound(String::from(parsed_error.message))
-                }
-                "InvalidTypeException" => {
-                    DefineIndexFieldError::InvalidType(String::from(parsed_error.message))
                 }
                 _ => DefineIndexFieldError::Unknown(String::from(body)),
             },
@@ -5936,9 +5936,9 @@ impl Error for DefineIndexFieldError {
         match *self {
             DefineIndexFieldError::Base(ref cause) => cause,
             DefineIndexFieldError::Internal(ref cause) => cause,
+            DefineIndexFieldError::InvalidType(ref cause) => cause,
             DefineIndexFieldError::LimitExceeded(ref cause) => cause,
             DefineIndexFieldError::ResourceNotFound(ref cause) => cause,
-            DefineIndexFieldError::InvalidType(ref cause) => cause,
             DefineIndexFieldError::Validation(ref cause) => cause,
             DefineIndexFieldError::Credentials(ref err) => err.description(),
             DefineIndexFieldError::HttpDispatch(ref dispatch_error) => dispatch_error.description(),
@@ -5953,12 +5953,12 @@ pub enum DefineSuggesterError {
     Base(String),
     /// <p>An internal error occurred while processing the request. If this problem persists, report an issue from the <a href="http://status.aws.amazon.com/" target="_blank">Service Health Dashboard</a>.</p>
     Internal(String),
+    /// <p>The request was rejected because it specified an invalid type definition.</p>
+    InvalidType(String),
     /// <p>The request was rejected because a resource limit has already been met.</p>
     LimitExceeded(String),
     /// <p>The request was rejected because it attempted to reference a resource that does not exist.</p>
     ResourceNotFound(String),
-    /// <p>The request was rejected because it specified an invalid type definition.</p>
-    InvalidType(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -5980,14 +5980,14 @@ impl DefineSuggesterError {
                 "InternalException" => {
                     DefineSuggesterError::Internal(String::from(parsed_error.message))
                 }
-                "LimitExceededException" => {
+                "InvalidType" => {
+                    DefineSuggesterError::InvalidType(String::from(parsed_error.message))
+                }
+                "LimitExceeded" => {
                     DefineSuggesterError::LimitExceeded(String::from(parsed_error.message))
                 }
-                "ResourceNotFoundException" => {
+                "ResourceNotFound" => {
                     DefineSuggesterError::ResourceNotFound(String::from(parsed_error.message))
-                }
-                "InvalidTypeException" => {
-                    DefineSuggesterError::InvalidType(String::from(parsed_error.message))
                 }
                 _ => DefineSuggesterError::Unknown(String::from(body)),
             },
@@ -6035,9 +6035,9 @@ impl Error for DefineSuggesterError {
         match *self {
             DefineSuggesterError::Base(ref cause) => cause,
             DefineSuggesterError::Internal(ref cause) => cause,
+            DefineSuggesterError::InvalidType(ref cause) => cause,
             DefineSuggesterError::LimitExceeded(ref cause) => cause,
             DefineSuggesterError::ResourceNotFound(ref cause) => cause,
-            DefineSuggesterError::InvalidType(ref cause) => cause,
             DefineSuggesterError::Validation(ref cause) => cause,
             DefineSuggesterError::Credentials(ref err) => err.description(),
             DefineSuggesterError::HttpDispatch(ref dispatch_error) => dispatch_error.description(),
@@ -6052,10 +6052,10 @@ pub enum DeleteAnalysisSchemeError {
     Base(String),
     /// <p>An internal error occurred while processing the request. If this problem persists, report an issue from the <a href="http://status.aws.amazon.com/" target="_blank">Service Health Dashboard</a>.</p>
     Internal(String),
-    /// <p>The request was rejected because it attempted to reference a resource that does not exist.</p>
-    ResourceNotFound(String),
     /// <p>The request was rejected because it specified an invalid type definition.</p>
     InvalidType(String),
+    /// <p>The request was rejected because it attempted to reference a resource that does not exist.</p>
+    ResourceNotFound(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -6079,11 +6079,11 @@ impl DeleteAnalysisSchemeError {
                 "InternalException" => {
                     DeleteAnalysisSchemeError::Internal(String::from(parsed_error.message))
                 }
-                "ResourceNotFoundException" => {
-                    DeleteAnalysisSchemeError::ResourceNotFound(String::from(parsed_error.message))
-                }
-                "InvalidTypeException" => {
+                "InvalidType" => {
                     DeleteAnalysisSchemeError::InvalidType(String::from(parsed_error.message))
+                }
+                "ResourceNotFound" => {
+                    DeleteAnalysisSchemeError::ResourceNotFound(String::from(parsed_error.message))
                 }
                 _ => DeleteAnalysisSchemeError::Unknown(String::from(body)),
             },
@@ -6131,8 +6131,8 @@ impl Error for DeleteAnalysisSchemeError {
         match *self {
             DeleteAnalysisSchemeError::Base(ref cause) => cause,
             DeleteAnalysisSchemeError::Internal(ref cause) => cause,
-            DeleteAnalysisSchemeError::ResourceNotFound(ref cause) => cause,
             DeleteAnalysisSchemeError::InvalidType(ref cause) => cause,
+            DeleteAnalysisSchemeError::ResourceNotFound(ref cause) => cause,
             DeleteAnalysisSchemeError::Validation(ref cause) => cause,
             DeleteAnalysisSchemeError::Credentials(ref err) => err.description(),
             DeleteAnalysisSchemeError::HttpDispatch(ref dispatch_error) => {
@@ -6230,10 +6230,10 @@ pub enum DeleteExpressionError {
     Base(String),
     /// <p>An internal error occurred while processing the request. If this problem persists, report an issue from the <a href="http://status.aws.amazon.com/" target="_blank">Service Health Dashboard</a>.</p>
     Internal(String),
-    /// <p>The request was rejected because it attempted to reference a resource that does not exist.</p>
-    ResourceNotFound(String),
     /// <p>The request was rejected because it specified an invalid type definition.</p>
     InvalidType(String),
+    /// <p>The request was rejected because it attempted to reference a resource that does not exist.</p>
+    ResourceNotFound(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -6255,11 +6255,11 @@ impl DeleteExpressionError {
                 "InternalException" => {
                     DeleteExpressionError::Internal(String::from(parsed_error.message))
                 }
-                "ResourceNotFoundException" => {
-                    DeleteExpressionError::ResourceNotFound(String::from(parsed_error.message))
-                }
-                "InvalidTypeException" => {
+                "InvalidType" => {
                     DeleteExpressionError::InvalidType(String::from(parsed_error.message))
+                }
+                "ResourceNotFound" => {
+                    DeleteExpressionError::ResourceNotFound(String::from(parsed_error.message))
                 }
                 _ => DeleteExpressionError::Unknown(String::from(body)),
             },
@@ -6307,8 +6307,8 @@ impl Error for DeleteExpressionError {
         match *self {
             DeleteExpressionError::Base(ref cause) => cause,
             DeleteExpressionError::Internal(ref cause) => cause,
-            DeleteExpressionError::ResourceNotFound(ref cause) => cause,
             DeleteExpressionError::InvalidType(ref cause) => cause,
+            DeleteExpressionError::ResourceNotFound(ref cause) => cause,
             DeleteExpressionError::Validation(ref cause) => cause,
             DeleteExpressionError::Credentials(ref err) => err.description(),
             DeleteExpressionError::HttpDispatch(ref dispatch_error) => dispatch_error.description(),
@@ -6323,10 +6323,10 @@ pub enum DeleteIndexFieldError {
     Base(String),
     /// <p>An internal error occurred while processing the request. If this problem persists, report an issue from the <a href="http://status.aws.amazon.com/" target="_blank">Service Health Dashboard</a>.</p>
     Internal(String),
-    /// <p>The request was rejected because it attempted to reference a resource that does not exist.</p>
-    ResourceNotFound(String),
     /// <p>The request was rejected because it specified an invalid type definition.</p>
     InvalidType(String),
+    /// <p>The request was rejected because it attempted to reference a resource that does not exist.</p>
+    ResourceNotFound(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -6348,11 +6348,11 @@ impl DeleteIndexFieldError {
                 "InternalException" => {
                     DeleteIndexFieldError::Internal(String::from(parsed_error.message))
                 }
-                "ResourceNotFoundException" => {
-                    DeleteIndexFieldError::ResourceNotFound(String::from(parsed_error.message))
-                }
-                "InvalidTypeException" => {
+                "InvalidType" => {
                     DeleteIndexFieldError::InvalidType(String::from(parsed_error.message))
+                }
+                "ResourceNotFound" => {
+                    DeleteIndexFieldError::ResourceNotFound(String::from(parsed_error.message))
                 }
                 _ => DeleteIndexFieldError::Unknown(String::from(body)),
             },
@@ -6400,8 +6400,8 @@ impl Error for DeleteIndexFieldError {
         match *self {
             DeleteIndexFieldError::Base(ref cause) => cause,
             DeleteIndexFieldError::Internal(ref cause) => cause,
-            DeleteIndexFieldError::ResourceNotFound(ref cause) => cause,
             DeleteIndexFieldError::InvalidType(ref cause) => cause,
+            DeleteIndexFieldError::ResourceNotFound(ref cause) => cause,
             DeleteIndexFieldError::Validation(ref cause) => cause,
             DeleteIndexFieldError::Credentials(ref err) => err.description(),
             DeleteIndexFieldError::HttpDispatch(ref dispatch_error) => dispatch_error.description(),
@@ -6416,10 +6416,10 @@ pub enum DeleteSuggesterError {
     Base(String),
     /// <p>An internal error occurred while processing the request. If this problem persists, report an issue from the <a href="http://status.aws.amazon.com/" target="_blank">Service Health Dashboard</a>.</p>
     Internal(String),
-    /// <p>The request was rejected because it attempted to reference a resource that does not exist.</p>
-    ResourceNotFound(String),
     /// <p>The request was rejected because it specified an invalid type definition.</p>
     InvalidType(String),
+    /// <p>The request was rejected because it attempted to reference a resource that does not exist.</p>
+    ResourceNotFound(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -6441,11 +6441,11 @@ impl DeleteSuggesterError {
                 "InternalException" => {
                     DeleteSuggesterError::Internal(String::from(parsed_error.message))
                 }
-                "ResourceNotFoundException" => {
-                    DeleteSuggesterError::ResourceNotFound(String::from(parsed_error.message))
-                }
-                "InvalidTypeException" => {
+                "InvalidType" => {
                     DeleteSuggesterError::InvalidType(String::from(parsed_error.message))
+                }
+                "ResourceNotFound" => {
+                    DeleteSuggesterError::ResourceNotFound(String::from(parsed_error.message))
                 }
                 _ => DeleteSuggesterError::Unknown(String::from(body)),
             },
@@ -6493,8 +6493,8 @@ impl Error for DeleteSuggesterError {
         match *self {
             DeleteSuggesterError::Base(ref cause) => cause,
             DeleteSuggesterError::Internal(ref cause) => cause,
-            DeleteSuggesterError::ResourceNotFound(ref cause) => cause,
             DeleteSuggesterError::InvalidType(ref cause) => cause,
+            DeleteSuggesterError::ResourceNotFound(ref cause) => cause,
             DeleteSuggesterError::Validation(ref cause) => cause,
             DeleteSuggesterError::Credentials(ref err) => err.description(),
             DeleteSuggesterError::HttpDispatch(ref dispatch_error) => dispatch_error.description(),
@@ -6534,7 +6534,7 @@ impl DescribeAnalysisSchemesError {
                 "InternalException" => {
                     DescribeAnalysisSchemesError::Internal(String::from(parsed_error.message))
                 }
-                "ResourceNotFoundException" => DescribeAnalysisSchemesError::ResourceNotFound(
+                "ResourceNotFound" => DescribeAnalysisSchemesError::ResourceNotFound(
                     String::from(parsed_error.message),
                 ),
                 _ => DescribeAnalysisSchemesError::Unknown(String::from(body)),
@@ -6598,16 +6598,16 @@ impl Error for DescribeAnalysisSchemesError {
 pub enum DescribeAvailabilityOptionsError {
     /// <p>An error occurred while processing the request.</p>
     Base(String),
-    /// <p>An internal error occurred while processing the request. If this problem persists, report an issue from the <a href="http://status.aws.amazon.com/" target="_blank">Service Health Dashboard</a>.</p>
-    Internal(String),
-    /// <p>The request was rejected because a resource limit has already been met.</p>
-    LimitExceeded(String),
     /// <p>The request was rejected because it attempted an operation which is not enabled.</p>
     DisabledOperation(String),
-    /// <p>The request was rejected because it attempted to reference a resource that does not exist.</p>
-    ResourceNotFound(String),
+    /// <p>An internal error occurred while processing the request. If this problem persists, report an issue from the <a href="http://status.aws.amazon.com/" target="_blank">Service Health Dashboard</a>.</p>
+    Internal(String),
     /// <p>The request was rejected because it specified an invalid type definition.</p>
     InvalidType(String),
+    /// <p>The request was rejected because a resource limit has already been met.</p>
+    LimitExceeded(String),
+    /// <p>The request was rejected because it attempted to reference a resource that does not exist.</p>
+    ResourceNotFound(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -6628,21 +6628,19 @@ impl DescribeAvailabilityOptionsError {
                 "BaseException" => {
                     DescribeAvailabilityOptionsError::Base(String::from(parsed_error.message))
                 }
+                "DisabledAction" => DescribeAvailabilityOptionsError::DisabledOperation(
+                    String::from(parsed_error.message),
+                ),
                 "InternalException" => {
                     DescribeAvailabilityOptionsError::Internal(String::from(parsed_error.message))
                 }
-                "LimitExceededException" => DescribeAvailabilityOptionsError::LimitExceeded(
-                    String::from(parsed_error.message),
-                ),
-                "DisabledOperationException" => {
-                    DescribeAvailabilityOptionsError::DisabledOperation(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "ResourceNotFoundException" => DescribeAvailabilityOptionsError::ResourceNotFound(
-                    String::from(parsed_error.message),
-                ),
-                "InvalidTypeException" => DescribeAvailabilityOptionsError::InvalidType(
+                "InvalidType" => DescribeAvailabilityOptionsError::InvalidType(String::from(
+                    parsed_error.message,
+                )),
+                "LimitExceeded" => DescribeAvailabilityOptionsError::LimitExceeded(String::from(
+                    parsed_error.message,
+                )),
+                "ResourceNotFound" => DescribeAvailabilityOptionsError::ResourceNotFound(
                     String::from(parsed_error.message),
                 ),
                 _ => DescribeAvailabilityOptionsError::Unknown(String::from(body)),
@@ -6690,11 +6688,11 @@ impl Error for DescribeAvailabilityOptionsError {
     fn description(&self) -> &str {
         match *self {
             DescribeAvailabilityOptionsError::Base(ref cause) => cause,
-            DescribeAvailabilityOptionsError::Internal(ref cause) => cause,
-            DescribeAvailabilityOptionsError::LimitExceeded(ref cause) => cause,
             DescribeAvailabilityOptionsError::DisabledOperation(ref cause) => cause,
-            DescribeAvailabilityOptionsError::ResourceNotFound(ref cause) => cause,
+            DescribeAvailabilityOptionsError::Internal(ref cause) => cause,
             DescribeAvailabilityOptionsError::InvalidType(ref cause) => cause,
+            DescribeAvailabilityOptionsError::LimitExceeded(ref cause) => cause,
+            DescribeAvailabilityOptionsError::ResourceNotFound(ref cause) => cause,
             DescribeAvailabilityOptionsError::Validation(ref cause) => cause,
             DescribeAvailabilityOptionsError::Credentials(ref err) => err.description(),
             DescribeAvailabilityOptionsError::HttpDispatch(ref dispatch_error) => {
@@ -6817,7 +6815,7 @@ impl DescribeExpressionsError {
                 "InternalException" => {
                     DescribeExpressionsError::Internal(String::from(parsed_error.message))
                 }
-                "ResourceNotFoundException" => {
+                "ResourceNotFound" => {
                     DescribeExpressionsError::ResourceNotFound(String::from(parsed_error.message))
                 }
                 _ => DescribeExpressionsError::Unknown(String::from(body)),
@@ -6908,7 +6906,7 @@ impl DescribeIndexFieldsError {
                 "InternalException" => {
                     DescribeIndexFieldsError::Internal(String::from(parsed_error.message))
                 }
-                "ResourceNotFoundException" => {
+                "ResourceNotFound" => {
                     DescribeIndexFieldsError::ResourceNotFound(String::from(parsed_error.message))
                 }
                 _ => DescribeIndexFieldsError::Unknown(String::from(body)),
@@ -6999,7 +6997,7 @@ impl DescribeScalingParametersError {
                 "InternalException" => {
                     DescribeScalingParametersError::Internal(String::from(parsed_error.message))
                 }
-                "ResourceNotFoundException" => DescribeScalingParametersError::ResourceNotFound(
+                "ResourceNotFound" => DescribeScalingParametersError::ResourceNotFound(
                     String::from(parsed_error.message),
                 ),
                 _ => DescribeScalingParametersError::Unknown(String::from(body)),
@@ -7090,11 +7088,9 @@ impl DescribeServiceAccessPoliciesError {
                 "InternalException" => {
                     DescribeServiceAccessPoliciesError::Internal(String::from(parsed_error.message))
                 }
-                "ResourceNotFoundException" => {
-                    DescribeServiceAccessPoliciesError::ResourceNotFound(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "ResourceNotFound" => DescribeServiceAccessPoliciesError::ResourceNotFound(
+                    String::from(parsed_error.message),
+                ),
                 _ => DescribeServiceAccessPoliciesError::Unknown(String::from(body)),
             },
             Err(_) => DescribeServiceAccessPoliciesError::Unknown(body.to_string()),
@@ -7183,7 +7179,7 @@ impl DescribeSuggestersError {
                 "InternalException" => {
                     DescribeSuggestersError::Internal(String::from(parsed_error.message))
                 }
-                "ResourceNotFoundException" => {
+                "ResourceNotFound" => {
                     DescribeSuggestersError::ResourceNotFound(String::from(parsed_error.message))
                 }
                 _ => DescribeSuggestersError::Unknown(String::from(body)),
@@ -7272,7 +7268,7 @@ impl IndexDocumentsError {
                 "InternalException" => {
                     IndexDocumentsError::Internal(String::from(parsed_error.message))
                 }
-                "ResourceNotFoundException" => {
+                "ResourceNotFound" => {
                     IndexDocumentsError::ResourceNotFound(String::from(parsed_error.message))
                 }
                 _ => IndexDocumentsError::Unknown(String::from(body)),
@@ -7409,16 +7405,16 @@ impl Error for ListDomainNamesError {
 pub enum UpdateAvailabilityOptionsError {
     /// <p>An error occurred while processing the request.</p>
     Base(String),
-    /// <p>An internal error occurred while processing the request. If this problem persists, report an issue from the <a href="http://status.aws.amazon.com/" target="_blank">Service Health Dashboard</a>.</p>
-    Internal(String),
-    /// <p>The request was rejected because a resource limit has already been met.</p>
-    LimitExceeded(String),
     /// <p>The request was rejected because it attempted an operation which is not enabled.</p>
     DisabledOperation(String),
-    /// <p>The request was rejected because it attempted to reference a resource that does not exist.</p>
-    ResourceNotFound(String),
+    /// <p>An internal error occurred while processing the request. If this problem persists, report an issue from the <a href="http://status.aws.amazon.com/" target="_blank">Service Health Dashboard</a>.</p>
+    Internal(String),
     /// <p>The request was rejected because it specified an invalid type definition.</p>
     InvalidType(String),
+    /// <p>The request was rejected because a resource limit has already been met.</p>
+    LimitExceeded(String),
+    /// <p>The request was rejected because it attempted to reference a resource that does not exist.</p>
+    ResourceNotFound(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -7439,21 +7435,21 @@ impl UpdateAvailabilityOptionsError {
                 "BaseException" => {
                     UpdateAvailabilityOptionsError::Base(String::from(parsed_error.message))
                 }
+                "DisabledAction" => UpdateAvailabilityOptionsError::DisabledOperation(
+                    String::from(parsed_error.message),
+                ),
                 "InternalException" => {
                     UpdateAvailabilityOptionsError::Internal(String::from(parsed_error.message))
                 }
-                "LimitExceededException" => UpdateAvailabilityOptionsError::LimitExceeded(
-                    String::from(parsed_error.message),
-                ),
-                "DisabledOperationException" => UpdateAvailabilityOptionsError::DisabledOperation(
-                    String::from(parsed_error.message),
-                ),
-                "ResourceNotFoundException" => UpdateAvailabilityOptionsError::ResourceNotFound(
-                    String::from(parsed_error.message),
-                ),
-                "InvalidTypeException" => {
+                "InvalidType" => {
                     UpdateAvailabilityOptionsError::InvalidType(String::from(parsed_error.message))
                 }
+                "LimitExceeded" => UpdateAvailabilityOptionsError::LimitExceeded(String::from(
+                    parsed_error.message,
+                )),
+                "ResourceNotFound" => UpdateAvailabilityOptionsError::ResourceNotFound(
+                    String::from(parsed_error.message),
+                ),
                 _ => UpdateAvailabilityOptionsError::Unknown(String::from(body)),
             },
             Err(_) => UpdateAvailabilityOptionsError::Unknown(body.to_string()),
@@ -7499,11 +7495,11 @@ impl Error for UpdateAvailabilityOptionsError {
     fn description(&self) -> &str {
         match *self {
             UpdateAvailabilityOptionsError::Base(ref cause) => cause,
-            UpdateAvailabilityOptionsError::Internal(ref cause) => cause,
-            UpdateAvailabilityOptionsError::LimitExceeded(ref cause) => cause,
             UpdateAvailabilityOptionsError::DisabledOperation(ref cause) => cause,
-            UpdateAvailabilityOptionsError::ResourceNotFound(ref cause) => cause,
+            UpdateAvailabilityOptionsError::Internal(ref cause) => cause,
             UpdateAvailabilityOptionsError::InvalidType(ref cause) => cause,
+            UpdateAvailabilityOptionsError::LimitExceeded(ref cause) => cause,
+            UpdateAvailabilityOptionsError::ResourceNotFound(ref cause) => cause,
             UpdateAvailabilityOptionsError::Validation(ref cause) => cause,
             UpdateAvailabilityOptionsError::Credentials(ref err) => err.description(),
             UpdateAvailabilityOptionsError::HttpDispatch(ref dispatch_error) => {
@@ -7520,12 +7516,12 @@ pub enum UpdateScalingParametersError {
     Base(String),
     /// <p>An internal error occurred while processing the request. If this problem persists, report an issue from the <a href="http://status.aws.amazon.com/" target="_blank">Service Health Dashboard</a>.</p>
     Internal(String),
+    /// <p>The request was rejected because it specified an invalid type definition.</p>
+    InvalidType(String),
     /// <p>The request was rejected because a resource limit has already been met.</p>
     LimitExceeded(String),
     /// <p>The request was rejected because it attempted to reference a resource that does not exist.</p>
     ResourceNotFound(String),
-    /// <p>The request was rejected because it specified an invalid type definition.</p>
-    InvalidType(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -7549,15 +7545,15 @@ impl UpdateScalingParametersError {
                 "InternalException" => {
                     UpdateScalingParametersError::Internal(String::from(parsed_error.message))
                 }
-                "LimitExceededException" => {
-                    UpdateScalingParametersError::LimitExceeded(String::from(parsed_error.message))
-                }
-                "ResourceNotFoundException" => UpdateScalingParametersError::ResourceNotFound(
-                    String::from(parsed_error.message),
-                ),
-                "InvalidTypeException" => {
+                "InvalidType" => {
                     UpdateScalingParametersError::InvalidType(String::from(parsed_error.message))
                 }
+                "LimitExceeded" => {
+                    UpdateScalingParametersError::LimitExceeded(String::from(parsed_error.message))
+                }
+                "ResourceNotFound" => UpdateScalingParametersError::ResourceNotFound(
+                    String::from(parsed_error.message),
+                ),
                 _ => UpdateScalingParametersError::Unknown(String::from(body)),
             },
             Err(_) => UpdateScalingParametersError::Unknown(body.to_string()),
@@ -7604,9 +7600,9 @@ impl Error for UpdateScalingParametersError {
         match *self {
             UpdateScalingParametersError::Base(ref cause) => cause,
             UpdateScalingParametersError::Internal(ref cause) => cause,
+            UpdateScalingParametersError::InvalidType(ref cause) => cause,
             UpdateScalingParametersError::LimitExceeded(ref cause) => cause,
             UpdateScalingParametersError::ResourceNotFound(ref cause) => cause,
-            UpdateScalingParametersError::InvalidType(ref cause) => cause,
             UpdateScalingParametersError::Validation(ref cause) => cause,
             UpdateScalingParametersError::Credentials(ref err) => err.description(),
             UpdateScalingParametersError::HttpDispatch(ref dispatch_error) => {
@@ -7623,12 +7619,12 @@ pub enum UpdateServiceAccessPoliciesError {
     Base(String),
     /// <p>An internal error occurred while processing the request. If this problem persists, report an issue from the <a href="http://status.aws.amazon.com/" target="_blank">Service Health Dashboard</a>.</p>
     Internal(String),
+    /// <p>The request was rejected because it specified an invalid type definition.</p>
+    InvalidType(String),
     /// <p>The request was rejected because a resource limit has already been met.</p>
     LimitExceeded(String),
     /// <p>The request was rejected because it attempted to reference a resource that does not exist.</p>
     ResourceNotFound(String),
-    /// <p>The request was rejected because it specified an invalid type definition.</p>
-    InvalidType(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -7652,13 +7648,13 @@ impl UpdateServiceAccessPoliciesError {
                 "InternalException" => {
                     UpdateServiceAccessPoliciesError::Internal(String::from(parsed_error.message))
                 }
-                "LimitExceededException" => UpdateServiceAccessPoliciesError::LimitExceeded(
-                    String::from(parsed_error.message),
-                ),
-                "ResourceNotFoundException" => UpdateServiceAccessPoliciesError::ResourceNotFound(
-                    String::from(parsed_error.message),
-                ),
-                "InvalidTypeException" => UpdateServiceAccessPoliciesError::InvalidType(
+                "InvalidType" => UpdateServiceAccessPoliciesError::InvalidType(String::from(
+                    parsed_error.message,
+                )),
+                "LimitExceeded" => UpdateServiceAccessPoliciesError::LimitExceeded(String::from(
+                    parsed_error.message,
+                )),
+                "ResourceNotFound" => UpdateServiceAccessPoliciesError::ResourceNotFound(
                     String::from(parsed_error.message),
                 ),
                 _ => UpdateServiceAccessPoliciesError::Unknown(String::from(body)),
@@ -7707,9 +7703,9 @@ impl Error for UpdateServiceAccessPoliciesError {
         match *self {
             UpdateServiceAccessPoliciesError::Base(ref cause) => cause,
             UpdateServiceAccessPoliciesError::Internal(ref cause) => cause,
+            UpdateServiceAccessPoliciesError::InvalidType(ref cause) => cause,
             UpdateServiceAccessPoliciesError::LimitExceeded(ref cause) => cause,
             UpdateServiceAccessPoliciesError::ResourceNotFound(ref cause) => cause,
-            UpdateServiceAccessPoliciesError::InvalidType(ref cause) => cause,
             UpdateServiceAccessPoliciesError::Validation(ref cause) => cause,
             UpdateServiceAccessPoliciesError::Credentials(ref err) => err.description(),
             UpdateServiceAccessPoliciesError::HttpDispatch(ref dispatch_error) => {

--- a/rusoto/services/cloudwatch/src/generated.rs
+++ b/rusoto/services/cloudwatch/src/generated.rs
@@ -2985,7 +2985,7 @@ impl DeleteAlarmsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceNotFound" => {
                     DeleteAlarmsError::ResourceNotFound(String::from(parsed_error.message))
@@ -2994,6 +2994,14 @@ impl DeleteAlarmsError {
             },
             Err(_) => DeleteAlarmsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -3058,7 +3066,7 @@ impl DeleteDashboardsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DashboardNotFoundError" => DeleteDashboardsError::DashboardNotFoundError(
                     String::from(parsed_error.message),
@@ -3073,6 +3081,14 @@ impl DeleteDashboardsError {
             },
             Err(_) => DeleteDashboardsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -3135,7 +3151,7 @@ impl DescribeAlarmHistoryError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidNextToken" => {
                     DescribeAlarmHistoryError::InvalidNextToken(String::from(parsed_error.message))
@@ -3144,6 +3160,14 @@ impl DescribeAlarmHistoryError {
             },
             Err(_) => DescribeAlarmHistoryError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -3206,7 +3230,7 @@ impl DescribeAlarmsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidNextToken" => {
                     DescribeAlarmsError::InvalidNextToken(String::from(parsed_error.message))
@@ -3215,6 +3239,14 @@ impl DescribeAlarmsError {
             },
             Err(_) => DescribeAlarmsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -3273,12 +3305,20 @@ impl DescribeAlarmsForMetricError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeAlarmsForMetricError::Unknown(String::from(body)),
             },
             Err(_) => DescribeAlarmsForMetricError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -3338,12 +3378,20 @@ impl DisableAlarmActionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DisableAlarmActionsError::Unknown(String::from(body)),
             },
             Err(_) => DisableAlarmActionsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -3403,12 +3451,20 @@ impl EnableAlarmActionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => EnableAlarmActionsError::Unknown(String::from(body)),
             },
             Err(_) => EnableAlarmActionsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -3474,7 +3530,7 @@ impl GetDashboardError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DashboardNotFoundError" => {
                     GetDashboardError::DashboardNotFoundError(String::from(parsed_error.message))
@@ -3489,6 +3545,14 @@ impl GetDashboardError {
             },
             Err(_) => GetDashboardError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -3557,7 +3621,7 @@ impl GetMetricStatisticsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InternalServiceFault" => GetMetricStatisticsError::InternalServiceFault(
                     String::from(parsed_error.message),
@@ -3581,6 +3645,14 @@ impl GetMetricStatisticsError {
             },
             Err(_) => GetMetricStatisticsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -3648,7 +3720,7 @@ impl ListDashboardsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InternalServiceFault" => {
                     ListDashboardsError::InternalServiceFault(String::from(parsed_error.message))
@@ -3660,6 +3732,14 @@ impl ListDashboardsError {
             },
             Err(_) => ListDashboardsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -3723,7 +3803,7 @@ impl ListMetricsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InternalServiceFault" => {
                     ListMetricsError::InternalServiceFault(String::from(parsed_error.message))
@@ -3735,6 +3815,14 @@ impl ListMetricsError {
             },
             Err(_) => ListMetricsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -3798,7 +3886,7 @@ impl PutDashboardError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DashboardInvalidInputError" => PutDashboardError::DashboardInvalidInputError(
                     String::from(parsed_error.message),
@@ -3810,6 +3898,14 @@ impl PutDashboardError {
             },
             Err(_) => PutDashboardError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -3871,7 +3967,7 @@ impl PutMetricAlarmError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "LimitExceededFault" => {
                     PutMetricAlarmError::LimitExceededFault(String::from(parsed_error.message))
@@ -3880,6 +3976,14 @@ impl PutMetricAlarmError {
             },
             Err(_) => PutMetricAlarmError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -3946,7 +4050,7 @@ impl PutMetricDataError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InternalServiceFault" => {
                     PutMetricDataError::InternalServiceFault(String::from(parsed_error.message))
@@ -3966,6 +4070,14 @@ impl PutMetricDataError {
             },
             Err(_) => PutMetricDataError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -4031,7 +4143,7 @@ impl SetAlarmStateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidFormatFault" => {
                     SetAlarmStateError::InvalidFormatFault(String::from(parsed_error.message))
@@ -4043,6 +4155,14 @@ impl SetAlarmStateError {
             },
             Err(_) => SetAlarmStateError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 

--- a/rusoto/services/cloudwatch/src/generated.rs
+++ b/rusoto/services/cloudwatch/src/generated.rs
@@ -3068,13 +3068,13 @@ impl DeleteDashboardsError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "DashboardNotFoundError" => DeleteDashboardsError::DashboardNotFoundError(
-                    String::from(parsed_error.message),
-                ),
-                "InternalServiceFault" => {
+                "ResourceNotFound" => DeleteDashboardsError::DashboardNotFoundError(String::from(
+                    parsed_error.message,
+                )),
+                "InternalServiceError" => {
                     DeleteDashboardsError::InternalServiceFault(String::from(parsed_error.message))
                 }
-                "InvalidParameterValueException" => {
+                "InvalidParameterValue" => {
                     DeleteDashboardsError::InvalidParameterValue(String::from(parsed_error.message))
                 }
                 _ => DeleteDashboardsError::Unknown(String::from(body)),
@@ -3532,13 +3532,13 @@ impl GetDashboardError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "DashboardNotFoundError" => {
+                "ResourceNotFound" => {
                     GetDashboardError::DashboardNotFoundError(String::from(parsed_error.message))
                 }
-                "InternalServiceFault" => {
+                "InternalServiceError" => {
                     GetDashboardError::InternalServiceFault(String::from(parsed_error.message))
                 }
-                "InvalidParameterValueException" => {
+                "InvalidParameterValue" => {
                     GetDashboardError::InvalidParameterValue(String::from(parsed_error.message))
                 }
                 _ => GetDashboardError::Unknown(String::from(body)),
@@ -3623,24 +3623,20 @@ impl GetMetricStatisticsError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "InternalServiceFault" => GetMetricStatisticsError::InternalServiceFault(
+                "InternalServiceError" => GetMetricStatisticsError::InternalServiceFault(
                     String::from(parsed_error.message),
                 ),
-                "InvalidParameterCombinationException" => {
+                "InvalidParameterCombination" => {
                     GetMetricStatisticsError::InvalidParameterCombination(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InvalidParameterValueException" => {
-                    GetMetricStatisticsError::InvalidParameterValue(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "MissingRequiredParameterException" => {
-                    GetMetricStatisticsError::MissingRequiredParameter(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "InvalidParameterValue" => GetMetricStatisticsError::InvalidParameterValue(
+                    String::from(parsed_error.message),
+                ),
+                "MissingParameter" => GetMetricStatisticsError::MissingRequiredParameter(
+                    String::from(parsed_error.message),
+                ),
                 _ => GetMetricStatisticsError::Unknown(String::from(body)),
             },
             Err(_) => GetMetricStatisticsError::Unknown(body.to_string()),
@@ -3722,10 +3718,10 @@ impl ListDashboardsError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "InternalServiceFault" => {
+                "InternalServiceError" => {
                     ListDashboardsError::InternalServiceFault(String::from(parsed_error.message))
                 }
-                "InvalidParameterValueException" => {
+                "InvalidParameterValue" => {
                     ListDashboardsError::InvalidParameterValue(String::from(parsed_error.message))
                 }
                 _ => ListDashboardsError::Unknown(String::from(body)),
@@ -3805,10 +3801,10 @@ impl ListMetricsError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "InternalServiceFault" => {
+                "InternalServiceError" => {
                     ListMetricsError::InternalServiceFault(String::from(parsed_error.message))
                 }
-                "InvalidParameterValueException" => {
+                "InvalidParameterValue" => {
                     ListMetricsError::InvalidParameterValue(String::from(parsed_error.message))
                 }
                 _ => ListMetricsError::Unknown(String::from(body)),
@@ -3888,10 +3884,10 @@ impl PutDashboardError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "DashboardInvalidInputError" => PutDashboardError::DashboardInvalidInputError(
+                "InvalidParameterInput" => PutDashboardError::DashboardInvalidInputError(
                     String::from(parsed_error.message),
                 ),
-                "InternalServiceFault" => {
+                "InternalServiceError" => {
                     PutDashboardError::InternalServiceFault(String::from(parsed_error.message))
                 }
                 _ => PutDashboardError::Unknown(String::from(body)),
@@ -3969,7 +3965,7 @@ impl PutMetricAlarmError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "LimitExceededFault" => {
+                "LimitExceeded" => {
                     PutMetricAlarmError::LimitExceededFault(String::from(parsed_error.message))
                 }
                 _ => PutMetricAlarmError::Unknown(String::from(body)),
@@ -4052,18 +4048,16 @@ impl PutMetricDataError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "InternalServiceFault" => {
+                "InternalServiceError" => {
                     PutMetricDataError::InternalServiceFault(String::from(parsed_error.message))
                 }
-                "InvalidParameterCombinationException" => {
-                    PutMetricDataError::InvalidParameterCombination(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "InvalidParameterValueException" => {
+                "InvalidParameterCombination" => PutMetricDataError::InvalidParameterCombination(
+                    String::from(parsed_error.message),
+                ),
+                "InvalidParameterValue" => {
                     PutMetricDataError::InvalidParameterValue(String::from(parsed_error.message))
                 }
-                "MissingRequiredParameterException" => {
+                "MissingParameter" => {
                     PutMetricDataError::MissingRequiredParameter(String::from(parsed_error.message))
                 }
                 _ => PutMetricDataError::Unknown(String::from(body)),
@@ -4145,7 +4139,7 @@ impl SetAlarmStateError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "InvalidFormatFault" => {
+                "InvalidFormat" => {
                     SetAlarmStateError::InvalidFormatFault(String::from(parsed_error.message))
                 }
                 "ResourceNotFound" => {

--- a/rusoto/services/cognito-sync/src/generated.rs
+++ b/rusoto/services/cognito-sync/src/generated.rs
@@ -665,12 +665,12 @@ pub enum BulkPublishError {
     DuplicateRequest(String),
     /// <p>Indicates an internal service error.</p>
     InternalError(String),
-    /// <p>Thrown if the resource doesn&#39;t exist.</p>
-    ResourceNotFound(String),
     /// <p>Thrown when a request parameter does not comply with the associated constraints.</p>
     InvalidParameter(String),
     /// <p>Thrown when a user is not authorized to access the requested resource.</p>
     NotAuthorized(String),
+    /// <p>Thrown if the resource doesn&#39;t exist.</p>
+    ResourceNotFound(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -703,14 +703,14 @@ impl BulkPublishError {
                     "InternalErrorException" => {
                         BulkPublishError::InternalError(String::from(error_message))
                     }
-                    "ResourceNotFoundException" => {
-                        BulkPublishError::ResourceNotFound(String::from(error_message))
-                    }
                     "InvalidParameterException" => {
                         BulkPublishError::InvalidParameter(String::from(error_message))
                     }
                     "NotAuthorizedException" => {
                         BulkPublishError::NotAuthorized(String::from(error_message))
+                    }
+                    "ResourceNotFoundException" => {
+                        BulkPublishError::ResourceNotFound(String::from(error_message))
                     }
                     "ValidationException" => {
                         BulkPublishError::Validation(error_message.to_string())
@@ -754,9 +754,9 @@ impl Error for BulkPublishError {
             BulkPublishError::AlreadyStreamed(ref cause) => cause,
             BulkPublishError::DuplicateRequest(ref cause) => cause,
             BulkPublishError::InternalError(ref cause) => cause,
-            BulkPublishError::ResourceNotFound(ref cause) => cause,
             BulkPublishError::InvalidParameter(ref cause) => cause,
             BulkPublishError::NotAuthorized(ref cause) => cause,
+            BulkPublishError::ResourceNotFound(ref cause) => cause,
             BulkPublishError::Validation(ref cause) => cause,
             BulkPublishError::Credentials(ref err) => err.description(),
             BulkPublishError::HttpDispatch(ref dispatch_error) => dispatch_error.description(),
@@ -769,16 +769,16 @@ impl Error for BulkPublishError {
 pub enum DeleteDatasetError {
     /// <p>Indicates an internal service error.</p>
     InternalError(String),
-    /// <p>Thrown if an update can&#39;t be applied because the resource was changed by another call and this would result in a conflict.</p>
-    ResourceConflict(String),
-    /// <p>Thrown if the request is throttled.</p>
-    TooManyRequests(String),
-    /// <p>Thrown if the resource doesn&#39;t exist.</p>
-    ResourceNotFound(String),
     /// <p>Thrown when a request parameter does not comply with the associated constraints.</p>
     InvalidParameter(String),
     /// <p>Thrown when a user is not authorized to access the requested resource.</p>
     NotAuthorized(String),
+    /// <p>Thrown if an update can&#39;t be applied because the resource was changed by another call and this would result in a conflict.</p>
+    ResourceConflict(String),
+    /// <p>Thrown if the resource doesn&#39;t exist.</p>
+    ResourceNotFound(String),
+    /// <p>Thrown if the request is throttled.</p>
+    TooManyRequests(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -805,20 +805,20 @@ impl DeleteDatasetError {
                     "InternalErrorException" => {
                         DeleteDatasetError::InternalError(String::from(error_message))
                     }
-                    "ResourceConflictException" => {
-                        DeleteDatasetError::ResourceConflict(String::from(error_message))
-                    }
-                    "TooManyRequestsException" => {
-                        DeleteDatasetError::TooManyRequests(String::from(error_message))
-                    }
-                    "ResourceNotFoundException" => {
-                        DeleteDatasetError::ResourceNotFound(String::from(error_message))
-                    }
                     "InvalidParameterException" => {
                         DeleteDatasetError::InvalidParameter(String::from(error_message))
                     }
                     "NotAuthorizedException" => {
                         DeleteDatasetError::NotAuthorized(String::from(error_message))
+                    }
+                    "ResourceConflictException" => {
+                        DeleteDatasetError::ResourceConflict(String::from(error_message))
+                    }
+                    "ResourceNotFoundException" => {
+                        DeleteDatasetError::ResourceNotFound(String::from(error_message))
+                    }
+                    "TooManyRequestsException" => {
+                        DeleteDatasetError::TooManyRequests(String::from(error_message))
                     }
                     "ValidationException" => {
                         DeleteDatasetError::Validation(error_message.to_string())
@@ -860,11 +860,11 @@ impl Error for DeleteDatasetError {
     fn description(&self) -> &str {
         match *self {
             DeleteDatasetError::InternalError(ref cause) => cause,
-            DeleteDatasetError::ResourceConflict(ref cause) => cause,
-            DeleteDatasetError::TooManyRequests(ref cause) => cause,
-            DeleteDatasetError::ResourceNotFound(ref cause) => cause,
             DeleteDatasetError::InvalidParameter(ref cause) => cause,
             DeleteDatasetError::NotAuthorized(ref cause) => cause,
+            DeleteDatasetError::ResourceConflict(ref cause) => cause,
+            DeleteDatasetError::ResourceNotFound(ref cause) => cause,
+            DeleteDatasetError::TooManyRequests(ref cause) => cause,
             DeleteDatasetError::Validation(ref cause) => cause,
             DeleteDatasetError::Credentials(ref err) => err.description(),
             DeleteDatasetError::HttpDispatch(ref dispatch_error) => dispatch_error.description(),
@@ -877,14 +877,14 @@ impl Error for DeleteDatasetError {
 pub enum DescribeDatasetError {
     /// <p>Indicates an internal service error.</p>
     InternalError(String),
-    /// <p>Thrown if the request is throttled.</p>
-    TooManyRequests(String),
-    /// <p>Thrown if the resource doesn&#39;t exist.</p>
-    ResourceNotFound(String),
     /// <p>Thrown when a request parameter does not comply with the associated constraints.</p>
     InvalidParameter(String),
     /// <p>Thrown when a user is not authorized to access the requested resource.</p>
     NotAuthorized(String),
+    /// <p>Thrown if the resource doesn&#39;t exist.</p>
+    ResourceNotFound(String),
+    /// <p>Thrown if the request is throttled.</p>
+    TooManyRequests(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -911,17 +911,17 @@ impl DescribeDatasetError {
                     "InternalErrorException" => {
                         DescribeDatasetError::InternalError(String::from(error_message))
                     }
-                    "TooManyRequestsException" => {
-                        DescribeDatasetError::TooManyRequests(String::from(error_message))
-                    }
-                    "ResourceNotFoundException" => {
-                        DescribeDatasetError::ResourceNotFound(String::from(error_message))
-                    }
                     "InvalidParameterException" => {
                         DescribeDatasetError::InvalidParameter(String::from(error_message))
                     }
                     "NotAuthorizedException" => {
                         DescribeDatasetError::NotAuthorized(String::from(error_message))
+                    }
+                    "ResourceNotFoundException" => {
+                        DescribeDatasetError::ResourceNotFound(String::from(error_message))
+                    }
+                    "TooManyRequestsException" => {
+                        DescribeDatasetError::TooManyRequests(String::from(error_message))
                     }
                     "ValidationException" => {
                         DescribeDatasetError::Validation(error_message.to_string())
@@ -963,10 +963,10 @@ impl Error for DescribeDatasetError {
     fn description(&self) -> &str {
         match *self {
             DescribeDatasetError::InternalError(ref cause) => cause,
-            DescribeDatasetError::TooManyRequests(ref cause) => cause,
-            DescribeDatasetError::ResourceNotFound(ref cause) => cause,
             DescribeDatasetError::InvalidParameter(ref cause) => cause,
             DescribeDatasetError::NotAuthorized(ref cause) => cause,
+            DescribeDatasetError::ResourceNotFound(ref cause) => cause,
+            DescribeDatasetError::TooManyRequests(ref cause) => cause,
             DescribeDatasetError::Validation(ref cause) => cause,
             DescribeDatasetError::Credentials(ref err) => err.description(),
             DescribeDatasetError::HttpDispatch(ref dispatch_error) => dispatch_error.description(),
@@ -979,14 +979,14 @@ impl Error for DescribeDatasetError {
 pub enum DescribeIdentityPoolUsageError {
     /// <p>Indicates an internal service error.</p>
     InternalError(String),
-    /// <p>Thrown if the request is throttled.</p>
-    TooManyRequests(String),
-    /// <p>Thrown if the resource doesn&#39;t exist.</p>
-    ResourceNotFound(String),
     /// <p>Thrown when a request parameter does not comply with the associated constraints.</p>
     InvalidParameter(String),
     /// <p>Thrown when a user is not authorized to access the requested resource.</p>
     NotAuthorized(String),
+    /// <p>Thrown if the resource doesn&#39;t exist.</p>
+    ResourceNotFound(String),
+    /// <p>Thrown if the request is throttled.</p>
+    TooManyRequests(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -1013,14 +1013,6 @@ impl DescribeIdentityPoolUsageError {
                     "InternalErrorException" => {
                         DescribeIdentityPoolUsageError::InternalError(String::from(error_message))
                     }
-                    "TooManyRequestsException" => {
-                        DescribeIdentityPoolUsageError::TooManyRequests(String::from(error_message))
-                    }
-                    "ResourceNotFoundException" => {
-                        DescribeIdentityPoolUsageError::ResourceNotFound(String::from(
-                            error_message,
-                        ))
-                    }
                     "InvalidParameterException" => {
                         DescribeIdentityPoolUsageError::InvalidParameter(String::from(
                             error_message,
@@ -1028,6 +1020,14 @@ impl DescribeIdentityPoolUsageError {
                     }
                     "NotAuthorizedException" => {
                         DescribeIdentityPoolUsageError::NotAuthorized(String::from(error_message))
+                    }
+                    "ResourceNotFoundException" => {
+                        DescribeIdentityPoolUsageError::ResourceNotFound(String::from(
+                            error_message,
+                        ))
+                    }
+                    "TooManyRequestsException" => {
+                        DescribeIdentityPoolUsageError::TooManyRequests(String::from(error_message))
                     }
                     "ValidationException" => {
                         DescribeIdentityPoolUsageError::Validation(error_message.to_string())
@@ -1069,10 +1069,10 @@ impl Error for DescribeIdentityPoolUsageError {
     fn description(&self) -> &str {
         match *self {
             DescribeIdentityPoolUsageError::InternalError(ref cause) => cause,
-            DescribeIdentityPoolUsageError::TooManyRequests(ref cause) => cause,
-            DescribeIdentityPoolUsageError::ResourceNotFound(ref cause) => cause,
             DescribeIdentityPoolUsageError::InvalidParameter(ref cause) => cause,
             DescribeIdentityPoolUsageError::NotAuthorized(ref cause) => cause,
+            DescribeIdentityPoolUsageError::ResourceNotFound(ref cause) => cause,
+            DescribeIdentityPoolUsageError::TooManyRequests(ref cause) => cause,
             DescribeIdentityPoolUsageError::Validation(ref cause) => cause,
             DescribeIdentityPoolUsageError::Credentials(ref err) => err.description(),
             DescribeIdentityPoolUsageError::HttpDispatch(ref dispatch_error) => {
@@ -1087,14 +1087,14 @@ impl Error for DescribeIdentityPoolUsageError {
 pub enum DescribeIdentityUsageError {
     /// <p>Indicates an internal service error.</p>
     InternalError(String),
-    /// <p>Thrown if the request is throttled.</p>
-    TooManyRequests(String),
-    /// <p>Thrown if the resource doesn&#39;t exist.</p>
-    ResourceNotFound(String),
     /// <p>Thrown when a request parameter does not comply with the associated constraints.</p>
     InvalidParameter(String),
     /// <p>Thrown when a user is not authorized to access the requested resource.</p>
     NotAuthorized(String),
+    /// <p>Thrown if the resource doesn&#39;t exist.</p>
+    ResourceNotFound(String),
+    /// <p>Thrown if the request is throttled.</p>
+    TooManyRequests(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -1121,17 +1121,17 @@ impl DescribeIdentityUsageError {
                     "InternalErrorException" => {
                         DescribeIdentityUsageError::InternalError(String::from(error_message))
                     }
-                    "TooManyRequestsException" => {
-                        DescribeIdentityUsageError::TooManyRequests(String::from(error_message))
-                    }
-                    "ResourceNotFoundException" => {
-                        DescribeIdentityUsageError::ResourceNotFound(String::from(error_message))
-                    }
                     "InvalidParameterException" => {
                         DescribeIdentityUsageError::InvalidParameter(String::from(error_message))
                     }
                     "NotAuthorizedException" => {
                         DescribeIdentityUsageError::NotAuthorized(String::from(error_message))
+                    }
+                    "ResourceNotFoundException" => {
+                        DescribeIdentityUsageError::ResourceNotFound(String::from(error_message))
+                    }
+                    "TooManyRequestsException" => {
+                        DescribeIdentityUsageError::TooManyRequests(String::from(error_message))
                     }
                     "ValidationException" => {
                         DescribeIdentityUsageError::Validation(error_message.to_string())
@@ -1173,10 +1173,10 @@ impl Error for DescribeIdentityUsageError {
     fn description(&self) -> &str {
         match *self {
             DescribeIdentityUsageError::InternalError(ref cause) => cause,
-            DescribeIdentityUsageError::TooManyRequests(ref cause) => cause,
-            DescribeIdentityUsageError::ResourceNotFound(ref cause) => cause,
             DescribeIdentityUsageError::InvalidParameter(ref cause) => cause,
             DescribeIdentityUsageError::NotAuthorized(ref cause) => cause,
+            DescribeIdentityUsageError::ResourceNotFound(ref cause) => cause,
+            DescribeIdentityUsageError::TooManyRequests(ref cause) => cause,
             DescribeIdentityUsageError::Validation(ref cause) => cause,
             DescribeIdentityUsageError::Credentials(ref err) => err.description(),
             DescribeIdentityUsageError::HttpDispatch(ref dispatch_error) => {
@@ -1191,12 +1191,12 @@ impl Error for DescribeIdentityUsageError {
 pub enum GetBulkPublishDetailsError {
     /// <p>Indicates an internal service error.</p>
     InternalError(String),
-    /// <p>Thrown if the resource doesn&#39;t exist.</p>
-    ResourceNotFound(String),
     /// <p>Thrown when a request parameter does not comply with the associated constraints.</p>
     InvalidParameter(String),
     /// <p>Thrown when a user is not authorized to access the requested resource.</p>
     NotAuthorized(String),
+    /// <p>Thrown if the resource doesn&#39;t exist.</p>
+    ResourceNotFound(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -1223,14 +1223,14 @@ impl GetBulkPublishDetailsError {
                     "InternalErrorException" => {
                         GetBulkPublishDetailsError::InternalError(String::from(error_message))
                     }
-                    "ResourceNotFoundException" => {
-                        GetBulkPublishDetailsError::ResourceNotFound(String::from(error_message))
-                    }
                     "InvalidParameterException" => {
                         GetBulkPublishDetailsError::InvalidParameter(String::from(error_message))
                     }
                     "NotAuthorizedException" => {
                         GetBulkPublishDetailsError::NotAuthorized(String::from(error_message))
+                    }
+                    "ResourceNotFoundException" => {
+                        GetBulkPublishDetailsError::ResourceNotFound(String::from(error_message))
                     }
                     "ValidationException" => {
                         GetBulkPublishDetailsError::Validation(error_message.to_string())
@@ -1272,9 +1272,9 @@ impl Error for GetBulkPublishDetailsError {
     fn description(&self) -> &str {
         match *self {
             GetBulkPublishDetailsError::InternalError(ref cause) => cause,
-            GetBulkPublishDetailsError::ResourceNotFound(ref cause) => cause,
             GetBulkPublishDetailsError::InvalidParameter(ref cause) => cause,
             GetBulkPublishDetailsError::NotAuthorized(ref cause) => cause,
+            GetBulkPublishDetailsError::ResourceNotFound(ref cause) => cause,
             GetBulkPublishDetailsError::Validation(ref cause) => cause,
             GetBulkPublishDetailsError::Credentials(ref err) => err.description(),
             GetBulkPublishDetailsError::HttpDispatch(ref dispatch_error) => {
@@ -1289,14 +1289,14 @@ impl Error for GetBulkPublishDetailsError {
 pub enum GetCognitoEventsError {
     /// <p>Indicates an internal service error.</p>
     InternalError(String),
-    /// <p>Thrown if the request is throttled.</p>
-    TooManyRequests(String),
-    /// <p>Thrown if the resource doesn&#39;t exist.</p>
-    ResourceNotFound(String),
     /// <p>Thrown when a request parameter does not comply with the associated constraints.</p>
     InvalidParameter(String),
     /// <p>Thrown when a user is not authorized to access the requested resource.</p>
     NotAuthorized(String),
+    /// <p>Thrown if the resource doesn&#39;t exist.</p>
+    ResourceNotFound(String),
+    /// <p>Thrown if the request is throttled.</p>
+    TooManyRequests(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -1323,17 +1323,17 @@ impl GetCognitoEventsError {
                     "InternalErrorException" => {
                         GetCognitoEventsError::InternalError(String::from(error_message))
                     }
-                    "TooManyRequestsException" => {
-                        GetCognitoEventsError::TooManyRequests(String::from(error_message))
-                    }
-                    "ResourceNotFoundException" => {
-                        GetCognitoEventsError::ResourceNotFound(String::from(error_message))
-                    }
                     "InvalidParameterException" => {
                         GetCognitoEventsError::InvalidParameter(String::from(error_message))
                     }
                     "NotAuthorizedException" => {
                         GetCognitoEventsError::NotAuthorized(String::from(error_message))
+                    }
+                    "ResourceNotFoundException" => {
+                        GetCognitoEventsError::ResourceNotFound(String::from(error_message))
+                    }
+                    "TooManyRequestsException" => {
+                        GetCognitoEventsError::TooManyRequests(String::from(error_message))
                     }
                     "ValidationException" => {
                         GetCognitoEventsError::Validation(error_message.to_string())
@@ -1375,10 +1375,10 @@ impl Error for GetCognitoEventsError {
     fn description(&self) -> &str {
         match *self {
             GetCognitoEventsError::InternalError(ref cause) => cause,
-            GetCognitoEventsError::TooManyRequests(ref cause) => cause,
-            GetCognitoEventsError::ResourceNotFound(ref cause) => cause,
             GetCognitoEventsError::InvalidParameter(ref cause) => cause,
             GetCognitoEventsError::NotAuthorized(ref cause) => cause,
+            GetCognitoEventsError::ResourceNotFound(ref cause) => cause,
+            GetCognitoEventsError::TooManyRequests(ref cause) => cause,
             GetCognitoEventsError::Validation(ref cause) => cause,
             GetCognitoEventsError::Credentials(ref err) => err.description(),
             GetCognitoEventsError::HttpDispatch(ref dispatch_error) => dispatch_error.description(),
@@ -1391,14 +1391,14 @@ impl Error for GetCognitoEventsError {
 pub enum GetIdentityPoolConfigurationError {
     /// <p>Indicates an internal service error.</p>
     InternalError(String),
-    /// <p>Thrown if the request is throttled.</p>
-    TooManyRequests(String),
-    /// <p>Thrown if the resource doesn&#39;t exist.</p>
-    ResourceNotFound(String),
     /// <p>Thrown when a request parameter does not comply with the associated constraints.</p>
     InvalidParameter(String),
     /// <p>Thrown when a user is not authorized to access the requested resource.</p>
     NotAuthorized(String),
+    /// <p>Thrown if the resource doesn&#39;t exist.</p>
+    ResourceNotFound(String),
+    /// <p>Thrown if the request is throttled.</p>
+    TooManyRequests(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -1425,16 +1425,6 @@ impl GetIdentityPoolConfigurationError {
                     "InternalErrorException" => GetIdentityPoolConfigurationError::InternalError(
                         String::from(error_message),
                     ),
-                    "TooManyRequestsException" => {
-                        GetIdentityPoolConfigurationError::TooManyRequests(String::from(
-                            error_message,
-                        ))
-                    }
-                    "ResourceNotFoundException" => {
-                        GetIdentityPoolConfigurationError::ResourceNotFound(String::from(
-                            error_message,
-                        ))
-                    }
                     "InvalidParameterException" => {
                         GetIdentityPoolConfigurationError::InvalidParameter(String::from(
                             error_message,
@@ -1443,6 +1433,16 @@ impl GetIdentityPoolConfigurationError {
                     "NotAuthorizedException" => GetIdentityPoolConfigurationError::NotAuthorized(
                         String::from(error_message),
                     ),
+                    "ResourceNotFoundException" => {
+                        GetIdentityPoolConfigurationError::ResourceNotFound(String::from(
+                            error_message,
+                        ))
+                    }
+                    "TooManyRequestsException" => {
+                        GetIdentityPoolConfigurationError::TooManyRequests(String::from(
+                            error_message,
+                        ))
+                    }
                     "ValidationException" => {
                         GetIdentityPoolConfigurationError::Validation(error_message.to_string())
                     }
@@ -1483,10 +1483,10 @@ impl Error for GetIdentityPoolConfigurationError {
     fn description(&self) -> &str {
         match *self {
             GetIdentityPoolConfigurationError::InternalError(ref cause) => cause,
-            GetIdentityPoolConfigurationError::TooManyRequests(ref cause) => cause,
-            GetIdentityPoolConfigurationError::ResourceNotFound(ref cause) => cause,
             GetIdentityPoolConfigurationError::InvalidParameter(ref cause) => cause,
             GetIdentityPoolConfigurationError::NotAuthorized(ref cause) => cause,
+            GetIdentityPoolConfigurationError::ResourceNotFound(ref cause) => cause,
+            GetIdentityPoolConfigurationError::TooManyRequests(ref cause) => cause,
             GetIdentityPoolConfigurationError::Validation(ref cause) => cause,
             GetIdentityPoolConfigurationError::Credentials(ref err) => err.description(),
             GetIdentityPoolConfigurationError::HttpDispatch(ref dispatch_error) => {
@@ -1501,12 +1501,12 @@ impl Error for GetIdentityPoolConfigurationError {
 pub enum ListDatasetsError {
     /// <p>Indicates an internal service error.</p>
     InternalError(String),
-    /// <p>Thrown if the request is throttled.</p>
-    TooManyRequests(String),
     /// <p>Thrown when a request parameter does not comply with the associated constraints.</p>
     InvalidParameter(String),
     /// <p>Thrown when a user is not authorized to access the requested resource.</p>
     NotAuthorized(String),
+    /// <p>Thrown if the request is throttled.</p>
+    TooManyRequests(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -1533,14 +1533,14 @@ impl ListDatasetsError {
                     "InternalErrorException" => {
                         ListDatasetsError::InternalError(String::from(error_message))
                     }
-                    "TooManyRequestsException" => {
-                        ListDatasetsError::TooManyRequests(String::from(error_message))
-                    }
                     "InvalidParameterException" => {
                         ListDatasetsError::InvalidParameter(String::from(error_message))
                     }
                     "NotAuthorizedException" => {
                         ListDatasetsError::NotAuthorized(String::from(error_message))
+                    }
+                    "TooManyRequestsException" => {
+                        ListDatasetsError::TooManyRequests(String::from(error_message))
                     }
                     "ValidationException" => {
                         ListDatasetsError::Validation(error_message.to_string())
@@ -1582,9 +1582,9 @@ impl Error for ListDatasetsError {
     fn description(&self) -> &str {
         match *self {
             ListDatasetsError::InternalError(ref cause) => cause,
-            ListDatasetsError::TooManyRequests(ref cause) => cause,
             ListDatasetsError::InvalidParameter(ref cause) => cause,
             ListDatasetsError::NotAuthorized(ref cause) => cause,
+            ListDatasetsError::TooManyRequests(ref cause) => cause,
             ListDatasetsError::Validation(ref cause) => cause,
             ListDatasetsError::Credentials(ref err) => err.description(),
             ListDatasetsError::HttpDispatch(ref dispatch_error) => dispatch_error.description(),
@@ -1597,12 +1597,12 @@ impl Error for ListDatasetsError {
 pub enum ListIdentityPoolUsageError {
     /// <p>Indicates an internal service error.</p>
     InternalError(String),
-    /// <p>Thrown if the request is throttled.</p>
-    TooManyRequests(String),
     /// <p>Thrown when a request parameter does not comply with the associated constraints.</p>
     InvalidParameter(String),
     /// <p>Thrown when a user is not authorized to access the requested resource.</p>
     NotAuthorized(String),
+    /// <p>Thrown if the request is throttled.</p>
+    TooManyRequests(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -1629,14 +1629,14 @@ impl ListIdentityPoolUsageError {
                     "InternalErrorException" => {
                         ListIdentityPoolUsageError::InternalError(String::from(error_message))
                     }
-                    "TooManyRequestsException" => {
-                        ListIdentityPoolUsageError::TooManyRequests(String::from(error_message))
-                    }
                     "InvalidParameterException" => {
                         ListIdentityPoolUsageError::InvalidParameter(String::from(error_message))
                     }
                     "NotAuthorizedException" => {
                         ListIdentityPoolUsageError::NotAuthorized(String::from(error_message))
+                    }
+                    "TooManyRequestsException" => {
+                        ListIdentityPoolUsageError::TooManyRequests(String::from(error_message))
                     }
                     "ValidationException" => {
                         ListIdentityPoolUsageError::Validation(error_message.to_string())
@@ -1678,9 +1678,9 @@ impl Error for ListIdentityPoolUsageError {
     fn description(&self) -> &str {
         match *self {
             ListIdentityPoolUsageError::InternalError(ref cause) => cause,
-            ListIdentityPoolUsageError::TooManyRequests(ref cause) => cause,
             ListIdentityPoolUsageError::InvalidParameter(ref cause) => cause,
             ListIdentityPoolUsageError::NotAuthorized(ref cause) => cause,
+            ListIdentityPoolUsageError::TooManyRequests(ref cause) => cause,
             ListIdentityPoolUsageError::Validation(ref cause) => cause,
             ListIdentityPoolUsageError::Credentials(ref err) => err.description(),
             ListIdentityPoolUsageError::HttpDispatch(ref dispatch_error) => {
@@ -1695,12 +1695,12 @@ impl Error for ListIdentityPoolUsageError {
 pub enum ListRecordsError {
     /// <p>Indicates an internal service error.</p>
     InternalError(String),
-    /// <p>Thrown if the request is throttled.</p>
-    TooManyRequests(String),
     /// <p>Thrown when a request parameter does not comply with the associated constraints.</p>
     InvalidParameter(String),
     /// <p>Thrown when a user is not authorized to access the requested resource.</p>
     NotAuthorized(String),
+    /// <p>Thrown if the request is throttled.</p>
+    TooManyRequests(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -1727,14 +1727,14 @@ impl ListRecordsError {
                     "InternalErrorException" => {
                         ListRecordsError::InternalError(String::from(error_message))
                     }
-                    "TooManyRequestsException" => {
-                        ListRecordsError::TooManyRequests(String::from(error_message))
-                    }
                     "InvalidParameterException" => {
                         ListRecordsError::InvalidParameter(String::from(error_message))
                     }
                     "NotAuthorizedException" => {
                         ListRecordsError::NotAuthorized(String::from(error_message))
+                    }
+                    "TooManyRequestsException" => {
+                        ListRecordsError::TooManyRequests(String::from(error_message))
                     }
                     "ValidationException" => {
                         ListRecordsError::Validation(error_message.to_string())
@@ -1776,9 +1776,9 @@ impl Error for ListRecordsError {
     fn description(&self) -> &str {
         match *self {
             ListRecordsError::InternalError(ref cause) => cause,
-            ListRecordsError::TooManyRequests(ref cause) => cause,
             ListRecordsError::InvalidParameter(ref cause) => cause,
             ListRecordsError::NotAuthorized(ref cause) => cause,
+            ListRecordsError::TooManyRequests(ref cause) => cause,
             ListRecordsError::Validation(ref cause) => cause,
             ListRecordsError::Credentials(ref err) => err.description(),
             ListRecordsError::HttpDispatch(ref dispatch_error) => dispatch_error.description(),
@@ -1789,17 +1789,18 @@ impl Error for ListRecordsError {
 /// Errors returned by RegisterDevice
 #[derive(Debug, PartialEq)]
 pub enum RegisterDeviceError {
-    InvalidConfiguration(String),
     /// <p>Indicates an internal service error.</p>
     InternalError(String),
-    /// <p>Thrown if the request is throttled.</p>
-    TooManyRequests(String),
-    /// <p>Thrown if the resource doesn&#39;t exist.</p>
-    ResourceNotFound(String),
+
+    InvalidConfiguration(String),
     /// <p>Thrown when a request parameter does not comply with the associated constraints.</p>
     InvalidParameter(String),
     /// <p>Thrown when a user is not authorized to access the requested resource.</p>
     NotAuthorized(String),
+    /// <p>Thrown if the resource doesn&#39;t exist.</p>
+    ResourceNotFound(String),
+    /// <p>Thrown if the request is throttled.</p>
+    TooManyRequests(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -1823,23 +1824,23 @@ impl RegisterDeviceError {
                 let error_type = pieces.last().expect("Expected error type");
 
                 match *error_type {
-                    "InvalidConfigurationException" => {
-                        RegisterDeviceError::InvalidConfiguration(String::from(error_message))
-                    }
                     "InternalErrorException" => {
                         RegisterDeviceError::InternalError(String::from(error_message))
                     }
-                    "TooManyRequestsException" => {
-                        RegisterDeviceError::TooManyRequests(String::from(error_message))
-                    }
-                    "ResourceNotFoundException" => {
-                        RegisterDeviceError::ResourceNotFound(String::from(error_message))
+                    "InvalidConfigurationException" => {
+                        RegisterDeviceError::InvalidConfiguration(String::from(error_message))
                     }
                     "InvalidParameterException" => {
                         RegisterDeviceError::InvalidParameter(String::from(error_message))
                     }
                     "NotAuthorizedException" => {
                         RegisterDeviceError::NotAuthorized(String::from(error_message))
+                    }
+                    "ResourceNotFoundException" => {
+                        RegisterDeviceError::ResourceNotFound(String::from(error_message))
+                    }
+                    "TooManyRequestsException" => {
+                        RegisterDeviceError::TooManyRequests(String::from(error_message))
                     }
                     "ValidationException" => {
                         RegisterDeviceError::Validation(error_message.to_string())
@@ -1880,12 +1881,12 @@ impl fmt::Display for RegisterDeviceError {
 impl Error for RegisterDeviceError {
     fn description(&self) -> &str {
         match *self {
-            RegisterDeviceError::InvalidConfiguration(ref cause) => cause,
             RegisterDeviceError::InternalError(ref cause) => cause,
-            RegisterDeviceError::TooManyRequests(ref cause) => cause,
-            RegisterDeviceError::ResourceNotFound(ref cause) => cause,
+            RegisterDeviceError::InvalidConfiguration(ref cause) => cause,
             RegisterDeviceError::InvalidParameter(ref cause) => cause,
             RegisterDeviceError::NotAuthorized(ref cause) => cause,
+            RegisterDeviceError::ResourceNotFound(ref cause) => cause,
+            RegisterDeviceError::TooManyRequests(ref cause) => cause,
             RegisterDeviceError::Validation(ref cause) => cause,
             RegisterDeviceError::Credentials(ref err) => err.description(),
             RegisterDeviceError::HttpDispatch(ref dispatch_error) => dispatch_error.description(),
@@ -1898,14 +1899,14 @@ impl Error for RegisterDeviceError {
 pub enum SetCognitoEventsError {
     /// <p>Indicates an internal service error.</p>
     InternalError(String),
-    /// <p>Thrown if the request is throttled.</p>
-    TooManyRequests(String),
-    /// <p>Thrown if the resource doesn&#39;t exist.</p>
-    ResourceNotFound(String),
     /// <p>Thrown when a request parameter does not comply with the associated constraints.</p>
     InvalidParameter(String),
     /// <p>Thrown when a user is not authorized to access the requested resource.</p>
     NotAuthorized(String),
+    /// <p>Thrown if the resource doesn&#39;t exist.</p>
+    ResourceNotFound(String),
+    /// <p>Thrown if the request is throttled.</p>
+    TooManyRequests(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -1932,17 +1933,17 @@ impl SetCognitoEventsError {
                     "InternalErrorException" => {
                         SetCognitoEventsError::InternalError(String::from(error_message))
                     }
-                    "TooManyRequestsException" => {
-                        SetCognitoEventsError::TooManyRequests(String::from(error_message))
-                    }
-                    "ResourceNotFoundException" => {
-                        SetCognitoEventsError::ResourceNotFound(String::from(error_message))
-                    }
                     "InvalidParameterException" => {
                         SetCognitoEventsError::InvalidParameter(String::from(error_message))
                     }
                     "NotAuthorizedException" => {
                         SetCognitoEventsError::NotAuthorized(String::from(error_message))
+                    }
+                    "ResourceNotFoundException" => {
+                        SetCognitoEventsError::ResourceNotFound(String::from(error_message))
+                    }
+                    "TooManyRequestsException" => {
+                        SetCognitoEventsError::TooManyRequests(String::from(error_message))
                     }
                     "ValidationException" => {
                         SetCognitoEventsError::Validation(error_message.to_string())
@@ -1984,10 +1985,10 @@ impl Error for SetCognitoEventsError {
     fn description(&self) -> &str {
         match *self {
             SetCognitoEventsError::InternalError(ref cause) => cause,
-            SetCognitoEventsError::TooManyRequests(ref cause) => cause,
-            SetCognitoEventsError::ResourceNotFound(ref cause) => cause,
             SetCognitoEventsError::InvalidParameter(ref cause) => cause,
             SetCognitoEventsError::NotAuthorized(ref cause) => cause,
+            SetCognitoEventsError::ResourceNotFound(ref cause) => cause,
+            SetCognitoEventsError::TooManyRequests(ref cause) => cause,
             SetCognitoEventsError::Validation(ref cause) => cause,
             SetCognitoEventsError::Credentials(ref err) => err.description(),
             SetCognitoEventsError::HttpDispatch(ref dispatch_error) => dispatch_error.description(),
@@ -2002,14 +2003,14 @@ pub enum SetIdentityPoolConfigurationError {
     ConcurrentModification(String),
     /// <p>Indicates an internal service error.</p>
     InternalError(String),
-    /// <p>Thrown if the request is throttled.</p>
-    TooManyRequests(String),
-    /// <p>Thrown if the resource doesn&#39;t exist.</p>
-    ResourceNotFound(String),
     /// <p>Thrown when a request parameter does not comply with the associated constraints.</p>
     InvalidParameter(String),
     /// <p>Thrown when a user is not authorized to access the requested resource.</p>
     NotAuthorized(String),
+    /// <p>Thrown if the resource doesn&#39;t exist.</p>
+    ResourceNotFound(String),
+    /// <p>Thrown if the request is throttled.</p>
+    TooManyRequests(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -2041,16 +2042,6 @@ impl SetIdentityPoolConfigurationError {
                     "InternalErrorException" => SetIdentityPoolConfigurationError::InternalError(
                         String::from(error_message),
                     ),
-                    "TooManyRequestsException" => {
-                        SetIdentityPoolConfigurationError::TooManyRequests(String::from(
-                            error_message,
-                        ))
-                    }
-                    "ResourceNotFoundException" => {
-                        SetIdentityPoolConfigurationError::ResourceNotFound(String::from(
-                            error_message,
-                        ))
-                    }
                     "InvalidParameterException" => {
                         SetIdentityPoolConfigurationError::InvalidParameter(String::from(
                             error_message,
@@ -2059,6 +2050,16 @@ impl SetIdentityPoolConfigurationError {
                     "NotAuthorizedException" => SetIdentityPoolConfigurationError::NotAuthorized(
                         String::from(error_message),
                     ),
+                    "ResourceNotFoundException" => {
+                        SetIdentityPoolConfigurationError::ResourceNotFound(String::from(
+                            error_message,
+                        ))
+                    }
+                    "TooManyRequestsException" => {
+                        SetIdentityPoolConfigurationError::TooManyRequests(String::from(
+                            error_message,
+                        ))
+                    }
                     "ValidationException" => {
                         SetIdentityPoolConfigurationError::Validation(error_message.to_string())
                     }
@@ -2100,10 +2101,10 @@ impl Error for SetIdentityPoolConfigurationError {
         match *self {
             SetIdentityPoolConfigurationError::ConcurrentModification(ref cause) => cause,
             SetIdentityPoolConfigurationError::InternalError(ref cause) => cause,
-            SetIdentityPoolConfigurationError::TooManyRequests(ref cause) => cause,
-            SetIdentityPoolConfigurationError::ResourceNotFound(ref cause) => cause,
             SetIdentityPoolConfigurationError::InvalidParameter(ref cause) => cause,
             SetIdentityPoolConfigurationError::NotAuthorized(ref cause) => cause,
+            SetIdentityPoolConfigurationError::ResourceNotFound(ref cause) => cause,
+            SetIdentityPoolConfigurationError::TooManyRequests(ref cause) => cause,
             SetIdentityPoolConfigurationError::Validation(ref cause) => cause,
             SetIdentityPoolConfigurationError::Credentials(ref err) => err.description(),
             SetIdentityPoolConfigurationError::HttpDispatch(ref dispatch_error) => {
@@ -2116,17 +2117,18 @@ impl Error for SetIdentityPoolConfigurationError {
 /// Errors returned by SubscribeToDataset
 #[derive(Debug, PartialEq)]
 pub enum SubscribeToDatasetError {
-    InvalidConfiguration(String),
     /// <p>Indicates an internal service error.</p>
     InternalError(String),
-    /// <p>Thrown if the request is throttled.</p>
-    TooManyRequests(String),
-    /// <p>Thrown if the resource doesn&#39;t exist.</p>
-    ResourceNotFound(String),
+
+    InvalidConfiguration(String),
     /// <p>Thrown when a request parameter does not comply with the associated constraints.</p>
     InvalidParameter(String),
     /// <p>Thrown when a user is not authorized to access the requested resource.</p>
     NotAuthorized(String),
+    /// <p>Thrown if the resource doesn&#39;t exist.</p>
+    ResourceNotFound(String),
+    /// <p>Thrown if the request is throttled.</p>
+    TooManyRequests(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -2150,23 +2152,23 @@ impl SubscribeToDatasetError {
                 let error_type = pieces.last().expect("Expected error type");
 
                 match *error_type {
-                    "InvalidConfigurationException" => {
-                        SubscribeToDatasetError::InvalidConfiguration(String::from(error_message))
-                    }
                     "InternalErrorException" => {
                         SubscribeToDatasetError::InternalError(String::from(error_message))
                     }
-                    "TooManyRequestsException" => {
-                        SubscribeToDatasetError::TooManyRequests(String::from(error_message))
-                    }
-                    "ResourceNotFoundException" => {
-                        SubscribeToDatasetError::ResourceNotFound(String::from(error_message))
+                    "InvalidConfigurationException" => {
+                        SubscribeToDatasetError::InvalidConfiguration(String::from(error_message))
                     }
                     "InvalidParameterException" => {
                         SubscribeToDatasetError::InvalidParameter(String::from(error_message))
                     }
                     "NotAuthorizedException" => {
                         SubscribeToDatasetError::NotAuthorized(String::from(error_message))
+                    }
+                    "ResourceNotFoundException" => {
+                        SubscribeToDatasetError::ResourceNotFound(String::from(error_message))
+                    }
+                    "TooManyRequestsException" => {
+                        SubscribeToDatasetError::TooManyRequests(String::from(error_message))
                     }
                     "ValidationException" => {
                         SubscribeToDatasetError::Validation(error_message.to_string())
@@ -2207,12 +2209,12 @@ impl fmt::Display for SubscribeToDatasetError {
 impl Error for SubscribeToDatasetError {
     fn description(&self) -> &str {
         match *self {
-            SubscribeToDatasetError::InvalidConfiguration(ref cause) => cause,
             SubscribeToDatasetError::InternalError(ref cause) => cause,
-            SubscribeToDatasetError::TooManyRequests(ref cause) => cause,
-            SubscribeToDatasetError::ResourceNotFound(ref cause) => cause,
+            SubscribeToDatasetError::InvalidConfiguration(ref cause) => cause,
             SubscribeToDatasetError::InvalidParameter(ref cause) => cause,
             SubscribeToDatasetError::NotAuthorized(ref cause) => cause,
+            SubscribeToDatasetError::ResourceNotFound(ref cause) => cause,
+            SubscribeToDatasetError::TooManyRequests(ref cause) => cause,
             SubscribeToDatasetError::Validation(ref cause) => cause,
             SubscribeToDatasetError::Credentials(ref err) => err.description(),
             SubscribeToDatasetError::HttpDispatch(ref dispatch_error) => {
@@ -2225,17 +2227,18 @@ impl Error for SubscribeToDatasetError {
 /// Errors returned by UnsubscribeFromDataset
 #[derive(Debug, PartialEq)]
 pub enum UnsubscribeFromDatasetError {
-    InvalidConfiguration(String),
     /// <p>Indicates an internal service error.</p>
     InternalError(String),
-    /// <p>Thrown if the request is throttled.</p>
-    TooManyRequests(String),
-    /// <p>Thrown if the resource doesn&#39;t exist.</p>
-    ResourceNotFound(String),
+
+    InvalidConfiguration(String),
     /// <p>Thrown when a request parameter does not comply with the associated constraints.</p>
     InvalidParameter(String),
     /// <p>Thrown when a user is not authorized to access the requested resource.</p>
     NotAuthorized(String),
+    /// <p>Thrown if the resource doesn&#39;t exist.</p>
+    ResourceNotFound(String),
+    /// <p>Thrown if the request is throttled.</p>
+    TooManyRequests(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -2259,25 +2262,25 @@ impl UnsubscribeFromDatasetError {
                 let error_type = pieces.last().expect("Expected error type");
 
                 match *error_type {
+                    "InternalErrorException" => {
+                        UnsubscribeFromDatasetError::InternalError(String::from(error_message))
+                    }
                     "InvalidConfigurationException" => {
                         UnsubscribeFromDatasetError::InvalidConfiguration(String::from(
                             error_message,
                         ))
-                    }
-                    "InternalErrorException" => {
-                        UnsubscribeFromDatasetError::InternalError(String::from(error_message))
-                    }
-                    "TooManyRequestsException" => {
-                        UnsubscribeFromDatasetError::TooManyRequests(String::from(error_message))
-                    }
-                    "ResourceNotFoundException" => {
-                        UnsubscribeFromDatasetError::ResourceNotFound(String::from(error_message))
                     }
                     "InvalidParameterException" => {
                         UnsubscribeFromDatasetError::InvalidParameter(String::from(error_message))
                     }
                     "NotAuthorizedException" => {
                         UnsubscribeFromDatasetError::NotAuthorized(String::from(error_message))
+                    }
+                    "ResourceNotFoundException" => {
+                        UnsubscribeFromDatasetError::ResourceNotFound(String::from(error_message))
+                    }
+                    "TooManyRequestsException" => {
+                        UnsubscribeFromDatasetError::TooManyRequests(String::from(error_message))
                     }
                     "ValidationException" => {
                         UnsubscribeFromDatasetError::Validation(error_message.to_string())
@@ -2318,12 +2321,12 @@ impl fmt::Display for UnsubscribeFromDatasetError {
 impl Error for UnsubscribeFromDatasetError {
     fn description(&self) -> &str {
         match *self {
-            UnsubscribeFromDatasetError::InvalidConfiguration(ref cause) => cause,
             UnsubscribeFromDatasetError::InternalError(ref cause) => cause,
-            UnsubscribeFromDatasetError::TooManyRequests(ref cause) => cause,
-            UnsubscribeFromDatasetError::ResourceNotFound(ref cause) => cause,
+            UnsubscribeFromDatasetError::InvalidConfiguration(ref cause) => cause,
             UnsubscribeFromDatasetError::InvalidParameter(ref cause) => cause,
             UnsubscribeFromDatasetError::NotAuthorized(ref cause) => cause,
+            UnsubscribeFromDatasetError::ResourceNotFound(ref cause) => cause,
+            UnsubscribeFromDatasetError::TooManyRequests(ref cause) => cause,
             UnsubscribeFromDatasetError::Validation(ref cause) => cause,
             UnsubscribeFromDatasetError::Credentials(ref err) => err.description(),
             UnsubscribeFromDatasetError::HttpDispatch(ref dispatch_error) => {
@@ -2336,24 +2339,24 @@ impl Error for UnsubscribeFromDatasetError {
 /// Errors returned by UpdateRecords
 #[derive(Debug, PartialEq)]
 pub enum UpdateRecordsError {
-    /// <p>AWS Lambda throttled your account, please contact AWS Support</p>
-    LambdaThrottled(String),
-    /// <p>The AWS Lambda function returned invalid output or an exception.</p>
-    InvalidLambdaFunctionOutput(String),
     /// <p>Indicates an internal service error.</p>
     InternalError(String),
-    /// <p>Thrown if an update can&#39;t be applied because the resource was changed by another call and this would result in a conflict.</p>
-    ResourceConflict(String),
-    /// <p>Thrown if the request is throttled.</p>
-    TooManyRequests(String),
-    /// <p>Thrown if the resource doesn&#39;t exist.</p>
-    ResourceNotFound(String),
+    /// <p>The AWS Lambda function returned invalid output or an exception.</p>
+    InvalidLambdaFunctionOutput(String),
     /// <p>Thrown when a request parameter does not comply with the associated constraints.</p>
     InvalidParameter(String),
-    /// <p>Thrown when a user is not authorized to access the requested resource.</p>
-    NotAuthorized(String),
+    /// <p>AWS Lambda throttled your account, please contact AWS Support</p>
+    LambdaThrottled(String),
     /// <p>Thrown when the limit on the number of objects or operations has been exceeded.</p>
     LimitExceeded(String),
+    /// <p>Thrown when a user is not authorized to access the requested resource.</p>
+    NotAuthorized(String),
+    /// <p>Thrown if an update can&#39;t be applied because the resource was changed by another call and this would result in a conflict.</p>
+    ResourceConflict(String),
+    /// <p>Thrown if the resource doesn&#39;t exist.</p>
+    ResourceNotFound(String),
+    /// <p>Thrown if the request is throttled.</p>
+    TooManyRequests(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -2377,32 +2380,32 @@ impl UpdateRecordsError {
                 let error_type = pieces.last().expect("Expected error type");
 
                 match *error_type {
-                    "LambdaThrottledException" => {
-                        UpdateRecordsError::LambdaThrottled(String::from(error_message))
+                    "InternalErrorException" => {
+                        UpdateRecordsError::InternalError(String::from(error_message))
                     }
                     "InvalidLambdaFunctionOutputException" => {
                         UpdateRecordsError::InvalidLambdaFunctionOutput(String::from(error_message))
                     }
-                    "InternalErrorException" => {
-                        UpdateRecordsError::InternalError(String::from(error_message))
-                    }
-                    "ResourceConflictException" => {
-                        UpdateRecordsError::ResourceConflict(String::from(error_message))
-                    }
-                    "TooManyRequestsException" => {
-                        UpdateRecordsError::TooManyRequests(String::from(error_message))
-                    }
-                    "ResourceNotFoundException" => {
-                        UpdateRecordsError::ResourceNotFound(String::from(error_message))
-                    }
                     "InvalidParameterException" => {
                         UpdateRecordsError::InvalidParameter(String::from(error_message))
+                    }
+                    "LambdaThrottledException" => {
+                        UpdateRecordsError::LambdaThrottled(String::from(error_message))
+                    }
+                    "LimitExceededException" => {
+                        UpdateRecordsError::LimitExceeded(String::from(error_message))
                     }
                     "NotAuthorizedException" => {
                         UpdateRecordsError::NotAuthorized(String::from(error_message))
                     }
-                    "LimitExceededException" => {
-                        UpdateRecordsError::LimitExceeded(String::from(error_message))
+                    "ResourceConflictException" => {
+                        UpdateRecordsError::ResourceConflict(String::from(error_message))
+                    }
+                    "ResourceNotFoundException" => {
+                        UpdateRecordsError::ResourceNotFound(String::from(error_message))
+                    }
+                    "TooManyRequestsException" => {
+                        UpdateRecordsError::TooManyRequests(String::from(error_message))
                     }
                     "ValidationException" => {
                         UpdateRecordsError::Validation(error_message.to_string())
@@ -2443,15 +2446,15 @@ impl fmt::Display for UpdateRecordsError {
 impl Error for UpdateRecordsError {
     fn description(&self) -> &str {
         match *self {
-            UpdateRecordsError::LambdaThrottled(ref cause) => cause,
-            UpdateRecordsError::InvalidLambdaFunctionOutput(ref cause) => cause,
             UpdateRecordsError::InternalError(ref cause) => cause,
-            UpdateRecordsError::ResourceConflict(ref cause) => cause,
-            UpdateRecordsError::TooManyRequests(ref cause) => cause,
-            UpdateRecordsError::ResourceNotFound(ref cause) => cause,
+            UpdateRecordsError::InvalidLambdaFunctionOutput(ref cause) => cause,
             UpdateRecordsError::InvalidParameter(ref cause) => cause,
-            UpdateRecordsError::NotAuthorized(ref cause) => cause,
+            UpdateRecordsError::LambdaThrottled(ref cause) => cause,
             UpdateRecordsError::LimitExceeded(ref cause) => cause,
+            UpdateRecordsError::NotAuthorized(ref cause) => cause,
+            UpdateRecordsError::ResourceConflict(ref cause) => cause,
+            UpdateRecordsError::ResourceNotFound(ref cause) => cause,
+            UpdateRecordsError::TooManyRequests(ref cause) => cause,
             UpdateRecordsError::Validation(ref cause) => cause,
             UpdateRecordsError::Credentials(ref err) => err.description(),
             UpdateRecordsError::HttpDispatch(ref dispatch_error) => dispatch_error.description(),

--- a/rusoto/services/ec2/src/generated.rs
+++ b/rusoto/services/ec2/src/generated.rs
@@ -54233,12 +54233,21 @@ impl AcceptReservedInstancesExchangeQuoteError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AcceptReservedInstancesExchangeQuoteError::Unknown(String::from(body)),
             },
             Err(_) => AcceptReservedInstancesExchangeQuoteError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -54298,12 +54307,21 @@ impl AcceptVpcEndpointConnectionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AcceptVpcEndpointConnectionsError::Unknown(String::from(body)),
             },
             Err(_) => AcceptVpcEndpointConnectionsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -54363,12 +54381,21 @@ impl AcceptVpcPeeringConnectionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AcceptVpcPeeringConnectionError::Unknown(String::from(body)),
             },
             Err(_) => AcceptVpcPeeringConnectionError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -54428,12 +54455,21 @@ impl AllocateAddressError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AllocateAddressError::Unknown(String::from(body)),
             },
             Err(_) => AllocateAddressError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -54491,12 +54527,21 @@ impl AllocateHostsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AllocateHostsError::Unknown(String::from(body)),
             },
             Err(_) => AllocateHostsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -54554,12 +54599,21 @@ impl AssignIpv6AddressesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AssignIpv6AddressesError::Unknown(String::from(body)),
             },
             Err(_) => AssignIpv6AddressesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -54619,12 +54673,21 @@ impl AssignPrivateIpAddressesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AssignPrivateIpAddressesError::Unknown(String::from(body)),
             },
             Err(_) => AssignPrivateIpAddressesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -54684,12 +54747,21 @@ impl AssociateAddressError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AssociateAddressError::Unknown(String::from(body)),
             },
             Err(_) => AssociateAddressError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -54747,12 +54819,21 @@ impl AssociateDhcpOptionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AssociateDhcpOptionsError::Unknown(String::from(body)),
             },
             Err(_) => AssociateDhcpOptionsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -54812,12 +54893,21 @@ impl AssociateIamInstanceProfileError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AssociateIamInstanceProfileError::Unknown(String::from(body)),
             },
             Err(_) => AssociateIamInstanceProfileError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -54877,12 +54967,21 @@ impl AssociateRouteTableError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AssociateRouteTableError::Unknown(String::from(body)),
             },
             Err(_) => AssociateRouteTableError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -54942,12 +55041,21 @@ impl AssociateSubnetCidrBlockError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AssociateSubnetCidrBlockError::Unknown(String::from(body)),
             },
             Err(_) => AssociateSubnetCidrBlockError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -55007,12 +55115,21 @@ impl AssociateVpcCidrBlockError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AssociateVpcCidrBlockError::Unknown(String::from(body)),
             },
             Err(_) => AssociateVpcCidrBlockError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -55072,12 +55189,21 @@ impl AttachClassicLinkVpcError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AttachClassicLinkVpcError::Unknown(String::from(body)),
             },
             Err(_) => AttachClassicLinkVpcError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -55137,12 +55263,21 @@ impl AttachInternetGatewayError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AttachInternetGatewayError::Unknown(String::from(body)),
             },
             Err(_) => AttachInternetGatewayError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -55202,12 +55337,21 @@ impl AttachNetworkInterfaceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AttachNetworkInterfaceError::Unknown(String::from(body)),
             },
             Err(_) => AttachNetworkInterfaceError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -55267,12 +55411,21 @@ impl AttachVolumeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AttachVolumeError::Unknown(String::from(body)),
             },
             Err(_) => AttachVolumeError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -55330,12 +55483,21 @@ impl AttachVpnGatewayError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AttachVpnGatewayError::Unknown(String::from(body)),
             },
             Err(_) => AttachVpnGatewayError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -55393,12 +55555,21 @@ impl AuthorizeSecurityGroupEgressError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AuthorizeSecurityGroupEgressError::Unknown(String::from(body)),
             },
             Err(_) => AuthorizeSecurityGroupEgressError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -55458,12 +55629,21 @@ impl AuthorizeSecurityGroupIngressError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AuthorizeSecurityGroupIngressError::Unknown(String::from(body)),
             },
             Err(_) => AuthorizeSecurityGroupIngressError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -55523,12 +55703,21 @@ impl BundleInstanceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => BundleInstanceError::Unknown(String::from(body)),
             },
             Err(_) => BundleInstanceError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -55586,12 +55775,21 @@ impl CancelBundleTaskError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CancelBundleTaskError::Unknown(String::from(body)),
             },
             Err(_) => CancelBundleTaskError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -55649,12 +55847,21 @@ impl CancelConversionTaskError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CancelConversionTaskError::Unknown(String::from(body)),
             },
             Err(_) => CancelConversionTaskError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -55714,12 +55921,21 @@ impl CancelExportTaskError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CancelExportTaskError::Unknown(String::from(body)),
             },
             Err(_) => CancelExportTaskError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -55777,12 +55993,21 @@ impl CancelImportTaskError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CancelImportTaskError::Unknown(String::from(body)),
             },
             Err(_) => CancelImportTaskError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -55840,12 +56065,21 @@ impl CancelReservedInstancesListingError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CancelReservedInstancesListingError::Unknown(String::from(body)),
             },
             Err(_) => CancelReservedInstancesListingError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -55905,12 +56139,21 @@ impl EC2CancelSpotFleetRequestsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => EC2CancelSpotFleetRequestsError::Unknown(String::from(body)),
             },
             Err(_) => EC2CancelSpotFleetRequestsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -55970,12 +56213,21 @@ impl CancelSpotInstanceRequestsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CancelSpotInstanceRequestsError::Unknown(String::from(body)),
             },
             Err(_) => CancelSpotInstanceRequestsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -56035,12 +56287,21 @@ impl ConfirmProductInstanceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ConfirmProductInstanceError::Unknown(String::from(body)),
             },
             Err(_) => ConfirmProductInstanceError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -56100,12 +56361,21 @@ impl CopyFpgaImageError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CopyFpgaImageError::Unknown(String::from(body)),
             },
             Err(_) => CopyFpgaImageError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -56163,12 +56433,21 @@ impl CopyImageError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CopyImageError::Unknown(String::from(body)),
             },
             Err(_) => CopyImageError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -56226,12 +56505,21 @@ impl CopySnapshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CopySnapshotError::Unknown(String::from(body)),
             },
             Err(_) => CopySnapshotError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -56289,12 +56577,21 @@ impl CreateCustomerGatewayError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateCustomerGatewayError::Unknown(String::from(body)),
             },
             Err(_) => CreateCustomerGatewayError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -56354,12 +56651,21 @@ impl CreateDefaultSubnetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateDefaultSubnetError::Unknown(String::from(body)),
             },
             Err(_) => CreateDefaultSubnetError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -56419,12 +56725,21 @@ impl CreateDefaultVpcError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateDefaultVpcError::Unknown(String::from(body)),
             },
             Err(_) => CreateDefaultVpcError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -56482,12 +56797,21 @@ impl CreateDhcpOptionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateDhcpOptionsError::Unknown(String::from(body)),
             },
             Err(_) => CreateDhcpOptionsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -56547,12 +56871,21 @@ impl CreateEgressOnlyInternetGatewayError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateEgressOnlyInternetGatewayError::Unknown(String::from(body)),
             },
             Err(_) => CreateEgressOnlyInternetGatewayError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -56612,12 +56945,21 @@ impl CreateFlowLogsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateFlowLogsError::Unknown(String::from(body)),
             },
             Err(_) => CreateFlowLogsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -56675,12 +57017,21 @@ impl CreateFpgaImageError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateFpgaImageError::Unknown(String::from(body)),
             },
             Err(_) => CreateFpgaImageError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -56738,12 +57089,21 @@ impl CreateImageError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateImageError::Unknown(String::from(body)),
             },
             Err(_) => CreateImageError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -56801,12 +57161,21 @@ impl CreateInstanceExportTaskError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateInstanceExportTaskError::Unknown(String::from(body)),
             },
             Err(_) => CreateInstanceExportTaskError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -56866,12 +57235,21 @@ impl CreateInternetGatewayError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateInternetGatewayError::Unknown(String::from(body)),
             },
             Err(_) => CreateInternetGatewayError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -56931,12 +57309,21 @@ impl CreateKeyPairError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateKeyPairError::Unknown(String::from(body)),
             },
             Err(_) => CreateKeyPairError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -56994,12 +57381,21 @@ impl CreateLaunchTemplateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateLaunchTemplateError::Unknown(String::from(body)),
             },
             Err(_) => CreateLaunchTemplateError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -57059,12 +57455,21 @@ impl CreateLaunchTemplateVersionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateLaunchTemplateVersionError::Unknown(String::from(body)),
             },
             Err(_) => CreateLaunchTemplateVersionError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -57124,12 +57529,21 @@ impl CreateNatGatewayError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateNatGatewayError::Unknown(String::from(body)),
             },
             Err(_) => CreateNatGatewayError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -57187,12 +57601,21 @@ impl CreateNetworkAclError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateNetworkAclError::Unknown(String::from(body)),
             },
             Err(_) => CreateNetworkAclError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -57250,12 +57673,21 @@ impl CreateNetworkAclEntryError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateNetworkAclEntryError::Unknown(String::from(body)),
             },
             Err(_) => CreateNetworkAclEntryError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -57315,12 +57747,21 @@ impl CreateNetworkInterfaceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateNetworkInterfaceError::Unknown(String::from(body)),
             },
             Err(_) => CreateNetworkInterfaceError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -57380,12 +57821,21 @@ impl CreateNetworkInterfacePermissionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateNetworkInterfacePermissionError::Unknown(String::from(body)),
             },
             Err(_) => CreateNetworkInterfacePermissionError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -57445,12 +57895,21 @@ impl CreatePlacementGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreatePlacementGroupError::Unknown(String::from(body)),
             },
             Err(_) => CreatePlacementGroupError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -57510,12 +57969,21 @@ impl CreateReservedInstancesListingError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateReservedInstancesListingError::Unknown(String::from(body)),
             },
             Err(_) => CreateReservedInstancesListingError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -57575,12 +58043,21 @@ impl CreateRouteError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateRouteError::Unknown(String::from(body)),
             },
             Err(_) => CreateRouteError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -57638,12 +58115,21 @@ impl CreateRouteTableError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateRouteTableError::Unknown(String::from(body)),
             },
             Err(_) => CreateRouteTableError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -57701,12 +58187,21 @@ impl CreateSecurityGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateSecurityGroupError::Unknown(String::from(body)),
             },
             Err(_) => CreateSecurityGroupError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -57766,12 +58261,21 @@ impl CreateSnapshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateSnapshotError::Unknown(String::from(body)),
             },
             Err(_) => CreateSnapshotError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -57829,12 +58333,21 @@ impl CreateSpotDatafeedSubscriptionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateSpotDatafeedSubscriptionError::Unknown(String::from(body)),
             },
             Err(_) => CreateSpotDatafeedSubscriptionError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -57894,12 +58407,21 @@ impl CreateSubnetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateSubnetError::Unknown(String::from(body)),
             },
             Err(_) => CreateSubnetError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -57957,12 +58479,21 @@ impl CreateTagsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateTagsError::Unknown(String::from(body)),
             },
             Err(_) => CreateTagsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -58020,12 +58551,21 @@ impl CreateVolumeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateVolumeError::Unknown(String::from(body)),
             },
             Err(_) => CreateVolumeError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -58083,12 +58623,21 @@ impl CreateVpcError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateVpcError::Unknown(String::from(body)),
             },
             Err(_) => CreateVpcError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -58146,12 +58695,21 @@ impl CreateVpcEndpointError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateVpcEndpointError::Unknown(String::from(body)),
             },
             Err(_) => CreateVpcEndpointError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -58211,12 +58769,21 @@ impl CreateVpcEndpointConnectionNotificationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateVpcEndpointConnectionNotificationError::Unknown(String::from(body)),
             },
             Err(_) => CreateVpcEndpointConnectionNotificationError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -58276,12 +58843,21 @@ impl CreateVpcEndpointServiceConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateVpcEndpointServiceConfigurationError::Unknown(String::from(body)),
             },
             Err(_) => CreateVpcEndpointServiceConfigurationError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -58341,12 +58917,21 @@ impl CreateVpcPeeringConnectionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateVpcPeeringConnectionError::Unknown(String::from(body)),
             },
             Err(_) => CreateVpcPeeringConnectionError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -58406,12 +58991,21 @@ impl CreateVpnConnectionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateVpnConnectionError::Unknown(String::from(body)),
             },
             Err(_) => CreateVpnConnectionError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -58471,12 +59065,21 @@ impl CreateVpnConnectionRouteError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateVpnConnectionRouteError::Unknown(String::from(body)),
             },
             Err(_) => CreateVpnConnectionRouteError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -58536,12 +59139,21 @@ impl CreateVpnGatewayError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateVpnGatewayError::Unknown(String::from(body)),
             },
             Err(_) => CreateVpnGatewayError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -58599,12 +59211,21 @@ impl DeleteCustomerGatewayError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteCustomerGatewayError::Unknown(String::from(body)),
             },
             Err(_) => DeleteCustomerGatewayError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -58664,12 +59285,21 @@ impl DeleteDhcpOptionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteDhcpOptionsError::Unknown(String::from(body)),
             },
             Err(_) => DeleteDhcpOptionsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -58729,12 +59359,21 @@ impl DeleteEgressOnlyInternetGatewayError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteEgressOnlyInternetGatewayError::Unknown(String::from(body)),
             },
             Err(_) => DeleteEgressOnlyInternetGatewayError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -58794,12 +59433,21 @@ impl DeleteFlowLogsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteFlowLogsError::Unknown(String::from(body)),
             },
             Err(_) => DeleteFlowLogsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -58857,12 +59505,21 @@ impl DeleteFpgaImageError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteFpgaImageError::Unknown(String::from(body)),
             },
             Err(_) => DeleteFpgaImageError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -58920,12 +59577,21 @@ impl DeleteInternetGatewayError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteInternetGatewayError::Unknown(String::from(body)),
             },
             Err(_) => DeleteInternetGatewayError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -58985,12 +59651,21 @@ impl DeleteKeyPairError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteKeyPairError::Unknown(String::from(body)),
             },
             Err(_) => DeleteKeyPairError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -59048,12 +59723,21 @@ impl DeleteLaunchTemplateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteLaunchTemplateError::Unknown(String::from(body)),
             },
             Err(_) => DeleteLaunchTemplateError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -59113,12 +59797,21 @@ impl DeleteLaunchTemplateVersionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteLaunchTemplateVersionsError::Unknown(String::from(body)),
             },
             Err(_) => DeleteLaunchTemplateVersionsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -59178,12 +59871,21 @@ impl DeleteNatGatewayError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteNatGatewayError::Unknown(String::from(body)),
             },
             Err(_) => DeleteNatGatewayError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -59241,12 +59943,21 @@ impl DeleteNetworkAclError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteNetworkAclError::Unknown(String::from(body)),
             },
             Err(_) => DeleteNetworkAclError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -59304,12 +60015,21 @@ impl DeleteNetworkAclEntryError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteNetworkAclEntryError::Unknown(String::from(body)),
             },
             Err(_) => DeleteNetworkAclEntryError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -59369,12 +60089,21 @@ impl DeleteNetworkInterfaceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteNetworkInterfaceError::Unknown(String::from(body)),
             },
             Err(_) => DeleteNetworkInterfaceError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -59434,12 +60163,21 @@ impl DeleteNetworkInterfacePermissionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteNetworkInterfacePermissionError::Unknown(String::from(body)),
             },
             Err(_) => DeleteNetworkInterfacePermissionError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -59499,12 +60237,21 @@ impl DeletePlacementGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeletePlacementGroupError::Unknown(String::from(body)),
             },
             Err(_) => DeletePlacementGroupError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -59564,12 +60311,21 @@ impl DeleteRouteError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteRouteError::Unknown(String::from(body)),
             },
             Err(_) => DeleteRouteError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -59627,12 +60383,21 @@ impl DeleteRouteTableError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteRouteTableError::Unknown(String::from(body)),
             },
             Err(_) => DeleteRouteTableError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -59690,12 +60455,21 @@ impl DeleteSecurityGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteSecurityGroupError::Unknown(String::from(body)),
             },
             Err(_) => DeleteSecurityGroupError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -59755,12 +60529,21 @@ impl DeleteSnapshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteSnapshotError::Unknown(String::from(body)),
             },
             Err(_) => DeleteSnapshotError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -59818,12 +60601,21 @@ impl DeleteSpotDatafeedSubscriptionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteSpotDatafeedSubscriptionError::Unknown(String::from(body)),
             },
             Err(_) => DeleteSpotDatafeedSubscriptionError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -59883,12 +60675,21 @@ impl DeleteSubnetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteSubnetError::Unknown(String::from(body)),
             },
             Err(_) => DeleteSubnetError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -59946,12 +60747,21 @@ impl DeleteTagsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteTagsError::Unknown(String::from(body)),
             },
             Err(_) => DeleteTagsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -60009,12 +60819,21 @@ impl DeleteVolumeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteVolumeError::Unknown(String::from(body)),
             },
             Err(_) => DeleteVolumeError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -60072,12 +60891,21 @@ impl DeleteVpcError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteVpcError::Unknown(String::from(body)),
             },
             Err(_) => DeleteVpcError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -60135,12 +60963,21 @@ impl DeleteVpcEndpointConnectionNotificationsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteVpcEndpointConnectionNotificationsError::Unknown(String::from(body)),
             },
             Err(_) => DeleteVpcEndpointConnectionNotificationsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -60202,12 +61039,21 @@ impl DeleteVpcEndpointServiceConfigurationsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteVpcEndpointServiceConfigurationsError::Unknown(String::from(body)),
             },
             Err(_) => DeleteVpcEndpointServiceConfigurationsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -60267,12 +61113,21 @@ impl DeleteVpcEndpointsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteVpcEndpointsError::Unknown(String::from(body)),
             },
             Err(_) => DeleteVpcEndpointsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -60332,12 +61187,21 @@ impl DeleteVpcPeeringConnectionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteVpcPeeringConnectionError::Unknown(String::from(body)),
             },
             Err(_) => DeleteVpcPeeringConnectionError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -60397,12 +61261,21 @@ impl DeleteVpnConnectionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteVpnConnectionError::Unknown(String::from(body)),
             },
             Err(_) => DeleteVpnConnectionError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -60462,12 +61335,21 @@ impl DeleteVpnConnectionRouteError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteVpnConnectionRouteError::Unknown(String::from(body)),
             },
             Err(_) => DeleteVpnConnectionRouteError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -60527,12 +61409,21 @@ impl DeleteVpnGatewayError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteVpnGatewayError::Unknown(String::from(body)),
             },
             Err(_) => DeleteVpnGatewayError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -60590,12 +61481,21 @@ impl DeregisterImageError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeregisterImageError::Unknown(String::from(body)),
             },
             Err(_) => DeregisterImageError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -60653,12 +61553,21 @@ impl DescribeAccountAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeAccountAttributesError::Unknown(String::from(body)),
             },
             Err(_) => DescribeAccountAttributesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -60718,12 +61627,21 @@ impl DescribeAddressesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeAddressesError::Unknown(String::from(body)),
             },
             Err(_) => DescribeAddressesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -60783,12 +61701,21 @@ impl DescribeAvailabilityZonesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeAvailabilityZonesError::Unknown(String::from(body)),
             },
             Err(_) => DescribeAvailabilityZonesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -60848,12 +61775,21 @@ impl DescribeBundleTasksError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeBundleTasksError::Unknown(String::from(body)),
             },
             Err(_) => DescribeBundleTasksError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -60913,12 +61849,21 @@ impl DescribeClassicLinkInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeClassicLinkInstancesError::Unknown(String::from(body)),
             },
             Err(_) => DescribeClassicLinkInstancesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -60978,12 +61923,21 @@ impl DescribeConversionTasksError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeConversionTasksError::Unknown(String::from(body)),
             },
             Err(_) => DescribeConversionTasksError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -61043,12 +61997,21 @@ impl DescribeCustomerGatewaysError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeCustomerGatewaysError::Unknown(String::from(body)),
             },
             Err(_) => DescribeCustomerGatewaysError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -61108,12 +62071,21 @@ impl DescribeDhcpOptionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeDhcpOptionsError::Unknown(String::from(body)),
             },
             Err(_) => DescribeDhcpOptionsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -61173,12 +62145,21 @@ impl DescribeEgressOnlyInternetGatewaysError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeEgressOnlyInternetGatewaysError::Unknown(String::from(body)),
             },
             Err(_) => DescribeEgressOnlyInternetGatewaysError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -61238,12 +62219,21 @@ impl DescribeElasticGpusError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeElasticGpusError::Unknown(String::from(body)),
             },
             Err(_) => DescribeElasticGpusError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -61303,12 +62293,21 @@ impl DescribeExportTasksError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeExportTasksError::Unknown(String::from(body)),
             },
             Err(_) => DescribeExportTasksError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -61368,12 +62367,21 @@ impl DescribeFlowLogsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeFlowLogsError::Unknown(String::from(body)),
             },
             Err(_) => DescribeFlowLogsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -61431,12 +62439,21 @@ impl DescribeFpgaImageAttributeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeFpgaImageAttributeError::Unknown(String::from(body)),
             },
             Err(_) => DescribeFpgaImageAttributeError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -61496,12 +62513,21 @@ impl DescribeFpgaImagesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeFpgaImagesError::Unknown(String::from(body)),
             },
             Err(_) => DescribeFpgaImagesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -61561,12 +62587,21 @@ impl DescribeHostReservationOfferingsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeHostReservationOfferingsError::Unknown(String::from(body)),
             },
             Err(_) => DescribeHostReservationOfferingsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -61626,12 +62661,21 @@ impl DescribeHostReservationsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeHostReservationsError::Unknown(String::from(body)),
             },
             Err(_) => DescribeHostReservationsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -61691,12 +62735,21 @@ impl DescribeHostsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeHostsError::Unknown(String::from(body)),
             },
             Err(_) => DescribeHostsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -61754,12 +62807,21 @@ impl DescribeIamInstanceProfileAssociationsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeIamInstanceProfileAssociationsError::Unknown(String::from(body)),
             },
             Err(_) => DescribeIamInstanceProfileAssociationsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -61819,12 +62881,21 @@ impl DescribeIdFormatError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeIdFormatError::Unknown(String::from(body)),
             },
             Err(_) => DescribeIdFormatError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -61882,12 +62953,21 @@ impl DescribeIdentityIdFormatError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeIdentityIdFormatError::Unknown(String::from(body)),
             },
             Err(_) => DescribeIdentityIdFormatError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -61947,12 +63027,21 @@ impl DescribeImageAttributeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeImageAttributeError::Unknown(String::from(body)),
             },
             Err(_) => DescribeImageAttributeError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -62012,12 +63101,21 @@ impl DescribeImagesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeImagesError::Unknown(String::from(body)),
             },
             Err(_) => DescribeImagesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -62075,12 +63173,21 @@ impl DescribeImportImageTasksError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeImportImageTasksError::Unknown(String::from(body)),
             },
             Err(_) => DescribeImportImageTasksError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -62140,12 +63247,21 @@ impl DescribeImportSnapshotTasksError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeImportSnapshotTasksError::Unknown(String::from(body)),
             },
             Err(_) => DescribeImportSnapshotTasksError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -62205,12 +63321,21 @@ impl DescribeInstanceAttributeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeInstanceAttributeError::Unknown(String::from(body)),
             },
             Err(_) => DescribeInstanceAttributeError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -62270,12 +63395,21 @@ impl DescribeInstanceCreditSpecificationsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeInstanceCreditSpecificationsError::Unknown(String::from(body)),
             },
             Err(_) => DescribeInstanceCreditSpecificationsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -62335,12 +63469,21 @@ impl DescribeInstanceStatusError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeInstanceStatusError::Unknown(String::from(body)),
             },
             Err(_) => DescribeInstanceStatusError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -62400,12 +63543,21 @@ impl DescribeInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeInstancesError::Unknown(String::from(body)),
             },
             Err(_) => DescribeInstancesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -62465,12 +63617,21 @@ impl DescribeInternetGatewaysError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeInternetGatewaysError::Unknown(String::from(body)),
             },
             Err(_) => DescribeInternetGatewaysError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -62530,12 +63691,21 @@ impl DescribeKeyPairsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeKeyPairsError::Unknown(String::from(body)),
             },
             Err(_) => DescribeKeyPairsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -62593,12 +63763,21 @@ impl DescribeLaunchTemplateVersionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeLaunchTemplateVersionsError::Unknown(String::from(body)),
             },
             Err(_) => DescribeLaunchTemplateVersionsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -62658,12 +63837,21 @@ impl DescribeLaunchTemplatesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeLaunchTemplatesError::Unknown(String::from(body)),
             },
             Err(_) => DescribeLaunchTemplatesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -62723,12 +63911,21 @@ impl DescribeMovingAddressesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeMovingAddressesError::Unknown(String::from(body)),
             },
             Err(_) => DescribeMovingAddressesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -62788,12 +63985,21 @@ impl DescribeNatGatewaysError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeNatGatewaysError::Unknown(String::from(body)),
             },
             Err(_) => DescribeNatGatewaysError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -62853,12 +64059,21 @@ impl DescribeNetworkAclsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeNetworkAclsError::Unknown(String::from(body)),
             },
             Err(_) => DescribeNetworkAclsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -62918,12 +64133,21 @@ impl DescribeNetworkInterfaceAttributeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeNetworkInterfaceAttributeError::Unknown(String::from(body)),
             },
             Err(_) => DescribeNetworkInterfaceAttributeError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -62983,12 +64207,21 @@ impl DescribeNetworkInterfacePermissionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeNetworkInterfacePermissionsError::Unknown(String::from(body)),
             },
             Err(_) => DescribeNetworkInterfacePermissionsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -63048,12 +64281,21 @@ impl DescribeNetworkInterfacesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeNetworkInterfacesError::Unknown(String::from(body)),
             },
             Err(_) => DescribeNetworkInterfacesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -63113,12 +64355,21 @@ impl DescribePlacementGroupsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribePlacementGroupsError::Unknown(String::from(body)),
             },
             Err(_) => DescribePlacementGroupsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -63178,12 +64429,21 @@ impl DescribePrefixListsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribePrefixListsError::Unknown(String::from(body)),
             },
             Err(_) => DescribePrefixListsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -63243,12 +64503,21 @@ impl DescribeRegionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeRegionsError::Unknown(String::from(body)),
             },
             Err(_) => DescribeRegionsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -63306,12 +64575,21 @@ impl DescribeReservedInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeReservedInstancesError::Unknown(String::from(body)),
             },
             Err(_) => DescribeReservedInstancesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -63371,12 +64649,21 @@ impl DescribeReservedInstancesListingsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeReservedInstancesListingsError::Unknown(String::from(body)),
             },
             Err(_) => DescribeReservedInstancesListingsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -63436,12 +64723,21 @@ impl DescribeReservedInstancesModificationsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeReservedInstancesModificationsError::Unknown(String::from(body)),
             },
             Err(_) => DescribeReservedInstancesModificationsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -63501,12 +64797,21 @@ impl DescribeReservedInstancesOfferingsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeReservedInstancesOfferingsError::Unknown(String::from(body)),
             },
             Err(_) => DescribeReservedInstancesOfferingsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -63566,12 +64871,21 @@ impl DescribeRouteTablesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeRouteTablesError::Unknown(String::from(body)),
             },
             Err(_) => DescribeRouteTablesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -63631,12 +64945,21 @@ impl DescribeScheduledInstanceAvailabilityError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeScheduledInstanceAvailabilityError::Unknown(String::from(body)),
             },
             Err(_) => DescribeScheduledInstanceAvailabilityError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -63696,12 +65019,21 @@ impl DescribeScheduledInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeScheduledInstancesError::Unknown(String::from(body)),
             },
             Err(_) => DescribeScheduledInstancesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -63761,12 +65093,21 @@ impl DescribeSecurityGroupReferencesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeSecurityGroupReferencesError::Unknown(String::from(body)),
             },
             Err(_) => DescribeSecurityGroupReferencesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -63826,12 +65167,21 @@ impl DescribeSecurityGroupsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeSecurityGroupsError::Unknown(String::from(body)),
             },
             Err(_) => DescribeSecurityGroupsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -63891,12 +65241,21 @@ impl DescribeSnapshotAttributeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeSnapshotAttributeError::Unknown(String::from(body)),
             },
             Err(_) => DescribeSnapshotAttributeError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -63956,12 +65315,21 @@ impl DescribeSnapshotsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeSnapshotsError::Unknown(String::from(body)),
             },
             Err(_) => DescribeSnapshotsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -64021,12 +65389,21 @@ impl DescribeSpotDatafeedSubscriptionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeSpotDatafeedSubscriptionError::Unknown(String::from(body)),
             },
             Err(_) => DescribeSpotDatafeedSubscriptionError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -64086,12 +65463,21 @@ impl DescribeSpotFleetInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeSpotFleetInstancesError::Unknown(String::from(body)),
             },
             Err(_) => DescribeSpotFleetInstancesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -64151,12 +65537,21 @@ impl DescribeSpotFleetRequestHistoryError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeSpotFleetRequestHistoryError::Unknown(String::from(body)),
             },
             Err(_) => DescribeSpotFleetRequestHistoryError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -64216,12 +65611,21 @@ impl DescribeSpotFleetRequestsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeSpotFleetRequestsError::Unknown(String::from(body)),
             },
             Err(_) => DescribeSpotFleetRequestsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -64281,12 +65685,21 @@ impl DescribeSpotInstanceRequestsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeSpotInstanceRequestsError::Unknown(String::from(body)),
             },
             Err(_) => DescribeSpotInstanceRequestsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -64346,12 +65759,21 @@ impl DescribeSpotPriceHistoryError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeSpotPriceHistoryError::Unknown(String::from(body)),
             },
             Err(_) => DescribeSpotPriceHistoryError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -64411,12 +65833,21 @@ impl DescribeStaleSecurityGroupsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeStaleSecurityGroupsError::Unknown(String::from(body)),
             },
             Err(_) => DescribeStaleSecurityGroupsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -64476,12 +65907,21 @@ impl DescribeSubnetsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeSubnetsError::Unknown(String::from(body)),
             },
             Err(_) => DescribeSubnetsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -64539,12 +65979,21 @@ impl DescribeTagsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeTagsError::Unknown(String::from(body)),
             },
             Err(_) => DescribeTagsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -64602,12 +66051,21 @@ impl DescribeVolumeAttributeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeVolumeAttributeError::Unknown(String::from(body)),
             },
             Err(_) => DescribeVolumeAttributeError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -64667,12 +66125,21 @@ impl DescribeVolumeStatusError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeVolumeStatusError::Unknown(String::from(body)),
             },
             Err(_) => DescribeVolumeStatusError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -64732,12 +66199,21 @@ impl DescribeVolumesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeVolumesError::Unknown(String::from(body)),
             },
             Err(_) => DescribeVolumesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -64795,12 +66271,21 @@ impl DescribeVolumesModificationsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeVolumesModificationsError::Unknown(String::from(body)),
             },
             Err(_) => DescribeVolumesModificationsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -64860,12 +66345,21 @@ impl DescribeVpcAttributeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeVpcAttributeError::Unknown(String::from(body)),
             },
             Err(_) => DescribeVpcAttributeError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -64925,12 +66419,21 @@ impl DescribeVpcClassicLinkError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeVpcClassicLinkError::Unknown(String::from(body)),
             },
             Err(_) => DescribeVpcClassicLinkError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -64990,12 +66493,21 @@ impl DescribeVpcClassicLinkDnsSupportError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeVpcClassicLinkDnsSupportError::Unknown(String::from(body)),
             },
             Err(_) => DescribeVpcClassicLinkDnsSupportError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -65055,12 +66567,21 @@ impl DescribeVpcEndpointConnectionNotificationsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeVpcEndpointConnectionNotificationsError::Unknown(String::from(body)),
             },
             Err(_) => DescribeVpcEndpointConnectionNotificationsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -65122,12 +66643,21 @@ impl DescribeVpcEndpointConnectionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeVpcEndpointConnectionsError::Unknown(String::from(body)),
             },
             Err(_) => DescribeVpcEndpointConnectionsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -65187,12 +66717,21 @@ impl DescribeVpcEndpointServiceConfigurationsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeVpcEndpointServiceConfigurationsError::Unknown(String::from(body)),
             },
             Err(_) => DescribeVpcEndpointServiceConfigurationsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -65254,12 +66793,21 @@ impl DescribeVpcEndpointServicePermissionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeVpcEndpointServicePermissionsError::Unknown(String::from(body)),
             },
             Err(_) => DescribeVpcEndpointServicePermissionsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -65319,12 +66867,21 @@ impl DescribeVpcEndpointServicesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeVpcEndpointServicesError::Unknown(String::from(body)),
             },
             Err(_) => DescribeVpcEndpointServicesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -65384,12 +66941,21 @@ impl DescribeVpcEndpointsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeVpcEndpointsError::Unknown(String::from(body)),
             },
             Err(_) => DescribeVpcEndpointsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -65449,12 +67015,21 @@ impl DescribeVpcPeeringConnectionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeVpcPeeringConnectionsError::Unknown(String::from(body)),
             },
             Err(_) => DescribeVpcPeeringConnectionsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -65514,12 +67089,21 @@ impl DescribeVpcsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeVpcsError::Unknown(String::from(body)),
             },
             Err(_) => DescribeVpcsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -65577,12 +67161,21 @@ impl DescribeVpnConnectionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeVpnConnectionsError::Unknown(String::from(body)),
             },
             Err(_) => DescribeVpnConnectionsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -65642,12 +67235,21 @@ impl DescribeVpnGatewaysError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeVpnGatewaysError::Unknown(String::from(body)),
             },
             Err(_) => DescribeVpnGatewaysError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -65707,12 +67309,21 @@ impl DetachClassicLinkVpcError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DetachClassicLinkVpcError::Unknown(String::from(body)),
             },
             Err(_) => DetachClassicLinkVpcError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -65772,12 +67383,21 @@ impl DetachInternetGatewayError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DetachInternetGatewayError::Unknown(String::from(body)),
             },
             Err(_) => DetachInternetGatewayError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -65837,12 +67457,21 @@ impl DetachNetworkInterfaceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DetachNetworkInterfaceError::Unknown(String::from(body)),
             },
             Err(_) => DetachNetworkInterfaceError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -65902,12 +67531,21 @@ impl DetachVolumeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DetachVolumeError::Unknown(String::from(body)),
             },
             Err(_) => DetachVolumeError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -65965,12 +67603,21 @@ impl DetachVpnGatewayError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DetachVpnGatewayError::Unknown(String::from(body)),
             },
             Err(_) => DetachVpnGatewayError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -66028,12 +67675,21 @@ impl DisableVgwRoutePropagationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DisableVgwRoutePropagationError::Unknown(String::from(body)),
             },
             Err(_) => DisableVgwRoutePropagationError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -66093,12 +67749,21 @@ impl DisableVpcClassicLinkError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DisableVpcClassicLinkError::Unknown(String::from(body)),
             },
             Err(_) => DisableVpcClassicLinkError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -66158,12 +67823,21 @@ impl DisableVpcClassicLinkDnsSupportError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DisableVpcClassicLinkDnsSupportError::Unknown(String::from(body)),
             },
             Err(_) => DisableVpcClassicLinkDnsSupportError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -66223,12 +67897,21 @@ impl DisassociateAddressError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DisassociateAddressError::Unknown(String::from(body)),
             },
             Err(_) => DisassociateAddressError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -66288,12 +67971,21 @@ impl DisassociateIamInstanceProfileError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DisassociateIamInstanceProfileError::Unknown(String::from(body)),
             },
             Err(_) => DisassociateIamInstanceProfileError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -66353,12 +68045,21 @@ impl DisassociateRouteTableError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DisassociateRouteTableError::Unknown(String::from(body)),
             },
             Err(_) => DisassociateRouteTableError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -66418,12 +68119,21 @@ impl DisassociateSubnetCidrBlockError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DisassociateSubnetCidrBlockError::Unknown(String::from(body)),
             },
             Err(_) => DisassociateSubnetCidrBlockError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -66483,12 +68193,21 @@ impl DisassociateVpcCidrBlockError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DisassociateVpcCidrBlockError::Unknown(String::from(body)),
             },
             Err(_) => DisassociateVpcCidrBlockError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -66548,12 +68267,21 @@ impl EnableVgwRoutePropagationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => EnableVgwRoutePropagationError::Unknown(String::from(body)),
             },
             Err(_) => EnableVgwRoutePropagationError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -66613,12 +68341,21 @@ impl EnableVolumeIOError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => EnableVolumeIOError::Unknown(String::from(body)),
             },
             Err(_) => EnableVolumeIOError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -66676,12 +68413,21 @@ impl EnableVpcClassicLinkError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => EnableVpcClassicLinkError::Unknown(String::from(body)),
             },
             Err(_) => EnableVpcClassicLinkError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -66741,12 +68487,21 @@ impl EnableVpcClassicLinkDnsSupportError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => EnableVpcClassicLinkDnsSupportError::Unknown(String::from(body)),
             },
             Err(_) => EnableVpcClassicLinkDnsSupportError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -66806,12 +68561,21 @@ impl GetConsoleOutputError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetConsoleOutputError::Unknown(String::from(body)),
             },
             Err(_) => GetConsoleOutputError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -66869,12 +68633,21 @@ impl GetConsoleScreenshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetConsoleScreenshotError::Unknown(String::from(body)),
             },
             Err(_) => GetConsoleScreenshotError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -66934,12 +68707,21 @@ impl GetHostReservationPurchasePreviewError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetHostReservationPurchasePreviewError::Unknown(String::from(body)),
             },
             Err(_) => GetHostReservationPurchasePreviewError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -66999,12 +68781,21 @@ impl GetLaunchTemplateDataError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetLaunchTemplateDataError::Unknown(String::from(body)),
             },
             Err(_) => GetLaunchTemplateDataError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -67064,12 +68855,21 @@ impl GetPasswordDataError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetPasswordDataError::Unknown(String::from(body)),
             },
             Err(_) => GetPasswordDataError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -67127,12 +68927,21 @@ impl GetReservedInstancesExchangeQuoteError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetReservedInstancesExchangeQuoteError::Unknown(String::from(body)),
             },
             Err(_) => GetReservedInstancesExchangeQuoteError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -67192,12 +69001,21 @@ impl ImportImageError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ImportImageError::Unknown(String::from(body)),
             },
             Err(_) => ImportImageError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -67255,12 +69073,21 @@ impl ImportInstanceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ImportInstanceError::Unknown(String::from(body)),
             },
             Err(_) => ImportInstanceError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -67318,12 +69145,21 @@ impl ImportKeyPairError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ImportKeyPairError::Unknown(String::from(body)),
             },
             Err(_) => ImportKeyPairError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -67381,12 +69217,21 @@ impl ImportSnapshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ImportSnapshotError::Unknown(String::from(body)),
             },
             Err(_) => ImportSnapshotError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -67444,12 +69289,21 @@ impl ImportVolumeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ImportVolumeError::Unknown(String::from(body)),
             },
             Err(_) => ImportVolumeError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -67507,12 +69361,21 @@ impl ModifyFpgaImageAttributeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifyFpgaImageAttributeError::Unknown(String::from(body)),
             },
             Err(_) => ModifyFpgaImageAttributeError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -67572,12 +69435,21 @@ impl ModifyHostsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifyHostsError::Unknown(String::from(body)),
             },
             Err(_) => ModifyHostsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -67635,12 +69507,21 @@ impl ModifyIdFormatError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifyIdFormatError::Unknown(String::from(body)),
             },
             Err(_) => ModifyIdFormatError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -67698,12 +69579,21 @@ impl ModifyIdentityIdFormatError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifyIdentityIdFormatError::Unknown(String::from(body)),
             },
             Err(_) => ModifyIdentityIdFormatError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -67763,12 +69653,21 @@ impl ModifyImageAttributeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifyImageAttributeError::Unknown(String::from(body)),
             },
             Err(_) => ModifyImageAttributeError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -67828,12 +69727,21 @@ impl ModifyInstanceAttributeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifyInstanceAttributeError::Unknown(String::from(body)),
             },
             Err(_) => ModifyInstanceAttributeError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -67893,12 +69801,21 @@ impl ModifyInstanceCreditSpecificationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifyInstanceCreditSpecificationError::Unknown(String::from(body)),
             },
             Err(_) => ModifyInstanceCreditSpecificationError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -67958,12 +69875,21 @@ impl ModifyInstancePlacementError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifyInstancePlacementError::Unknown(String::from(body)),
             },
             Err(_) => ModifyInstancePlacementError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -68023,12 +69949,21 @@ impl ModifyLaunchTemplateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifyLaunchTemplateError::Unknown(String::from(body)),
             },
             Err(_) => ModifyLaunchTemplateError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -68088,12 +70023,21 @@ impl ModifyNetworkInterfaceAttributeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifyNetworkInterfaceAttributeError::Unknown(String::from(body)),
             },
             Err(_) => ModifyNetworkInterfaceAttributeError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -68153,12 +70097,21 @@ impl ModifyReservedInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifyReservedInstancesError::Unknown(String::from(body)),
             },
             Err(_) => ModifyReservedInstancesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -68218,12 +70171,21 @@ impl ModifySnapshotAttributeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifySnapshotAttributeError::Unknown(String::from(body)),
             },
             Err(_) => ModifySnapshotAttributeError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -68283,12 +70245,21 @@ impl ModifySpotFleetRequestError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifySpotFleetRequestError::Unknown(String::from(body)),
             },
             Err(_) => ModifySpotFleetRequestError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -68348,12 +70319,21 @@ impl ModifySubnetAttributeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifySubnetAttributeError::Unknown(String::from(body)),
             },
             Err(_) => ModifySubnetAttributeError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -68413,12 +70393,21 @@ impl ModifyVolumeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifyVolumeError::Unknown(String::from(body)),
             },
             Err(_) => ModifyVolumeError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -68476,12 +70465,21 @@ impl ModifyVolumeAttributeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifyVolumeAttributeError::Unknown(String::from(body)),
             },
             Err(_) => ModifyVolumeAttributeError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -68541,12 +70539,21 @@ impl ModifyVpcAttributeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifyVpcAttributeError::Unknown(String::from(body)),
             },
             Err(_) => ModifyVpcAttributeError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -68606,12 +70613,21 @@ impl ModifyVpcEndpointError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifyVpcEndpointError::Unknown(String::from(body)),
             },
             Err(_) => ModifyVpcEndpointError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -68671,12 +70687,21 @@ impl ModifyVpcEndpointConnectionNotificationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifyVpcEndpointConnectionNotificationError::Unknown(String::from(body)),
             },
             Err(_) => ModifyVpcEndpointConnectionNotificationError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -68736,12 +70761,21 @@ impl ModifyVpcEndpointServiceConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifyVpcEndpointServiceConfigurationError::Unknown(String::from(body)),
             },
             Err(_) => ModifyVpcEndpointServiceConfigurationError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -68801,12 +70835,21 @@ impl ModifyVpcEndpointServicePermissionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifyVpcEndpointServicePermissionsError::Unknown(String::from(body)),
             },
             Err(_) => ModifyVpcEndpointServicePermissionsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -68866,12 +70909,21 @@ impl ModifyVpcPeeringConnectionOptionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifyVpcPeeringConnectionOptionsError::Unknown(String::from(body)),
             },
             Err(_) => ModifyVpcPeeringConnectionOptionsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -68931,12 +70983,21 @@ impl ModifyVpcTenancyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifyVpcTenancyError::Unknown(String::from(body)),
             },
             Err(_) => ModifyVpcTenancyError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -68994,12 +71055,21 @@ impl MonitorInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => MonitorInstancesError::Unknown(String::from(body)),
             },
             Err(_) => MonitorInstancesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -69057,12 +71127,21 @@ impl MoveAddressToVpcError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => MoveAddressToVpcError::Unknown(String::from(body)),
             },
             Err(_) => MoveAddressToVpcError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -69120,12 +71199,21 @@ impl PurchaseHostReservationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PurchaseHostReservationError::Unknown(String::from(body)),
             },
             Err(_) => PurchaseHostReservationError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -69185,12 +71273,21 @@ impl PurchaseReservedInstancesOfferingError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PurchaseReservedInstancesOfferingError::Unknown(String::from(body)),
             },
             Err(_) => PurchaseReservedInstancesOfferingError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -69250,12 +71347,21 @@ impl PurchaseScheduledInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PurchaseScheduledInstancesError::Unknown(String::from(body)),
             },
             Err(_) => PurchaseScheduledInstancesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -69315,12 +71421,21 @@ impl RebootInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => RebootInstancesError::Unknown(String::from(body)),
             },
             Err(_) => RebootInstancesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -69378,12 +71493,21 @@ impl RegisterImageError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => RegisterImageError::Unknown(String::from(body)),
             },
             Err(_) => RegisterImageError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -69441,12 +71565,21 @@ impl RejectVpcEndpointConnectionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => RejectVpcEndpointConnectionsError::Unknown(String::from(body)),
             },
             Err(_) => RejectVpcEndpointConnectionsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -69506,12 +71639,21 @@ impl RejectVpcPeeringConnectionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => RejectVpcPeeringConnectionError::Unknown(String::from(body)),
             },
             Err(_) => RejectVpcPeeringConnectionError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -69571,12 +71713,21 @@ impl ReleaseAddressError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ReleaseAddressError::Unknown(String::from(body)),
             },
             Err(_) => ReleaseAddressError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -69634,12 +71785,21 @@ impl ReleaseHostsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ReleaseHostsError::Unknown(String::from(body)),
             },
             Err(_) => ReleaseHostsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -69697,12 +71857,21 @@ impl ReplaceIamInstanceProfileAssociationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ReplaceIamInstanceProfileAssociationError::Unknown(String::from(body)),
             },
             Err(_) => ReplaceIamInstanceProfileAssociationError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -69762,12 +71931,21 @@ impl ReplaceNetworkAclAssociationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ReplaceNetworkAclAssociationError::Unknown(String::from(body)),
             },
             Err(_) => ReplaceNetworkAclAssociationError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -69827,12 +72005,21 @@ impl ReplaceNetworkAclEntryError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ReplaceNetworkAclEntryError::Unknown(String::from(body)),
             },
             Err(_) => ReplaceNetworkAclEntryError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -69892,12 +72079,21 @@ impl ReplaceRouteError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ReplaceRouteError::Unknown(String::from(body)),
             },
             Err(_) => ReplaceRouteError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -69955,12 +72151,21 @@ impl ReplaceRouteTableAssociationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ReplaceRouteTableAssociationError::Unknown(String::from(body)),
             },
             Err(_) => ReplaceRouteTableAssociationError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -70020,12 +72225,21 @@ impl ReportInstanceStatusError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ReportInstanceStatusError::Unknown(String::from(body)),
             },
             Err(_) => ReportInstanceStatusError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -70085,12 +72299,21 @@ impl RequestSpotFleetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => RequestSpotFleetError::Unknown(String::from(body)),
             },
             Err(_) => RequestSpotFleetError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -70148,12 +72371,21 @@ impl RequestSpotInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => RequestSpotInstancesError::Unknown(String::from(body)),
             },
             Err(_) => RequestSpotInstancesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -70213,12 +72445,21 @@ impl ResetFpgaImageAttributeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ResetFpgaImageAttributeError::Unknown(String::from(body)),
             },
             Err(_) => ResetFpgaImageAttributeError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -70278,12 +72519,21 @@ impl ResetImageAttributeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ResetImageAttributeError::Unknown(String::from(body)),
             },
             Err(_) => ResetImageAttributeError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -70343,12 +72593,21 @@ impl ResetInstanceAttributeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ResetInstanceAttributeError::Unknown(String::from(body)),
             },
             Err(_) => ResetInstanceAttributeError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -70408,12 +72667,21 @@ impl ResetNetworkInterfaceAttributeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ResetNetworkInterfaceAttributeError::Unknown(String::from(body)),
             },
             Err(_) => ResetNetworkInterfaceAttributeError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -70473,12 +72741,21 @@ impl ResetSnapshotAttributeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ResetSnapshotAttributeError::Unknown(String::from(body)),
             },
             Err(_) => ResetSnapshotAttributeError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -70538,12 +72815,21 @@ impl RestoreAddressToClassicError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => RestoreAddressToClassicError::Unknown(String::from(body)),
             },
             Err(_) => RestoreAddressToClassicError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -70603,12 +72889,21 @@ impl RevokeSecurityGroupEgressError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => RevokeSecurityGroupEgressError::Unknown(String::from(body)),
             },
             Err(_) => RevokeSecurityGroupEgressError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -70668,12 +72963,21 @@ impl RevokeSecurityGroupIngressError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => RevokeSecurityGroupIngressError::Unknown(String::from(body)),
             },
             Err(_) => RevokeSecurityGroupIngressError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -70733,12 +73037,21 @@ impl RunInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => RunInstancesError::Unknown(String::from(body)),
             },
             Err(_) => RunInstancesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -70796,12 +73109,21 @@ impl RunScheduledInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => RunScheduledInstancesError::Unknown(String::from(body)),
             },
             Err(_) => RunScheduledInstancesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -70861,12 +73183,21 @@ impl StartInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => StartInstancesError::Unknown(String::from(body)),
             },
             Err(_) => StartInstancesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -70924,12 +73255,21 @@ impl StopInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => StopInstancesError::Unknown(String::from(body)),
             },
             Err(_) => StopInstancesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -70987,12 +73327,21 @@ impl TerminateInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => TerminateInstancesError::Unknown(String::from(body)),
             },
             Err(_) => TerminateInstancesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -71052,12 +73401,21 @@ impl UnassignIpv6AddressesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => UnassignIpv6AddressesError::Unknown(String::from(body)),
             },
             Err(_) => UnassignIpv6AddressesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -71117,12 +73475,21 @@ impl UnassignPrivateIpAddressesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => UnassignPrivateIpAddressesError::Unknown(String::from(body)),
             },
             Err(_) => UnassignPrivateIpAddressesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -71182,12 +73549,21 @@ impl UnmonitorInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => UnmonitorInstancesError::Unknown(String::from(body)),
             },
             Err(_) => UnmonitorInstancesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -71247,12 +73623,21 @@ impl UpdateSecurityGroupRuleDescriptionsEgressError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => UpdateSecurityGroupRuleDescriptionsEgressError::Unknown(String::from(body)),
             },
             Err(_) => UpdateSecurityGroupRuleDescriptionsEgressError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -71314,12 +73699,21 @@ impl UpdateSecurityGroupRuleDescriptionsIngressError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => UpdateSecurityGroupRuleDescriptionsIngressError::Unknown(String::from(body)),
             },
             Err(_) => UpdateSecurityGroupRuleDescriptionsIngressError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("Response", stack)?;
+        start_element("Errors", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 

--- a/rusoto/services/elasticache/src/generated.rs
+++ b/rusoto/services/elasticache/src/generated.rs
@@ -8227,10 +8227,10 @@ impl AddTagsToResourceError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "CacheClusterNotFoundFault" => AddTagsToResourceError::CacheClusterNotFoundFault(
+                "CacheClusterNotFound" => AddTagsToResourceError::CacheClusterNotFoundFault(
                     String::from(parsed_error.message),
                 ),
-                "InvalidARNFault" => {
+                "InvalidARN" => {
                     AddTagsToResourceError::InvalidARNFault(String::from(parsed_error.message))
                 }
                 "SnapshotNotFoundFault" => AddTagsToResourceError::SnapshotNotFoundFault(
@@ -8328,27 +8328,27 @@ impl AuthorizeCacheSecurityGroupIngressError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AuthorizationAlreadyExistsFault" => {
+                "AuthorizationAlreadyExists" => {
                     AuthorizeCacheSecurityGroupIngressError::AuthorizationAlreadyExistsFault(
                         String::from(parsed_error.message),
                     )
                 }
-                "CacheSecurityGroupNotFoundFault" => {
+                "CacheSecurityGroupNotFound" => {
                     AuthorizeCacheSecurityGroupIngressError::CacheSecurityGroupNotFoundFault(
                         String::from(parsed_error.message),
                     )
                 }
-                "InvalidCacheSecurityGroupStateFault" => {
+                "InvalidCacheSecurityGroupState" => {
                     AuthorizeCacheSecurityGroupIngressError::InvalidCacheSecurityGroupStateFault(
                         String::from(parsed_error.message),
                     )
                 }
-                "InvalidParameterCombinationException" => {
+                "InvalidParameterCombination" => {
                     AuthorizeCacheSecurityGroupIngressError::InvalidParameterCombination(
                         String::from(parsed_error.message),
                     )
                 }
-                "InvalidParameterValueException" => {
+                "InvalidParameterValue" => {
                     AuthorizeCacheSecurityGroupIngressError::InvalidParameterValue(String::from(
                         parsed_error.message,
                     ))
@@ -8451,15 +8451,13 @@ impl CopySnapshotError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "InvalidParameterCombinationException" => {
-                    CopySnapshotError::InvalidParameterCombination(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "InvalidParameterValueException" => {
+                "InvalidParameterCombination" => CopySnapshotError::InvalidParameterCombination(
+                    String::from(parsed_error.message),
+                ),
+                "InvalidParameterValue" => {
                     CopySnapshotError::InvalidParameterValue(String::from(parsed_error.message))
                 }
-                "InvalidSnapshotStateFault" => {
+                "InvalidSnapshotState" => {
                     CopySnapshotError::InvalidSnapshotStateFault(String::from(parsed_error.message))
                 }
                 "SnapshotAlreadyExistsFault" => CopySnapshotError::SnapshotAlreadyExistsFault(
@@ -8576,17 +8574,17 @@ impl CreateCacheClusterError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "CacheClusterAlreadyExistsFault" => {
+                "CacheClusterAlreadyExists" => {
                     CreateCacheClusterError::CacheClusterAlreadyExistsFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "CacheParameterGroupNotFoundFault" => {
+                "CacheParameterGroupNotFound" => {
                     CreateCacheClusterError::CacheParameterGroupNotFoundFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "CacheSecurityGroupNotFoundFault" => {
+                "CacheSecurityGroupNotFound" => {
                     CreateCacheClusterError::CacheSecurityGroupNotFoundFault(String::from(
                         parsed_error.message,
                     ))
@@ -8596,27 +8594,25 @@ impl CreateCacheClusterError {
                         parsed_error.message,
                     ))
                 }
-                "ClusterQuotaForCustomerExceededFault" => {
+                "ClusterQuotaForCustomerExceeded" => {
                     CreateCacheClusterError::ClusterQuotaForCustomerExceededFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InsufficientCacheClusterCapacityFault" => {
+                "InsufficientCacheClusterCapacity" => {
                     CreateCacheClusterError::InsufficientCacheClusterCapacityFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InvalidParameterCombinationException" => {
+                "InvalidParameterCombination" => {
                     CreateCacheClusterError::InvalidParameterCombination(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InvalidParameterValueException" => {
-                    CreateCacheClusterError::InvalidParameterValue(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "InvalidReplicationGroupStateFault" => {
+                "InvalidParameterValue" => CreateCacheClusterError::InvalidParameterValue(
+                    String::from(parsed_error.message),
+                ),
+                "InvalidReplicationGroupState" => {
                     CreateCacheClusterError::InvalidReplicationGroupStateFault(String::from(
                         parsed_error.message,
                     ))
@@ -8626,12 +8622,12 @@ impl CreateCacheClusterError {
                         parsed_error.message,
                     ))
                 }
-                "NodeQuotaForClusterExceededFault" => {
+                "NodeQuotaForClusterExceeded" => {
                     CreateCacheClusterError::NodeQuotaForClusterExceededFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "NodeQuotaForCustomerExceededFault" => {
+                "NodeQuotaForCustomerExceeded" => {
                     CreateCacheClusterError::NodeQuotaForCustomerExceededFault(String::from(
                         parsed_error.message,
                     ))
@@ -8743,31 +8739,29 @@ impl CreateCacheParameterGroupError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "CacheParameterGroupAlreadyExistsFault" => {
+                "CacheParameterGroupAlreadyExists" => {
                     CreateCacheParameterGroupError::CacheParameterGroupAlreadyExistsFault(
                         String::from(parsed_error.message),
                     )
                 }
-                "CacheParameterGroupQuotaExceededFault" => {
+                "CacheParameterGroupQuotaExceeded" => {
                     CreateCacheParameterGroupError::CacheParameterGroupQuotaExceededFault(
                         String::from(parsed_error.message),
                     )
                 }
-                "InvalidCacheParameterGroupStateFault" => {
+                "InvalidCacheParameterGroupState" => {
                     CreateCacheParameterGroupError::InvalidCacheParameterGroupStateFault(
                         String::from(parsed_error.message),
                     )
                 }
-                "InvalidParameterCombinationException" => {
+                "InvalidParameterCombination" => {
                     CreateCacheParameterGroupError::InvalidParameterCombination(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InvalidParameterValueException" => {
-                    CreateCacheParameterGroupError::InvalidParameterValue(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "InvalidParameterValue" => CreateCacheParameterGroupError::InvalidParameterValue(
+                    String::from(parsed_error.message),
+                ),
                 _ => CreateCacheParameterGroupError::Unknown(String::from(body)),
             },
             Err(_) => CreateCacheParameterGroupError::Unknown(body.to_string()),
@@ -8860,26 +8854,24 @@ impl CreateCacheSecurityGroupError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "CacheSecurityGroupAlreadyExistsFault" => {
+                "CacheSecurityGroupAlreadyExists" => {
                     CreateCacheSecurityGroupError::CacheSecurityGroupAlreadyExistsFault(
                         String::from(parsed_error.message),
                     )
                 }
-                "CacheSecurityGroupQuotaExceededFault" => {
+                "QuotaExceeded.CacheSecurityGroup" => {
                     CreateCacheSecurityGroupError::CacheSecurityGroupQuotaExceededFault(
                         String::from(parsed_error.message),
                     )
                 }
-                "InvalidParameterCombinationException" => {
+                "InvalidParameterCombination" => {
                     CreateCacheSecurityGroupError::InvalidParameterCombination(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InvalidParameterValueException" => {
-                    CreateCacheSecurityGroupError::InvalidParameterValue(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "InvalidParameterValue" => CreateCacheSecurityGroupError::InvalidParameterValue(
+                    String::from(parsed_error.message),
+                ),
                 _ => CreateCacheSecurityGroupError::Unknown(String::from(body)),
             },
             Err(_) => CreateCacheSecurityGroupError::Unknown(body.to_string()),
@@ -8965,12 +8957,12 @@ impl CreateCacheSubnetGroupError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "CacheSubnetGroupAlreadyExistsFault" => {
+                "CacheSubnetGroupAlreadyExists" => {
                     CreateCacheSubnetGroupError::CacheSubnetGroupAlreadyExistsFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "CacheSubnetGroupQuotaExceededFault" => {
+                "CacheSubnetGroupQuotaExceeded" => {
                     CreateCacheSubnetGroupError::CacheSubnetGroupQuotaExceededFault(String::from(
                         parsed_error.message,
                     ))
@@ -9090,17 +9082,15 @@ impl CreateReplicationGroupError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "CacheClusterNotFoundFault" => {
-                    CreateReplicationGroupError::CacheClusterNotFoundFault(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "CacheParameterGroupNotFoundFault" => {
+                "CacheClusterNotFound" => CreateReplicationGroupError::CacheClusterNotFoundFault(
+                    String::from(parsed_error.message),
+                ),
+                "CacheParameterGroupNotFound" => {
                     CreateReplicationGroupError::CacheParameterGroupNotFoundFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "CacheSecurityGroupNotFoundFault" => {
+                "CacheSecurityGroupNotFound" => {
                     CreateReplicationGroupError::CacheSecurityGroupNotFoundFault(String::from(
                         parsed_error.message,
                     ))
@@ -9110,52 +9100,50 @@ impl CreateReplicationGroupError {
                         parsed_error.message,
                     ))
                 }
-                "ClusterQuotaForCustomerExceededFault" => {
+                "ClusterQuotaForCustomerExceeded" => {
                     CreateReplicationGroupError::ClusterQuotaForCustomerExceededFault(
                         String::from(parsed_error.message),
                     )
                 }
-                "InsufficientCacheClusterCapacityFault" => {
+                "InsufficientCacheClusterCapacity" => {
                     CreateReplicationGroupError::InsufficientCacheClusterCapacityFault(
                         String::from(parsed_error.message),
                     )
                 }
-                "InvalidCacheClusterStateFault" => {
+                "InvalidCacheClusterState" => {
                     CreateReplicationGroupError::InvalidCacheClusterStateFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InvalidParameterCombinationException" => {
+                "InvalidParameterCombination" => {
                     CreateReplicationGroupError::InvalidParameterCombination(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InvalidParameterValueException" => {
-                    CreateReplicationGroupError::InvalidParameterValue(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "InvalidParameterValue" => CreateReplicationGroupError::InvalidParameterValue(
+                    String::from(parsed_error.message),
+                ),
                 "InvalidVPCNetworkStateFault" => {
                     CreateReplicationGroupError::InvalidVPCNetworkStateFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "NodeGroupsPerReplicationGroupQuotaExceededFault" => {
+                "NodeGroupsPerReplicationGroupQuotaExceeded" => {
                     CreateReplicationGroupError::NodeGroupsPerReplicationGroupQuotaExceededFault(
                         String::from(parsed_error.message),
                     )
                 }
-                "NodeQuotaForClusterExceededFault" => {
+                "NodeQuotaForClusterExceeded" => {
                     CreateReplicationGroupError::NodeQuotaForClusterExceededFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "NodeQuotaForCustomerExceededFault" => {
+                "NodeQuotaForCustomerExceeded" => {
                     CreateReplicationGroupError::NodeQuotaForCustomerExceededFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "ReplicationGroupAlreadyExistsFault" => {
+                "ReplicationGroupAlreadyExists" => {
                     CreateReplicationGroupError::ReplicationGroupAlreadyExistsFault(String::from(
                         parsed_error.message,
                     ))
@@ -9273,23 +9261,19 @@ impl CreateSnapshotError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "CacheClusterNotFoundFault" => CreateSnapshotError::CacheClusterNotFoundFault(
+                "CacheClusterNotFound" => CreateSnapshotError::CacheClusterNotFoundFault(
                     String::from(parsed_error.message),
                 ),
-                "InvalidCacheClusterStateFault" => {
-                    CreateSnapshotError::InvalidCacheClusterStateFault(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "InvalidParameterCombinationException" => {
-                    CreateSnapshotError::InvalidParameterCombination(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "InvalidParameterValueException" => {
+                "InvalidCacheClusterState" => CreateSnapshotError::InvalidCacheClusterStateFault(
+                    String::from(parsed_error.message),
+                ),
+                "InvalidParameterCombination" => CreateSnapshotError::InvalidParameterCombination(
+                    String::from(parsed_error.message),
+                ),
+                "InvalidParameterValue" => {
                     CreateSnapshotError::InvalidParameterValue(String::from(parsed_error.message))
                 }
-                "InvalidReplicationGroupStateFault" => {
+                "InvalidReplicationGroupState" => {
                     CreateSnapshotError::InvalidReplicationGroupStateFault(String::from(
                         parsed_error.message,
                     ))
@@ -9404,24 +9388,22 @@ impl DeleteCacheClusterError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "CacheClusterNotFoundFault" => DeleteCacheClusterError::CacheClusterNotFoundFault(
+                "CacheClusterNotFound" => DeleteCacheClusterError::CacheClusterNotFoundFault(
                     String::from(parsed_error.message),
                 ),
-                "InvalidCacheClusterStateFault" => {
+                "InvalidCacheClusterState" => {
                     DeleteCacheClusterError::InvalidCacheClusterStateFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InvalidParameterCombinationException" => {
+                "InvalidParameterCombination" => {
                     DeleteCacheClusterError::InvalidParameterCombination(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InvalidParameterValueException" => {
-                    DeleteCacheClusterError::InvalidParameterValue(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "InvalidParameterValue" => DeleteCacheClusterError::InvalidParameterValue(
+                    String::from(parsed_error.message),
+                ),
                 "SnapshotAlreadyExistsFault" => {
                     DeleteCacheClusterError::SnapshotAlreadyExistsFault(String::from(
                         parsed_error.message,
@@ -9525,26 +9507,24 @@ impl DeleteCacheParameterGroupError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "CacheParameterGroupNotFoundFault" => {
+                "CacheParameterGroupNotFound" => {
                     DeleteCacheParameterGroupError::CacheParameterGroupNotFoundFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InvalidCacheParameterGroupStateFault" => {
+                "InvalidCacheParameterGroupState" => {
                     DeleteCacheParameterGroupError::InvalidCacheParameterGroupStateFault(
                         String::from(parsed_error.message),
                     )
                 }
-                "InvalidParameterCombinationException" => {
+                "InvalidParameterCombination" => {
                     DeleteCacheParameterGroupError::InvalidParameterCombination(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InvalidParameterValueException" => {
-                    DeleteCacheParameterGroupError::InvalidParameterValue(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "InvalidParameterValue" => DeleteCacheParameterGroupError::InvalidParameterValue(
+                    String::from(parsed_error.message),
+                ),
                 _ => DeleteCacheParameterGroupError::Unknown(String::from(body)),
             },
             Err(_) => DeleteCacheParameterGroupError::Unknown(body.to_string()),
@@ -9632,26 +9612,24 @@ impl DeleteCacheSecurityGroupError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "CacheSecurityGroupNotFoundFault" => {
+                "CacheSecurityGroupNotFound" => {
                     DeleteCacheSecurityGroupError::CacheSecurityGroupNotFoundFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InvalidCacheSecurityGroupStateFault" => {
+                "InvalidCacheSecurityGroupState" => {
                     DeleteCacheSecurityGroupError::InvalidCacheSecurityGroupStateFault(
                         String::from(parsed_error.message),
                     )
                 }
-                "InvalidParameterCombinationException" => {
+                "InvalidParameterCombination" => {
                     DeleteCacheSecurityGroupError::InvalidParameterCombination(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InvalidParameterValueException" => {
-                    DeleteCacheSecurityGroupError::InvalidParameterValue(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "InvalidParameterValue" => DeleteCacheSecurityGroupError::InvalidParameterValue(
+                    String::from(parsed_error.message),
+                ),
                 _ => DeleteCacheSecurityGroupError::Unknown(String::from(body)),
             },
             Err(_) => DeleteCacheSecurityGroupError::Unknown(body.to_string()),
@@ -9830,17 +9808,15 @@ impl DeleteReplicationGroupError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "InvalidParameterCombinationException" => {
+                "InvalidParameterCombination" => {
                     DeleteReplicationGroupError::InvalidParameterCombination(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InvalidParameterValueException" => {
-                    DeleteReplicationGroupError::InvalidParameterValue(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "InvalidReplicationGroupStateFault" => {
+                "InvalidParameterValue" => DeleteReplicationGroupError::InvalidParameterValue(
+                    String::from(parsed_error.message),
+                ),
+                "InvalidReplicationGroupState" => {
                     DeleteReplicationGroupError::InvalidReplicationGroupStateFault(String::from(
                         parsed_error.message,
                     ))
@@ -9953,15 +9929,13 @@ impl DeleteSnapshotError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "InvalidParameterCombinationException" => {
-                    DeleteSnapshotError::InvalidParameterCombination(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "InvalidParameterValueException" => {
+                "InvalidParameterCombination" => DeleteSnapshotError::InvalidParameterCombination(
+                    String::from(parsed_error.message),
+                ),
+                "InvalidParameterValue" => {
                     DeleteSnapshotError::InvalidParameterValue(String::from(parsed_error.message))
                 }
-                "InvalidSnapshotStateFault" => DeleteSnapshotError::InvalidSnapshotStateFault(
+                "InvalidSnapshotState" => DeleteSnapshotError::InvalidSnapshotStateFault(
                     String::from(parsed_error.message),
                 ),
                 "SnapshotNotFoundFault" => {
@@ -10048,21 +10022,17 @@ impl DescribeCacheClustersError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "CacheClusterNotFoundFault" => {
-                    DescribeCacheClustersError::CacheClusterNotFoundFault(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "InvalidParameterCombinationException" => {
+                "CacheClusterNotFound" => DescribeCacheClustersError::CacheClusterNotFoundFault(
+                    String::from(parsed_error.message),
+                ),
+                "InvalidParameterCombination" => {
                     DescribeCacheClustersError::InvalidParameterCombination(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InvalidParameterValueException" => {
-                    DescribeCacheClustersError::InvalidParameterValue(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "InvalidParameterValue" => DescribeCacheClustersError::InvalidParameterValue(
+                    String::from(parsed_error.message),
+                ),
                 _ => DescribeCacheClustersError::Unknown(String::from(body)),
             },
             Err(_) => DescribeCacheClustersError::Unknown(body.to_string()),
@@ -10218,17 +10188,17 @@ impl DescribeCacheParameterGroupsError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "CacheParameterGroupNotFoundFault" => {
+                "CacheParameterGroupNotFound" => {
                     DescribeCacheParameterGroupsError::CacheParameterGroupNotFoundFault(
                         String::from(parsed_error.message),
                     )
                 }
-                "InvalidParameterCombinationException" => {
+                "InvalidParameterCombination" => {
                     DescribeCacheParameterGroupsError::InvalidParameterCombination(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InvalidParameterValueException" => {
+                "InvalidParameterValue" => {
                     DescribeCacheParameterGroupsError::InvalidParameterValue(String::from(
                         parsed_error.message,
                     ))
@@ -10315,21 +10285,19 @@ impl DescribeCacheParametersError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "CacheParameterGroupNotFoundFault" => {
+                "CacheParameterGroupNotFound" => {
                     DescribeCacheParametersError::CacheParameterGroupNotFoundFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InvalidParameterCombinationException" => {
+                "InvalidParameterCombination" => {
                     DescribeCacheParametersError::InvalidParameterCombination(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InvalidParameterValueException" => {
-                    DescribeCacheParametersError::InvalidParameterValue(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "InvalidParameterValue" => DescribeCacheParametersError::InvalidParameterValue(
+                    String::from(parsed_error.message),
+                ),
                 _ => DescribeCacheParametersError::Unknown(String::from(body)),
             },
             Err(_) => DescribeCacheParametersError::Unknown(body.to_string()),
@@ -10412,17 +10380,17 @@ impl DescribeCacheSecurityGroupsError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "CacheSecurityGroupNotFoundFault" => {
+                "CacheSecurityGroupNotFound" => {
                     DescribeCacheSecurityGroupsError::CacheSecurityGroupNotFoundFault(
                         String::from(parsed_error.message),
                     )
                 }
-                "InvalidParameterCombinationException" => {
+                "InvalidParameterCombination" => {
                     DescribeCacheSecurityGroupsError::InvalidParameterCombination(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InvalidParameterValueException" => {
+                "InvalidParameterValue" => {
                     DescribeCacheSecurityGroupsError::InvalidParameterValue(String::from(
                         parsed_error.message,
                     ))
@@ -10588,12 +10556,12 @@ impl DescribeEngineDefaultParametersError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "InvalidParameterCombinationException" => {
+                "InvalidParameterCombination" => {
                     DescribeEngineDefaultParametersError::InvalidParameterCombination(
                         String::from(parsed_error.message),
                     )
                 }
-                "InvalidParameterValueException" => {
+                "InvalidParameterValue" => {
                     DescribeEngineDefaultParametersError::InvalidParameterValue(String::from(
                         parsed_error.message,
                     ))
@@ -10677,12 +10645,10 @@ impl DescribeEventsError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "InvalidParameterCombinationException" => {
-                    DescribeEventsError::InvalidParameterCombination(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "InvalidParameterValueException" => {
+                "InvalidParameterCombination" => DescribeEventsError::InvalidParameterCombination(
+                    String::from(parsed_error.message),
+                ),
+                "InvalidParameterValue" => {
                     DescribeEventsError::InvalidParameterValue(String::from(parsed_error.message))
                 }
                 _ => DescribeEventsError::Unknown(String::from(body)),
@@ -10764,16 +10730,14 @@ impl DescribeReplicationGroupsError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "InvalidParameterCombinationException" => {
+                "InvalidParameterCombination" => {
                     DescribeReplicationGroupsError::InvalidParameterCombination(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InvalidParameterValueException" => {
-                    DescribeReplicationGroupsError::InvalidParameterValue(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "InvalidParameterValue" => DescribeReplicationGroupsError::InvalidParameterValue(
+                    String::from(parsed_error.message),
+                ),
                 "ReplicationGroupNotFoundFault" => {
                     DescribeReplicationGroupsError::ReplicationGroupNotFoundFault(String::from(
                         parsed_error.message,
@@ -10861,17 +10825,15 @@ impl DescribeReservedCacheNodesError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "InvalidParameterCombinationException" => {
+                "InvalidParameterCombination" => {
                     DescribeReservedCacheNodesError::InvalidParameterCombination(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InvalidParameterValueException" => {
-                    DescribeReservedCacheNodesError::InvalidParameterValue(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "ReservedCacheNodeNotFoundFault" => {
+                "InvalidParameterValue" => DescribeReservedCacheNodesError::InvalidParameterValue(
+                    String::from(parsed_error.message),
+                ),
+                "ReservedCacheNodeNotFound" => {
                     DescribeReservedCacheNodesError::ReservedCacheNodeNotFoundFault(String::from(
                         parsed_error.message,
                     ))
@@ -10959,7 +10921,7 @@ impl DescribeReservedCacheNodesOfferingsError {
         match Self::deserialize(&mut stack) {
                             Ok(parsed_error) => {
                                 match &parsed_error.code[..] {
-                                    "InvalidParameterCombinationException" => DescribeReservedCacheNodesOfferingsError::InvalidParameterCombination(String::from(parsed_error.message)),"InvalidParameterValueException" => DescribeReservedCacheNodesOfferingsError::InvalidParameterValue(String::from(parsed_error.message)),"ReservedCacheNodesOfferingNotFoundFault" => DescribeReservedCacheNodesOfferingsError::ReservedCacheNodesOfferingNotFoundFault(String::from(parsed_error.message)),_ => DescribeReservedCacheNodesOfferingsError::Unknown(String::from(body))
+                                    "InvalidParameterCombination" => DescribeReservedCacheNodesOfferingsError::InvalidParameterCombination(String::from(parsed_error.message)),"InvalidParameterValue" => DescribeReservedCacheNodesOfferingsError::InvalidParameterValue(String::from(parsed_error.message)),"ReservedCacheNodesOfferingNotFound" => DescribeReservedCacheNodesOfferingsError::ReservedCacheNodesOfferingNotFoundFault(String::from(parsed_error.message)),_ => DescribeReservedCacheNodesOfferingsError::Unknown(String::from(body))
                                 }
                            },
                            Err(_) => DescribeReservedCacheNodesOfferingsError::Unknown(body.to_string())
@@ -11048,15 +11010,15 @@ impl DescribeSnapshotsError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "CacheClusterNotFoundFault" => DescribeSnapshotsError::CacheClusterNotFoundFault(
+                "CacheClusterNotFound" => DescribeSnapshotsError::CacheClusterNotFoundFault(
                     String::from(parsed_error.message),
                 ),
-                "InvalidParameterCombinationException" => {
+                "InvalidParameterCombination" => {
                     DescribeSnapshotsError::InvalidParameterCombination(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InvalidParameterValueException" => DescribeSnapshotsError::InvalidParameterValue(
+                "InvalidParameterValue" => DescribeSnapshotsError::InvalidParameterValue(
                     String::from(parsed_error.message),
                 ),
                 "SnapshotNotFoundFault" => DescribeSnapshotsError::SnapshotNotFoundFault(
@@ -11147,17 +11109,17 @@ impl ListAllowedNodeTypeModificationsError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "CacheClusterNotFoundFault" => {
+                "CacheClusterNotFound" => {
                     ListAllowedNodeTypeModificationsError::CacheClusterNotFoundFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InvalidParameterCombinationException" => {
+                "InvalidParameterCombination" => {
                     ListAllowedNodeTypeModificationsError::InvalidParameterCombination(
                         String::from(parsed_error.message),
                     )
                 }
-                "InvalidParameterValueException" => {
+                "InvalidParameterValue" => {
                     ListAllowedNodeTypeModificationsError::InvalidParameterValue(String::from(
                         parsed_error.message,
                     ))
@@ -11252,12 +11214,10 @@ impl ListTagsForResourceError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "CacheClusterNotFoundFault" => {
-                    ListTagsForResourceError::CacheClusterNotFoundFault(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "InvalidARNFault" => {
+                "CacheClusterNotFound" => ListTagsForResourceError::CacheClusterNotFoundFault(
+                    String::from(parsed_error.message),
+                ),
+                "InvalidARN" => {
                     ListTagsForResourceError::InvalidARNFault(String::from(parsed_error.message))
                 }
                 "SnapshotNotFoundFault" => ListTagsForResourceError::SnapshotNotFoundFault(
@@ -11361,55 +11321,53 @@ impl ModifyCacheClusterError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "CacheClusterNotFoundFault" => ModifyCacheClusterError::CacheClusterNotFoundFault(
+                "CacheClusterNotFound" => ModifyCacheClusterError::CacheClusterNotFoundFault(
                     String::from(parsed_error.message),
                 ),
-                "CacheParameterGroupNotFoundFault" => {
+                "CacheParameterGroupNotFound" => {
                     ModifyCacheClusterError::CacheParameterGroupNotFoundFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "CacheSecurityGroupNotFoundFault" => {
+                "CacheSecurityGroupNotFound" => {
                     ModifyCacheClusterError::CacheSecurityGroupNotFoundFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InsufficientCacheClusterCapacityFault" => {
+                "InsufficientCacheClusterCapacity" => {
                     ModifyCacheClusterError::InsufficientCacheClusterCapacityFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InvalidCacheClusterStateFault" => {
+                "InvalidCacheClusterState" => {
                     ModifyCacheClusterError::InvalidCacheClusterStateFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InvalidCacheSecurityGroupStateFault" => {
+                "InvalidCacheSecurityGroupState" => {
                     ModifyCacheClusterError::InvalidCacheSecurityGroupStateFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InvalidParameterCombinationException" => {
+                "InvalidParameterCombination" => {
                     ModifyCacheClusterError::InvalidParameterCombination(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InvalidParameterValueException" => {
-                    ModifyCacheClusterError::InvalidParameterValue(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "InvalidParameterValue" => ModifyCacheClusterError::InvalidParameterValue(
+                    String::from(parsed_error.message),
+                ),
                 "InvalidVPCNetworkStateFault" => {
                     ModifyCacheClusterError::InvalidVPCNetworkStateFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "NodeQuotaForClusterExceededFault" => {
+                "NodeQuotaForClusterExceeded" => {
                     ModifyCacheClusterError::NodeQuotaForClusterExceededFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "NodeQuotaForCustomerExceededFault" => {
+                "NodeQuotaForCustomerExceeded" => {
                     ModifyCacheClusterError::NodeQuotaForCustomerExceededFault(String::from(
                         parsed_error.message,
                     ))
@@ -11506,26 +11464,24 @@ impl ModifyCacheParameterGroupError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "CacheParameterGroupNotFoundFault" => {
+                "CacheParameterGroupNotFound" => {
                     ModifyCacheParameterGroupError::CacheParameterGroupNotFoundFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InvalidCacheParameterGroupStateFault" => {
+                "InvalidCacheParameterGroupState" => {
                     ModifyCacheParameterGroupError::InvalidCacheParameterGroupStateFault(
                         String::from(parsed_error.message),
                     )
                 }
-                "InvalidParameterCombinationException" => {
+                "InvalidParameterCombination" => {
                     ModifyCacheParameterGroupError::InvalidParameterCombination(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InvalidParameterValueException" => {
-                    ModifyCacheParameterGroupError::InvalidParameterValue(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "InvalidParameterValue" => ModifyCacheParameterGroupError::InvalidParameterValue(
+                    String::from(parsed_error.message),
+                ),
                 _ => ModifyCacheParameterGroupError::Unknown(String::from(body)),
             },
             Err(_) => ModifyCacheParameterGroupError::Unknown(body.to_string()),
@@ -11732,47 +11688,43 @@ impl ModifyReplicationGroupError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "CacheClusterNotFoundFault" => {
-                    ModifyReplicationGroupError::CacheClusterNotFoundFault(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "CacheParameterGroupNotFoundFault" => {
+                "CacheClusterNotFound" => ModifyReplicationGroupError::CacheClusterNotFoundFault(
+                    String::from(parsed_error.message),
+                ),
+                "CacheParameterGroupNotFound" => {
                     ModifyReplicationGroupError::CacheParameterGroupNotFoundFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "CacheSecurityGroupNotFoundFault" => {
+                "CacheSecurityGroupNotFound" => {
                     ModifyReplicationGroupError::CacheSecurityGroupNotFoundFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InsufficientCacheClusterCapacityFault" => {
+                "InsufficientCacheClusterCapacity" => {
                     ModifyReplicationGroupError::InsufficientCacheClusterCapacityFault(
                         String::from(parsed_error.message),
                     )
                 }
-                "InvalidCacheClusterStateFault" => {
+                "InvalidCacheClusterState" => {
                     ModifyReplicationGroupError::InvalidCacheClusterStateFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InvalidCacheSecurityGroupStateFault" => {
+                "InvalidCacheSecurityGroupState" => {
                     ModifyReplicationGroupError::InvalidCacheSecurityGroupStateFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InvalidParameterCombinationException" => {
+                "InvalidParameterCombination" => {
                     ModifyReplicationGroupError::InvalidParameterCombination(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InvalidParameterValueException" => {
-                    ModifyReplicationGroupError::InvalidParameterValue(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "InvalidReplicationGroupStateFault" => {
+                "InvalidParameterValue" => ModifyReplicationGroupError::InvalidParameterValue(
+                    String::from(parsed_error.message),
+                ),
+                "InvalidReplicationGroupState" => {
                     ModifyReplicationGroupError::InvalidReplicationGroupStateFault(String::from(
                         parsed_error.message,
                     ))
@@ -11782,12 +11734,12 @@ impl ModifyReplicationGroupError {
                         parsed_error.message,
                     ))
                 }
-                "NodeQuotaForClusterExceededFault" => {
+                "NodeQuotaForClusterExceeded" => {
                     ModifyReplicationGroupError::NodeQuotaForClusterExceededFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "NodeQuotaForCustomerExceededFault" => {
+                "NodeQuotaForCustomerExceeded" => {
                     ModifyReplicationGroupError::NodeQuotaForCustomerExceededFault(String::from(
                         parsed_error.message,
                     ))
@@ -11902,7 +11854,7 @@ impl ModifyReplicationGroupShardConfigurationError {
         match Self::deserialize(&mut stack) {
                             Ok(parsed_error) => {
                                 match &parsed_error.code[..] {
-                                    "InsufficientCacheClusterCapacityFault" => ModifyReplicationGroupShardConfigurationError::InsufficientCacheClusterCapacityFault(String::from(parsed_error.message)),"InvalidCacheClusterStateFault" => ModifyReplicationGroupShardConfigurationError::InvalidCacheClusterStateFault(String::from(parsed_error.message)),"InvalidParameterCombinationException" => ModifyReplicationGroupShardConfigurationError::InvalidParameterCombination(String::from(parsed_error.message)),"InvalidParameterValueException" => ModifyReplicationGroupShardConfigurationError::InvalidParameterValue(String::from(parsed_error.message)),"InvalidReplicationGroupStateFault" => ModifyReplicationGroupShardConfigurationError::InvalidReplicationGroupStateFault(String::from(parsed_error.message)),"InvalidVPCNetworkStateFault" => ModifyReplicationGroupShardConfigurationError::InvalidVPCNetworkStateFault(String::from(parsed_error.message)),"NodeGroupsPerReplicationGroupQuotaExceededFault" => ModifyReplicationGroupShardConfigurationError::NodeGroupsPerReplicationGroupQuotaExceededFault(String::from(parsed_error.message)),"NodeQuotaForCustomerExceededFault" => ModifyReplicationGroupShardConfigurationError::NodeQuotaForCustomerExceededFault(String::from(parsed_error.message)),"ReplicationGroupNotFoundFault" => ModifyReplicationGroupShardConfigurationError::ReplicationGroupNotFoundFault(String::from(parsed_error.message)),_ => ModifyReplicationGroupShardConfigurationError::Unknown(String::from(body))
+                                    "InsufficientCacheClusterCapacity" => ModifyReplicationGroupShardConfigurationError::InsufficientCacheClusterCapacityFault(String::from(parsed_error.message)),"InvalidCacheClusterState" => ModifyReplicationGroupShardConfigurationError::InvalidCacheClusterStateFault(String::from(parsed_error.message)),"InvalidParameterCombination" => ModifyReplicationGroupShardConfigurationError::InvalidParameterCombination(String::from(parsed_error.message)),"InvalidParameterValue" => ModifyReplicationGroupShardConfigurationError::InvalidParameterValue(String::from(parsed_error.message)),"InvalidReplicationGroupState" => ModifyReplicationGroupShardConfigurationError::InvalidReplicationGroupStateFault(String::from(parsed_error.message)),"InvalidVPCNetworkStateFault" => ModifyReplicationGroupShardConfigurationError::InvalidVPCNetworkStateFault(String::from(parsed_error.message)),"NodeGroupsPerReplicationGroupQuotaExceeded" => ModifyReplicationGroupShardConfigurationError::NodeGroupsPerReplicationGroupQuotaExceededFault(String::from(parsed_error.message)),"NodeQuotaForCustomerExceeded" => ModifyReplicationGroupShardConfigurationError::NodeQuotaForCustomerExceededFault(String::from(parsed_error.message)),"ReplicationGroupNotFoundFault" => ModifyReplicationGroupShardConfigurationError::ReplicationGroupNotFoundFault(String::from(parsed_error.message)),_ => ModifyReplicationGroupShardConfigurationError::Unknown(String::from(body))
                                 }
                            },
                            Err(_) => ModifyReplicationGroupShardConfigurationError::Unknown(body.to_string())
@@ -11994,7 +11946,7 @@ impl PurchaseReservedCacheNodesOfferingError {
         match Self::deserialize(&mut stack) {
                             Ok(parsed_error) => {
                                 match &parsed_error.code[..] {
-                                    "InvalidParameterCombinationException" => PurchaseReservedCacheNodesOfferingError::InvalidParameterCombination(String::from(parsed_error.message)),"InvalidParameterValueException" => PurchaseReservedCacheNodesOfferingError::InvalidParameterValue(String::from(parsed_error.message)),"ReservedCacheNodeAlreadyExistsFault" => PurchaseReservedCacheNodesOfferingError::ReservedCacheNodeAlreadyExistsFault(String::from(parsed_error.message)),"ReservedCacheNodeQuotaExceededFault" => PurchaseReservedCacheNodesOfferingError::ReservedCacheNodeQuotaExceededFault(String::from(parsed_error.message)),"ReservedCacheNodesOfferingNotFoundFault" => PurchaseReservedCacheNodesOfferingError::ReservedCacheNodesOfferingNotFoundFault(String::from(parsed_error.message)),_ => PurchaseReservedCacheNodesOfferingError::Unknown(String::from(body))
+                                    "InvalidParameterCombination" => PurchaseReservedCacheNodesOfferingError::InvalidParameterCombination(String::from(parsed_error.message)),"InvalidParameterValue" => PurchaseReservedCacheNodesOfferingError::InvalidParameterValue(String::from(parsed_error.message)),"ReservedCacheNodeAlreadyExists" => PurchaseReservedCacheNodesOfferingError::ReservedCacheNodeAlreadyExistsFault(String::from(parsed_error.message)),"ReservedCacheNodeQuotaExceeded" => PurchaseReservedCacheNodesOfferingError::ReservedCacheNodeQuotaExceededFault(String::from(parsed_error.message)),"ReservedCacheNodesOfferingNotFound" => PurchaseReservedCacheNodesOfferingError::ReservedCacheNodesOfferingNotFoundFault(String::from(parsed_error.message)),_ => PurchaseReservedCacheNodesOfferingError::Unknown(String::from(body))
                                 }
                            },
                            Err(_) => PurchaseReservedCacheNodesOfferingError::Unknown(body.to_string())
@@ -12085,10 +12037,10 @@ impl RebootCacheClusterError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "CacheClusterNotFoundFault" => RebootCacheClusterError::CacheClusterNotFoundFault(
+                "CacheClusterNotFound" => RebootCacheClusterError::CacheClusterNotFoundFault(
                     String::from(parsed_error.message),
                 ),
-                "InvalidCacheClusterStateFault" => {
+                "InvalidCacheClusterState" => {
                     RebootCacheClusterError::InvalidCacheClusterStateFault(String::from(
                         parsed_error.message,
                     ))
@@ -12176,18 +12128,16 @@ impl RemoveTagsFromResourceError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "CacheClusterNotFoundFault" => {
-                    RemoveTagsFromResourceError::CacheClusterNotFoundFault(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "InvalidARNFault" => {
+                "CacheClusterNotFound" => RemoveTagsFromResourceError::CacheClusterNotFoundFault(
+                    String::from(parsed_error.message),
+                ),
+                "InvalidARN" => {
                     RemoveTagsFromResourceError::InvalidARNFault(String::from(parsed_error.message))
                 }
                 "SnapshotNotFoundFault" => RemoveTagsFromResourceError::SnapshotNotFoundFault(
                     String::from(parsed_error.message),
                 ),
-                "TagNotFoundFault" => RemoveTagsFromResourceError::TagNotFoundFault(String::from(
+                "TagNotFound" => RemoveTagsFromResourceError::TagNotFoundFault(String::from(
                     parsed_error.message,
                 )),
                 _ => RemoveTagsFromResourceError::Unknown(String::from(body)),
@@ -12275,26 +12225,24 @@ impl ResetCacheParameterGroupError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "CacheParameterGroupNotFoundFault" => {
+                "CacheParameterGroupNotFound" => {
                     ResetCacheParameterGroupError::CacheParameterGroupNotFoundFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InvalidCacheParameterGroupStateFault" => {
+                "InvalidCacheParameterGroupState" => {
                     ResetCacheParameterGroupError::InvalidCacheParameterGroupStateFault(
                         String::from(parsed_error.message),
                     )
                 }
-                "InvalidParameterCombinationException" => {
+                "InvalidParameterCombination" => {
                     ResetCacheParameterGroupError::InvalidParameterCombination(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InvalidParameterValueException" => {
-                    ResetCacheParameterGroupError::InvalidParameterValue(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "InvalidParameterValue" => ResetCacheParameterGroupError::InvalidParameterValue(
+                    String::from(parsed_error.message),
+                ),
                 _ => ResetCacheParameterGroupError::Unknown(String::from(body)),
             },
             Err(_) => ResetCacheParameterGroupError::Unknown(body.to_string()),
@@ -12382,27 +12330,27 @@ impl RevokeCacheSecurityGroupIngressError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AuthorizationNotFoundFault" => {
+                "AuthorizationNotFound" => {
                     RevokeCacheSecurityGroupIngressError::AuthorizationNotFoundFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "CacheSecurityGroupNotFoundFault" => {
+                "CacheSecurityGroupNotFound" => {
                     RevokeCacheSecurityGroupIngressError::CacheSecurityGroupNotFoundFault(
                         String::from(parsed_error.message),
                     )
                 }
-                "InvalidCacheSecurityGroupStateFault" => {
+                "InvalidCacheSecurityGroupState" => {
                     RevokeCacheSecurityGroupIngressError::InvalidCacheSecurityGroupStateFault(
                         String::from(parsed_error.message),
                     )
                 }
-                "InvalidParameterCombinationException" => {
+                "InvalidParameterCombination" => {
                     RevokeCacheSecurityGroupIngressError::InvalidParameterCombination(
                         String::from(parsed_error.message),
                     )
                 }
-                "InvalidParameterValueException" => {
+                "InvalidParameterValue" => {
                     RevokeCacheSecurityGroupIngressError::InvalidParameterValue(String::from(
                         parsed_error.message,
                     ))
@@ -12505,25 +12453,21 @@ impl TestFailoverError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "APICallRateForCustomerExceededFault" => {
+                "APICallRateForCustomerExceeded" => {
                     TestFailoverError::APICallRateForCustomerExceededFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InvalidCacheClusterStateFault" => {
-                    TestFailoverError::InvalidCacheClusterStateFault(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "InvalidParameterCombinationException" => {
-                    TestFailoverError::InvalidParameterCombination(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "InvalidParameterValueException" => {
+                "InvalidCacheClusterState" => TestFailoverError::InvalidCacheClusterStateFault(
+                    String::from(parsed_error.message),
+                ),
+                "InvalidParameterCombination" => TestFailoverError::InvalidParameterCombination(
+                    String::from(parsed_error.message),
+                ),
+                "InvalidParameterValue" => {
                     TestFailoverError::InvalidParameterValue(String::from(parsed_error.message))
                 }
-                "InvalidReplicationGroupStateFault" => {
+                "InvalidReplicationGroupState" => {
                     TestFailoverError::InvalidReplicationGroupStateFault(String::from(
                         parsed_error.message,
                     ))

--- a/rusoto/services/elasticache/src/generated.rs
+++ b/rusoto/services/elasticache/src/generated.rs
@@ -8225,7 +8225,7 @@ impl AddTagsToResourceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CacheClusterNotFoundFault" => AddTagsToResourceError::CacheClusterNotFoundFault(
                     String::from(parsed_error.message),
@@ -8245,6 +8245,14 @@ impl AddTagsToResourceError {
             },
             Err(_) => AddTagsToResourceError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -8318,7 +8326,7 @@ impl AuthorizeCacheSecurityGroupIngressError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationAlreadyExistsFault" => {
                     AuthorizeCacheSecurityGroupIngressError::AuthorizationAlreadyExistsFault(
@@ -8349,6 +8357,14 @@ impl AuthorizeCacheSecurityGroupIngressError {
             },
             Err(_) => AuthorizeCacheSecurityGroupIngressError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -8433,7 +8449,7 @@ impl CopySnapshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidParameterCombinationException" => {
                     CopySnapshotError::InvalidParameterCombination(String::from(
@@ -8459,6 +8475,14 @@ impl CopySnapshotError {
             },
             Err(_) => CopySnapshotError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -8550,7 +8574,7 @@ impl CreateCacheClusterError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CacheClusterAlreadyExistsFault" => {
                     CreateCacheClusterError::CacheClusterAlreadyExistsFault(String::from(
@@ -8626,6 +8650,14 @@ impl CreateCacheClusterError {
             },
             Err(_) => CreateCacheClusterError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -8709,7 +8741,7 @@ impl CreateCacheParameterGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CacheParameterGroupAlreadyExistsFault" => {
                     CreateCacheParameterGroupError::CacheParameterGroupAlreadyExistsFault(
@@ -8740,6 +8772,14 @@ impl CreateCacheParameterGroupError {
             },
             Err(_) => CreateCacheParameterGroupError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -8818,7 +8858,7 @@ impl CreateCacheSecurityGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CacheSecurityGroupAlreadyExistsFault" => {
                     CreateCacheSecurityGroupError::CacheSecurityGroupAlreadyExistsFault(
@@ -8844,6 +8884,14 @@ impl CreateCacheSecurityGroupError {
             },
             Err(_) => CreateCacheSecurityGroupError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -8915,7 +8963,7 @@ impl CreateCacheSubnetGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CacheSubnetGroupAlreadyExistsFault" => {
                     CreateCacheSubnetGroupError::CacheSubnetGroupAlreadyExistsFault(String::from(
@@ -8939,6 +8987,14 @@ impl CreateCacheSubnetGroupError {
             },
             Err(_) => CreateCacheSubnetGroupError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -9032,7 +9088,7 @@ impl CreateReplicationGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CacheClusterNotFoundFault" => {
                     CreateReplicationGroupError::CacheClusterNotFoundFault(String::from(
@@ -9113,6 +9169,14 @@ impl CreateReplicationGroupError {
             },
             Err(_) => CreateReplicationGroupError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -9207,7 +9271,7 @@ impl CreateSnapshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CacheClusterNotFoundFault" => CreateSnapshotError::CacheClusterNotFoundFault(
                     String::from(parsed_error.message),
@@ -9250,6 +9314,14 @@ impl CreateSnapshotError {
             },
             Err(_) => CreateSnapshotError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -9330,7 +9402,7 @@ impl DeleteCacheClusterError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CacheClusterNotFoundFault" => DeleteCacheClusterError::CacheClusterNotFoundFault(
                     String::from(parsed_error.message),
@@ -9369,6 +9441,14 @@ impl DeleteCacheClusterError {
             },
             Err(_) => DeleteCacheClusterError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -9443,7 +9523,7 @@ impl DeleteCacheParameterGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CacheParameterGroupNotFoundFault" => {
                     DeleteCacheParameterGroupError::CacheParameterGroupNotFoundFault(String::from(
@@ -9469,6 +9549,14 @@ impl DeleteCacheParameterGroupError {
             },
             Err(_) => DeleteCacheParameterGroupError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -9542,7 +9630,7 @@ impl DeleteCacheSecurityGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CacheSecurityGroupNotFoundFault" => {
                     DeleteCacheSecurityGroupError::CacheSecurityGroupNotFoundFault(String::from(
@@ -9568,6 +9656,14 @@ impl DeleteCacheSecurityGroupError {
             },
             Err(_) => DeleteCacheSecurityGroupError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -9635,7 +9731,7 @@ impl DeleteCacheSubnetGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CacheSubnetGroupInUse" => DeleteCacheSubnetGroupError::CacheSubnetGroupInUse(
                     String::from(parsed_error.message),
@@ -9649,6 +9745,14 @@ impl DeleteCacheSubnetGroupError {
             },
             Err(_) => DeleteCacheSubnetGroupError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -9724,7 +9828,7 @@ impl DeleteReplicationGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidParameterCombinationException" => {
                     DeleteReplicationGroupError::InvalidParameterCombination(String::from(
@@ -9765,6 +9869,14 @@ impl DeleteReplicationGroupError {
             },
             Err(_) => DeleteReplicationGroupError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -9839,7 +9951,7 @@ impl DeleteSnapshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidParameterCombinationException" => {
                     DeleteSnapshotError::InvalidParameterCombination(String::from(
@@ -9859,6 +9971,14 @@ impl DeleteSnapshotError {
             },
             Err(_) => DeleteSnapshotError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -9926,7 +10046,7 @@ impl DescribeCacheClustersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CacheClusterNotFoundFault" => {
                     DescribeCacheClustersError::CacheClusterNotFoundFault(String::from(
@@ -9947,6 +10067,14 @@ impl DescribeCacheClustersError {
             },
             Err(_) => DescribeCacheClustersError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10009,12 +10137,20 @@ impl DescribeCacheEngineVersionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeCacheEngineVersionsError::Unknown(String::from(body)),
             },
             Err(_) => DescribeCacheEngineVersionsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10080,7 +10216,7 @@ impl DescribeCacheParameterGroupsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CacheParameterGroupNotFoundFault" => {
                     DescribeCacheParameterGroupsError::CacheParameterGroupNotFoundFault(
@@ -10101,6 +10237,14 @@ impl DescribeCacheParameterGroupsError {
             },
             Err(_) => DescribeCacheParameterGroupsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10169,7 +10313,7 @@ impl DescribeCacheParametersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CacheParameterGroupNotFoundFault" => {
                     DescribeCacheParametersError::CacheParameterGroupNotFoundFault(String::from(
@@ -10190,6 +10334,14 @@ impl DescribeCacheParametersError {
             },
             Err(_) => DescribeCacheParametersError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10258,7 +10410,7 @@ impl DescribeCacheSecurityGroupsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CacheSecurityGroupNotFoundFault" => {
                     DescribeCacheSecurityGroupsError::CacheSecurityGroupNotFoundFault(
@@ -10279,6 +10431,14 @@ impl DescribeCacheSecurityGroupsError {
             },
             Err(_) => DescribeCacheSecurityGroupsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10343,7 +10503,7 @@ impl DescribeCacheSubnetGroupsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CacheSubnetGroupNotFoundFault" => {
                     DescribeCacheSubnetGroupsError::CacheSubnetGroupNotFoundFault(String::from(
@@ -10354,6 +10514,14 @@ impl DescribeCacheSubnetGroupsError {
             },
             Err(_) => DescribeCacheSubnetGroupsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10418,7 +10586,7 @@ impl DescribeEngineDefaultParametersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidParameterCombinationException" => {
                     DescribeEngineDefaultParametersError::InvalidParameterCombination(
@@ -10434,6 +10602,14 @@ impl DescribeEngineDefaultParametersError {
             },
             Err(_) => DescribeEngineDefaultParametersError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10499,7 +10675,7 @@ impl DescribeEventsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidParameterCombinationException" => {
                     DescribeEventsError::InvalidParameterCombination(String::from(
@@ -10513,6 +10689,14 @@ impl DescribeEventsError {
             },
             Err(_) => DescribeEventsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10578,7 +10762,7 @@ impl DescribeReplicationGroupsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidParameterCombinationException" => {
                     DescribeReplicationGroupsError::InvalidParameterCombination(String::from(
@@ -10599,6 +10783,14 @@ impl DescribeReplicationGroupsError {
             },
             Err(_) => DescribeReplicationGroupsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10667,7 +10859,7 @@ impl DescribeReservedCacheNodesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidParameterCombinationException" => {
                     DescribeReservedCacheNodesError::InvalidParameterCombination(String::from(
@@ -10688,6 +10880,14 @@ impl DescribeReservedCacheNodesError {
             },
             Err(_) => DescribeReservedCacheNodesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10756,7 +10956,7 @@ impl DescribeReservedCacheNodesOfferingsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
                             Ok(parsed_error) => {
                                 match &parsed_error.code[..] {
                                     "InvalidParameterCombinationException" => DescribeReservedCacheNodesOfferingsError::InvalidParameterCombination(String::from(parsed_error.message)),"InvalidParameterValueException" => DescribeReservedCacheNodesOfferingsError::InvalidParameterValue(String::from(parsed_error.message)),"ReservedCacheNodesOfferingNotFoundFault" => DescribeReservedCacheNodesOfferingsError::ReservedCacheNodesOfferingNotFoundFault(String::from(parsed_error.message)),_ => DescribeReservedCacheNodesOfferingsError::Unknown(String::from(body))
@@ -10764,6 +10964,14 @@ impl DescribeReservedCacheNodesOfferingsError {
                            },
                            Err(_) => DescribeReservedCacheNodesOfferingsError::Unknown(body.to_string())
                        }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10838,7 +11046,7 @@ impl DescribeSnapshotsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CacheClusterNotFoundFault" => DescribeSnapshotsError::CacheClusterNotFoundFault(
                     String::from(parsed_error.message),
@@ -10858,6 +11066,14 @@ impl DescribeSnapshotsError {
             },
             Err(_) => DescribeSnapshotsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10929,7 +11145,7 @@ impl ListAllowedNodeTypeModificationsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CacheClusterNotFoundFault" => {
                     ListAllowedNodeTypeModificationsError::CacheClusterNotFoundFault(String::from(
@@ -10955,6 +11171,14 @@ impl ListAllowedNodeTypeModificationsError {
             },
             Err(_) => ListAllowedNodeTypeModificationsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11026,7 +11250,7 @@ impl ListTagsForResourceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CacheClusterNotFoundFault" => {
                     ListTagsForResourceError::CacheClusterNotFoundFault(String::from(
@@ -11043,6 +11267,14 @@ impl ListTagsForResourceError {
             },
             Err(_) => ListTagsForResourceError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11127,7 +11359,7 @@ impl ModifyCacheClusterError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CacheClusterNotFoundFault" => ModifyCacheClusterError::CacheClusterNotFoundFault(
                     String::from(parsed_error.message),
@@ -11186,6 +11418,14 @@ impl ModifyCacheClusterError {
             },
             Err(_) => ModifyCacheClusterError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11264,7 +11504,7 @@ impl ModifyCacheParameterGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CacheParameterGroupNotFoundFault" => {
                     ModifyCacheParameterGroupError::CacheParameterGroupNotFoundFault(String::from(
@@ -11290,6 +11530,14 @@ impl ModifyCacheParameterGroupError {
             },
             Err(_) => ModifyCacheParameterGroupError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11363,7 +11611,7 @@ impl ModifyCacheSubnetGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CacheSubnetGroupNotFoundFault" => {
                     ModifyCacheSubnetGroupError::CacheSubnetGroupNotFoundFault(String::from(
@@ -11385,6 +11633,14 @@ impl ModifyCacheSubnetGroupError {
             },
             Err(_) => ModifyCacheSubnetGroupError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11474,7 +11730,7 @@ impl ModifyReplicationGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CacheClusterNotFoundFault" => {
                     ModifyReplicationGroupError::CacheClusterNotFoundFault(String::from(
@@ -11545,6 +11801,14 @@ impl ModifyReplicationGroupError {
             },
             Err(_) => ModifyReplicationGroupError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11635,7 +11899,7 @@ impl ModifyReplicationGroupShardConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
                             Ok(parsed_error) => {
                                 match &parsed_error.code[..] {
                                     "InsufficientCacheClusterCapacityFault" => ModifyReplicationGroupShardConfigurationError::InsufficientCacheClusterCapacityFault(String::from(parsed_error.message)),"InvalidCacheClusterStateFault" => ModifyReplicationGroupShardConfigurationError::InvalidCacheClusterStateFault(String::from(parsed_error.message)),"InvalidParameterCombinationException" => ModifyReplicationGroupShardConfigurationError::InvalidParameterCombination(String::from(parsed_error.message)),"InvalidParameterValueException" => ModifyReplicationGroupShardConfigurationError::InvalidParameterValue(String::from(parsed_error.message)),"InvalidReplicationGroupStateFault" => ModifyReplicationGroupShardConfigurationError::InvalidReplicationGroupStateFault(String::from(parsed_error.message)),"InvalidVPCNetworkStateFault" => ModifyReplicationGroupShardConfigurationError::InvalidVPCNetworkStateFault(String::from(parsed_error.message)),"NodeGroupsPerReplicationGroupQuotaExceededFault" => ModifyReplicationGroupShardConfigurationError::NodeGroupsPerReplicationGroupQuotaExceededFault(String::from(parsed_error.message)),"NodeQuotaForCustomerExceededFault" => ModifyReplicationGroupShardConfigurationError::NodeQuotaForCustomerExceededFault(String::from(parsed_error.message)),"ReplicationGroupNotFoundFault" => ModifyReplicationGroupShardConfigurationError::ReplicationGroupNotFoundFault(String::from(parsed_error.message)),_ => ModifyReplicationGroupShardConfigurationError::Unknown(String::from(body))
@@ -11643,6 +11907,14 @@ impl ModifyReplicationGroupShardConfigurationError {
                            },
                            Err(_) => ModifyReplicationGroupShardConfigurationError::Unknown(body.to_string())
                        }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11719,7 +11991,7 @@ impl PurchaseReservedCacheNodesOfferingError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
                             Ok(parsed_error) => {
                                 match &parsed_error.code[..] {
                                     "InvalidParameterCombinationException" => PurchaseReservedCacheNodesOfferingError::InvalidParameterCombination(String::from(parsed_error.message)),"InvalidParameterValueException" => PurchaseReservedCacheNodesOfferingError::InvalidParameterValue(String::from(parsed_error.message)),"ReservedCacheNodeAlreadyExistsFault" => PurchaseReservedCacheNodesOfferingError::ReservedCacheNodeAlreadyExistsFault(String::from(parsed_error.message)),"ReservedCacheNodeQuotaExceededFault" => PurchaseReservedCacheNodesOfferingError::ReservedCacheNodeQuotaExceededFault(String::from(parsed_error.message)),"ReservedCacheNodesOfferingNotFoundFault" => PurchaseReservedCacheNodesOfferingError::ReservedCacheNodesOfferingNotFoundFault(String::from(parsed_error.message)),_ => PurchaseReservedCacheNodesOfferingError::Unknown(String::from(body))
@@ -11727,6 +11999,14 @@ impl PurchaseReservedCacheNodesOfferingError {
                            },
                            Err(_) => PurchaseReservedCacheNodesOfferingError::Unknown(body.to_string())
                        }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11803,7 +12083,7 @@ impl RebootCacheClusterError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CacheClusterNotFoundFault" => RebootCacheClusterError::CacheClusterNotFoundFault(
                     String::from(parsed_error.message),
@@ -11817,6 +12097,14 @@ impl RebootCacheClusterError {
             },
             Err(_) => RebootCacheClusterError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11886,7 +12174,7 @@ impl RemoveTagsFromResourceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CacheClusterNotFoundFault" => {
                     RemoveTagsFromResourceError::CacheClusterNotFoundFault(String::from(
@@ -11906,6 +12194,14 @@ impl RemoveTagsFromResourceError {
             },
             Err(_) => RemoveTagsFromResourceError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11977,7 +12273,7 @@ impl ResetCacheParameterGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CacheParameterGroupNotFoundFault" => {
                     ResetCacheParameterGroupError::CacheParameterGroupNotFoundFault(String::from(
@@ -12003,6 +12299,14 @@ impl ResetCacheParameterGroupError {
             },
             Err(_) => ResetCacheParameterGroupError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -12076,7 +12380,7 @@ impl RevokeCacheSecurityGroupIngressError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationNotFoundFault" => {
                     RevokeCacheSecurityGroupIngressError::AuthorizationNotFoundFault(String::from(
@@ -12107,6 +12411,14 @@ impl RevokeCacheSecurityGroupIngressError {
             },
             Err(_) => RevokeCacheSecurityGroupIngressError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -12191,7 +12503,7 @@ impl TestFailoverError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "APICallRateForCustomerExceededFault" => {
                     TestFailoverError::APICallRateForCustomerExceededFault(String::from(
@@ -12233,6 +12545,14 @@ impl TestFailoverError {
             },
             Err(_) => TestFailoverError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 

--- a/rusoto/services/elasticbeanstalk/src/generated.rs
+++ b/rusoto/services/elasticbeanstalk/src/generated.rs
@@ -11072,7 +11072,7 @@ impl DeleteApplicationError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "OperationInProgressException" => {
+                "OperationInProgressFailure" => {
                     DeleteApplicationError::OperationInProgress(String::from(parsed_error.message))
                 }
                 _ => DeleteApplicationError::Unknown(String::from(body)),
@@ -11162,7 +11162,7 @@ impl DeleteApplicationVersionError {
                         parsed_error.message,
                     ))
                 }
-                "OperationInProgressException" => {
+                "OperationInProgressFailure" => {
                     DeleteApplicationVersionError::OperationInProgress(String::from(
                         parsed_error.message,
                     ))
@@ -11172,7 +11172,7 @@ impl DeleteApplicationVersionError {
                         parsed_error.message,
                     ))
                 }
-                "SourceBundleDeletionException" => {
+                "SourceBundleDeletionFailure" => {
                     DeleteApplicationVersionError::SourceBundleDeletion(String::from(
                         parsed_error.message,
                     ))
@@ -11256,7 +11256,7 @@ impl DeleteConfigurationTemplateError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "OperationInProgressException" => {
+                "OperationInProgressFailure" => {
                     DeleteConfigurationTemplateError::OperationInProgress(String::from(
                         parsed_error.message,
                     ))
@@ -11426,7 +11426,7 @@ impl DeletePlatformVersionError {
                         parsed_error.message,
                     ))
                 }
-                "OperationInProgressException" => DeletePlatformVersionError::OperationInProgress(
+                "OperationInProgressFailure" => DeletePlatformVersionError::OperationInProgress(
                     String::from(parsed_error.message),
                 ),
                 "PlatformVersionStillReferencedException" => {
@@ -13592,7 +13592,7 @@ impl UpdateTagsForResourceError {
                         parsed_error.message,
                     ))
                 }
-                "OperationInProgressException" => UpdateTagsForResourceError::OperationInProgress(
+                "OperationInProgressFailure" => UpdateTagsForResourceError::OperationInProgress(
                     String::from(parsed_error.message),
                 ),
                 "ResourceNotFoundException" => {

--- a/rusoto/services/elasticbeanstalk/src/generated.rs
+++ b/rusoto/services/elasticbeanstalk/src/generated.rs
@@ -10176,7 +10176,7 @@ impl AbortEnvironmentUpdateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InsufficientPrivilegesException" => {
                     AbortEnvironmentUpdateError::InsufficientPrivileges(String::from(
@@ -10187,6 +10187,14 @@ impl AbortEnvironmentUpdateError {
             },
             Err(_) => AbortEnvironmentUpdateError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10251,7 +10259,7 @@ impl ApplyEnvironmentManagedActionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ElasticBeanstalkServiceException" => {
                     ApplyEnvironmentManagedActionError::ElasticBeanstalkService(String::from(
@@ -10267,6 +10275,14 @@ impl ApplyEnvironmentManagedActionError {
             },
             Err(_) => ApplyEnvironmentManagedActionError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10328,12 +10344,20 @@ impl CheckDNSAvailabilityError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CheckDNSAvailabilityError::Unknown(String::from(body)),
             },
             Err(_) => CheckDNSAvailabilityError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10397,7 +10421,7 @@ impl ComposeEnvironmentsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InsufficientPrivilegesException" => {
                     ComposeEnvironmentsError::InsufficientPrivileges(String::from(
@@ -10411,6 +10435,14 @@ impl ComposeEnvironmentsError {
             },
             Err(_) => ComposeEnvironmentsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10474,7 +10506,7 @@ impl CreateApplicationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "TooManyApplicationsException" => {
                     CreateApplicationError::TooManyApplications(String::from(parsed_error.message))
@@ -10483,6 +10515,14 @@ impl CreateApplicationError {
             },
             Err(_) => CreateApplicationError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10553,7 +10593,7 @@ impl CreateApplicationVersionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CodeBuildNotInServiceRegionException" => {
                     CreateApplicationVersionError::CodeBuildNotInServiceRegion(String::from(
@@ -10584,6 +10624,14 @@ impl CreateApplicationVersionError {
             },
             Err(_) => CreateApplicationVersionError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10654,7 +10702,7 @@ impl CreateConfigurationTemplateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InsufficientPrivilegesException" => {
                     CreateConfigurationTemplateError::InsufficientPrivileges(String::from(
@@ -10673,6 +10721,14 @@ impl CreateConfigurationTemplateError {
             },
             Err(_) => CreateConfigurationTemplateError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10739,7 +10795,7 @@ impl CreateEnvironmentError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InsufficientPrivilegesException" => {
                     CreateEnvironmentError::InsufficientPrivileges(String::from(
@@ -10753,6 +10809,14 @@ impl CreateEnvironmentError {
             },
             Err(_) => CreateEnvironmentError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10820,7 +10884,7 @@ impl CreatePlatformVersionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ElasticBeanstalkServiceException" => {
                     CreatePlatformVersionError::ElasticBeanstalkService(String::from(
@@ -10839,6 +10903,14 @@ impl CreatePlatformVersionError {
             },
             Err(_) => CreatePlatformVersionError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10907,7 +10979,7 @@ impl CreateStorageLocationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InsufficientPrivilegesException" => {
                     CreateStorageLocationError::InsufficientPrivileges(String::from(
@@ -10926,6 +10998,14 @@ impl CreateStorageLocationError {
             },
             Err(_) => CreateStorageLocationError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10990,7 +11070,7 @@ impl DeleteApplicationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "OperationInProgressException" => {
                     DeleteApplicationError::OperationInProgress(String::from(parsed_error.message))
@@ -10999,6 +11079,14 @@ impl DeleteApplicationError {
             },
             Err(_) => DeleteApplicationError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11067,7 +11155,7 @@ impl DeleteApplicationVersionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InsufficientPrivilegesException" => {
                     DeleteApplicationVersionError::InsufficientPrivileges(String::from(
@@ -11093,6 +11181,14 @@ impl DeleteApplicationVersionError {
             },
             Err(_) => DeleteApplicationVersionError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11158,7 +11254,7 @@ impl DeleteConfigurationTemplateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "OperationInProgressException" => {
                     DeleteConfigurationTemplateError::OperationInProgress(String::from(
@@ -11169,6 +11265,14 @@ impl DeleteConfigurationTemplateError {
             },
             Err(_) => DeleteConfigurationTemplateError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11229,12 +11333,20 @@ impl DeleteEnvironmentConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteEnvironmentConfigurationError::Unknown(String::from(body)),
             },
             Err(_) => DeleteEnvironmentConfigurationError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11302,7 +11414,7 @@ impl DeletePlatformVersionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ElasticBeanstalkServiceException" => {
                     DeletePlatformVersionError::ElasticBeanstalkService(String::from(
@@ -11326,6 +11438,14 @@ impl DeletePlatformVersionError {
             },
             Err(_) => DeletePlatformVersionError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11389,12 +11509,20 @@ impl DescribeApplicationVersionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeApplicationVersionsError::Unknown(String::from(body)),
             },
             Err(_) => DescribeApplicationVersionsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11454,12 +11582,20 @@ impl DescribeApplicationsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeApplicationsError::Unknown(String::from(body)),
             },
             Err(_) => DescribeApplicationsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11521,7 +11657,7 @@ impl DescribeConfigurationOptionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "TooManyBucketsException" => DescribeConfigurationOptionsError::TooManyBuckets(
                     String::from(parsed_error.message),
@@ -11530,6 +11666,14 @@ impl DescribeConfigurationOptionsError {
             },
             Err(_) => DescribeConfigurationOptionsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11592,7 +11736,7 @@ impl DescribeConfigurationSettingsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "TooManyBucketsException" => DescribeConfigurationSettingsError::TooManyBuckets(
                     String::from(parsed_error.message),
@@ -11601,6 +11745,14 @@ impl DescribeConfigurationSettingsError {
             },
             Err(_) => DescribeConfigurationSettingsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11665,7 +11817,7 @@ impl DescribeEnvironmentHealthError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ElasticBeanstalkServiceException" => {
                     DescribeEnvironmentHealthError::ElasticBeanstalkService(String::from(
@@ -11679,6 +11831,14 @@ impl DescribeEnvironmentHealthError {
             },
             Err(_) => DescribeEnvironmentHealthError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11742,7 +11902,7 @@ impl DescribeEnvironmentManagedActionHistoryError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ElasticBeanstalkServiceException" => {
                     DescribeEnvironmentManagedActionHistoryError::ElasticBeanstalkService(
@@ -11753,6 +11913,14 @@ impl DescribeEnvironmentManagedActionHistoryError {
             },
             Err(_) => DescribeEnvironmentManagedActionHistoryError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11817,7 +11985,7 @@ impl DescribeEnvironmentManagedActionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ElasticBeanstalkServiceException" => {
                     DescribeEnvironmentManagedActionsError::ElasticBeanstalkService(String::from(
@@ -11828,6 +11996,14 @@ impl DescribeEnvironmentManagedActionsError {
             },
             Err(_) => DescribeEnvironmentManagedActionsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11890,7 +12066,7 @@ impl DescribeEnvironmentResourcesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InsufficientPrivilegesException" => {
                     DescribeEnvironmentResourcesError::InsufficientPrivileges(String::from(
@@ -11901,6 +12077,14 @@ impl DescribeEnvironmentResourcesError {
             },
             Err(_) => DescribeEnvironmentResourcesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11961,12 +12145,20 @@ impl DescribeEnvironmentsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeEnvironmentsError::Unknown(String::from(body)),
             },
             Err(_) => DescribeEnvironmentsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -12026,12 +12218,20 @@ impl DescribeEventsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeEventsError::Unknown(String::from(body)),
             },
             Err(_) => DescribeEventsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -12093,7 +12293,7 @@ impl DescribeInstancesHealthError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ElasticBeanstalkServiceException" => {
                     DescribeInstancesHealthError::ElasticBeanstalkService(String::from(
@@ -12107,6 +12307,14 @@ impl DescribeInstancesHealthError {
             },
             Err(_) => DescribeInstancesHealthError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -12172,7 +12380,7 @@ impl DescribePlatformVersionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ElasticBeanstalkServiceException" => {
                     DescribePlatformVersionError::ElasticBeanstalkService(String::from(
@@ -12188,6 +12396,14 @@ impl DescribePlatformVersionError {
             },
             Err(_) => DescribePlatformVersionError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -12249,12 +12465,20 @@ impl ListAvailableSolutionStacksError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListAvailableSolutionStacksError::Unknown(String::from(body)),
             },
             Err(_) => ListAvailableSolutionStacksError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -12318,7 +12542,7 @@ impl ListPlatformVersionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ElasticBeanstalkServiceException" => {
                     ListPlatformVersionsError::ElasticBeanstalkService(String::from(
@@ -12334,6 +12558,14 @@ impl ListPlatformVersionsError {
             },
             Err(_) => ListPlatformVersionsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -12401,7 +12633,7 @@ impl ListTagsForResourceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InsufficientPrivilegesException" => {
                     ListTagsForResourceError::InsufficientPrivileges(String::from(
@@ -12420,6 +12652,14 @@ impl ListTagsForResourceError {
             },
             Err(_) => ListTagsForResourceError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -12484,7 +12724,7 @@ impl RebuildEnvironmentError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InsufficientPrivilegesException" => {
                     RebuildEnvironmentError::InsufficientPrivileges(String::from(
@@ -12495,6 +12735,14 @@ impl RebuildEnvironmentError {
             },
             Err(_) => RebuildEnvironmentError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -12555,12 +12803,20 @@ impl RequestEnvironmentInfoError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => RequestEnvironmentInfoError::Unknown(String::from(body)),
             },
             Err(_) => RequestEnvironmentInfoError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -12620,12 +12876,20 @@ impl RestartAppServerError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => RestartAppServerError::Unknown(String::from(body)),
             },
             Err(_) => RestartAppServerError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -12683,12 +12947,20 @@ impl RetrieveEnvironmentInfoError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => RetrieveEnvironmentInfoError::Unknown(String::from(body)),
             },
             Err(_) => RetrieveEnvironmentInfoError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -12748,12 +13020,20 @@ impl SwapEnvironmentCNAMEsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => SwapEnvironmentCNAMEsError::Unknown(String::from(body)),
             },
             Err(_) => SwapEnvironmentCNAMEsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -12815,7 +13095,7 @@ impl TerminateEnvironmentError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InsufficientPrivilegesException" => {
                     TerminateEnvironmentError::InsufficientPrivileges(String::from(
@@ -12826,6 +13106,14 @@ impl TerminateEnvironmentError {
             },
             Err(_) => TerminateEnvironmentError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -12886,12 +13174,20 @@ impl UpdateApplicationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => UpdateApplicationError::Unknown(String::from(body)),
             },
             Err(_) => UpdateApplicationError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -12953,7 +13249,7 @@ impl UpdateApplicationResourceLifecycleError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InsufficientPrivilegesException" => {
                     UpdateApplicationResourceLifecycleError::InsufficientPrivileges(String::from(
@@ -12964,6 +13260,14 @@ impl UpdateApplicationResourceLifecycleError {
             },
             Err(_) => UpdateApplicationResourceLifecycleError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -13024,12 +13328,20 @@ impl UpdateApplicationVersionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => UpdateApplicationVersionError::Unknown(String::from(body)),
             },
             Err(_) => UpdateApplicationVersionError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -13093,7 +13405,7 @@ impl UpdateConfigurationTemplateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InsufficientPrivilegesException" => {
                     UpdateConfigurationTemplateError::InsufficientPrivileges(String::from(
@@ -13107,6 +13419,14 @@ impl UpdateConfigurationTemplateError {
             },
             Err(_) => UpdateConfigurationTemplateError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -13172,7 +13492,7 @@ impl UpdateEnvironmentError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InsufficientPrivilegesException" => {
                     UpdateEnvironmentError::InsufficientPrivileges(String::from(
@@ -13186,6 +13506,14 @@ impl UpdateEnvironmentError {
             },
             Err(_) => UpdateEnvironmentError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -13257,7 +13585,7 @@ impl UpdateTagsForResourceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InsufficientPrivilegesException" => {
                     UpdateTagsForResourceError::InsufficientPrivileges(String::from(
@@ -13282,6 +13610,14 @@ impl UpdateTagsForResourceError {
             },
             Err(_) => UpdateTagsForResourceError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -13350,7 +13686,7 @@ impl ValidateConfigurationSettingsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InsufficientPrivilegesException" => {
                     ValidateConfigurationSettingsError::InsufficientPrivileges(String::from(
@@ -13364,6 +13700,14 @@ impl ValidateConfigurationSettingsError {
             },
             Err(_) => ValidateConfigurationSettingsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 

--- a/rusoto/services/elb/src/generated.rs
+++ b/rusoto/services/elb/src/generated.rs
@@ -5616,15 +5616,13 @@ impl AddTagsError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AccessPointNotFoundException" => {
+                "LoadBalancerNotFound" => {
                     AddTagsError::AccessPointNotFound(String::from(parsed_error.message))
                 }
-                "DuplicateTagKeysException" => {
+                "DuplicateTagKeys" => {
                     AddTagsError::DuplicateTagKeys(String::from(parsed_error.message))
                 }
-                "TooManyTagsException" => {
-                    AddTagsError::TooManyTags(String::from(parsed_error.message))
-                }
+                "TooManyTags" => AddTagsError::TooManyTags(String::from(parsed_error.message)),
                 _ => AddTagsError::Unknown(String::from(body)),
             },
             Err(_) => AddTagsError::Unknown(body.to_string()),
@@ -5705,17 +5703,17 @@ impl ApplySecurityGroupsToLoadBalancerError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AccessPointNotFoundException" => {
+                "LoadBalancerNotFound" => {
                     ApplySecurityGroupsToLoadBalancerError::AccessPointNotFound(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InvalidConfigurationRequestException" => {
+                "InvalidConfigurationRequest" => {
                     ApplySecurityGroupsToLoadBalancerError::InvalidConfigurationRequest(
                         String::from(parsed_error.message),
                     )
                 }
-                "InvalidSecurityGroupException" => {
+                "InvalidSecurityGroup" => {
                     ApplySecurityGroupsToLoadBalancerError::InvalidSecurityGroup(String::from(
                         parsed_error.message,
                     ))
@@ -5804,20 +5802,18 @@ impl AttachLoadBalancerToSubnetsError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AccessPointNotFoundException" => {
-                    AttachLoadBalancerToSubnetsError::AccessPointNotFound(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "InvalidConfigurationRequestException" => {
+                "LoadBalancerNotFound" => AttachLoadBalancerToSubnetsError::AccessPointNotFound(
+                    String::from(parsed_error.message),
+                ),
+                "InvalidConfigurationRequest" => {
                     AttachLoadBalancerToSubnetsError::InvalidConfigurationRequest(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InvalidSubnetException" => AttachLoadBalancerToSubnetsError::InvalidSubnet(
-                    String::from(parsed_error.message),
-                ),
-                "SubnetNotFoundException" => AttachLoadBalancerToSubnetsError::SubnetNotFound(
+                "InvalidSubnet" => AttachLoadBalancerToSubnetsError::InvalidSubnet(String::from(
+                    parsed_error.message,
+                )),
+                "SubnetNotFound" => AttachLoadBalancerToSubnetsError::SubnetNotFound(
                     String::from(parsed_error.message),
                 ),
                 _ => AttachLoadBalancerToSubnetsError::Unknown(String::from(body)),
@@ -5899,7 +5895,7 @@ impl ConfigureHealthCheckError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AccessPointNotFoundException" => ConfigureHealthCheckError::AccessPointNotFound(
+                "LoadBalancerNotFound" => ConfigureHealthCheckError::AccessPointNotFound(
                     String::from(parsed_error.message),
                 ),
                 _ => ConfigureHealthCheckError::Unknown(String::from(body)),
@@ -5984,26 +5980,24 @@ impl CreateAppCookieStickinessPolicyError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AccessPointNotFoundException" => {
+                "LoadBalancerNotFound" => {
                     CreateAppCookieStickinessPolicyError::AccessPointNotFound(String::from(
                         parsed_error.message,
                     ))
                 }
-                "DuplicatePolicyNameException" => {
+                "DuplicatePolicyName" => {
                     CreateAppCookieStickinessPolicyError::DuplicatePolicyName(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InvalidConfigurationRequestException" => {
+                "InvalidConfigurationRequest" => {
                     CreateAppCookieStickinessPolicyError::InvalidConfigurationRequest(
                         String::from(parsed_error.message),
                     )
                 }
-                "TooManyPoliciesException" => {
-                    CreateAppCookieStickinessPolicyError::TooManyPolicies(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "TooManyPolicies" => CreateAppCookieStickinessPolicyError::TooManyPolicies(
+                    String::from(parsed_error.message),
+                ),
                 _ => CreateAppCookieStickinessPolicyError::Unknown(String::from(body)),
             },
             Err(_) => CreateAppCookieStickinessPolicyError::Unknown(body.to_string()),
@@ -6089,26 +6083,22 @@ impl CreateLBCookieStickinessPolicyError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AccessPointNotFoundException" => {
+                "LoadBalancerNotFound" => {
                     CreateLBCookieStickinessPolicyError::AccessPointNotFound(String::from(
                         parsed_error.message,
                     ))
                 }
-                "DuplicatePolicyNameException" => {
-                    CreateLBCookieStickinessPolicyError::DuplicatePolicyName(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "InvalidConfigurationRequestException" => {
+                "DuplicatePolicyName" => CreateLBCookieStickinessPolicyError::DuplicatePolicyName(
+                    String::from(parsed_error.message),
+                ),
+                "InvalidConfigurationRequest" => {
                     CreateLBCookieStickinessPolicyError::InvalidConfigurationRequest(String::from(
                         parsed_error.message,
                     ))
                 }
-                "TooManyPoliciesException" => {
-                    CreateLBCookieStickinessPolicyError::TooManyPolicies(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "TooManyPolicies" => CreateLBCookieStickinessPolicyError::TooManyPolicies(
+                    String::from(parsed_error.message),
+                ),
                 _ => CreateLBCookieStickinessPolicyError::Unknown(String::from(body)),
             },
             Err(_) => CreateLBCookieStickinessPolicyError::Unknown(body.to_string()),
@@ -6208,41 +6198,39 @@ impl CreateLoadBalancerError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "CertificateNotFoundException" => {
+                "CertificateNotFound" => {
                     CreateLoadBalancerError::CertificateNotFound(String::from(parsed_error.message))
                 }
-                "DuplicateAccessPointNameException" => {
-                    CreateLoadBalancerError::DuplicateAccessPointName(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "DuplicateTagKeysException" => {
+                "DuplicateLoadBalancerName" => CreateLoadBalancerError::DuplicateAccessPointName(
+                    String::from(parsed_error.message),
+                ),
+                "DuplicateTagKeys" => {
                     CreateLoadBalancerError::DuplicateTagKeys(String::from(parsed_error.message))
                 }
-                "InvalidConfigurationRequestException" => {
+                "InvalidConfigurationRequest" => {
                     CreateLoadBalancerError::InvalidConfigurationRequest(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InvalidSchemeException" => {
+                "InvalidScheme" => {
                     CreateLoadBalancerError::InvalidScheme(String::from(parsed_error.message))
                 }
-                "InvalidSecurityGroupException" => CreateLoadBalancerError::InvalidSecurityGroup(
+                "InvalidSecurityGroup" => CreateLoadBalancerError::InvalidSecurityGroup(
                     String::from(parsed_error.message),
                 ),
-                "InvalidSubnetException" => {
+                "InvalidSubnet" => {
                     CreateLoadBalancerError::InvalidSubnet(String::from(parsed_error.message))
                 }
-                "SubnetNotFoundException" => {
+                "SubnetNotFound" => {
                     CreateLoadBalancerError::SubnetNotFound(String::from(parsed_error.message))
                 }
-                "TooManyAccessPointsException" => {
+                "TooManyLoadBalancers" => {
                     CreateLoadBalancerError::TooManyAccessPoints(String::from(parsed_error.message))
                 }
-                "TooManyTagsException" => {
+                "TooManyTags" => {
                     CreateLoadBalancerError::TooManyTags(String::from(parsed_error.message))
                 }
-                "UnsupportedProtocolException" => {
+                "UnsupportedProtocol" => {
                     CreateLoadBalancerError::UnsupportedProtocol(String::from(parsed_error.message))
                 }
                 _ => CreateLoadBalancerError::Unknown(String::from(body)),
@@ -6339,31 +6327,23 @@ impl CreateLoadBalancerListenersError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AccessPointNotFoundException" => {
-                    CreateLoadBalancerListenersError::AccessPointNotFound(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "CertificateNotFoundException" => {
-                    CreateLoadBalancerListenersError::CertificateNotFound(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "DuplicateListenerException" => {
-                    CreateLoadBalancerListenersError::DuplicateListener(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "InvalidConfigurationRequestException" => {
+                "LoadBalancerNotFound" => CreateLoadBalancerListenersError::AccessPointNotFound(
+                    String::from(parsed_error.message),
+                ),
+                "CertificateNotFound" => CreateLoadBalancerListenersError::CertificateNotFound(
+                    String::from(parsed_error.message),
+                ),
+                "DuplicateListener" => CreateLoadBalancerListenersError::DuplicateListener(
+                    String::from(parsed_error.message),
+                ),
+                "InvalidConfigurationRequest" => {
                     CreateLoadBalancerListenersError::InvalidConfigurationRequest(String::from(
                         parsed_error.message,
                     ))
                 }
-                "UnsupportedProtocolException" => {
-                    CreateLoadBalancerListenersError::UnsupportedProtocol(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "UnsupportedProtocol" => CreateLoadBalancerListenersError::UnsupportedProtocol(
+                    String::from(parsed_error.message),
+                ),
                 _ => CreateLoadBalancerListenersError::Unknown(String::from(body)),
             },
             Err(_) => CreateLoadBalancerListenersError::Unknown(body.to_string()),
@@ -6452,29 +6432,23 @@ impl CreateLoadBalancerPolicyError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AccessPointNotFoundException" => {
-                    CreateLoadBalancerPolicyError::AccessPointNotFound(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "DuplicatePolicyNameException" => {
-                    CreateLoadBalancerPolicyError::DuplicatePolicyName(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "InvalidConfigurationRequestException" => {
+                "LoadBalancerNotFound" => CreateLoadBalancerPolicyError::AccessPointNotFound(
+                    String::from(parsed_error.message),
+                ),
+                "DuplicatePolicyName" => CreateLoadBalancerPolicyError::DuplicatePolicyName(
+                    String::from(parsed_error.message),
+                ),
+                "InvalidConfigurationRequest" => {
                     CreateLoadBalancerPolicyError::InvalidConfigurationRequest(String::from(
                         parsed_error.message,
                     ))
                 }
-                "PolicyTypeNotFoundException" => {
-                    CreateLoadBalancerPolicyError::PolicyTypeNotFound(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "TooManyPoliciesException" => CreateLoadBalancerPolicyError::TooManyPolicies(
+                "PolicyTypeNotFound" => CreateLoadBalancerPolicyError::PolicyTypeNotFound(
                     String::from(parsed_error.message),
                 ),
+                "TooManyPolicies" => CreateLoadBalancerPolicyError::TooManyPolicies(String::from(
+                    parsed_error.message,
+                )),
                 _ => CreateLoadBalancerPolicyError::Unknown(String::from(body)),
             },
             Err(_) => CreateLoadBalancerPolicyError::Unknown(body.to_string()),
@@ -6628,11 +6602,9 @@ impl DeleteLoadBalancerListenersError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AccessPointNotFoundException" => {
-                    DeleteLoadBalancerListenersError::AccessPointNotFound(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "LoadBalancerNotFound" => DeleteLoadBalancerListenersError::AccessPointNotFound(
+                    String::from(parsed_error.message),
+                ),
                 _ => DeleteLoadBalancerListenersError::Unknown(String::from(body)),
             },
             Err(_) => DeleteLoadBalancerListenersError::Unknown(body.to_string()),
@@ -6711,12 +6683,10 @@ impl DeleteLoadBalancerPolicyError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AccessPointNotFoundException" => {
-                    DeleteLoadBalancerPolicyError::AccessPointNotFound(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "InvalidConfigurationRequestException" => {
+                "LoadBalancerNotFound" => DeleteLoadBalancerPolicyError::AccessPointNotFound(
+                    String::from(parsed_error.message),
+                ),
+                "InvalidConfigurationRequest" => {
                     DeleteLoadBalancerPolicyError::InvalidConfigurationRequest(String::from(
                         parsed_error.message,
                     ))
@@ -6800,16 +6770,14 @@ impl DeregisterInstancesFromLoadBalancerError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AccessPointNotFoundException" => {
+                "LoadBalancerNotFound" => {
                     DeregisterInstancesFromLoadBalancerError::AccessPointNotFound(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InvalidEndPointException" => {
-                    DeregisterInstancesFromLoadBalancerError::InvalidEndPoint(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "InvalidInstance" => DeregisterInstancesFromLoadBalancerError::InvalidEndPoint(
+                    String::from(parsed_error.message),
+                ),
                 _ => DeregisterInstancesFromLoadBalancerError::Unknown(String::from(body)),
             },
             Err(_) => DeregisterInstancesFromLoadBalancerError::Unknown(body.to_string()),
@@ -6962,12 +6930,10 @@ impl DescribeInstanceHealthError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AccessPointNotFoundException" => {
-                    DescribeInstanceHealthError::AccessPointNotFound(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "InvalidEndPointException" => {
+                "LoadBalancerNotFound" => DescribeInstanceHealthError::AccessPointNotFound(
+                    String::from(parsed_error.message),
+                ),
+                "InvalidInstance" => {
                     DescribeInstanceHealthError::InvalidEndPoint(String::from(parsed_error.message))
                 }
                 _ => DescribeInstanceHealthError::Unknown(String::from(body)),
@@ -7049,12 +7015,12 @@ impl DescribeLoadBalancerAttributesError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AccessPointNotFoundException" => {
+                "LoadBalancerNotFound" => {
                     DescribeLoadBalancerAttributesError::AccessPointNotFound(String::from(
                         parsed_error.message,
                     ))
                 }
-                "LoadBalancerAttributeNotFoundException" => {
+                "LoadBalancerAttributeNotFound" => {
                     DescribeLoadBalancerAttributesError::LoadBalancerAttributeNotFound(
                         String::from(parsed_error.message),
                     )
@@ -7138,12 +7104,10 @@ impl DescribeLoadBalancerPoliciesError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AccessPointNotFoundException" => {
-                    DescribeLoadBalancerPoliciesError::AccessPointNotFound(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "PolicyNotFoundException" => DescribeLoadBalancerPoliciesError::PolicyNotFound(
+                "LoadBalancerNotFound" => DescribeLoadBalancerPoliciesError::AccessPointNotFound(
+                    String::from(parsed_error.message),
+                ),
+                "PolicyNotFound" => DescribeLoadBalancerPoliciesError::PolicyNotFound(
                     String::from(parsed_error.message),
                 ),
                 _ => DescribeLoadBalancerPoliciesError::Unknown(String::from(body)),
@@ -7223,11 +7187,9 @@ impl DescribeLoadBalancerPolicyTypesError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "PolicyTypeNotFoundException" => {
-                    DescribeLoadBalancerPolicyTypesError::PolicyTypeNotFound(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "PolicyTypeNotFound" => DescribeLoadBalancerPolicyTypesError::PolicyTypeNotFound(
+                    String::from(parsed_error.message),
+                ),
                 _ => DescribeLoadBalancerPolicyTypesError::Unknown(String::from(body)),
             },
             Err(_) => DescribeLoadBalancerPolicyTypesError::Unknown(body.to_string()),
@@ -7306,10 +7268,10 @@ impl DescribeLoadBalancersError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AccessPointNotFoundException" => DescribeLoadBalancersError::AccessPointNotFound(
+                "LoadBalancerNotFound" => DescribeLoadBalancersError::AccessPointNotFound(
                     String::from(parsed_error.message),
                 ),
-                "DependencyThrottleException" => DescribeLoadBalancersError::DependencyThrottle(
+                "DependencyThrottle" => DescribeLoadBalancersError::DependencyThrottle(
                     String::from(parsed_error.message),
                 ),
                 _ => DescribeLoadBalancersError::Unknown(String::from(body)),
@@ -7389,7 +7351,7 @@ impl DescribeTagsError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AccessPointNotFoundException" => {
+                "LoadBalancerNotFound" => {
                     DescribeTagsError::AccessPointNotFound(String::from(parsed_error.message))
                 }
                 _ => DescribeTagsError::Unknown(String::from(body)),
@@ -7468,12 +7430,10 @@ impl DetachLoadBalancerFromSubnetsError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AccessPointNotFoundException" => {
-                    DetachLoadBalancerFromSubnetsError::AccessPointNotFound(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "InvalidConfigurationRequestException" => {
+                "LoadBalancerNotFound" => DetachLoadBalancerFromSubnetsError::AccessPointNotFound(
+                    String::from(parsed_error.message),
+                ),
+                "InvalidConfigurationRequest" => {
                     DetachLoadBalancerFromSubnetsError::InvalidConfigurationRequest(String::from(
                         parsed_error.message,
                     ))
@@ -7557,12 +7517,12 @@ impl DisableAvailabilityZonesForLoadBalancerError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AccessPointNotFoundException" => {
+                "LoadBalancerNotFound" => {
                     DisableAvailabilityZonesForLoadBalancerError::AccessPointNotFound(
                         String::from(parsed_error.message),
                     )
                 }
-                "InvalidConfigurationRequestException" => {
+                "InvalidConfigurationRequest" => {
                     DisableAvailabilityZonesForLoadBalancerError::InvalidConfigurationRequest(
                         String::from(parsed_error.message),
                     )
@@ -7646,7 +7606,7 @@ impl EnableAvailabilityZonesForLoadBalancerError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AccessPointNotFoundException" => {
+                "LoadBalancerNotFound" => {
                     EnableAvailabilityZonesForLoadBalancerError::AccessPointNotFound(String::from(
                         parsed_error.message,
                     ))
@@ -7731,17 +7691,15 @@ impl ModifyLoadBalancerAttributesError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AccessPointNotFoundException" => {
-                    ModifyLoadBalancerAttributesError::AccessPointNotFound(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "InvalidConfigurationRequestException" => {
+                "LoadBalancerNotFound" => ModifyLoadBalancerAttributesError::AccessPointNotFound(
+                    String::from(parsed_error.message),
+                ),
+                "InvalidConfigurationRequest" => {
                     ModifyLoadBalancerAttributesError::InvalidConfigurationRequest(String::from(
                         parsed_error.message,
                     ))
                 }
-                "LoadBalancerAttributeNotFoundException" => {
+                "LoadBalancerAttributeNotFound" => {
                     ModifyLoadBalancerAttributesError::LoadBalancerAttributeNotFound(String::from(
                         parsed_error.message,
                     ))
@@ -7826,16 +7784,14 @@ impl RegisterInstancesWithLoadBalancerError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AccessPointNotFoundException" => {
+                "LoadBalancerNotFound" => {
                     RegisterInstancesWithLoadBalancerError::AccessPointNotFound(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InvalidEndPointException" => {
-                    RegisterInstancesWithLoadBalancerError::InvalidEndPoint(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "InvalidInstance" => RegisterInstancesWithLoadBalancerError::InvalidEndPoint(
+                    String::from(parsed_error.message),
+                ),
                 _ => RegisterInstancesWithLoadBalancerError::Unknown(String::from(body)),
             },
             Err(_) => RegisterInstancesWithLoadBalancerError::Unknown(body.to_string()),
@@ -7913,7 +7869,7 @@ impl RemoveTagsError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AccessPointNotFoundException" => {
+                "LoadBalancerNotFound" => {
                     RemoveTagsError::AccessPointNotFound(String::from(parsed_error.message))
                 }
                 _ => RemoveTagsError::Unknown(String::from(body)),
@@ -7998,27 +7954,27 @@ impl SetLoadBalancerListenerSSLCertificateError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AccessPointNotFoundException" => {
+                "LoadBalancerNotFound" => {
                     SetLoadBalancerListenerSSLCertificateError::AccessPointNotFound(String::from(
                         parsed_error.message,
                     ))
                 }
-                "CertificateNotFoundException" => {
+                "CertificateNotFound" => {
                     SetLoadBalancerListenerSSLCertificateError::CertificateNotFound(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InvalidConfigurationRequestException" => {
+                "InvalidConfigurationRequest" => {
                     SetLoadBalancerListenerSSLCertificateError::InvalidConfigurationRequest(
                         String::from(parsed_error.message),
                     )
                 }
-                "ListenerNotFoundException" => {
+                "ListenerNotFound" => {
                     SetLoadBalancerListenerSSLCertificateError::ListenerNotFound(String::from(
                         parsed_error.message,
                     ))
                 }
-                "UnsupportedProtocolException" => {
+                "UnsupportedProtocol" => {
                     SetLoadBalancerListenerSSLCertificateError::UnsupportedProtocol(String::from(
                         parsed_error.message,
                     ))
@@ -8109,21 +8065,19 @@ impl SetLoadBalancerPoliciesForBackendServerError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AccessPointNotFoundException" => {
+                "LoadBalancerNotFound" => {
                     SetLoadBalancerPoliciesForBackendServerError::AccessPointNotFound(
                         String::from(parsed_error.message),
                     )
                 }
-                "InvalidConfigurationRequestException" => {
+                "InvalidConfigurationRequest" => {
                     SetLoadBalancerPoliciesForBackendServerError::InvalidConfigurationRequest(
                         String::from(parsed_error.message),
                     )
                 }
-                "PolicyNotFoundException" => {
-                    SetLoadBalancerPoliciesForBackendServerError::PolicyNotFound(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "PolicyNotFound" => SetLoadBalancerPoliciesForBackendServerError::PolicyNotFound(
+                    String::from(parsed_error.message),
+                ),
                 _ => SetLoadBalancerPoliciesForBackendServerError::Unknown(String::from(body)),
             },
             Err(_) => SetLoadBalancerPoliciesForBackendServerError::Unknown(body.to_string()),
@@ -8210,26 +8164,22 @@ impl SetLoadBalancerPoliciesOfListenerError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AccessPointNotFoundException" => {
+                "LoadBalancerNotFound" => {
                     SetLoadBalancerPoliciesOfListenerError::AccessPointNotFound(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InvalidConfigurationRequestException" => {
+                "InvalidConfigurationRequest" => {
                     SetLoadBalancerPoliciesOfListenerError::InvalidConfigurationRequest(
                         String::from(parsed_error.message),
                     )
                 }
-                "ListenerNotFoundException" => {
-                    SetLoadBalancerPoliciesOfListenerError::ListenerNotFound(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "PolicyNotFoundException" => {
-                    SetLoadBalancerPoliciesOfListenerError::PolicyNotFound(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "ListenerNotFound" => SetLoadBalancerPoliciesOfListenerError::ListenerNotFound(
+                    String::from(parsed_error.message),
+                ),
+                "PolicyNotFound" => SetLoadBalancerPoliciesOfListenerError::PolicyNotFound(
+                    String::from(parsed_error.message),
+                ),
                 _ => SetLoadBalancerPoliciesOfListenerError::Unknown(String::from(body)),
             },
             Err(_) => SetLoadBalancerPoliciesOfListenerError::Unknown(body.to_string()),

--- a/rusoto/services/elb/src/generated.rs
+++ b/rusoto/services/elb/src/generated.rs
@@ -5614,7 +5614,7 @@ impl AddTagsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessPointNotFoundException" => {
                     AddTagsError::AccessPointNotFound(String::from(parsed_error.message))
@@ -5629,6 +5629,14 @@ impl AddTagsError {
             },
             Err(_) => AddTagsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -5695,7 +5703,7 @@ impl ApplySecurityGroupsToLoadBalancerError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessPointNotFoundException" => {
                     ApplySecurityGroupsToLoadBalancerError::AccessPointNotFound(String::from(
@@ -5716,6 +5724,14 @@ impl ApplySecurityGroupsToLoadBalancerError {
             },
             Err(_) => ApplySecurityGroupsToLoadBalancerError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -5786,7 +5802,7 @@ impl AttachLoadBalancerToSubnetsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessPointNotFoundException" => {
                     AttachLoadBalancerToSubnetsError::AccessPointNotFound(String::from(
@@ -5808,6 +5824,14 @@ impl AttachLoadBalancerToSubnetsError {
             },
             Err(_) => AttachLoadBalancerToSubnetsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -5873,7 +5897,7 @@ impl ConfigureHealthCheckError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessPointNotFoundException" => ConfigureHealthCheckError::AccessPointNotFound(
                     String::from(parsed_error.message),
@@ -5882,6 +5906,14 @@ impl ConfigureHealthCheckError {
             },
             Err(_) => ConfigureHealthCheckError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -5950,7 +5982,7 @@ impl CreateAppCookieStickinessPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessPointNotFoundException" => {
                     CreateAppCookieStickinessPolicyError::AccessPointNotFound(String::from(
@@ -5976,6 +6008,14 @@ impl CreateAppCookieStickinessPolicyError {
             },
             Err(_) => CreateAppCookieStickinessPolicyError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -6047,7 +6087,7 @@ impl CreateLBCookieStickinessPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessPointNotFoundException" => {
                     CreateLBCookieStickinessPolicyError::AccessPointNotFound(String::from(
@@ -6073,6 +6113,14 @@ impl CreateLBCookieStickinessPolicyError {
             },
             Err(_) => CreateLBCookieStickinessPolicyError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -6158,7 +6206,7 @@ impl CreateLoadBalancerError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CertificateNotFoundException" => {
                     CreateLoadBalancerError::CertificateNotFound(String::from(parsed_error.message))
@@ -6201,6 +6249,14 @@ impl CreateLoadBalancerError {
             },
             Err(_) => CreateLoadBalancerError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -6281,7 +6337,7 @@ impl CreateLoadBalancerListenersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessPointNotFoundException" => {
                     CreateLoadBalancerListenersError::AccessPointNotFound(String::from(
@@ -6312,6 +6368,14 @@ impl CreateLoadBalancerListenersError {
             },
             Err(_) => CreateLoadBalancerListenersError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -6386,7 +6450,7 @@ impl CreateLoadBalancerPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessPointNotFoundException" => {
                     CreateLoadBalancerPolicyError::AccessPointNotFound(String::from(
@@ -6415,6 +6479,14 @@ impl CreateLoadBalancerPolicyError {
             },
             Err(_) => CreateLoadBalancerPolicyError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -6479,12 +6551,20 @@ impl DeleteLoadBalancerError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteLoadBalancerError::Unknown(String::from(body)),
             },
             Err(_) => DeleteLoadBalancerError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -6546,7 +6626,7 @@ impl DeleteLoadBalancerListenersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessPointNotFoundException" => {
                     DeleteLoadBalancerListenersError::AccessPointNotFound(String::from(
@@ -6557,6 +6637,14 @@ impl DeleteLoadBalancerListenersError {
             },
             Err(_) => DeleteLoadBalancerListenersError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -6621,7 +6709,7 @@ impl DeleteLoadBalancerPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessPointNotFoundException" => {
                     DeleteLoadBalancerPolicyError::AccessPointNotFound(String::from(
@@ -6637,6 +6725,14 @@ impl DeleteLoadBalancerPolicyError {
             },
             Err(_) => DeleteLoadBalancerPolicyError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -6702,7 +6798,7 @@ impl DeregisterInstancesFromLoadBalancerError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessPointNotFoundException" => {
                     DeregisterInstancesFromLoadBalancerError::AccessPointNotFound(String::from(
@@ -6718,6 +6814,14 @@ impl DeregisterInstancesFromLoadBalancerError {
             },
             Err(_) => DeregisterInstancesFromLoadBalancerError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -6779,12 +6883,20 @@ impl DescribeAccountLimitsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeAccountLimitsError::Unknown(String::from(body)),
             },
             Err(_) => DescribeAccountLimitsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -6848,7 +6960,7 @@ impl DescribeInstanceHealthError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessPointNotFoundException" => {
                     DescribeInstanceHealthError::AccessPointNotFound(String::from(
@@ -6862,6 +6974,14 @@ impl DescribeInstanceHealthError {
             },
             Err(_) => DescribeInstanceHealthError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -6927,7 +7047,7 @@ impl DescribeLoadBalancerAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessPointNotFoundException" => {
                     DescribeLoadBalancerAttributesError::AccessPointNotFound(String::from(
@@ -6943,6 +7063,14 @@ impl DescribeLoadBalancerAttributesError {
             },
             Err(_) => DescribeLoadBalancerAttributesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -7008,7 +7136,7 @@ impl DescribeLoadBalancerPoliciesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessPointNotFoundException" => {
                     DescribeLoadBalancerPoliciesError::AccessPointNotFound(String::from(
@@ -7022,6 +7150,14 @@ impl DescribeLoadBalancerPoliciesError {
             },
             Err(_) => DescribeLoadBalancerPoliciesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -7085,7 +7221,7 @@ impl DescribeLoadBalancerPolicyTypesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "PolicyTypeNotFoundException" => {
                     DescribeLoadBalancerPolicyTypesError::PolicyTypeNotFound(String::from(
@@ -7096,6 +7232,14 @@ impl DescribeLoadBalancerPolicyTypesError {
             },
             Err(_) => DescribeLoadBalancerPolicyTypesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -7160,7 +7304,7 @@ impl DescribeLoadBalancersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessPointNotFoundException" => DescribeLoadBalancersError::AccessPointNotFound(
                     String::from(parsed_error.message),
@@ -7172,6 +7316,14 @@ impl DescribeLoadBalancersError {
             },
             Err(_) => DescribeLoadBalancersError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -7235,7 +7387,7 @@ impl DescribeTagsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessPointNotFoundException" => {
                     DescribeTagsError::AccessPointNotFound(String::from(parsed_error.message))
@@ -7244,6 +7396,14 @@ impl DescribeTagsError {
             },
             Err(_) => DescribeTagsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -7306,7 +7466,7 @@ impl DetachLoadBalancerFromSubnetsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessPointNotFoundException" => {
                     DetachLoadBalancerFromSubnetsError::AccessPointNotFound(String::from(
@@ -7322,6 +7482,14 @@ impl DetachLoadBalancerFromSubnetsError {
             },
             Err(_) => DetachLoadBalancerFromSubnetsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -7387,7 +7555,7 @@ impl DisableAvailabilityZonesForLoadBalancerError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessPointNotFoundException" => {
                     DisableAvailabilityZonesForLoadBalancerError::AccessPointNotFound(
@@ -7403,6 +7571,14 @@ impl DisableAvailabilityZonesForLoadBalancerError {
             },
             Err(_) => DisableAvailabilityZonesForLoadBalancerError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -7468,7 +7644,7 @@ impl EnableAvailabilityZonesForLoadBalancerError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessPointNotFoundException" => {
                     EnableAvailabilityZonesForLoadBalancerError::AccessPointNotFound(String::from(
@@ -7479,6 +7655,14 @@ impl EnableAvailabilityZonesForLoadBalancerError {
             },
             Err(_) => EnableAvailabilityZonesForLoadBalancerError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -7545,7 +7729,7 @@ impl ModifyLoadBalancerAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessPointNotFoundException" => {
                     ModifyLoadBalancerAttributesError::AccessPointNotFound(String::from(
@@ -7566,6 +7750,14 @@ impl ModifyLoadBalancerAttributesError {
             },
             Err(_) => ModifyLoadBalancerAttributesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -7632,7 +7824,7 @@ impl RegisterInstancesWithLoadBalancerError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessPointNotFoundException" => {
                     RegisterInstancesWithLoadBalancerError::AccessPointNotFound(String::from(
@@ -7648,6 +7840,14 @@ impl RegisterInstancesWithLoadBalancerError {
             },
             Err(_) => RegisterInstancesWithLoadBalancerError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -7711,7 +7911,7 @@ impl RemoveTagsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessPointNotFoundException" => {
                     RemoveTagsError::AccessPointNotFound(String::from(parsed_error.message))
@@ -7720,6 +7920,14 @@ impl RemoveTagsError {
             },
             Err(_) => RemoveTagsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -7788,7 +7996,7 @@ impl SetLoadBalancerListenerSSLCertificateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessPointNotFoundException" => {
                     SetLoadBalancerListenerSSLCertificateError::AccessPointNotFound(String::from(
@@ -7819,6 +8027,14 @@ impl SetLoadBalancerListenerSSLCertificateError {
             },
             Err(_) => SetLoadBalancerListenerSSLCertificateError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -7891,7 +8107,7 @@ impl SetLoadBalancerPoliciesForBackendServerError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessPointNotFoundException" => {
                     SetLoadBalancerPoliciesForBackendServerError::AccessPointNotFound(
@@ -7912,6 +8128,14 @@ impl SetLoadBalancerPoliciesForBackendServerError {
             },
             Err(_) => SetLoadBalancerPoliciesForBackendServerError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -7984,7 +8208,7 @@ impl SetLoadBalancerPoliciesOfListenerError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessPointNotFoundException" => {
                     SetLoadBalancerPoliciesOfListenerError::AccessPointNotFound(String::from(
@@ -8010,6 +8234,14 @@ impl SetLoadBalancerPoliciesOfListenerError {
             },
             Err(_) => SetLoadBalancerPoliciesOfListenerError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 

--- a/rusoto/services/elbv2/src/generated.rs
+++ b/rusoto/services/elbv2/src/generated.rs
@@ -6283,7 +6283,7 @@ impl AddListenerCertificatesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CertificateNotFoundException" => {
                     AddListenerCertificatesError::CertificateNotFound(String::from(
@@ -6302,6 +6302,14 @@ impl AddListenerCertificatesError {
             },
             Err(_) => AddListenerCertificatesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -6372,7 +6380,7 @@ impl AddTagsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DuplicateTagKeysException" => {
                     AddTagsError::DuplicateTagKeys(String::from(parsed_error.message))
@@ -6390,6 +6398,14 @@ impl AddTagsError {
             },
             Err(_) => AddTagsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -6477,7 +6493,7 @@ impl CreateListenerError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CertificateNotFoundException" => {
                     CreateListenerError::CertificateNotFound(String::from(parsed_error.message))
@@ -6528,6 +6544,14 @@ impl CreateListenerError {
             },
             Err(_) => CreateListenerError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -6622,7 +6646,7 @@ impl CreateLoadBalancerError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AllocationIdNotFoundException" => CreateLoadBalancerError::AllocationIdNotFound(
                     String::from(parsed_error.message),
@@ -6670,6 +6694,14 @@ impl CreateLoadBalancerError {
             },
             Err(_) => CreateLoadBalancerError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -6761,7 +6793,7 @@ impl CreateRuleError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "IncompatibleProtocolsException" => {
                     CreateRuleError::IncompatibleProtocols(String::from(parsed_error.message))
@@ -6799,6 +6831,14 @@ impl CreateRuleError {
             },
             Err(_) => CreateRuleError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -6872,7 +6912,7 @@ impl CreateTargetGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DuplicateTargetGroupNameException" => {
                     CreateTargetGroupError::DuplicateTargetGroupName(String::from(
@@ -6891,6 +6931,14 @@ impl CreateTargetGroupError {
             },
             Err(_) => CreateTargetGroupError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -6955,7 +7003,7 @@ impl DeleteListenerError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ListenerNotFoundException" => {
                     DeleteListenerError::ListenerNotFound(String::from(parsed_error.message))
@@ -6964,6 +7012,14 @@ impl DeleteListenerError {
             },
             Err(_) => DeleteListenerError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -7028,7 +7084,7 @@ impl DeleteLoadBalancerError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "LoadBalancerNotFoundException" => DeleteLoadBalancerError::LoadBalancerNotFound(
                     String::from(parsed_error.message),
@@ -7045,6 +7101,14 @@ impl DeleteLoadBalancerError {
             },
             Err(_) => DeleteLoadBalancerError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -7111,7 +7175,7 @@ impl DeleteRuleError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "OperationNotPermittedException" => {
                     DeleteRuleError::OperationNotPermitted(String::from(parsed_error.message))
@@ -7123,6 +7187,14 @@ impl DeleteRuleError {
             },
             Err(_) => DeleteRuleError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -7184,7 +7256,7 @@ impl DeleteTargetGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceInUseException" => {
                     DeleteTargetGroupError::ResourceInUse(String::from(parsed_error.message))
@@ -7193,6 +7265,14 @@ impl DeleteTargetGroupError {
             },
             Err(_) => DeleteTargetGroupError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -7257,7 +7337,7 @@ impl DeregisterTargetsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidTargetException" => {
                     DeregisterTargetsError::InvalidTarget(String::from(parsed_error.message))
@@ -7269,6 +7349,14 @@ impl DeregisterTargetsError {
             },
             Err(_) => DeregisterTargetsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -7330,12 +7418,20 @@ impl DescribeAccountLimitsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeAccountLimitsError::Unknown(String::from(body)),
             },
             Err(_) => DescribeAccountLimitsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -7397,7 +7493,7 @@ impl DescribeListenerCertificatesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ListenerNotFoundException" => {
                     DescribeListenerCertificatesError::ListenerNotFound(String::from(
@@ -7408,6 +7504,14 @@ impl DescribeListenerCertificatesError {
             },
             Err(_) => DescribeListenerCertificatesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -7472,7 +7576,7 @@ impl DescribeListenersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ListenerNotFoundException" => {
                     DescribeListenersError::ListenerNotFound(String::from(parsed_error.message))
@@ -7484,6 +7588,14 @@ impl DescribeListenersError {
             },
             Err(_) => DescribeListenersError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -7547,7 +7659,7 @@ impl DescribeLoadBalancerAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "LoadBalancerNotFoundException" => {
                     DescribeLoadBalancerAttributesError::LoadBalancerNotFound(String::from(
@@ -7558,6 +7670,14 @@ impl DescribeLoadBalancerAttributesError {
             },
             Err(_) => DescribeLoadBalancerAttributesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -7620,7 +7740,7 @@ impl DescribeLoadBalancersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "LoadBalancerNotFoundException" => {
                     DescribeLoadBalancersError::LoadBalancerNotFound(String::from(
@@ -7631,6 +7751,14 @@ impl DescribeLoadBalancersError {
             },
             Err(_) => DescribeLoadBalancersError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -7695,7 +7823,7 @@ impl DescribeRulesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ListenerNotFoundException" => {
                     DescribeRulesError::ListenerNotFound(String::from(parsed_error.message))
@@ -7707,6 +7835,14 @@ impl DescribeRulesError {
             },
             Err(_) => DescribeRulesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -7768,7 +7904,7 @@ impl DescribeSSLPoliciesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "SSLPolicyNotFoundException" => {
                     DescribeSSLPoliciesError::SSLPolicyNotFound(String::from(parsed_error.message))
@@ -7777,6 +7913,14 @@ impl DescribeSSLPoliciesError {
             },
             Err(_) => DescribeSSLPoliciesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -7845,7 +7989,7 @@ impl DescribeTagsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ListenerNotFoundException" => {
                     DescribeTagsError::ListenerNotFound(String::from(parsed_error.message))
@@ -7863,6 +8007,14 @@ impl DescribeTagsError {
             },
             Err(_) => DescribeTagsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -7926,7 +8078,7 @@ impl DescribeTargetGroupAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "TargetGroupNotFoundException" => {
                     DescribeTargetGroupAttributesError::TargetGroupNotFound(String::from(
@@ -7937,6 +8089,14 @@ impl DescribeTargetGroupAttributesError {
             },
             Err(_) => DescribeTargetGroupAttributesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -8001,7 +8161,7 @@ impl DescribeTargetGroupsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "LoadBalancerNotFoundException" => {
                     DescribeTargetGroupsError::LoadBalancerNotFound(String::from(
@@ -8015,6 +8175,14 @@ impl DescribeTargetGroupsError {
             },
             Err(_) => DescribeTargetGroupsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -8082,7 +8250,7 @@ impl DescribeTargetHealthError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "HealthUnavailableException" => {
                     DescribeTargetHealthError::HealthUnavailable(String::from(parsed_error.message))
@@ -8097,6 +8265,14 @@ impl DescribeTargetHealthError {
             },
             Err(_) => DescribeTargetHealthError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -8185,7 +8361,7 @@ impl ModifyListenerError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CertificateNotFoundException" => {
                     ModifyListenerError::CertificateNotFound(String::from(parsed_error.message))
@@ -8236,6 +8412,14 @@ impl ModifyListenerError {
             },
             Err(_) => ModifyListenerError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -8310,7 +8494,7 @@ impl ModifyLoadBalancerAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidConfigurationRequestException" => {
                     ModifyLoadBalancerAttributesError::InvalidConfigurationRequest(String::from(
@@ -8326,6 +8510,14 @@ impl ModifyLoadBalancerAttributesError {
             },
             Err(_) => ModifyLoadBalancerAttributesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -8401,7 +8593,7 @@ impl ModifyRuleError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "IncompatibleProtocolsException" => {
                     ModifyRuleError::IncompatibleProtocols(String::from(parsed_error.message))
@@ -8430,6 +8622,14 @@ impl ModifyRuleError {
             },
             Err(_) => ModifyRuleError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -8498,7 +8698,7 @@ impl ModifyTargetGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidConfigurationRequestException" => {
                     ModifyTargetGroupError::InvalidConfigurationRequest(String::from(
@@ -8512,6 +8712,14 @@ impl ModifyTargetGroupError {
             },
             Err(_) => ModifyTargetGroupError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -8577,7 +8785,7 @@ impl ModifyTargetGroupAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidConfigurationRequestException" => {
                     ModifyTargetGroupAttributesError::InvalidConfigurationRequest(String::from(
@@ -8593,6 +8801,14 @@ impl ModifyTargetGroupAttributesError {
             },
             Err(_) => ModifyTargetGroupAttributesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -8662,7 +8878,7 @@ impl RegisterTargetsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidTargetException" => {
                     RegisterTargetsError::InvalidTarget(String::from(parsed_error.message))
@@ -8682,6 +8898,14 @@ impl RegisterTargetsError {
             },
             Err(_) => RegisterTargetsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -8747,7 +8971,7 @@ impl RemoveListenerCertificatesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ListenerNotFoundException" => RemoveListenerCertificatesError::ListenerNotFound(
                     String::from(parsed_error.message),
@@ -8761,6 +8985,14 @@ impl RemoveListenerCertificatesError {
             },
             Err(_) => RemoveListenerCertificatesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -8832,7 +9064,7 @@ impl RemoveTagsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ListenerNotFoundException" => {
                     RemoveTagsError::ListenerNotFound(String::from(parsed_error.message))
@@ -8853,6 +9085,14 @@ impl RemoveTagsError {
             },
             Err(_) => RemoveTagsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -8921,7 +9161,7 @@ impl SetIpAddressTypeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidConfigurationRequestException" => {
                     SetIpAddressTypeError::InvalidConfigurationRequest(String::from(
@@ -8938,6 +9178,14 @@ impl SetIpAddressTypeError {
             },
             Err(_) => SetIpAddressTypeError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -9004,7 +9252,7 @@ impl SetRulePrioritiesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "OperationNotPermittedException" => SetRulePrioritiesError::OperationNotPermitted(
                     String::from(parsed_error.message),
@@ -9019,6 +9267,14 @@ impl SetRulePrioritiesError {
             },
             Err(_) => SetRulePrioritiesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -9087,7 +9343,7 @@ impl SetSecurityGroupsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidConfigurationRequestException" => {
                     SetSecurityGroupsError::InvalidConfigurationRequest(String::from(
@@ -9104,6 +9360,14 @@ impl SetSecurityGroupsError {
             },
             Err(_) => SetSecurityGroupsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -9178,7 +9442,7 @@ impl SetSubnetsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AllocationIdNotFoundException" => {
                     SetSubnetsError::AllocationIdNotFound(String::from(parsed_error.message))
@@ -9204,6 +9468,14 @@ impl SetSubnetsError {
             },
             Err(_) => SetSubnetsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 

--- a/rusoto/services/elbv2/src/generated.rs
+++ b/rusoto/services/elbv2/src/generated.rs
@@ -6285,19 +6285,15 @@ impl AddListenerCertificatesError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "CertificateNotFoundException" => {
-                    AddListenerCertificatesError::CertificateNotFound(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "ListenerNotFoundException" => AddListenerCertificatesError::ListenerNotFound(
+                "CertificateNotFound" => AddListenerCertificatesError::CertificateNotFound(
                     String::from(parsed_error.message),
                 ),
-                "TooManyCertificatesException" => {
-                    AddListenerCertificatesError::TooManyCertificates(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "ListenerNotFound" => AddListenerCertificatesError::ListenerNotFound(
+                    String::from(parsed_error.message),
+                ),
+                "TooManyCertificates" => AddListenerCertificatesError::TooManyCertificates(
+                    String::from(parsed_error.message),
+                ),
                 _ => AddListenerCertificatesError::Unknown(String::from(body)),
             },
             Err(_) => AddListenerCertificatesError::Unknown(body.to_string()),
@@ -6382,18 +6378,16 @@ impl AddTagsError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "DuplicateTagKeysException" => {
+                "DuplicateTagKeys" => {
                     AddTagsError::DuplicateTagKeys(String::from(parsed_error.message))
                 }
-                "LoadBalancerNotFoundException" => {
+                "LoadBalancerNotFound" => {
                     AddTagsError::LoadBalancerNotFound(String::from(parsed_error.message))
                 }
-                "TargetGroupNotFoundException" => {
+                "TargetGroupNotFound" => {
                     AddTagsError::TargetGroupNotFound(String::from(parsed_error.message))
                 }
-                "TooManyTagsException" => {
-                    AddTagsError::TooManyTags(String::from(parsed_error.message))
-                }
+                "TooManyTags" => AddTagsError::TooManyTags(String::from(parsed_error.message)),
                 _ => AddTagsError::Unknown(String::from(body)),
             },
             Err(_) => AddTagsError::Unknown(body.to_string()),
@@ -6495,49 +6489,45 @@ impl CreateListenerError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "CertificateNotFoundException" => {
+                "CertificateNotFound" => {
                     CreateListenerError::CertificateNotFound(String::from(parsed_error.message))
                 }
-                "DuplicateListenerException" => {
+                "DuplicateListener" => {
                     CreateListenerError::DuplicateListener(String::from(parsed_error.message))
                 }
-                "IncompatibleProtocolsException" => {
+                "IncompatibleProtocols" => {
                     CreateListenerError::IncompatibleProtocols(String::from(parsed_error.message))
                 }
-                "InvalidConfigurationRequestException" => {
-                    CreateListenerError::InvalidConfigurationRequest(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "LoadBalancerNotFoundException" => {
+                "InvalidConfigurationRequest" => CreateListenerError::InvalidConfigurationRequest(
+                    String::from(parsed_error.message),
+                ),
+                "LoadBalancerNotFound" => {
                     CreateListenerError::LoadBalancerNotFound(String::from(parsed_error.message))
                 }
-                "SSLPolicyNotFoundException" => {
+                "SSLPolicyNotFound" => {
                     CreateListenerError::SSLPolicyNotFound(String::from(parsed_error.message))
                 }
-                "TargetGroupAssociationLimitException" => {
-                    CreateListenerError::TargetGroupAssociationLimit(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "TargetGroupNotFoundException" => {
+                "TargetGroupAssociationLimit" => CreateListenerError::TargetGroupAssociationLimit(
+                    String::from(parsed_error.message),
+                ),
+                "TargetGroupNotFound" => {
                     CreateListenerError::TargetGroupNotFound(String::from(parsed_error.message))
                 }
-                "TooManyCertificatesException" => {
+                "TooManyCertificates" => {
                     CreateListenerError::TooManyCertificates(String::from(parsed_error.message))
                 }
-                "TooManyListenersException" => {
+                "TooManyListeners" => {
                     CreateListenerError::TooManyListeners(String::from(parsed_error.message))
                 }
-                "TooManyRegistrationsForTargetIdException" => {
+                "TooManyRegistrationsForTargetId" => {
                     CreateListenerError::TooManyRegistrationsForTargetId(String::from(
                         parsed_error.message,
                     ))
                 }
-                "TooManyTargetsException" => {
+                "TooManyTargets" => {
                     CreateListenerError::TooManyTargets(String::from(parsed_error.message))
                 }
-                "UnsupportedProtocolException" => {
+                "UnsupportedProtocol" => {
                     CreateListenerError::UnsupportedProtocol(String::from(parsed_error.message))
                 }
                 _ => CreateListenerError::Unknown(String::from(body)),
@@ -6648,46 +6638,44 @@ impl CreateLoadBalancerError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AllocationIdNotFoundException" => CreateLoadBalancerError::AllocationIdNotFound(
+                "AllocationIdNotFound" => CreateLoadBalancerError::AllocationIdNotFound(
                     String::from(parsed_error.message),
                 ),
-                "AvailabilityZoneNotSupportedException" => {
+                "AvailabilityZoneNotSupported" => {
                     CreateLoadBalancerError::AvailabilityZoneNotSupported(String::from(
                         parsed_error.message,
                     ))
                 }
-                "DuplicateLoadBalancerNameException" => {
-                    CreateLoadBalancerError::DuplicateLoadBalancerName(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "DuplicateTagKeysException" => {
+                "DuplicateLoadBalancerName" => CreateLoadBalancerError::DuplicateLoadBalancerName(
+                    String::from(parsed_error.message),
+                ),
+                "DuplicateTagKeys" => {
                     CreateLoadBalancerError::DuplicateTagKeys(String::from(parsed_error.message))
                 }
-                "InvalidConfigurationRequestException" => {
+                "InvalidConfigurationRequest" => {
                     CreateLoadBalancerError::InvalidConfigurationRequest(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InvalidSchemeException" => {
+                "InvalidScheme" => {
                     CreateLoadBalancerError::InvalidScheme(String::from(parsed_error.message))
                 }
-                "InvalidSecurityGroupException" => CreateLoadBalancerError::InvalidSecurityGroup(
+                "InvalidSecurityGroup" => CreateLoadBalancerError::InvalidSecurityGroup(
                     String::from(parsed_error.message),
                 ),
-                "InvalidSubnetException" => {
+                "InvalidSubnet" => {
                     CreateLoadBalancerError::InvalidSubnet(String::from(parsed_error.message))
                 }
-                "ResourceInUseException" => {
+                "ResourceInUse" => {
                     CreateLoadBalancerError::ResourceInUse(String::from(parsed_error.message))
                 }
-                "SubnetNotFoundException" => {
+                "SubnetNotFound" => {
                     CreateLoadBalancerError::SubnetNotFound(String::from(parsed_error.message))
                 }
-                "TooManyLoadBalancersException" => CreateLoadBalancerError::TooManyLoadBalancers(
+                "TooManyLoadBalancers" => CreateLoadBalancerError::TooManyLoadBalancers(
                     String::from(parsed_error.message),
                 ),
-                "TooManyTagsException" => {
+                "TooManyTags" => {
                     CreateLoadBalancerError::TooManyTags(String::from(parsed_error.message))
                 }
                 _ => CreateLoadBalancerError::Unknown(String::from(body)),
@@ -6795,36 +6783,34 @@ impl CreateRuleError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "IncompatibleProtocolsException" => {
+                "IncompatibleProtocols" => {
                     CreateRuleError::IncompatibleProtocols(String::from(parsed_error.message))
                 }
-                "InvalidConfigurationRequestException" => {
+                "InvalidConfigurationRequest" => {
                     CreateRuleError::InvalidConfigurationRequest(String::from(parsed_error.message))
                 }
-                "ListenerNotFoundException" => {
+                "ListenerNotFound" => {
                     CreateRuleError::ListenerNotFound(String::from(parsed_error.message))
                 }
-                "PriorityInUseException" => {
+                "PriorityInUse" => {
                     CreateRuleError::PriorityInUse(String::from(parsed_error.message))
                 }
-                "TargetGroupAssociationLimitException" => {
+                "TargetGroupAssociationLimit" => {
                     CreateRuleError::TargetGroupAssociationLimit(String::from(parsed_error.message))
                 }
-                "TargetGroupNotFoundException" => {
+                "TargetGroupNotFound" => {
                     CreateRuleError::TargetGroupNotFound(String::from(parsed_error.message))
                 }
-                "TooManyRegistrationsForTargetIdException" => {
+                "TooManyRegistrationsForTargetId" => {
                     CreateRuleError::TooManyRegistrationsForTargetId(String::from(
                         parsed_error.message,
                     ))
                 }
-                "TooManyRulesException" => {
-                    CreateRuleError::TooManyRules(String::from(parsed_error.message))
-                }
-                "TooManyTargetGroupsException" => {
+                "TooManyRules" => CreateRuleError::TooManyRules(String::from(parsed_error.message)),
+                "TooManyTargetGroups" => {
                     CreateRuleError::TooManyTargetGroups(String::from(parsed_error.message))
                 }
-                "TooManyTargetsException" => {
+                "TooManyTargets" => {
                     CreateRuleError::TooManyTargets(String::from(parsed_error.message))
                 }
                 _ => CreateRuleError::Unknown(String::from(body)),
@@ -6914,17 +6900,15 @@ impl CreateTargetGroupError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "DuplicateTargetGroupNameException" => {
-                    CreateTargetGroupError::DuplicateTargetGroupName(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "InvalidConfigurationRequestException" => {
+                "DuplicateTargetGroupName" => CreateTargetGroupError::DuplicateTargetGroupName(
+                    String::from(parsed_error.message),
+                ),
+                "InvalidConfigurationRequest" => {
                     CreateTargetGroupError::InvalidConfigurationRequest(String::from(
                         parsed_error.message,
                     ))
                 }
-                "TooManyTargetGroupsException" => {
+                "TooManyTargetGroups" => {
                     CreateTargetGroupError::TooManyTargetGroups(String::from(parsed_error.message))
                 }
                 _ => CreateTargetGroupError::Unknown(String::from(body)),
@@ -7005,7 +6989,7 @@ impl DeleteListenerError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ListenerNotFoundException" => {
+                "ListenerNotFound" => {
                     DeleteListenerError::ListenerNotFound(String::from(parsed_error.message))
                 }
                 _ => DeleteListenerError::Unknown(String::from(body)),
@@ -7086,15 +7070,13 @@ impl DeleteLoadBalancerError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "LoadBalancerNotFoundException" => DeleteLoadBalancerError::LoadBalancerNotFound(
+                "LoadBalancerNotFound" => DeleteLoadBalancerError::LoadBalancerNotFound(
                     String::from(parsed_error.message),
                 ),
-                "OperationNotPermittedException" => {
-                    DeleteLoadBalancerError::OperationNotPermitted(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "ResourceInUseException" => {
+                "OperationNotPermitted" => DeleteLoadBalancerError::OperationNotPermitted(
+                    String::from(parsed_error.message),
+                ),
+                "ResourceInUse" => {
                     DeleteLoadBalancerError::ResourceInUse(String::from(parsed_error.message))
                 }
                 _ => DeleteLoadBalancerError::Unknown(String::from(body)),
@@ -7177,12 +7159,10 @@ impl DeleteRuleError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "OperationNotPermittedException" => {
+                "OperationNotPermitted" => {
                     DeleteRuleError::OperationNotPermitted(String::from(parsed_error.message))
                 }
-                "RuleNotFoundException" => {
-                    DeleteRuleError::RuleNotFound(String::from(parsed_error.message))
-                }
+                "RuleNotFound" => DeleteRuleError::RuleNotFound(String::from(parsed_error.message)),
                 _ => DeleteRuleError::Unknown(String::from(body)),
             },
             Err(_) => DeleteRuleError::Unknown(body.to_string()),
@@ -7258,7 +7238,7 @@ impl DeleteTargetGroupError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ResourceInUseException" => {
+                "ResourceInUse" => {
                     DeleteTargetGroupError::ResourceInUse(String::from(parsed_error.message))
                 }
                 _ => DeleteTargetGroupError::Unknown(String::from(body)),
@@ -7339,10 +7319,10 @@ impl DeregisterTargetsError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "InvalidTargetException" => {
+                "InvalidTarget" => {
                     DeregisterTargetsError::InvalidTarget(String::from(parsed_error.message))
                 }
-                "TargetGroupNotFoundException" => {
+                "TargetGroupNotFound" => {
                     DeregisterTargetsError::TargetGroupNotFound(String::from(parsed_error.message))
                 }
                 _ => DeregisterTargetsError::Unknown(String::from(body)),
@@ -7495,11 +7475,9 @@ impl DescribeListenerCertificatesError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ListenerNotFoundException" => {
-                    DescribeListenerCertificatesError::ListenerNotFound(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "ListenerNotFound" => DescribeListenerCertificatesError::ListenerNotFound(
+                    String::from(parsed_error.message),
+                ),
                 _ => DescribeListenerCertificatesError::Unknown(String::from(body)),
             },
             Err(_) => DescribeListenerCertificatesError::Unknown(body.to_string()),
@@ -7578,10 +7556,10 @@ impl DescribeListenersError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ListenerNotFoundException" => {
+                "ListenerNotFound" => {
                     DescribeListenersError::ListenerNotFound(String::from(parsed_error.message))
                 }
-                "LoadBalancerNotFoundException" => {
+                "LoadBalancerNotFound" => {
                     DescribeListenersError::LoadBalancerNotFound(String::from(parsed_error.message))
                 }
                 _ => DescribeListenersError::Unknown(String::from(body)),
@@ -7661,7 +7639,7 @@ impl DescribeLoadBalancerAttributesError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "LoadBalancerNotFoundException" => {
+                "LoadBalancerNotFound" => {
                     DescribeLoadBalancerAttributesError::LoadBalancerNotFound(String::from(
                         parsed_error.message,
                     ))
@@ -7742,11 +7720,9 @@ impl DescribeLoadBalancersError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "LoadBalancerNotFoundException" => {
-                    DescribeLoadBalancersError::LoadBalancerNotFound(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "LoadBalancerNotFound" => DescribeLoadBalancersError::LoadBalancerNotFound(
+                    String::from(parsed_error.message),
+                ),
                 _ => DescribeLoadBalancersError::Unknown(String::from(body)),
             },
             Err(_) => DescribeLoadBalancersError::Unknown(body.to_string()),
@@ -7825,10 +7801,10 @@ impl DescribeRulesError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ListenerNotFoundException" => {
+                "ListenerNotFound" => {
                     DescribeRulesError::ListenerNotFound(String::from(parsed_error.message))
                 }
-                "RuleNotFoundException" => {
+                "RuleNotFound" => {
                     DescribeRulesError::RuleNotFound(String::from(parsed_error.message))
                 }
                 _ => DescribeRulesError::Unknown(String::from(body)),
@@ -7906,7 +7882,7 @@ impl DescribeSSLPoliciesError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "SSLPolicyNotFoundException" => {
+                "SSLPolicyNotFound" => {
                     DescribeSSLPoliciesError::SSLPolicyNotFound(String::from(parsed_error.message))
                 }
                 _ => DescribeSSLPoliciesError::Unknown(String::from(body)),
@@ -7991,16 +7967,16 @@ impl DescribeTagsError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ListenerNotFoundException" => {
+                "ListenerNotFound" => {
                     DescribeTagsError::ListenerNotFound(String::from(parsed_error.message))
                 }
-                "LoadBalancerNotFoundException" => {
+                "LoadBalancerNotFound" => {
                     DescribeTagsError::LoadBalancerNotFound(String::from(parsed_error.message))
                 }
-                "RuleNotFoundException" => {
+                "RuleNotFound" => {
                     DescribeTagsError::RuleNotFound(String::from(parsed_error.message))
                 }
-                "TargetGroupNotFoundException" => {
+                "TargetGroupNotFound" => {
                     DescribeTagsError::TargetGroupNotFound(String::from(parsed_error.message))
                 }
                 _ => DescribeTagsError::Unknown(String::from(body)),
@@ -8080,11 +8056,9 @@ impl DescribeTargetGroupAttributesError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "TargetGroupNotFoundException" => {
-                    DescribeTargetGroupAttributesError::TargetGroupNotFound(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "TargetGroupNotFound" => DescribeTargetGroupAttributesError::TargetGroupNotFound(
+                    String::from(parsed_error.message),
+                ),
                 _ => DescribeTargetGroupAttributesError::Unknown(String::from(body)),
             },
             Err(_) => DescribeTargetGroupAttributesError::Unknown(body.to_string()),
@@ -8163,12 +8137,10 @@ impl DescribeTargetGroupsError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "LoadBalancerNotFoundException" => {
-                    DescribeTargetGroupsError::LoadBalancerNotFound(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "TargetGroupNotFoundException" => DescribeTargetGroupsError::TargetGroupNotFound(
+                "LoadBalancerNotFound" => DescribeTargetGroupsError::LoadBalancerNotFound(
+                    String::from(parsed_error.message),
+                ),
+                "TargetGroupNotFound" => DescribeTargetGroupsError::TargetGroupNotFound(
                     String::from(parsed_error.message),
                 ),
                 _ => DescribeTargetGroupsError::Unknown(String::from(body)),
@@ -8252,13 +8224,13 @@ impl DescribeTargetHealthError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "HealthUnavailableException" => {
+                "HealthUnavailable" => {
                     DescribeTargetHealthError::HealthUnavailable(String::from(parsed_error.message))
                 }
-                "InvalidTargetException" => {
+                "InvalidTarget" => {
                     DescribeTargetHealthError::InvalidTarget(String::from(parsed_error.message))
                 }
-                "TargetGroupNotFoundException" => DescribeTargetHealthError::TargetGroupNotFound(
+                "TargetGroupNotFound" => DescribeTargetHealthError::TargetGroupNotFound(
                     String::from(parsed_error.message),
                 ),
                 _ => DescribeTargetHealthError::Unknown(String::from(body)),
@@ -8363,49 +8335,45 @@ impl ModifyListenerError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "CertificateNotFoundException" => {
+                "CertificateNotFound" => {
                     ModifyListenerError::CertificateNotFound(String::from(parsed_error.message))
                 }
-                "DuplicateListenerException" => {
+                "DuplicateListener" => {
                     ModifyListenerError::DuplicateListener(String::from(parsed_error.message))
                 }
-                "IncompatibleProtocolsException" => {
+                "IncompatibleProtocols" => {
                     ModifyListenerError::IncompatibleProtocols(String::from(parsed_error.message))
                 }
-                "InvalidConfigurationRequestException" => {
-                    ModifyListenerError::InvalidConfigurationRequest(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "ListenerNotFoundException" => {
+                "InvalidConfigurationRequest" => ModifyListenerError::InvalidConfigurationRequest(
+                    String::from(parsed_error.message),
+                ),
+                "ListenerNotFound" => {
                     ModifyListenerError::ListenerNotFound(String::from(parsed_error.message))
                 }
-                "SSLPolicyNotFoundException" => {
+                "SSLPolicyNotFound" => {
                     ModifyListenerError::SSLPolicyNotFound(String::from(parsed_error.message))
                 }
-                "TargetGroupAssociationLimitException" => {
-                    ModifyListenerError::TargetGroupAssociationLimit(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "TargetGroupNotFoundException" => {
+                "TargetGroupAssociationLimit" => ModifyListenerError::TargetGroupAssociationLimit(
+                    String::from(parsed_error.message),
+                ),
+                "TargetGroupNotFound" => {
                     ModifyListenerError::TargetGroupNotFound(String::from(parsed_error.message))
                 }
-                "TooManyCertificatesException" => {
+                "TooManyCertificates" => {
                     ModifyListenerError::TooManyCertificates(String::from(parsed_error.message))
                 }
-                "TooManyListenersException" => {
+                "TooManyListeners" => {
                     ModifyListenerError::TooManyListeners(String::from(parsed_error.message))
                 }
-                "TooManyRegistrationsForTargetIdException" => {
+                "TooManyRegistrationsForTargetId" => {
                     ModifyListenerError::TooManyRegistrationsForTargetId(String::from(
                         parsed_error.message,
                     ))
                 }
-                "TooManyTargetsException" => {
+                "TooManyTargets" => {
                     ModifyListenerError::TooManyTargets(String::from(parsed_error.message))
                 }
-                "UnsupportedProtocolException" => {
+                "UnsupportedProtocol" => {
                     ModifyListenerError::UnsupportedProtocol(String::from(parsed_error.message))
                 }
                 _ => ModifyListenerError::Unknown(String::from(body)),
@@ -8496,16 +8464,14 @@ impl ModifyLoadBalancerAttributesError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "InvalidConfigurationRequestException" => {
+                "InvalidConfigurationRequest" => {
                     ModifyLoadBalancerAttributesError::InvalidConfigurationRequest(String::from(
                         parsed_error.message,
                     ))
                 }
-                "LoadBalancerNotFoundException" => {
-                    ModifyLoadBalancerAttributesError::LoadBalancerNotFound(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "LoadBalancerNotFound" => ModifyLoadBalancerAttributesError::LoadBalancerNotFound(
+                    String::from(parsed_error.message),
+                ),
                 _ => ModifyLoadBalancerAttributesError::Unknown(String::from(body)),
             },
             Err(_) => ModifyLoadBalancerAttributesError::Unknown(body.to_string()),
@@ -8595,27 +8561,25 @@ impl ModifyRuleError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "IncompatibleProtocolsException" => {
+                "IncompatibleProtocols" => {
                     ModifyRuleError::IncompatibleProtocols(String::from(parsed_error.message))
                 }
-                "OperationNotPermittedException" => {
+                "OperationNotPermitted" => {
                     ModifyRuleError::OperationNotPermitted(String::from(parsed_error.message))
                 }
-                "RuleNotFoundException" => {
-                    ModifyRuleError::RuleNotFound(String::from(parsed_error.message))
-                }
-                "TargetGroupAssociationLimitException" => {
+                "RuleNotFound" => ModifyRuleError::RuleNotFound(String::from(parsed_error.message)),
+                "TargetGroupAssociationLimit" => {
                     ModifyRuleError::TargetGroupAssociationLimit(String::from(parsed_error.message))
                 }
-                "TargetGroupNotFoundException" => {
+                "TargetGroupNotFound" => {
                     ModifyRuleError::TargetGroupNotFound(String::from(parsed_error.message))
                 }
-                "TooManyRegistrationsForTargetIdException" => {
+                "TooManyRegistrationsForTargetId" => {
                     ModifyRuleError::TooManyRegistrationsForTargetId(String::from(
                         parsed_error.message,
                     ))
                 }
-                "TooManyTargetsException" => {
+                "TooManyTargets" => {
                     ModifyRuleError::TooManyTargets(String::from(parsed_error.message))
                 }
                 _ => ModifyRuleError::Unknown(String::from(body)),
@@ -8700,12 +8664,12 @@ impl ModifyTargetGroupError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "InvalidConfigurationRequestException" => {
+                "InvalidConfigurationRequest" => {
                     ModifyTargetGroupError::InvalidConfigurationRequest(String::from(
                         parsed_error.message,
                     ))
                 }
-                "TargetGroupNotFoundException" => {
+                "TargetGroupNotFound" => {
                     ModifyTargetGroupError::TargetGroupNotFound(String::from(parsed_error.message))
                 }
                 _ => ModifyTargetGroupError::Unknown(String::from(body)),
@@ -8787,16 +8751,14 @@ impl ModifyTargetGroupAttributesError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "InvalidConfigurationRequestException" => {
+                "InvalidConfigurationRequest" => {
                     ModifyTargetGroupAttributesError::InvalidConfigurationRequest(String::from(
                         parsed_error.message,
                     ))
                 }
-                "TargetGroupNotFoundException" => {
-                    ModifyTargetGroupAttributesError::TargetGroupNotFound(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "TargetGroupNotFound" => ModifyTargetGroupAttributesError::TargetGroupNotFound(
+                    String::from(parsed_error.message),
+                ),
                 _ => ModifyTargetGroupAttributesError::Unknown(String::from(body)),
             },
             Err(_) => ModifyTargetGroupAttributesError::Unknown(body.to_string()),
@@ -8880,18 +8842,18 @@ impl RegisterTargetsError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "InvalidTargetException" => {
+                "InvalidTarget" => {
                     RegisterTargetsError::InvalidTarget(String::from(parsed_error.message))
                 }
-                "TargetGroupNotFoundException" => {
+                "TargetGroupNotFound" => {
                     RegisterTargetsError::TargetGroupNotFound(String::from(parsed_error.message))
                 }
-                "TooManyRegistrationsForTargetIdException" => {
+                "TooManyRegistrationsForTargetId" => {
                     RegisterTargetsError::TooManyRegistrationsForTargetId(String::from(
                         parsed_error.message,
                     ))
                 }
-                "TooManyTargetsException" => {
+                "TooManyTargets" => {
                     RegisterTargetsError::TooManyTargets(String::from(parsed_error.message))
                 }
                 _ => RegisterTargetsError::Unknown(String::from(body)),
@@ -8973,14 +8935,12 @@ impl RemoveListenerCertificatesError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ListenerNotFoundException" => RemoveListenerCertificatesError::ListenerNotFound(
+                "ListenerNotFound" => RemoveListenerCertificatesError::ListenerNotFound(
                     String::from(parsed_error.message),
                 ),
-                "OperationNotPermittedException" => {
-                    RemoveListenerCertificatesError::OperationNotPermitted(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "OperationNotPermitted" => RemoveListenerCertificatesError::OperationNotPermitted(
+                    String::from(parsed_error.message),
+                ),
                 _ => RemoveListenerCertificatesError::Unknown(String::from(body)),
             },
             Err(_) => RemoveListenerCertificatesError::Unknown(body.to_string()),
@@ -9066,21 +9026,17 @@ impl RemoveTagsError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ListenerNotFoundException" => {
+                "ListenerNotFound" => {
                     RemoveTagsError::ListenerNotFound(String::from(parsed_error.message))
                 }
-                "LoadBalancerNotFoundException" => {
+                "LoadBalancerNotFound" => {
                     RemoveTagsError::LoadBalancerNotFound(String::from(parsed_error.message))
                 }
-                "RuleNotFoundException" => {
-                    RemoveTagsError::RuleNotFound(String::from(parsed_error.message))
-                }
-                "TargetGroupNotFoundException" => {
+                "RuleNotFound" => RemoveTagsError::RuleNotFound(String::from(parsed_error.message)),
+                "TargetGroupNotFound" => {
                     RemoveTagsError::TargetGroupNotFound(String::from(parsed_error.message))
                 }
-                "TooManyTagsException" => {
-                    RemoveTagsError::TooManyTags(String::from(parsed_error.message))
-                }
+                "TooManyTags" => RemoveTagsError::TooManyTags(String::from(parsed_error.message)),
                 _ => RemoveTagsError::Unknown(String::from(body)),
             },
             Err(_) => RemoveTagsError::Unknown(body.to_string()),
@@ -9163,15 +9119,15 @@ impl SetIpAddressTypeError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "InvalidConfigurationRequestException" => {
+                "InvalidConfigurationRequest" => {
                     SetIpAddressTypeError::InvalidConfigurationRequest(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InvalidSubnetException" => {
+                "InvalidSubnet" => {
                     SetIpAddressTypeError::InvalidSubnet(String::from(parsed_error.message))
                 }
-                "LoadBalancerNotFoundException" => {
+                "LoadBalancerNotFound" => {
                     SetIpAddressTypeError::LoadBalancerNotFound(String::from(parsed_error.message))
                 }
                 _ => SetIpAddressTypeError::Unknown(String::from(body)),
@@ -9254,13 +9210,13 @@ impl SetRulePrioritiesError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "OperationNotPermittedException" => SetRulePrioritiesError::OperationNotPermitted(
+                "OperationNotPermitted" => SetRulePrioritiesError::OperationNotPermitted(
                     String::from(parsed_error.message),
                 ),
-                "PriorityInUseException" => {
+                "PriorityInUse" => {
                     SetRulePrioritiesError::PriorityInUse(String::from(parsed_error.message))
                 }
-                "RuleNotFoundException" => {
+                "RuleNotFound" => {
                     SetRulePrioritiesError::RuleNotFound(String::from(parsed_error.message))
                 }
                 _ => SetRulePrioritiesError::Unknown(String::from(body)),
@@ -9345,15 +9301,15 @@ impl SetSecurityGroupsError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "InvalidConfigurationRequestException" => {
+                "InvalidConfigurationRequest" => {
                     SetSecurityGroupsError::InvalidConfigurationRequest(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InvalidSecurityGroupException" => {
+                "InvalidSecurityGroup" => {
                     SetSecurityGroupsError::InvalidSecurityGroup(String::from(parsed_error.message))
                 }
-                "LoadBalancerNotFoundException" => {
+                "LoadBalancerNotFound" => {
                     SetSecurityGroupsError::LoadBalancerNotFound(String::from(parsed_error.message))
                 }
                 _ => SetSecurityGroupsError::Unknown(String::from(body)),
@@ -9444,24 +9400,22 @@ impl SetSubnetsError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AllocationIdNotFoundException" => {
+                "AllocationIdNotFound" => {
                     SetSubnetsError::AllocationIdNotFound(String::from(parsed_error.message))
                 }
-                "AvailabilityZoneNotSupportedException" => {
-                    SetSubnetsError::AvailabilityZoneNotSupported(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "InvalidConfigurationRequestException" => {
+                "AvailabilityZoneNotSupported" => SetSubnetsError::AvailabilityZoneNotSupported(
+                    String::from(parsed_error.message),
+                ),
+                "InvalidConfigurationRequest" => {
                     SetSubnetsError::InvalidConfigurationRequest(String::from(parsed_error.message))
                 }
-                "InvalidSubnetException" => {
+                "InvalidSubnet" => {
                     SetSubnetsError::InvalidSubnet(String::from(parsed_error.message))
                 }
-                "LoadBalancerNotFoundException" => {
+                "LoadBalancerNotFound" => {
                     SetSubnetsError::LoadBalancerNotFound(String::from(parsed_error.message))
                 }
-                "SubnetNotFoundException" => {
+                "SubnetNotFound" => {
                     SetSubnetsError::SubnetNotFound(String::from(parsed_error.message))
                 }
                 _ => SetSubnetsError::Unknown(String::from(body)),

--- a/rusoto/services/greengrass/src/generated.rs
+++ b/rusoto/services/greengrass/src/generated.rs
@@ -2604,9 +2604,9 @@ pub struct VersionInformation {
 #[derive(Debug, PartialEq)]
 pub enum AssociateRoleToGroupError {
     /// <p>General Error</p>
-    InternalServerError(String),
-    /// <p>General Error</p>
     BadRequest(String),
+    /// <p>General Error</p>
+    InternalServerError(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -2630,11 +2630,11 @@ impl AssociateRoleToGroupError {
                 let error_type = pieces.last().expect("Expected error type");
 
                 match *error_type {
-                    "InternalServerErrorException" => {
-                        AssociateRoleToGroupError::InternalServerError(String::from(error_message))
-                    }
                     "BadRequestException" => {
                         AssociateRoleToGroupError::BadRequest(String::from(error_message))
+                    }
+                    "InternalServerErrorException" => {
+                        AssociateRoleToGroupError::InternalServerError(String::from(error_message))
                     }
                     "ValidationException" => {
                         AssociateRoleToGroupError::Validation(error_message.to_string())
@@ -2675,8 +2675,8 @@ impl fmt::Display for AssociateRoleToGroupError {
 impl Error for AssociateRoleToGroupError {
     fn description(&self) -> &str {
         match *self {
-            AssociateRoleToGroupError::InternalServerError(ref cause) => cause,
             AssociateRoleToGroupError::BadRequest(ref cause) => cause,
+            AssociateRoleToGroupError::InternalServerError(ref cause) => cause,
             AssociateRoleToGroupError::Validation(ref cause) => cause,
             AssociateRoleToGroupError::Credentials(ref err) => err.description(),
             AssociateRoleToGroupError::HttpDispatch(ref dispatch_error) => {
@@ -2690,9 +2690,9 @@ impl Error for AssociateRoleToGroupError {
 #[derive(Debug, PartialEq)]
 pub enum AssociateServiceRoleToAccountError {
     /// <p>General Error</p>
-    InternalServerError(String),
-    /// <p>General Error</p>
     BadRequest(String),
+    /// <p>General Error</p>
+    InternalServerError(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -2716,13 +2716,13 @@ impl AssociateServiceRoleToAccountError {
                 let error_type = pieces.last().expect("Expected error type");
 
                 match *error_type {
+                    "BadRequestException" => {
+                        AssociateServiceRoleToAccountError::BadRequest(String::from(error_message))
+                    }
                     "InternalServerErrorException" => {
                         AssociateServiceRoleToAccountError::InternalServerError(String::from(
                             error_message,
                         ))
-                    }
-                    "BadRequestException" => {
-                        AssociateServiceRoleToAccountError::BadRequest(String::from(error_message))
                     }
                     "ValidationException" => {
                         AssociateServiceRoleToAccountError::Validation(error_message.to_string())
@@ -2763,8 +2763,8 @@ impl fmt::Display for AssociateServiceRoleToAccountError {
 impl Error for AssociateServiceRoleToAccountError {
     fn description(&self) -> &str {
         match *self {
-            AssociateServiceRoleToAccountError::InternalServerError(ref cause) => cause,
             AssociateServiceRoleToAccountError::BadRequest(ref cause) => cause,
+            AssociateServiceRoleToAccountError::InternalServerError(ref cause) => cause,
             AssociateServiceRoleToAccountError::Validation(ref cause) => cause,
             AssociateServiceRoleToAccountError::Credentials(ref err) => err.description(),
             AssociateServiceRoleToAccountError::HttpDispatch(ref dispatch_error) => {
@@ -3414,9 +3414,9 @@ impl Error for CreateGroupError {
 #[derive(Debug, PartialEq)]
 pub enum CreateGroupCertificateAuthorityError {
     /// <p>General Error</p>
-    InternalServerError(String),
-    /// <p>General Error</p>
     BadRequest(String),
+    /// <p>General Error</p>
+    InternalServerError(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -3440,14 +3440,14 @@ impl CreateGroupCertificateAuthorityError {
                 let error_type = pieces.last().expect("Expected error type");
 
                 match *error_type {
+                    "BadRequestException" => CreateGroupCertificateAuthorityError::BadRequest(
+                        String::from(error_message),
+                    ),
                     "InternalServerErrorException" => {
                         CreateGroupCertificateAuthorityError::InternalServerError(String::from(
                             error_message,
                         ))
                     }
-                    "BadRequestException" => CreateGroupCertificateAuthorityError::BadRequest(
-                        String::from(error_message),
-                    ),
                     "ValidationException" => {
                         CreateGroupCertificateAuthorityError::Validation(error_message.to_string())
                     }
@@ -3487,8 +3487,8 @@ impl fmt::Display for CreateGroupCertificateAuthorityError {
 impl Error for CreateGroupCertificateAuthorityError {
     fn description(&self) -> &str {
         match *self {
-            CreateGroupCertificateAuthorityError::InternalServerError(ref cause) => cause,
             CreateGroupCertificateAuthorityError::BadRequest(ref cause) => cause,
+            CreateGroupCertificateAuthorityError::InternalServerError(ref cause) => cause,
             CreateGroupCertificateAuthorityError::Validation(ref cause) => cause,
             CreateGroupCertificateAuthorityError::Credentials(ref err) => err.description(),
             CreateGroupCertificateAuthorityError::HttpDispatch(ref dispatch_error) => {
@@ -4708,9 +4708,9 @@ impl Error for DeleteSubscriptionDefinitionError {
 #[derive(Debug, PartialEq)]
 pub enum DisassociateRoleFromGroupError {
     /// <p>General Error</p>
-    InternalServerError(String),
-    /// <p>General Error</p>
     BadRequest(String),
+    /// <p>General Error</p>
+    InternalServerError(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -4734,13 +4734,13 @@ impl DisassociateRoleFromGroupError {
                 let error_type = pieces.last().expect("Expected error type");
 
                 match *error_type {
+                    "BadRequestException" => {
+                        DisassociateRoleFromGroupError::BadRequest(String::from(error_message))
+                    }
                     "InternalServerErrorException" => {
                         DisassociateRoleFromGroupError::InternalServerError(String::from(
                             error_message,
                         ))
-                    }
-                    "BadRequestException" => {
-                        DisassociateRoleFromGroupError::BadRequest(String::from(error_message))
                     }
                     "ValidationException" => {
                         DisassociateRoleFromGroupError::Validation(error_message.to_string())
@@ -4781,8 +4781,8 @@ impl fmt::Display for DisassociateRoleFromGroupError {
 impl Error for DisassociateRoleFromGroupError {
     fn description(&self) -> &str {
         match *self {
-            DisassociateRoleFromGroupError::InternalServerError(ref cause) => cause,
             DisassociateRoleFromGroupError::BadRequest(ref cause) => cause,
+            DisassociateRoleFromGroupError::InternalServerError(ref cause) => cause,
             DisassociateRoleFromGroupError::Validation(ref cause) => cause,
             DisassociateRoleFromGroupError::Credentials(ref err) => err.description(),
             DisassociateRoleFromGroupError::HttpDispatch(ref dispatch_error) => {
@@ -4878,9 +4878,9 @@ impl Error for DisassociateServiceRoleFromAccountError {
 #[derive(Debug, PartialEq)]
 pub enum GetAssociatedRoleError {
     /// <p>General Error</p>
-    InternalServerError(String),
-    /// <p>General Error</p>
     BadRequest(String),
+    /// <p>General Error</p>
+    InternalServerError(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -4904,11 +4904,11 @@ impl GetAssociatedRoleError {
                 let error_type = pieces.last().expect("Expected error type");
 
                 match *error_type {
-                    "InternalServerErrorException" => {
-                        GetAssociatedRoleError::InternalServerError(String::from(error_message))
-                    }
                     "BadRequestException" => {
                         GetAssociatedRoleError::BadRequest(String::from(error_message))
+                    }
+                    "InternalServerErrorException" => {
+                        GetAssociatedRoleError::InternalServerError(String::from(error_message))
                     }
                     "ValidationException" => {
                         GetAssociatedRoleError::Validation(error_message.to_string())
@@ -4949,8 +4949,8 @@ impl fmt::Display for GetAssociatedRoleError {
 impl Error for GetAssociatedRoleError {
     fn description(&self) -> &str {
         match *self {
-            GetAssociatedRoleError::InternalServerError(ref cause) => cause,
             GetAssociatedRoleError::BadRequest(ref cause) => cause,
+            GetAssociatedRoleError::InternalServerError(ref cause) => cause,
             GetAssociatedRoleError::Validation(ref cause) => cause,
             GetAssociatedRoleError::Credentials(ref err) => err.description(),
             GetAssociatedRoleError::HttpDispatch(ref dispatch_error) => {

--- a/rusoto/services/iam/src/generated.rs
+++ b/rusoto/services/iam/src/generated.rs
@@ -13052,22 +13052,18 @@ impl AddClientIDToOpenIDConnectProviderError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "InvalidInputException" => AddClientIDToOpenIDConnectProviderError::InvalidInput(
+                "InvalidInput" => AddClientIDToOpenIDConnectProviderError::InvalidInput(
                     String::from(parsed_error.message),
                 ),
-                "LimitExceededException" => {
-                    AddClientIDToOpenIDConnectProviderError::LimitExceeded(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "NoSuchEntityException" => AddClientIDToOpenIDConnectProviderError::NoSuchEntity(
+                "LimitExceeded" => AddClientIDToOpenIDConnectProviderError::LimitExceeded(
                     String::from(parsed_error.message),
                 ),
-                "ServiceFailureException" => {
-                    AddClientIDToOpenIDConnectProviderError::ServiceFailure(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "NoSuchEntity" => AddClientIDToOpenIDConnectProviderError::NoSuchEntity(
+                    String::from(parsed_error.message),
+                ),
+                "ServiceFailure" => AddClientIDToOpenIDConnectProviderError::ServiceFailure(
+                    String::from(parsed_error.message),
+                ),
                 _ => AddClientIDToOpenIDConnectProviderError::Unknown(String::from(body)),
             },
             Err(_) => AddClientIDToOpenIDConnectProviderError::Unknown(body.to_string()),
@@ -13155,25 +13151,21 @@ impl AddRoleToInstanceProfileError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "EntityAlreadyExistsException" => {
-                    AddRoleToInstanceProfileError::EntityAlreadyExists(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "LimitExceededException" => {
-                    AddRoleToInstanceProfileError::LimitExceeded(String::from(parsed_error.message))
-                }
-                "NoSuchEntityException" => {
-                    AddRoleToInstanceProfileError::NoSuchEntity(String::from(parsed_error.message))
-                }
-                "ServiceFailureException" => AddRoleToInstanceProfileError::ServiceFailure(
+                "EntityAlreadyExists" => AddRoleToInstanceProfileError::EntityAlreadyExists(
                     String::from(parsed_error.message),
                 ),
-                "UnmodifiableEntityException" => {
-                    AddRoleToInstanceProfileError::UnmodifiableEntity(String::from(
-                        parsed_error.message,
-                    ))
+                "LimitExceeded" => {
+                    AddRoleToInstanceProfileError::LimitExceeded(String::from(parsed_error.message))
                 }
+                "NoSuchEntity" => {
+                    AddRoleToInstanceProfileError::NoSuchEntity(String::from(parsed_error.message))
+                }
+                "ServiceFailure" => AddRoleToInstanceProfileError::ServiceFailure(String::from(
+                    parsed_error.message,
+                )),
+                "UnmodifiableEntity" => AddRoleToInstanceProfileError::UnmodifiableEntity(
+                    String::from(parsed_error.message),
+                ),
                 _ => AddRoleToInstanceProfileError::Unknown(String::from(body)),
             },
             Err(_) => AddRoleToInstanceProfileError::Unknown(body.to_string()),
@@ -13258,13 +13250,13 @@ impl AddUserToGroupError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "LimitExceededException" => {
+                "LimitExceeded" => {
                     AddUserToGroupError::LimitExceeded(String::from(parsed_error.message))
                 }
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     AddUserToGroupError::NoSuchEntity(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     AddUserToGroupError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => AddUserToGroupError::Unknown(String::from(body)),
@@ -13351,19 +13343,19 @@ impl AttachGroupPolicyError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "InvalidInputException" => {
+                "InvalidInput" => {
                     AttachGroupPolicyError::InvalidInput(String::from(parsed_error.message))
                 }
-                "LimitExceededException" => {
+                "LimitExceeded" => {
                     AttachGroupPolicyError::LimitExceeded(String::from(parsed_error.message))
                 }
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     AttachGroupPolicyError::NoSuchEntity(String::from(parsed_error.message))
                 }
-                "PolicyNotAttachableException" => {
+                "PolicyNotAttachable" => {
                     AttachGroupPolicyError::PolicyNotAttachable(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     AttachGroupPolicyError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => AttachGroupPolicyError::Unknown(String::from(body)),
@@ -13456,22 +13448,22 @@ impl AttachRolePolicyError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "InvalidInputException" => {
+                "InvalidInput" => {
                     AttachRolePolicyError::InvalidInput(String::from(parsed_error.message))
                 }
-                "LimitExceededException" => {
+                "LimitExceeded" => {
                     AttachRolePolicyError::LimitExceeded(String::from(parsed_error.message))
                 }
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     AttachRolePolicyError::NoSuchEntity(String::from(parsed_error.message))
                 }
-                "PolicyNotAttachableException" => {
+                "PolicyNotAttachable" => {
                     AttachRolePolicyError::PolicyNotAttachable(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     AttachRolePolicyError::ServiceFailure(String::from(parsed_error.message))
                 }
-                "UnmodifiableEntityException" => {
+                "UnmodifiableEntity" => {
                     AttachRolePolicyError::UnmodifiableEntity(String::from(parsed_error.message))
                 }
                 _ => AttachRolePolicyError::Unknown(String::from(body)),
@@ -13561,19 +13553,19 @@ impl AttachUserPolicyError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "InvalidInputException" => {
+                "InvalidInput" => {
                     AttachUserPolicyError::InvalidInput(String::from(parsed_error.message))
                 }
-                "LimitExceededException" => {
+                "LimitExceeded" => {
                     AttachUserPolicyError::LimitExceeded(String::from(parsed_error.message))
                 }
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     AttachUserPolicyError::NoSuchEntity(String::from(parsed_error.message))
                 }
-                "PolicyNotAttachableException" => {
+                "PolicyNotAttachable" => {
                     AttachUserPolicyError::PolicyNotAttachable(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     AttachUserPolicyError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => AttachUserPolicyError::Unknown(String::from(body)),
@@ -13664,24 +13656,24 @@ impl ChangePasswordError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "EntityTemporarilyUnmodifiableException" => {
+                "EntityTemporarilyUnmodifiable" => {
                     ChangePasswordError::EntityTemporarilyUnmodifiable(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InvalidUserTypeException" => {
+                "InvalidUserType" => {
                     ChangePasswordError::InvalidUserType(String::from(parsed_error.message))
                 }
-                "LimitExceededException" => {
+                "LimitExceeded" => {
                     ChangePasswordError::LimitExceeded(String::from(parsed_error.message))
                 }
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     ChangePasswordError::NoSuchEntity(String::from(parsed_error.message))
                 }
-                "PasswordPolicyViolationException" => {
+                "PasswordPolicyViolation" => {
                     ChangePasswordError::PasswordPolicyViolation(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     ChangePasswordError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => ChangePasswordError::Unknown(String::from(body)),
@@ -13767,13 +13759,13 @@ impl CreateAccessKeyError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "LimitExceededException" => {
+                "LimitExceeded" => {
                     CreateAccessKeyError::LimitExceeded(String::from(parsed_error.message))
                 }
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     CreateAccessKeyError::NoSuchEntity(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     CreateAccessKeyError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => CreateAccessKeyError::Unknown(String::from(body)),
@@ -13856,13 +13848,13 @@ impl CreateAccountAliasError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "EntityAlreadyExistsException" => {
+                "EntityAlreadyExists" => {
                     CreateAccountAliasError::EntityAlreadyExists(String::from(parsed_error.message))
                 }
-                "LimitExceededException" => {
+                "LimitExceeded" => {
                     CreateAccountAliasError::LimitExceeded(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     CreateAccountAliasError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => CreateAccountAliasError::Unknown(String::from(body)),
@@ -13949,16 +13941,16 @@ impl CreateGroupError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "EntityAlreadyExistsException" => {
+                "EntityAlreadyExists" => {
                     CreateGroupError::EntityAlreadyExists(String::from(parsed_error.message))
                 }
-                "LimitExceededException" => {
+                "LimitExceeded" => {
                     CreateGroupError::LimitExceeded(String::from(parsed_error.message))
                 }
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     CreateGroupError::NoSuchEntity(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     CreateGroupError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => CreateGroupError::Unknown(String::from(body)),
@@ -14042,13 +14034,13 @@ impl CreateInstanceProfileError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "EntityAlreadyExistsException" => CreateInstanceProfileError::EntityAlreadyExists(
+                "EntityAlreadyExists" => CreateInstanceProfileError::EntityAlreadyExists(
                     String::from(parsed_error.message),
                 ),
-                "LimitExceededException" => {
+                "LimitExceeded" => {
                     CreateInstanceProfileError::LimitExceeded(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     CreateInstanceProfileError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => CreateInstanceProfileError::Unknown(String::from(body)),
@@ -14137,21 +14129,19 @@ impl CreateLoginProfileError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "EntityAlreadyExistsException" => {
+                "EntityAlreadyExists" => {
                     CreateLoginProfileError::EntityAlreadyExists(String::from(parsed_error.message))
                 }
-                "LimitExceededException" => {
+                "LimitExceeded" => {
                     CreateLoginProfileError::LimitExceeded(String::from(parsed_error.message))
                 }
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     CreateLoginProfileError::NoSuchEntity(String::from(parsed_error.message))
                 }
-                "PasswordPolicyViolationException" => {
-                    CreateLoginProfileError::PasswordPolicyViolation(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "ServiceFailureException" => {
+                "PasswordPolicyViolation" => CreateLoginProfileError::PasswordPolicyViolation(
+                    String::from(parsed_error.message),
+                ),
+                "ServiceFailure" => {
                     CreateLoginProfileError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => CreateLoginProfileError::Unknown(String::from(body)),
@@ -14240,18 +14230,16 @@ impl CreateOpenIDConnectProviderError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "EntityAlreadyExistsException" => {
-                    CreateOpenIDConnectProviderError::EntityAlreadyExists(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "InvalidInputException" => CreateOpenIDConnectProviderError::InvalidInput(
+                "EntityAlreadyExists" => CreateOpenIDConnectProviderError::EntityAlreadyExists(
                     String::from(parsed_error.message),
                 ),
-                "LimitExceededException" => CreateOpenIDConnectProviderError::LimitExceeded(
-                    String::from(parsed_error.message),
-                ),
-                "ServiceFailureException" => CreateOpenIDConnectProviderError::ServiceFailure(
+                "InvalidInput" => CreateOpenIDConnectProviderError::InvalidInput(String::from(
+                    parsed_error.message,
+                )),
+                "LimitExceeded" => CreateOpenIDConnectProviderError::LimitExceeded(String::from(
+                    parsed_error.message,
+                )),
+                "ServiceFailure" => CreateOpenIDConnectProviderError::ServiceFailure(
                     String::from(parsed_error.message),
                 ),
                 _ => CreateOpenIDConnectProviderError::Unknown(String::from(body)),
@@ -14341,19 +14329,19 @@ impl CreatePolicyError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "EntityAlreadyExistsException" => {
+                "EntityAlreadyExists" => {
                     CreatePolicyError::EntityAlreadyExists(String::from(parsed_error.message))
                 }
-                "InvalidInputException" => {
+                "InvalidInput" => {
                     CreatePolicyError::InvalidInput(String::from(parsed_error.message))
                 }
-                "LimitExceededException" => {
+                "LimitExceeded" => {
                     CreatePolicyError::LimitExceeded(String::from(parsed_error.message))
                 }
-                "MalformedPolicyDocumentException" => {
+                "MalformedPolicyDocument" => {
                     CreatePolicyError::MalformedPolicyDocument(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     CreatePolicyError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => CreatePolicyError::Unknown(String::from(body)),
@@ -14442,21 +14430,19 @@ impl CreatePolicyVersionError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "InvalidInputException" => {
+                "InvalidInput" => {
                     CreatePolicyVersionError::InvalidInput(String::from(parsed_error.message))
                 }
-                "LimitExceededException" => {
+                "LimitExceeded" => {
                     CreatePolicyVersionError::LimitExceeded(String::from(parsed_error.message))
                 }
-                "MalformedPolicyDocumentException" => {
-                    CreatePolicyVersionError::MalformedPolicyDocument(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "NoSuchEntityException" => {
+                "MalformedPolicyDocument" => CreatePolicyVersionError::MalformedPolicyDocument(
+                    String::from(parsed_error.message),
+                ),
+                "NoSuchEntity" => {
                     CreatePolicyVersionError::NoSuchEntity(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     CreatePolicyVersionError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => CreatePolicyVersionError::Unknown(String::from(body)),
@@ -14547,19 +14533,17 @@ impl CreateRoleError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "EntityAlreadyExistsException" => {
+                "EntityAlreadyExists" => {
                     CreateRoleError::EntityAlreadyExists(String::from(parsed_error.message))
                 }
-                "InvalidInputException" => {
-                    CreateRoleError::InvalidInput(String::from(parsed_error.message))
-                }
-                "LimitExceededException" => {
+                "InvalidInput" => CreateRoleError::InvalidInput(String::from(parsed_error.message)),
+                "LimitExceeded" => {
                     CreateRoleError::LimitExceeded(String::from(parsed_error.message))
                 }
-                "MalformedPolicyDocumentException" => {
+                "MalformedPolicyDocument" => {
                     CreateRoleError::MalformedPolicyDocument(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     CreateRoleError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => CreateRoleError::Unknown(String::from(body)),
@@ -14646,16 +14630,16 @@ impl CreateSAMLProviderError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "EntityAlreadyExistsException" => {
+                "EntityAlreadyExists" => {
                     CreateSAMLProviderError::EntityAlreadyExists(String::from(parsed_error.message))
                 }
-                "InvalidInputException" => {
+                "InvalidInput" => {
                     CreateSAMLProviderError::InvalidInput(String::from(parsed_error.message))
                 }
-                "LimitExceededException" => {
+                "LimitExceeded" => {
                     CreateSAMLProviderError::LimitExceeded(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     CreateSAMLProviderError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => CreateSAMLProviderError::Unknown(String::from(body)),
@@ -14743,16 +14727,16 @@ impl CreateServiceLinkedRoleError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "InvalidInputException" => {
+                "InvalidInput" => {
                     CreateServiceLinkedRoleError::InvalidInput(String::from(parsed_error.message))
                 }
-                "LimitExceededException" => {
+                "LimitExceeded" => {
                     CreateServiceLinkedRoleError::LimitExceeded(String::from(parsed_error.message))
                 }
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     CreateServiceLinkedRoleError::NoSuchEntity(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     CreateServiceLinkedRoleError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => CreateServiceLinkedRoleError::Unknown(String::from(body)),
@@ -14838,13 +14822,13 @@ impl CreateServiceSpecificCredentialError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "LimitExceededException" => CreateServiceSpecificCredentialError::LimitExceeded(
+                "LimitExceeded" => CreateServiceSpecificCredentialError::LimitExceeded(
                     String::from(parsed_error.message),
                 ),
-                "NoSuchEntityException" => CreateServiceSpecificCredentialError::NoSuchEntity(
+                "NoSuchEntity" => CreateServiceSpecificCredentialError::NoSuchEntity(
                     String::from(parsed_error.message),
                 ),
-                "ServiceNotSupportedException" => {
+                "NotSupportedService" => {
                     CreateServiceSpecificCredentialError::ServiceNotSupported(String::from(
                         parsed_error.message,
                     ))
@@ -14933,16 +14917,14 @@ impl CreateUserError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "EntityAlreadyExistsException" => {
+                "EntityAlreadyExists" => {
                     CreateUserError::EntityAlreadyExists(String::from(parsed_error.message))
                 }
-                "LimitExceededException" => {
+                "LimitExceeded" => {
                     CreateUserError::LimitExceeded(String::from(parsed_error.message))
                 }
-                "NoSuchEntityException" => {
-                    CreateUserError::NoSuchEntity(String::from(parsed_error.message))
-                }
-                "ServiceFailureException" => {
+                "NoSuchEntity" => CreateUserError::NoSuchEntity(String::from(parsed_error.message)),
+                "ServiceFailure" => {
                     CreateUserError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => CreateUserError::Unknown(String::from(body)),
@@ -15026,15 +15008,13 @@ impl CreateVirtualMFADeviceError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "EntityAlreadyExistsException" => {
-                    CreateVirtualMFADeviceError::EntityAlreadyExists(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "LimitExceededException" => {
+                "EntityAlreadyExists" => CreateVirtualMFADeviceError::EntityAlreadyExists(
+                    String::from(parsed_error.message),
+                ),
+                "LimitExceeded" => {
                     CreateVirtualMFADeviceError::LimitExceeded(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     CreateVirtualMFADeviceError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => CreateVirtualMFADeviceError::Unknown(String::from(body)),
@@ -15121,18 +15101,18 @@ impl DeactivateMFADeviceError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "EntityTemporarilyUnmodifiableException" => {
+                "EntityTemporarilyUnmodifiable" => {
                     DeactivateMFADeviceError::EntityTemporarilyUnmodifiable(String::from(
                         parsed_error.message,
                     ))
                 }
-                "LimitExceededException" => {
+                "LimitExceeded" => {
                     DeactivateMFADeviceError::LimitExceeded(String::from(parsed_error.message))
                 }
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     DeactivateMFADeviceError::NoSuchEntity(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     DeactivateMFADeviceError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => DeactivateMFADeviceError::Unknown(String::from(body)),
@@ -15218,13 +15198,13 @@ impl DeleteAccessKeyError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "LimitExceededException" => {
+                "LimitExceeded" => {
                     DeleteAccessKeyError::LimitExceeded(String::from(parsed_error.message))
                 }
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     DeleteAccessKeyError::NoSuchEntity(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     DeleteAccessKeyError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => DeleteAccessKeyError::Unknown(String::from(body)),
@@ -15307,13 +15287,13 @@ impl DeleteAccountAliasError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "LimitExceededException" => {
+                "LimitExceeded" => {
                     DeleteAccountAliasError::LimitExceeded(String::from(parsed_error.message))
                 }
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     DeleteAccountAliasError::NoSuchEntity(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     DeleteAccountAliasError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => DeleteAccountAliasError::Unknown(String::from(body)),
@@ -15398,13 +15378,13 @@ impl DeleteAccountPasswordPolicyError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "LimitExceededException" => DeleteAccountPasswordPolicyError::LimitExceeded(
-                    String::from(parsed_error.message),
-                ),
-                "NoSuchEntityException" => DeleteAccountPasswordPolicyError::NoSuchEntity(
-                    String::from(parsed_error.message),
-                ),
-                "ServiceFailureException" => DeleteAccountPasswordPolicyError::ServiceFailure(
+                "LimitExceeded" => DeleteAccountPasswordPolicyError::LimitExceeded(String::from(
+                    parsed_error.message,
+                )),
+                "NoSuchEntity" => DeleteAccountPasswordPolicyError::NoSuchEntity(String::from(
+                    parsed_error.message,
+                )),
+                "ServiceFailure" => DeleteAccountPasswordPolicyError::ServiceFailure(
                     String::from(parsed_error.message),
                 ),
                 _ => DeleteAccountPasswordPolicyError::Unknown(String::from(body)),
@@ -15491,16 +15471,16 @@ impl DeleteGroupError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "DeleteConflictException" => {
+                "DeleteConflict" => {
                     DeleteGroupError::DeleteConflict(String::from(parsed_error.message))
                 }
-                "LimitExceededException" => {
+                "LimitExceeded" => {
                     DeleteGroupError::LimitExceeded(String::from(parsed_error.message))
                 }
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     DeleteGroupError::NoSuchEntity(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     DeleteGroupError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => DeleteGroupError::Unknown(String::from(body)),
@@ -15584,13 +15564,13 @@ impl DeleteGroupPolicyError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "LimitExceededException" => {
+                "LimitExceeded" => {
                     DeleteGroupPolicyError::LimitExceeded(String::from(parsed_error.message))
                 }
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     DeleteGroupPolicyError::NoSuchEntity(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     DeleteGroupPolicyError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => DeleteGroupPolicyError::Unknown(String::from(body)),
@@ -15677,16 +15657,16 @@ impl DeleteInstanceProfileError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "DeleteConflictException" => {
+                "DeleteConflict" => {
                     DeleteInstanceProfileError::DeleteConflict(String::from(parsed_error.message))
                 }
-                "LimitExceededException" => {
+                "LimitExceeded" => {
                     DeleteInstanceProfileError::LimitExceeded(String::from(parsed_error.message))
                 }
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     DeleteInstanceProfileError::NoSuchEntity(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     DeleteInstanceProfileError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => DeleteInstanceProfileError::Unknown(String::from(body)),
@@ -15774,18 +15754,18 @@ impl DeleteLoginProfileError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "EntityTemporarilyUnmodifiableException" => {
+                "EntityTemporarilyUnmodifiable" => {
                     DeleteLoginProfileError::EntityTemporarilyUnmodifiable(String::from(
                         parsed_error.message,
                     ))
                 }
-                "LimitExceededException" => {
+                "LimitExceeded" => {
                     DeleteLoginProfileError::LimitExceeded(String::from(parsed_error.message))
                 }
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     DeleteLoginProfileError::NoSuchEntity(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     DeleteLoginProfileError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => DeleteLoginProfileError::Unknown(String::from(body)),
@@ -15871,13 +15851,13 @@ impl DeleteOpenIDConnectProviderError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "InvalidInputException" => DeleteOpenIDConnectProviderError::InvalidInput(
-                    String::from(parsed_error.message),
-                ),
-                "NoSuchEntityException" => DeleteOpenIDConnectProviderError::NoSuchEntity(
-                    String::from(parsed_error.message),
-                ),
-                "ServiceFailureException" => DeleteOpenIDConnectProviderError::ServiceFailure(
+                "InvalidInput" => DeleteOpenIDConnectProviderError::InvalidInput(String::from(
+                    parsed_error.message,
+                )),
+                "NoSuchEntity" => DeleteOpenIDConnectProviderError::NoSuchEntity(String::from(
+                    parsed_error.message,
+                )),
+                "ServiceFailure" => DeleteOpenIDConnectProviderError::ServiceFailure(
                     String::from(parsed_error.message),
                 ),
                 _ => DeleteOpenIDConnectProviderError::Unknown(String::from(body)),
@@ -15966,19 +15946,19 @@ impl DeletePolicyError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "DeleteConflictException" => {
+                "DeleteConflict" => {
                     DeletePolicyError::DeleteConflict(String::from(parsed_error.message))
                 }
-                "InvalidInputException" => {
+                "InvalidInput" => {
                     DeletePolicyError::InvalidInput(String::from(parsed_error.message))
                 }
-                "LimitExceededException" => {
+                "LimitExceeded" => {
                     DeletePolicyError::LimitExceeded(String::from(parsed_error.message))
                 }
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     DeletePolicyError::NoSuchEntity(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     DeletePolicyError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => DeletePolicyError::Unknown(String::from(body)),
@@ -16067,19 +16047,19 @@ impl DeletePolicyVersionError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "DeleteConflictException" => {
+                "DeleteConflict" => {
                     DeletePolicyVersionError::DeleteConflict(String::from(parsed_error.message))
                 }
-                "InvalidInputException" => {
+                "InvalidInput" => {
                     DeletePolicyVersionError::InvalidInput(String::from(parsed_error.message))
                 }
-                "LimitExceededException" => {
+                "LimitExceeded" => {
                     DeletePolicyVersionError::LimitExceeded(String::from(parsed_error.message))
                 }
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     DeletePolicyVersionError::NoSuchEntity(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     DeletePolicyVersionError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => DeletePolicyVersionError::Unknown(String::from(body)),
@@ -16170,19 +16150,17 @@ impl DeleteRoleError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "DeleteConflictException" => {
+                "DeleteConflict" => {
                     DeleteRoleError::DeleteConflict(String::from(parsed_error.message))
                 }
-                "LimitExceededException" => {
+                "LimitExceeded" => {
                     DeleteRoleError::LimitExceeded(String::from(parsed_error.message))
                 }
-                "NoSuchEntityException" => {
-                    DeleteRoleError::NoSuchEntity(String::from(parsed_error.message))
-                }
-                "ServiceFailureException" => {
+                "NoSuchEntity" => DeleteRoleError::NoSuchEntity(String::from(parsed_error.message)),
+                "ServiceFailure" => {
                     DeleteRoleError::ServiceFailure(String::from(parsed_error.message))
                 }
-                "UnmodifiableEntityException" => {
+                "UnmodifiableEntity" => {
                     DeleteRoleError::UnmodifiableEntity(String::from(parsed_error.message))
                 }
                 _ => DeleteRoleError::Unknown(String::from(body)),
@@ -16269,16 +16247,16 @@ impl DeleteRolePolicyError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "LimitExceededException" => {
+                "LimitExceeded" => {
                     DeleteRolePolicyError::LimitExceeded(String::from(parsed_error.message))
                 }
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     DeleteRolePolicyError::NoSuchEntity(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     DeleteRolePolicyError::ServiceFailure(String::from(parsed_error.message))
                 }
-                "UnmodifiableEntityException" => {
+                "UnmodifiableEntity" => {
                     DeleteRolePolicyError::UnmodifiableEntity(String::from(parsed_error.message))
                 }
                 _ => DeleteRolePolicyError::Unknown(String::from(body)),
@@ -16364,16 +16342,16 @@ impl DeleteSAMLProviderError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "InvalidInputException" => {
+                "InvalidInput" => {
                     DeleteSAMLProviderError::InvalidInput(String::from(parsed_error.message))
                 }
-                "LimitExceededException" => {
+                "LimitExceeded" => {
                     DeleteSAMLProviderError::LimitExceeded(String::from(parsed_error.message))
                 }
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     DeleteSAMLProviderError::NoSuchEntity(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     DeleteSAMLProviderError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => DeleteSAMLProviderError::Unknown(String::from(body)),
@@ -16455,7 +16433,7 @@ impl DeleteSSHPublicKeyError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     DeleteSSHPublicKeyError::NoSuchEntity(String::from(parsed_error.message))
                 }
                 _ => DeleteSSHPublicKeyError::Unknown(String::from(body)),
@@ -16540,16 +16518,16 @@ impl DeleteServerCertificateError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "DeleteConflictException" => {
+                "DeleteConflict" => {
                     DeleteServerCertificateError::DeleteConflict(String::from(parsed_error.message))
                 }
-                "LimitExceededException" => {
+                "LimitExceeded" => {
                     DeleteServerCertificateError::LimitExceeded(String::from(parsed_error.message))
                 }
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     DeleteServerCertificateError::NoSuchEntity(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     DeleteServerCertificateError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => DeleteServerCertificateError::Unknown(String::from(body)),
@@ -16635,13 +16613,13 @@ impl DeleteServiceLinkedRoleError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "LimitExceededException" => {
+                "LimitExceeded" => {
                     DeleteServiceLinkedRoleError::LimitExceeded(String::from(parsed_error.message))
                 }
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     DeleteServiceLinkedRoleError::NoSuchEntity(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     DeleteServiceLinkedRoleError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => DeleteServiceLinkedRoleError::Unknown(String::from(body)),
@@ -16722,7 +16700,7 @@ impl DeleteServiceSpecificCredentialError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "NoSuchEntityException" => DeleteServiceSpecificCredentialError::NoSuchEntity(
+                "NoSuchEntity" => DeleteServiceSpecificCredentialError::NoSuchEntity(
                     String::from(parsed_error.message),
                 ),
                 _ => DeleteServiceSpecificCredentialError::Unknown(String::from(body)),
@@ -16805,15 +16783,15 @@ impl DeleteSigningCertificateError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "LimitExceededException" => {
+                "LimitExceeded" => {
                     DeleteSigningCertificateError::LimitExceeded(String::from(parsed_error.message))
                 }
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     DeleteSigningCertificateError::NoSuchEntity(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => DeleteSigningCertificateError::ServiceFailure(
-                    String::from(parsed_error.message),
-                ),
+                "ServiceFailure" => DeleteSigningCertificateError::ServiceFailure(String::from(
+                    parsed_error.message,
+                )),
                 _ => DeleteSigningCertificateError::Unknown(String::from(body)),
             },
             Err(_) => DeleteSigningCertificateError::Unknown(body.to_string()),
@@ -16898,16 +16876,14 @@ impl DeleteUserError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "DeleteConflictException" => {
+                "DeleteConflict" => {
                     DeleteUserError::DeleteConflict(String::from(parsed_error.message))
                 }
-                "LimitExceededException" => {
+                "LimitExceeded" => {
                     DeleteUserError::LimitExceeded(String::from(parsed_error.message))
                 }
-                "NoSuchEntityException" => {
-                    DeleteUserError::NoSuchEntity(String::from(parsed_error.message))
-                }
-                "ServiceFailureException" => {
+                "NoSuchEntity" => DeleteUserError::NoSuchEntity(String::from(parsed_error.message)),
+                "ServiceFailure" => {
                     DeleteUserError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => DeleteUserError::Unknown(String::from(body)),
@@ -16991,13 +16967,13 @@ impl DeleteUserPolicyError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "LimitExceededException" => {
+                "LimitExceeded" => {
                     DeleteUserPolicyError::LimitExceeded(String::from(parsed_error.message))
                 }
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     DeleteUserPolicyError::NoSuchEntity(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     DeleteUserPolicyError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => DeleteUserPolicyError::Unknown(String::from(body)),
@@ -17082,16 +17058,16 @@ impl DeleteVirtualMFADeviceError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "DeleteConflictException" => {
+                "DeleteConflict" => {
                     DeleteVirtualMFADeviceError::DeleteConflict(String::from(parsed_error.message))
                 }
-                "LimitExceededException" => {
+                "LimitExceeded" => {
                     DeleteVirtualMFADeviceError::LimitExceeded(String::from(parsed_error.message))
                 }
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     DeleteVirtualMFADeviceError::NoSuchEntity(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     DeleteVirtualMFADeviceError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => DeleteVirtualMFADeviceError::Unknown(String::from(body)),
@@ -17179,16 +17155,16 @@ impl DetachGroupPolicyError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "InvalidInputException" => {
+                "InvalidInput" => {
                     DetachGroupPolicyError::InvalidInput(String::from(parsed_error.message))
                 }
-                "LimitExceededException" => {
+                "LimitExceeded" => {
                     DetachGroupPolicyError::LimitExceeded(String::from(parsed_error.message))
                 }
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     DetachGroupPolicyError::NoSuchEntity(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     DetachGroupPolicyError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => DetachGroupPolicyError::Unknown(String::from(body)),
@@ -17278,19 +17254,19 @@ impl DetachRolePolicyError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "InvalidInputException" => {
+                "InvalidInput" => {
                     DetachRolePolicyError::InvalidInput(String::from(parsed_error.message))
                 }
-                "LimitExceededException" => {
+                "LimitExceeded" => {
                     DetachRolePolicyError::LimitExceeded(String::from(parsed_error.message))
                 }
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     DetachRolePolicyError::NoSuchEntity(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     DetachRolePolicyError::ServiceFailure(String::from(parsed_error.message))
                 }
-                "UnmodifiableEntityException" => {
+                "UnmodifiableEntity" => {
                     DetachRolePolicyError::UnmodifiableEntity(String::from(parsed_error.message))
                 }
                 _ => DetachRolePolicyError::Unknown(String::from(body)),
@@ -17377,16 +17353,16 @@ impl DetachUserPolicyError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "InvalidInputException" => {
+                "InvalidInput" => {
                     DetachUserPolicyError::InvalidInput(String::from(parsed_error.message))
                 }
-                "LimitExceededException" => {
+                "LimitExceeded" => {
                     DetachUserPolicyError::LimitExceeded(String::from(parsed_error.message))
                 }
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     DetachUserPolicyError::NoSuchEntity(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     DetachUserPolicyError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => DetachUserPolicyError::Unknown(String::from(body)),
@@ -17476,26 +17452,24 @@ impl EnableMFADeviceError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "EntityAlreadyExistsException" => {
+                "EntityAlreadyExists" => {
                     EnableMFADeviceError::EntityAlreadyExists(String::from(parsed_error.message))
                 }
-                "EntityTemporarilyUnmodifiableException" => {
+                "EntityTemporarilyUnmodifiable" => {
                     EnableMFADeviceError::EntityTemporarilyUnmodifiable(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InvalidAuthenticationCodeException" => {
-                    EnableMFADeviceError::InvalidAuthenticationCode(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "LimitExceededException" => {
+                "InvalidAuthenticationCode" => EnableMFADeviceError::InvalidAuthenticationCode(
+                    String::from(parsed_error.message),
+                ),
+                "LimitExceeded" => {
                     EnableMFADeviceError::LimitExceeded(String::from(parsed_error.message))
                 }
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     EnableMFADeviceError::NoSuchEntity(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     EnableMFADeviceError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => EnableMFADeviceError::Unknown(String::from(body)),
@@ -17579,12 +17553,12 @@ impl GenerateCredentialReportError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "LimitExceededException" => {
+                "LimitExceeded" => {
                     GenerateCredentialReportError::LimitExceeded(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => GenerateCredentialReportError::ServiceFailure(
-                    String::from(parsed_error.message),
-                ),
+                "ServiceFailure" => GenerateCredentialReportError::ServiceFailure(String::from(
+                    parsed_error.message,
+                )),
                 _ => GenerateCredentialReportError::Unknown(String::from(body)),
             },
             Err(_) => GenerateCredentialReportError::Unknown(body.to_string()),
@@ -17662,7 +17636,7 @@ impl GetAccessKeyLastUsedError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     GetAccessKeyLastUsedError::NoSuchEntity(String::from(parsed_error.message))
                 }
                 _ => GetAccessKeyLastUsedError::Unknown(String::from(body)),
@@ -17741,7 +17715,7 @@ impl GetAccountAuthorizationDetailsError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ServiceFailureException" => GetAccountAuthorizationDetailsError::ServiceFailure(
+                "ServiceFailure" => GetAccountAuthorizationDetailsError::ServiceFailure(
                     String::from(parsed_error.message),
                 ),
                 _ => GetAccountAuthorizationDetailsError::Unknown(String::from(body)),
@@ -17822,12 +17796,12 @@ impl GetAccountPasswordPolicyError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     GetAccountPasswordPolicyError::NoSuchEntity(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => GetAccountPasswordPolicyError::ServiceFailure(
-                    String::from(parsed_error.message),
-                ),
+                "ServiceFailure" => GetAccountPasswordPolicyError::ServiceFailure(String::from(
+                    parsed_error.message,
+                )),
                 _ => GetAccountPasswordPolicyError::Unknown(String::from(body)),
             },
             Err(_) => GetAccountPasswordPolicyError::Unknown(body.to_string()),
@@ -17905,7 +17879,7 @@ impl GetAccountSummaryError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     GetAccountSummaryError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => GetAccountSummaryError::Unknown(String::from(body)),
@@ -17984,9 +17958,9 @@ impl GetContextKeysForCustomPolicyError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "InvalidInputException" => GetContextKeysForCustomPolicyError::InvalidInput(
-                    String::from(parsed_error.message),
-                ),
+                "InvalidInput" => GetContextKeysForCustomPolicyError::InvalidInput(String::from(
+                    parsed_error.message,
+                )),
                 _ => GetContextKeysForCustomPolicyError::Unknown(String::from(body)),
             },
             Err(_) => GetContextKeysForCustomPolicyError::Unknown(body.to_string()),
@@ -18065,10 +18039,10 @@ impl GetContextKeysForPrincipalPolicyError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "InvalidInputException" => GetContextKeysForPrincipalPolicyError::InvalidInput(
+                "InvalidInput" => GetContextKeysForPrincipalPolicyError::InvalidInput(
                     String::from(parsed_error.message),
                 ),
-                "NoSuchEntityException" => GetContextKeysForPrincipalPolicyError::NoSuchEntity(
+                "NoSuchEntity" => GetContextKeysForPrincipalPolicyError::NoSuchEntity(
                     String::from(parsed_error.message),
                 ),
                 _ => GetContextKeysForPrincipalPolicyError::Unknown(String::from(body)),
@@ -18154,22 +18128,16 @@ impl GetCredentialReportError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "CredentialReportExpiredException" => {
-                    GetCredentialReportError::CredentialReportExpired(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "CredentialReportNotPresentException" => {
-                    GetCredentialReportError::CredentialReportNotPresent(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "CredentialReportNotReadyException" => {
-                    GetCredentialReportError::CredentialReportNotReady(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "ServiceFailureException" => {
+                "ReportExpired" => GetCredentialReportError::CredentialReportExpired(
+                    String::from(parsed_error.message),
+                ),
+                "ReportNotPresent" => GetCredentialReportError::CredentialReportNotPresent(
+                    String::from(parsed_error.message),
+                ),
+                "ReportInProgress" => GetCredentialReportError::CredentialReportNotReady(
+                    String::from(parsed_error.message),
+                ),
+                "ServiceFailure" => {
                     GetCredentialReportError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => GetCredentialReportError::Unknown(String::from(body)),
@@ -18253,10 +18221,8 @@ impl GetGroupError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "NoSuchEntityException" => {
-                    GetGroupError::NoSuchEntity(String::from(parsed_error.message))
-                }
-                "ServiceFailureException" => {
+                "NoSuchEntity" => GetGroupError::NoSuchEntity(String::from(parsed_error.message)),
+                "ServiceFailure" => {
                     GetGroupError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => GetGroupError::Unknown(String::from(body)),
@@ -18336,10 +18302,10 @@ impl GetGroupPolicyError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     GetGroupPolicyError::NoSuchEntity(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     GetGroupPolicyError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => GetGroupPolicyError::Unknown(String::from(body)),
@@ -18419,10 +18385,10 @@ impl GetInstanceProfileError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     GetInstanceProfileError::NoSuchEntity(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     GetInstanceProfileError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => GetInstanceProfileError::Unknown(String::from(body)),
@@ -18504,10 +18470,10 @@ impl GetLoginProfileError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     GetLoginProfileError::NoSuchEntity(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     GetLoginProfileError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => GetLoginProfileError::Unknown(String::from(body)),
@@ -18589,15 +18555,15 @@ impl GetOpenIDConnectProviderError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "InvalidInputException" => {
+                "InvalidInput" => {
                     GetOpenIDConnectProviderError::InvalidInput(String::from(parsed_error.message))
                 }
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     GetOpenIDConnectProviderError::NoSuchEntity(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => GetOpenIDConnectProviderError::ServiceFailure(
-                    String::from(parsed_error.message),
-                ),
+                "ServiceFailure" => GetOpenIDConnectProviderError::ServiceFailure(String::from(
+                    parsed_error.message,
+                )),
                 _ => GetOpenIDConnectProviderError::Unknown(String::from(body)),
             },
             Err(_) => GetOpenIDConnectProviderError::Unknown(body.to_string()),
@@ -18680,13 +18646,9 @@ impl GetPolicyError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "InvalidInputException" => {
-                    GetPolicyError::InvalidInput(String::from(parsed_error.message))
-                }
-                "NoSuchEntityException" => {
-                    GetPolicyError::NoSuchEntity(String::from(parsed_error.message))
-                }
-                "ServiceFailureException" => {
+                "InvalidInput" => GetPolicyError::InvalidInput(String::from(parsed_error.message)),
+                "NoSuchEntity" => GetPolicyError::NoSuchEntity(String::from(parsed_error.message)),
+                "ServiceFailure" => {
                     GetPolicyError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => GetPolicyError::Unknown(String::from(body)),
@@ -18769,13 +18731,13 @@ impl GetPolicyVersionError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "InvalidInputException" => {
+                "InvalidInput" => {
                     GetPolicyVersionError::InvalidInput(String::from(parsed_error.message))
                 }
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     GetPolicyVersionError::NoSuchEntity(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     GetPolicyVersionError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => GetPolicyVersionError::Unknown(String::from(body)),
@@ -18856,10 +18818,8 @@ impl GetRoleError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "NoSuchEntityException" => {
-                    GetRoleError::NoSuchEntity(String::from(parsed_error.message))
-                }
-                "ServiceFailureException" => {
+                "NoSuchEntity" => GetRoleError::NoSuchEntity(String::from(parsed_error.message)),
+                "ServiceFailure" => {
                     GetRoleError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => GetRoleError::Unknown(String::from(body)),
@@ -18939,10 +18899,10 @@ impl GetRolePolicyError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     GetRolePolicyError::NoSuchEntity(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     GetRolePolicyError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => GetRolePolicyError::Unknown(String::from(body)),
@@ -19024,13 +18984,13 @@ impl GetSAMLProviderError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "InvalidInputException" => {
+                "InvalidInput" => {
                     GetSAMLProviderError::InvalidInput(String::from(parsed_error.message))
                 }
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     GetSAMLProviderError::NoSuchEntity(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     GetSAMLProviderError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => GetSAMLProviderError::Unknown(String::from(body)),
@@ -19111,10 +19071,10 @@ impl GetSSHPublicKeyError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     GetSSHPublicKeyError::NoSuchEntity(String::from(parsed_error.message))
                 }
-                "UnrecognizedPublicKeyEncodingException" => {
+                "UnrecognizedPublicKeyEncoding" => {
                     GetSSHPublicKeyError::UnrecognizedPublicKeyEncoding(String::from(
                         parsed_error.message,
                     ))
@@ -19196,10 +19156,10 @@ impl GetServerCertificateError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     GetServerCertificateError::NoSuchEntity(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     GetServerCertificateError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => GetServerCertificateError::Unknown(String::from(body)),
@@ -19283,17 +19243,15 @@ impl GetServiceLinkedRoleDeletionStatusError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "InvalidInputException" => GetServiceLinkedRoleDeletionStatusError::InvalidInput(
+                "InvalidInput" => GetServiceLinkedRoleDeletionStatusError::InvalidInput(
                     String::from(parsed_error.message),
                 ),
-                "NoSuchEntityException" => GetServiceLinkedRoleDeletionStatusError::NoSuchEntity(
+                "NoSuchEntity" => GetServiceLinkedRoleDeletionStatusError::NoSuchEntity(
                     String::from(parsed_error.message),
                 ),
-                "ServiceFailureException" => {
-                    GetServiceLinkedRoleDeletionStatusError::ServiceFailure(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "ServiceFailure" => GetServiceLinkedRoleDeletionStatusError::ServiceFailure(
+                    String::from(parsed_error.message),
+                ),
                 _ => GetServiceLinkedRoleDeletionStatusError::Unknown(String::from(body)),
             },
             Err(_) => GetServiceLinkedRoleDeletionStatusError::Unknown(body.to_string()),
@@ -19374,10 +19332,8 @@ impl GetUserError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "NoSuchEntityException" => {
-                    GetUserError::NoSuchEntity(String::from(parsed_error.message))
-                }
-                "ServiceFailureException" => {
+                "NoSuchEntity" => GetUserError::NoSuchEntity(String::from(parsed_error.message)),
+                "ServiceFailure" => {
                     GetUserError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => GetUserError::Unknown(String::from(body)),
@@ -19457,10 +19413,10 @@ impl GetUserPolicyError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     GetUserPolicyError::NoSuchEntity(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     GetUserPolicyError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => GetUserPolicyError::Unknown(String::from(body)),
@@ -19540,10 +19496,10 @@ impl ListAccessKeysError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     ListAccessKeysError::NoSuchEntity(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     ListAccessKeysError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => ListAccessKeysError::Unknown(String::from(body)),
@@ -19621,7 +19577,7 @@ impl ListAccountAliasesError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     ListAccountAliasesError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => ListAccountAliasesError::Unknown(String::from(body)),
@@ -19704,15 +19660,15 @@ impl ListAttachedGroupPoliciesError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "InvalidInputException" => {
+                "InvalidInput" => {
                     ListAttachedGroupPoliciesError::InvalidInput(String::from(parsed_error.message))
                 }
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     ListAttachedGroupPoliciesError::NoSuchEntity(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => ListAttachedGroupPoliciesError::ServiceFailure(
-                    String::from(parsed_error.message),
-                ),
+                "ServiceFailure" => ListAttachedGroupPoliciesError::ServiceFailure(String::from(
+                    parsed_error.message,
+                )),
                 _ => ListAttachedGroupPoliciesError::Unknown(String::from(body)),
             },
             Err(_) => ListAttachedGroupPoliciesError::Unknown(body.to_string()),
@@ -19795,15 +19751,15 @@ impl ListAttachedRolePoliciesError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "InvalidInputException" => {
+                "InvalidInput" => {
                     ListAttachedRolePoliciesError::InvalidInput(String::from(parsed_error.message))
                 }
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     ListAttachedRolePoliciesError::NoSuchEntity(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => ListAttachedRolePoliciesError::ServiceFailure(
-                    String::from(parsed_error.message),
-                ),
+                "ServiceFailure" => ListAttachedRolePoliciesError::ServiceFailure(String::from(
+                    parsed_error.message,
+                )),
                 _ => ListAttachedRolePoliciesError::Unknown(String::from(body)),
             },
             Err(_) => ListAttachedRolePoliciesError::Unknown(body.to_string()),
@@ -19886,15 +19842,15 @@ impl ListAttachedUserPoliciesError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "InvalidInputException" => {
+                "InvalidInput" => {
                     ListAttachedUserPoliciesError::InvalidInput(String::from(parsed_error.message))
                 }
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     ListAttachedUserPoliciesError::NoSuchEntity(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => ListAttachedUserPoliciesError::ServiceFailure(
-                    String::from(parsed_error.message),
-                ),
+                "ServiceFailure" => ListAttachedUserPoliciesError::ServiceFailure(String::from(
+                    parsed_error.message,
+                )),
                 _ => ListAttachedUserPoliciesError::Unknown(String::from(body)),
             },
             Err(_) => ListAttachedUserPoliciesError::Unknown(body.to_string()),
@@ -19977,13 +19933,13 @@ impl ListEntitiesForPolicyError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "InvalidInputException" => {
+                "InvalidInput" => {
                     ListEntitiesForPolicyError::InvalidInput(String::from(parsed_error.message))
                 }
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     ListEntitiesForPolicyError::NoSuchEntity(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     ListEntitiesForPolicyError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => ListEntitiesForPolicyError::Unknown(String::from(body)),
@@ -20066,10 +20022,10 @@ impl ListGroupPoliciesError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     ListGroupPoliciesError::NoSuchEntity(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     ListGroupPoliciesError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => ListGroupPoliciesError::Unknown(String::from(body)),
@@ -20149,7 +20105,7 @@ impl ListGroupsError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     ListGroupsError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => ListGroupsError::Unknown(String::from(body)),
@@ -20228,10 +20184,10 @@ impl ListGroupsForUserError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     ListGroupsForUserError::NoSuchEntity(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     ListGroupsForUserError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => ListGroupsForUserError::Unknown(String::from(body)),
@@ -20311,7 +20267,7 @@ impl ListInstanceProfilesError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     ListInstanceProfilesError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => ListInstanceProfilesError::Unknown(String::from(body)),
@@ -20392,10 +20348,10 @@ impl ListInstanceProfilesForRoleError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "NoSuchEntityException" => ListInstanceProfilesForRoleError::NoSuchEntity(
-                    String::from(parsed_error.message),
-                ),
-                "ServiceFailureException" => ListInstanceProfilesForRoleError::ServiceFailure(
+                "NoSuchEntity" => ListInstanceProfilesForRoleError::NoSuchEntity(String::from(
+                    parsed_error.message,
+                )),
+                "ServiceFailure" => ListInstanceProfilesForRoleError::ServiceFailure(
                     String::from(parsed_error.message),
                 ),
                 _ => ListInstanceProfilesForRoleError::Unknown(String::from(body)),
@@ -20477,10 +20433,10 @@ impl ListMFADevicesError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     ListMFADevicesError::NoSuchEntity(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     ListMFADevicesError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => ListMFADevicesError::Unknown(String::from(body)),
@@ -20558,9 +20514,9 @@ impl ListOpenIDConnectProvidersError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ServiceFailureException" => ListOpenIDConnectProvidersError::ServiceFailure(
-                    String::from(parsed_error.message),
-                ),
+                "ServiceFailure" => ListOpenIDConnectProvidersError::ServiceFailure(String::from(
+                    parsed_error.message,
+                )),
                 _ => ListOpenIDConnectProvidersError::Unknown(String::from(body)),
             },
             Err(_) => ListOpenIDConnectProvidersError::Unknown(body.to_string()),
@@ -20637,7 +20593,7 @@ impl ListPoliciesError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     ListPoliciesError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => ListPoliciesError::Unknown(String::from(body)),
@@ -20718,13 +20674,13 @@ impl ListPolicyVersionsError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "InvalidInputException" => {
+                "InvalidInput" => {
                     ListPolicyVersionsError::InvalidInput(String::from(parsed_error.message))
                 }
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     ListPolicyVersionsError::NoSuchEntity(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     ListPolicyVersionsError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => ListPolicyVersionsError::Unknown(String::from(body)),
@@ -20807,10 +20763,10 @@ impl ListRolePoliciesError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     ListRolePoliciesError::NoSuchEntity(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     ListRolePoliciesError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => ListRolePoliciesError::Unknown(String::from(body)),
@@ -20888,7 +20844,7 @@ impl ListRolesError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     ListRolesError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => ListRolesError::Unknown(String::from(body)),
@@ -20965,7 +20921,7 @@ impl ListSAMLProvidersError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     ListSAMLProvidersError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => ListSAMLProvidersError::Unknown(String::from(body)),
@@ -21044,7 +21000,7 @@ impl ListSSHPublicKeysError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     ListSSHPublicKeysError::NoSuchEntity(String::from(parsed_error.message))
                 }
                 _ => ListSSHPublicKeysError::Unknown(String::from(body)),
@@ -21123,7 +21079,7 @@ impl ListServerCertificatesError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     ListServerCertificatesError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => ListServerCertificatesError::Unknown(String::from(body)),
@@ -21204,14 +21160,12 @@ impl ListServiceSpecificCredentialsError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "NoSuchEntityException" => ListServiceSpecificCredentialsError::NoSuchEntity(
+                "NoSuchEntity" => ListServiceSpecificCredentialsError::NoSuchEntity(String::from(
+                    parsed_error.message,
+                )),
+                "NotSupportedService" => ListServiceSpecificCredentialsError::ServiceNotSupported(
                     String::from(parsed_error.message),
                 ),
-                "ServiceNotSupportedException" => {
-                    ListServiceSpecificCredentialsError::ServiceNotSupported(String::from(
-                        parsed_error.message,
-                    ))
-                }
                 _ => ListServiceSpecificCredentialsError::Unknown(String::from(body)),
             },
             Err(_) => ListServiceSpecificCredentialsError::Unknown(body.to_string()),
@@ -21291,10 +21245,10 @@ impl ListSigningCertificatesError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     ListSigningCertificatesError::NoSuchEntity(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     ListSigningCertificatesError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => ListSigningCertificatesError::Unknown(String::from(body)),
@@ -21376,10 +21330,10 @@ impl ListUserPoliciesError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     ListUserPoliciesError::NoSuchEntity(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     ListUserPoliciesError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => ListUserPoliciesError::Unknown(String::from(body)),
@@ -21457,7 +21411,7 @@ impl ListUsersError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     ListUsersError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => ListUsersError::Unknown(String::from(body)),
@@ -21613,16 +21567,16 @@ impl PutGroupPolicyError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "LimitExceededException" => {
+                "LimitExceeded" => {
                     PutGroupPolicyError::LimitExceeded(String::from(parsed_error.message))
                 }
-                "MalformedPolicyDocumentException" => {
+                "MalformedPolicyDocument" => {
                     PutGroupPolicyError::MalformedPolicyDocument(String::from(parsed_error.message))
                 }
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     PutGroupPolicyError::NoSuchEntity(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     PutGroupPolicyError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => PutGroupPolicyError::Unknown(String::from(body)),
@@ -21710,19 +21664,19 @@ impl PutRolePolicyError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "LimitExceededException" => {
+                "LimitExceeded" => {
                     PutRolePolicyError::LimitExceeded(String::from(parsed_error.message))
                 }
-                "MalformedPolicyDocumentException" => {
+                "MalformedPolicyDocument" => {
                     PutRolePolicyError::MalformedPolicyDocument(String::from(parsed_error.message))
                 }
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     PutRolePolicyError::NoSuchEntity(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     PutRolePolicyError::ServiceFailure(String::from(parsed_error.message))
                 }
-                "UnmodifiableEntityException" => {
+                "UnmodifiableEntity" => {
                     PutRolePolicyError::UnmodifiableEntity(String::from(parsed_error.message))
                 }
                 _ => PutRolePolicyError::Unknown(String::from(body)),
@@ -21809,16 +21763,16 @@ impl PutUserPolicyError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "LimitExceededException" => {
+                "LimitExceeded" => {
                     PutUserPolicyError::LimitExceeded(String::from(parsed_error.message))
                 }
-                "MalformedPolicyDocumentException" => {
+                "MalformedPolicyDocument" => {
                     PutUserPolicyError::MalformedPolicyDocument(String::from(parsed_error.message))
                 }
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     PutUserPolicyError::NoSuchEntity(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     PutUserPolicyError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => PutUserPolicyError::Unknown(String::from(body)),
@@ -21902,21 +21856,15 @@ impl RemoveClientIDFromOpenIDConnectProviderError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "InvalidInputException" => {
-                    RemoveClientIDFromOpenIDConnectProviderError::InvalidInput(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "NoSuchEntityException" => {
-                    RemoveClientIDFromOpenIDConnectProviderError::NoSuchEntity(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "ServiceFailureException" => {
-                    RemoveClientIDFromOpenIDConnectProviderError::ServiceFailure(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "InvalidInput" => RemoveClientIDFromOpenIDConnectProviderError::InvalidInput(
+                    String::from(parsed_error.message),
+                ),
+                "NoSuchEntity" => RemoveClientIDFromOpenIDConnectProviderError::NoSuchEntity(
+                    String::from(parsed_error.message),
+                ),
+                "ServiceFailure" => RemoveClientIDFromOpenIDConnectProviderError::ServiceFailure(
+                    String::from(parsed_error.message),
+                ),
                 _ => RemoveClientIDFromOpenIDConnectProviderError::Unknown(String::from(body)),
             },
             Err(_) => RemoveClientIDFromOpenIDConnectProviderError::Unknown(body.to_string()),
@@ -22001,20 +21949,18 @@ impl RemoveRoleFromInstanceProfileError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "LimitExceededException" => RemoveRoleFromInstanceProfileError::LimitExceeded(
+                "LimitExceeded" => RemoveRoleFromInstanceProfileError::LimitExceeded(
                     String::from(parsed_error.message),
                 ),
-                "NoSuchEntityException" => RemoveRoleFromInstanceProfileError::NoSuchEntity(
+                "NoSuchEntity" => RemoveRoleFromInstanceProfileError::NoSuchEntity(String::from(
+                    parsed_error.message,
+                )),
+                "ServiceFailure" => RemoveRoleFromInstanceProfileError::ServiceFailure(
                     String::from(parsed_error.message),
                 ),
-                "ServiceFailureException" => RemoveRoleFromInstanceProfileError::ServiceFailure(
+                "UnmodifiableEntity" => RemoveRoleFromInstanceProfileError::UnmodifiableEntity(
                     String::from(parsed_error.message),
                 ),
-                "UnmodifiableEntityException" => {
-                    RemoveRoleFromInstanceProfileError::UnmodifiableEntity(String::from(
-                        parsed_error.message,
-                    ))
-                }
                 _ => RemoveRoleFromInstanceProfileError::Unknown(String::from(body)),
             },
             Err(_) => RemoveRoleFromInstanceProfileError::Unknown(body.to_string()),
@@ -22098,13 +22044,13 @@ impl RemoveUserFromGroupError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "LimitExceededException" => {
+                "LimitExceeded" => {
                     RemoveUserFromGroupError::LimitExceeded(String::from(parsed_error.message))
                 }
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     RemoveUserFromGroupError::NoSuchEntity(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     RemoveUserFromGroupError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => RemoveUserFromGroupError::Unknown(String::from(body)),
@@ -22185,9 +22131,9 @@ impl ResetServiceSpecificCredentialError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "NoSuchEntityException" => ResetServiceSpecificCredentialError::NoSuchEntity(
-                    String::from(parsed_error.message),
-                ),
+                "NoSuchEntity" => ResetServiceSpecificCredentialError::NoSuchEntity(String::from(
+                    parsed_error.message,
+                )),
                 _ => ResetServiceSpecificCredentialError::Unknown(String::from(body)),
             },
             Err(_) => ResetServiceSpecificCredentialError::Unknown(body.to_string()),
@@ -22270,18 +22216,16 @@ impl ResyncMFADeviceError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "InvalidAuthenticationCodeException" => {
-                    ResyncMFADeviceError::InvalidAuthenticationCode(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "LimitExceededException" => {
+                "InvalidAuthenticationCode" => ResyncMFADeviceError::InvalidAuthenticationCode(
+                    String::from(parsed_error.message),
+                ),
+                "LimitExceeded" => {
                     ResyncMFADeviceError::LimitExceeded(String::from(parsed_error.message))
                 }
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     ResyncMFADeviceError::NoSuchEntity(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     ResyncMFADeviceError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => ResyncMFADeviceError::Unknown(String::from(body)),
@@ -22367,16 +22311,16 @@ impl SetDefaultPolicyVersionError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "InvalidInputException" => {
+                "InvalidInput" => {
                     SetDefaultPolicyVersionError::InvalidInput(String::from(parsed_error.message))
                 }
-                "LimitExceededException" => {
+                "LimitExceeded" => {
                     SetDefaultPolicyVersionError::LimitExceeded(String::from(parsed_error.message))
                 }
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     SetDefaultPolicyVersionError::NoSuchEntity(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     SetDefaultPolicyVersionError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => SetDefaultPolicyVersionError::Unknown(String::from(body)),
@@ -22460,10 +22404,10 @@ impl SimulateCustomPolicyError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "InvalidInputException" => {
+                "InvalidInput" => {
                     SimulateCustomPolicyError::InvalidInput(String::from(parsed_error.message))
                 }
-                "PolicyEvaluationException" => {
+                "PolicyEvaluation" => {
                     SimulateCustomPolicyError::PolicyEvaluation(String::from(parsed_error.message))
                 }
                 _ => SimulateCustomPolicyError::Unknown(String::from(body)),
@@ -22547,13 +22491,13 @@ impl SimulatePrincipalPolicyError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "InvalidInputException" => {
+                "InvalidInput" => {
                     SimulatePrincipalPolicyError::InvalidInput(String::from(parsed_error.message))
                 }
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     SimulatePrincipalPolicyError::NoSuchEntity(String::from(parsed_error.message))
                 }
-                "PolicyEvaluationException" => SimulatePrincipalPolicyError::PolicyEvaluation(
+                "PolicyEvaluation" => SimulatePrincipalPolicyError::PolicyEvaluation(
                     String::from(parsed_error.message),
                 ),
                 _ => SimulatePrincipalPolicyError::Unknown(String::from(body)),
@@ -22638,13 +22582,13 @@ impl UpdateAccessKeyError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "LimitExceededException" => {
+                "LimitExceeded" => {
                     UpdateAccessKeyError::LimitExceeded(String::from(parsed_error.message))
                 }
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     UpdateAccessKeyError::NoSuchEntity(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     UpdateAccessKeyError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => UpdateAccessKeyError::Unknown(String::from(body)),
@@ -22729,18 +22673,18 @@ impl UpdateAccountPasswordPolicyError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "LimitExceededException" => UpdateAccountPasswordPolicyError::LimitExceeded(
-                    String::from(parsed_error.message),
-                ),
-                "MalformedPolicyDocumentException" => {
+                "LimitExceeded" => UpdateAccountPasswordPolicyError::LimitExceeded(String::from(
+                    parsed_error.message,
+                )),
+                "MalformedPolicyDocument" => {
                     UpdateAccountPasswordPolicyError::MalformedPolicyDocument(String::from(
                         parsed_error.message,
                     ))
                 }
-                "NoSuchEntityException" => UpdateAccountPasswordPolicyError::NoSuchEntity(
-                    String::from(parsed_error.message),
-                ),
-                "ServiceFailureException" => UpdateAccountPasswordPolicyError::ServiceFailure(
+                "NoSuchEntity" => UpdateAccountPasswordPolicyError::NoSuchEntity(String::from(
+                    parsed_error.message,
+                )),
+                "ServiceFailure" => UpdateAccountPasswordPolicyError::ServiceFailure(
                     String::from(parsed_error.message),
                 ),
                 _ => UpdateAccountPasswordPolicyError::Unknown(String::from(body)),
@@ -22830,21 +22774,19 @@ impl UpdateAssumeRolePolicyError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "LimitExceededException" => {
+                "LimitExceeded" => {
                     UpdateAssumeRolePolicyError::LimitExceeded(String::from(parsed_error.message))
                 }
-                "MalformedPolicyDocumentException" => {
-                    UpdateAssumeRolePolicyError::MalformedPolicyDocument(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "NoSuchEntityException" => {
+                "MalformedPolicyDocument" => UpdateAssumeRolePolicyError::MalformedPolicyDocument(
+                    String::from(parsed_error.message),
+                ),
+                "NoSuchEntity" => {
                     UpdateAssumeRolePolicyError::NoSuchEntity(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     UpdateAssumeRolePolicyError::ServiceFailure(String::from(parsed_error.message))
                 }
-                "UnmodifiableEntityException" => UpdateAssumeRolePolicyError::UnmodifiableEntity(
+                "UnmodifiableEntity" => UpdateAssumeRolePolicyError::UnmodifiableEntity(
                     String::from(parsed_error.message),
                 ),
                 _ => UpdateAssumeRolePolicyError::Unknown(String::from(body)),
@@ -22933,16 +22875,16 @@ impl UpdateGroupError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "EntityAlreadyExistsException" => {
+                "EntityAlreadyExists" => {
                     UpdateGroupError::EntityAlreadyExists(String::from(parsed_error.message))
                 }
-                "LimitExceededException" => {
+                "LimitExceeded" => {
                     UpdateGroupError::LimitExceeded(String::from(parsed_error.message))
                 }
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     UpdateGroupError::NoSuchEntity(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     UpdateGroupError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => UpdateGroupError::Unknown(String::from(body)),
@@ -23030,23 +22972,21 @@ impl UpdateLoginProfileError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "EntityTemporarilyUnmodifiableException" => {
+                "EntityTemporarilyUnmodifiable" => {
                     UpdateLoginProfileError::EntityTemporarilyUnmodifiable(String::from(
                         parsed_error.message,
                     ))
                 }
-                "LimitExceededException" => {
+                "LimitExceeded" => {
                     UpdateLoginProfileError::LimitExceeded(String::from(parsed_error.message))
                 }
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     UpdateLoginProfileError::NoSuchEntity(String::from(parsed_error.message))
                 }
-                "PasswordPolicyViolationException" => {
-                    UpdateLoginProfileError::PasswordPolicyViolation(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "ServiceFailureException" => {
+                "PasswordPolicyViolation" => UpdateLoginProfileError::PasswordPolicyViolation(
+                    String::from(parsed_error.message),
+                ),
+                "ServiceFailure" => {
                     UpdateLoginProfileError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => UpdateLoginProfileError::Unknown(String::from(body)),
@@ -23133,21 +23073,15 @@ impl UpdateOpenIDConnectProviderThumbprintError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "InvalidInputException" => {
-                    UpdateOpenIDConnectProviderThumbprintError::InvalidInput(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "NoSuchEntityException" => {
-                    UpdateOpenIDConnectProviderThumbprintError::NoSuchEntity(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "ServiceFailureException" => {
-                    UpdateOpenIDConnectProviderThumbprintError::ServiceFailure(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "InvalidInput" => UpdateOpenIDConnectProviderThumbprintError::InvalidInput(
+                    String::from(parsed_error.message),
+                ),
+                "NoSuchEntity" => UpdateOpenIDConnectProviderThumbprintError::NoSuchEntity(
+                    String::from(parsed_error.message),
+                ),
+                "ServiceFailure" => UpdateOpenIDConnectProviderThumbprintError::ServiceFailure(
+                    String::from(parsed_error.message),
+                ),
                 _ => UpdateOpenIDConnectProviderThumbprintError::Unknown(String::from(body)),
             },
             Err(_) => UpdateOpenIDConnectProviderThumbprintError::Unknown(body.to_string()),
@@ -23230,13 +23164,13 @@ impl UpdateRoleDescriptionError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     UpdateRoleDescriptionError::NoSuchEntity(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     UpdateRoleDescriptionError::ServiceFailure(String::from(parsed_error.message))
                 }
-                "UnmodifiableEntityException" => UpdateRoleDescriptionError::UnmodifiableEntity(
+                "UnmodifiableEntity" => UpdateRoleDescriptionError::UnmodifiableEntity(
                     String::from(parsed_error.message),
                 ),
                 _ => UpdateRoleDescriptionError::Unknown(String::from(body)),
@@ -23323,16 +23257,16 @@ impl UpdateSAMLProviderError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "InvalidInputException" => {
+                "InvalidInput" => {
                     UpdateSAMLProviderError::InvalidInput(String::from(parsed_error.message))
                 }
-                "LimitExceededException" => {
+                "LimitExceeded" => {
                     UpdateSAMLProviderError::LimitExceeded(String::from(parsed_error.message))
                 }
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     UpdateSAMLProviderError::NoSuchEntity(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     UpdateSAMLProviderError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => UpdateSAMLProviderError::Unknown(String::from(body)),
@@ -23414,7 +23348,7 @@ impl UpdateSSHPublicKeyError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     UpdateSSHPublicKeyError::NoSuchEntity(String::from(parsed_error.message))
                 }
                 _ => UpdateSSHPublicKeyError::Unknown(String::from(body)),
@@ -23499,18 +23433,16 @@ impl UpdateServerCertificateError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "EntityAlreadyExistsException" => {
-                    UpdateServerCertificateError::EntityAlreadyExists(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "LimitExceededException" => {
+                "EntityAlreadyExists" => UpdateServerCertificateError::EntityAlreadyExists(
+                    String::from(parsed_error.message),
+                ),
+                "LimitExceeded" => {
                     UpdateServerCertificateError::LimitExceeded(String::from(parsed_error.message))
                 }
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     UpdateServerCertificateError::NoSuchEntity(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => {
+                "ServiceFailure" => {
                     UpdateServerCertificateError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => UpdateServerCertificateError::Unknown(String::from(body)),
@@ -23592,7 +23524,7 @@ impl UpdateServiceSpecificCredentialError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "NoSuchEntityException" => UpdateServiceSpecificCredentialError::NoSuchEntity(
+                "NoSuchEntity" => UpdateServiceSpecificCredentialError::NoSuchEntity(
                     String::from(parsed_error.message),
                 ),
                 _ => UpdateServiceSpecificCredentialError::Unknown(String::from(body)),
@@ -23675,15 +23607,15 @@ impl UpdateSigningCertificateError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "LimitExceededException" => {
+                "LimitExceeded" => {
                     UpdateSigningCertificateError::LimitExceeded(String::from(parsed_error.message))
                 }
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     UpdateSigningCertificateError::NoSuchEntity(String::from(parsed_error.message))
                 }
-                "ServiceFailureException" => UpdateSigningCertificateError::ServiceFailure(
-                    String::from(parsed_error.message),
-                ),
+                "ServiceFailure" => UpdateSigningCertificateError::ServiceFailure(String::from(
+                    parsed_error.message,
+                )),
                 _ => UpdateSigningCertificateError::Unknown(String::from(body)),
             },
             Err(_) => UpdateSigningCertificateError::Unknown(body.to_string()),
@@ -23770,21 +23702,17 @@ impl UpdateUserError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "EntityAlreadyExistsException" => {
+                "EntityAlreadyExists" => {
                     UpdateUserError::EntityAlreadyExists(String::from(parsed_error.message))
                 }
-                "EntityTemporarilyUnmodifiableException" => {
-                    UpdateUserError::EntityTemporarilyUnmodifiable(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "LimitExceededException" => {
+                "EntityTemporarilyUnmodifiable" => UpdateUserError::EntityTemporarilyUnmodifiable(
+                    String::from(parsed_error.message),
+                ),
+                "LimitExceeded" => {
                     UpdateUserError::LimitExceeded(String::from(parsed_error.message))
                 }
-                "NoSuchEntityException" => {
-                    UpdateUserError::NoSuchEntity(String::from(parsed_error.message))
-                }
-                "ServiceFailureException" => {
+                "NoSuchEntity" => UpdateUserError::NoSuchEntity(String::from(parsed_error.message)),
+                "ServiceFailure" => {
                     UpdateUserError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => UpdateUserError::Unknown(String::from(body)),
@@ -23873,21 +23801,19 @@ impl UploadSSHPublicKeyError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "DuplicateSSHPublicKeyException" => {
-                    UploadSSHPublicKeyError::DuplicateSSHPublicKey(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "InvalidPublicKeyException" => {
+                "DuplicateSSHPublicKey" => UploadSSHPublicKeyError::DuplicateSSHPublicKey(
+                    String::from(parsed_error.message),
+                ),
+                "InvalidPublicKey" => {
                     UploadSSHPublicKeyError::InvalidPublicKey(String::from(parsed_error.message))
                 }
-                "LimitExceededException" => {
+                "LimitExceeded" => {
                     UploadSSHPublicKeyError::LimitExceeded(String::from(parsed_error.message))
                 }
-                "NoSuchEntityException" => {
+                "NoSuchEntity" => {
                     UploadSSHPublicKeyError::NoSuchEntity(String::from(parsed_error.message))
                 }
-                "UnrecognizedPublicKeyEncodingException" => {
+                "UnrecognizedPublicKeyEncoding" => {
                     UploadSSHPublicKeyError::UnrecognizedPublicKeyEncoding(String::from(
                         parsed_error.message,
                     ))
@@ -23980,23 +23906,19 @@ impl UploadServerCertificateError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "EntityAlreadyExistsException" => {
-                    UploadServerCertificateError::EntityAlreadyExists(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "KeyPairMismatchException" => UploadServerCertificateError::KeyPairMismatch(
+                "EntityAlreadyExists" => UploadServerCertificateError::EntityAlreadyExists(
                     String::from(parsed_error.message),
                 ),
-                "LimitExceededException" => {
+                "KeyPairMismatch" => UploadServerCertificateError::KeyPairMismatch(String::from(
+                    parsed_error.message,
+                )),
+                "LimitExceeded" => {
                     UploadServerCertificateError::LimitExceeded(String::from(parsed_error.message))
                 }
-                "MalformedCertificateException" => {
-                    UploadServerCertificateError::MalformedCertificate(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "ServiceFailureException" => {
+                "MalformedCertificate" => UploadServerCertificateError::MalformedCertificate(
+                    String::from(parsed_error.message),
+                ),
+                "ServiceFailure" => {
                     UploadServerCertificateError::ServiceFailure(String::from(parsed_error.message))
                 }
                 _ => UploadServerCertificateError::Unknown(String::from(body)),
@@ -24091,35 +24013,27 @@ impl UploadSigningCertificateError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "DuplicateCertificateException" => {
-                    UploadSigningCertificateError::DuplicateCertificate(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "EntityAlreadyExistsException" => {
-                    UploadSigningCertificateError::EntityAlreadyExists(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "InvalidCertificateException" => {
-                    UploadSigningCertificateError::InvalidCertificate(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "LimitExceededException" => {
-                    UploadSigningCertificateError::LimitExceeded(String::from(parsed_error.message))
-                }
-                "MalformedCertificateException" => {
-                    UploadSigningCertificateError::MalformedCertificate(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "NoSuchEntityException" => {
-                    UploadSigningCertificateError::NoSuchEntity(String::from(parsed_error.message))
-                }
-                "ServiceFailureException" => UploadSigningCertificateError::ServiceFailure(
+                "DuplicateCertificate" => UploadSigningCertificateError::DuplicateCertificate(
                     String::from(parsed_error.message),
                 ),
+                "EntityAlreadyExists" => UploadSigningCertificateError::EntityAlreadyExists(
+                    String::from(parsed_error.message),
+                ),
+                "InvalidCertificate" => UploadSigningCertificateError::InvalidCertificate(
+                    String::from(parsed_error.message),
+                ),
+                "LimitExceeded" => {
+                    UploadSigningCertificateError::LimitExceeded(String::from(parsed_error.message))
+                }
+                "MalformedCertificate" => UploadSigningCertificateError::MalformedCertificate(
+                    String::from(parsed_error.message),
+                ),
+                "NoSuchEntity" => {
+                    UploadSigningCertificateError::NoSuchEntity(String::from(parsed_error.message))
+                }
+                "ServiceFailure" => UploadSigningCertificateError::ServiceFailure(String::from(
+                    parsed_error.message,
+                )),
                 _ => UploadSigningCertificateError::Unknown(String::from(body)),
             },
             Err(_) => UploadSigningCertificateError::Unknown(body.to_string()),

--- a/rusoto/services/iam/src/generated.rs
+++ b/rusoto/services/iam/src/generated.rs
@@ -13050,7 +13050,7 @@ impl AddClientIDToOpenIDConnectProviderError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInputException" => AddClientIDToOpenIDConnectProviderError::InvalidInput(
                     String::from(parsed_error.message),
@@ -13072,6 +13072,14 @@ impl AddClientIDToOpenIDConnectProviderError {
             },
             Err(_) => AddClientIDToOpenIDConnectProviderError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -13145,7 +13153,7 @@ impl AddRoleToInstanceProfileError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "EntityAlreadyExistsException" => {
                     AddRoleToInstanceProfileError::EntityAlreadyExists(String::from(
@@ -13170,6 +13178,14 @@ impl AddRoleToInstanceProfileError {
             },
             Err(_) => AddRoleToInstanceProfileError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -13240,7 +13256,7 @@ impl AddUserToGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "LimitExceededException" => {
                     AddUserToGroupError::LimitExceeded(String::from(parsed_error.message))
@@ -13255,6 +13271,14 @@ impl AddUserToGroupError {
             },
             Err(_) => AddUserToGroupError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -13325,7 +13349,7 @@ impl AttachGroupPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInputException" => {
                     AttachGroupPolicyError::InvalidInput(String::from(parsed_error.message))
@@ -13346,6 +13370,14 @@ impl AttachGroupPolicyError {
             },
             Err(_) => AttachGroupPolicyError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -13422,7 +13454,7 @@ impl AttachRolePolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInputException" => {
                     AttachRolePolicyError::InvalidInput(String::from(parsed_error.message))
@@ -13446,6 +13478,14 @@ impl AttachRolePolicyError {
             },
             Err(_) => AttachRolePolicyError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -13519,7 +13559,7 @@ impl AttachUserPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInputException" => {
                     AttachUserPolicyError::InvalidInput(String::from(parsed_error.message))
@@ -13540,6 +13580,14 @@ impl AttachUserPolicyError {
             },
             Err(_) => AttachUserPolicyError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -13614,7 +13662,7 @@ impl ChangePasswordError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "EntityTemporarilyUnmodifiableException" => {
                     ChangePasswordError::EntityTemporarilyUnmodifiable(String::from(
@@ -13640,6 +13688,14 @@ impl ChangePasswordError {
             },
             Err(_) => ChangePasswordError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -13709,7 +13765,7 @@ impl CreateAccessKeyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "LimitExceededException" => {
                     CreateAccessKeyError::LimitExceeded(String::from(parsed_error.message))
@@ -13724,6 +13780,14 @@ impl CreateAccessKeyError {
             },
             Err(_) => CreateAccessKeyError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -13790,7 +13854,7 @@ impl CreateAccountAliasError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "EntityAlreadyExistsException" => {
                     CreateAccountAliasError::EntityAlreadyExists(String::from(parsed_error.message))
@@ -13805,6 +13869,14 @@ impl CreateAccountAliasError {
             },
             Err(_) => CreateAccountAliasError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -13875,7 +13947,7 @@ impl CreateGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "EntityAlreadyExistsException" => {
                     CreateGroupError::EntityAlreadyExists(String::from(parsed_error.message))
@@ -13893,6 +13965,14 @@ impl CreateGroupError {
             },
             Err(_) => CreateGroupError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -13960,7 +14040,7 @@ impl CreateInstanceProfileError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "EntityAlreadyExistsException" => CreateInstanceProfileError::EntityAlreadyExists(
                     String::from(parsed_error.message),
@@ -13975,6 +14055,14 @@ impl CreateInstanceProfileError {
             },
             Err(_) => CreateInstanceProfileError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -14047,7 +14135,7 @@ impl CreateLoginProfileError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "EntityAlreadyExistsException" => {
                     CreateLoginProfileError::EntityAlreadyExists(String::from(parsed_error.message))
@@ -14070,6 +14158,14 @@ impl CreateLoginProfileError {
             },
             Err(_) => CreateLoginProfileError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -14142,7 +14238,7 @@ impl CreateOpenIDConnectProviderError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "EntityAlreadyExistsException" => {
                     CreateOpenIDConnectProviderError::EntityAlreadyExists(String::from(
@@ -14162,6 +14258,14 @@ impl CreateOpenIDConnectProviderError {
             },
             Err(_) => CreateOpenIDConnectProviderError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -14235,7 +14339,7 @@ impl CreatePolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "EntityAlreadyExistsException" => {
                     CreatePolicyError::EntityAlreadyExists(String::from(parsed_error.message))
@@ -14256,6 +14360,14 @@ impl CreatePolicyError {
             },
             Err(_) => CreatePolicyError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -14328,7 +14440,7 @@ impl CreatePolicyVersionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInputException" => {
                     CreatePolicyVersionError::InvalidInput(String::from(parsed_error.message))
@@ -14351,6 +14463,14 @@ impl CreatePolicyVersionError {
             },
             Err(_) => CreatePolicyVersionError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -14425,7 +14545,7 @@ impl CreateRoleError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "EntityAlreadyExistsException" => {
                     CreateRoleError::EntityAlreadyExists(String::from(parsed_error.message))
@@ -14446,6 +14566,14 @@ impl CreateRoleError {
             },
             Err(_) => CreateRoleError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -14516,7 +14644,7 @@ impl CreateSAMLProviderError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "EntityAlreadyExistsException" => {
                     CreateSAMLProviderError::EntityAlreadyExists(String::from(parsed_error.message))
@@ -14534,6 +14662,14 @@ impl CreateSAMLProviderError {
             },
             Err(_) => CreateSAMLProviderError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -14605,7 +14741,7 @@ impl CreateServiceLinkedRoleError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInputException" => {
                     CreateServiceLinkedRoleError::InvalidInput(String::from(parsed_error.message))
@@ -14623,6 +14759,14 @@ impl CreateServiceLinkedRoleError {
             },
             Err(_) => CreateServiceLinkedRoleError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -14692,7 +14836,7 @@ impl CreateServiceSpecificCredentialError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "LimitExceededException" => CreateServiceSpecificCredentialError::LimitExceeded(
                     String::from(parsed_error.message),
@@ -14709,6 +14853,14 @@ impl CreateServiceSpecificCredentialError {
             },
             Err(_) => CreateServiceSpecificCredentialError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -14779,7 +14931,7 @@ impl CreateUserError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "EntityAlreadyExistsException" => {
                     CreateUserError::EntityAlreadyExists(String::from(parsed_error.message))
@@ -14797,6 +14949,14 @@ impl CreateUserError {
             },
             Err(_) => CreateUserError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -14864,7 +15024,7 @@ impl CreateVirtualMFADeviceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "EntityAlreadyExistsException" => {
                     CreateVirtualMFADeviceError::EntityAlreadyExists(String::from(
@@ -14881,6 +15041,14 @@ impl CreateVirtualMFADeviceError {
             },
             Err(_) => CreateVirtualMFADeviceError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -14951,7 +15119,7 @@ impl DeactivateMFADeviceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "EntityTemporarilyUnmodifiableException" => {
                     DeactivateMFADeviceError::EntityTemporarilyUnmodifiable(String::from(
@@ -14971,6 +15139,14 @@ impl DeactivateMFADeviceError {
             },
             Err(_) => DeactivateMFADeviceError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -15040,7 +15216,7 @@ impl DeleteAccessKeyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "LimitExceededException" => {
                     DeleteAccessKeyError::LimitExceeded(String::from(parsed_error.message))
@@ -15055,6 +15231,14 @@ impl DeleteAccessKeyError {
             },
             Err(_) => DeleteAccessKeyError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -15121,7 +15305,7 @@ impl DeleteAccountAliasError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "LimitExceededException" => {
                     DeleteAccountAliasError::LimitExceeded(String::from(parsed_error.message))
@@ -15136,6 +15320,14 @@ impl DeleteAccountAliasError {
             },
             Err(_) => DeleteAccountAliasError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -15204,7 +15396,7 @@ impl DeleteAccountPasswordPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "LimitExceededException" => DeleteAccountPasswordPolicyError::LimitExceeded(
                     String::from(parsed_error.message),
@@ -15219,6 +15411,14 @@ impl DeleteAccountPasswordPolicyError {
             },
             Err(_) => DeleteAccountPasswordPolicyError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -15289,7 +15489,7 @@ impl DeleteGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DeleteConflictException" => {
                     DeleteGroupError::DeleteConflict(String::from(parsed_error.message))
@@ -15307,6 +15507,14 @@ impl DeleteGroupError {
             },
             Err(_) => DeleteGroupError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -15374,7 +15582,7 @@ impl DeleteGroupPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "LimitExceededException" => {
                     DeleteGroupPolicyError::LimitExceeded(String::from(parsed_error.message))
@@ -15389,6 +15597,14 @@ impl DeleteGroupPolicyError {
             },
             Err(_) => DeleteGroupPolicyError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -15459,7 +15675,7 @@ impl DeleteInstanceProfileError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DeleteConflictException" => {
                     DeleteInstanceProfileError::DeleteConflict(String::from(parsed_error.message))
@@ -15477,6 +15693,14 @@ impl DeleteInstanceProfileError {
             },
             Err(_) => DeleteInstanceProfileError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -15548,7 +15772,7 @@ impl DeleteLoginProfileError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "EntityTemporarilyUnmodifiableException" => {
                     DeleteLoginProfileError::EntityTemporarilyUnmodifiable(String::from(
@@ -15568,6 +15792,14 @@ impl DeleteLoginProfileError {
             },
             Err(_) => DeleteLoginProfileError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -15637,7 +15869,7 @@ impl DeleteOpenIDConnectProviderError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInputException" => DeleteOpenIDConnectProviderError::InvalidInput(
                     String::from(parsed_error.message),
@@ -15652,6 +15884,14 @@ impl DeleteOpenIDConnectProviderError {
             },
             Err(_) => DeleteOpenIDConnectProviderError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -15724,7 +15964,7 @@ impl DeletePolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DeleteConflictException" => {
                     DeletePolicyError::DeleteConflict(String::from(parsed_error.message))
@@ -15745,6 +15985,14 @@ impl DeletePolicyError {
             },
             Err(_) => DeletePolicyError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -15817,7 +16065,7 @@ impl DeletePolicyVersionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DeleteConflictException" => {
                     DeletePolicyVersionError::DeleteConflict(String::from(parsed_error.message))
@@ -15838,6 +16086,14 @@ impl DeletePolicyVersionError {
             },
             Err(_) => DeletePolicyVersionError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -15912,7 +16168,7 @@ impl DeleteRoleError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DeleteConflictException" => {
                     DeleteRoleError::DeleteConflict(String::from(parsed_error.message))
@@ -15933,6 +16189,14 @@ impl DeleteRoleError {
             },
             Err(_) => DeleteRoleError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -16003,7 +16267,7 @@ impl DeleteRolePolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "LimitExceededException" => {
                     DeleteRolePolicyError::LimitExceeded(String::from(parsed_error.message))
@@ -16021,6 +16285,14 @@ impl DeleteRolePolicyError {
             },
             Err(_) => DeleteRolePolicyError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -16090,7 +16362,7 @@ impl DeleteSAMLProviderError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInputException" => {
                     DeleteSAMLProviderError::InvalidInput(String::from(parsed_error.message))
@@ -16108,6 +16380,14 @@ impl DeleteSAMLProviderError {
             },
             Err(_) => DeleteSAMLProviderError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -16173,7 +16453,7 @@ impl DeleteSSHPublicKeyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchEntityException" => {
                     DeleteSSHPublicKeyError::NoSuchEntity(String::from(parsed_error.message))
@@ -16182,6 +16462,14 @@ impl DeleteSSHPublicKeyError {
             },
             Err(_) => DeleteSSHPublicKeyError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -16250,7 +16538,7 @@ impl DeleteServerCertificateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DeleteConflictException" => {
                     DeleteServerCertificateError::DeleteConflict(String::from(parsed_error.message))
@@ -16268,6 +16556,14 @@ impl DeleteServerCertificateError {
             },
             Err(_) => DeleteServerCertificateError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -16337,7 +16633,7 @@ impl DeleteServiceLinkedRoleError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "LimitExceededException" => {
                     DeleteServiceLinkedRoleError::LimitExceeded(String::from(parsed_error.message))
@@ -16352,6 +16648,14 @@ impl DeleteServiceLinkedRoleError {
             },
             Err(_) => DeleteServiceLinkedRoleError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -16416,7 +16720,7 @@ impl DeleteServiceSpecificCredentialError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchEntityException" => DeleteServiceSpecificCredentialError::NoSuchEntity(
                     String::from(parsed_error.message),
@@ -16425,6 +16729,14 @@ impl DeleteServiceSpecificCredentialError {
             },
             Err(_) => DeleteServiceSpecificCredentialError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -16491,7 +16803,7 @@ impl DeleteSigningCertificateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "LimitExceededException" => {
                     DeleteSigningCertificateError::LimitExceeded(String::from(parsed_error.message))
@@ -16506,6 +16818,14 @@ impl DeleteSigningCertificateError {
             },
             Err(_) => DeleteSigningCertificateError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -16576,7 +16896,7 @@ impl DeleteUserError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DeleteConflictException" => {
                     DeleteUserError::DeleteConflict(String::from(parsed_error.message))
@@ -16594,6 +16914,14 @@ impl DeleteUserError {
             },
             Err(_) => DeleteUserError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -16661,7 +16989,7 @@ impl DeleteUserPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "LimitExceededException" => {
                     DeleteUserPolicyError::LimitExceeded(String::from(parsed_error.message))
@@ -16676,6 +17004,14 @@ impl DeleteUserPolicyError {
             },
             Err(_) => DeleteUserPolicyError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -16744,7 +17080,7 @@ impl DeleteVirtualMFADeviceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DeleteConflictException" => {
                     DeleteVirtualMFADeviceError::DeleteConflict(String::from(parsed_error.message))
@@ -16762,6 +17098,14 @@ impl DeleteVirtualMFADeviceError {
             },
             Err(_) => DeleteVirtualMFADeviceError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -16833,7 +17177,7 @@ impl DetachGroupPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInputException" => {
                     DetachGroupPolicyError::InvalidInput(String::from(parsed_error.message))
@@ -16851,6 +17195,14 @@ impl DetachGroupPolicyError {
             },
             Err(_) => DetachGroupPolicyError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -16924,7 +17276,7 @@ impl DetachRolePolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInputException" => {
                     DetachRolePolicyError::InvalidInput(String::from(parsed_error.message))
@@ -16945,6 +17297,14 @@ impl DetachRolePolicyError {
             },
             Err(_) => DetachRolePolicyError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -17015,7 +17375,7 @@ impl DetachUserPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInputException" => {
                     DetachUserPolicyError::InvalidInput(String::from(parsed_error.message))
@@ -17033,6 +17393,14 @@ impl DetachUserPolicyError {
             },
             Err(_) => DetachUserPolicyError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -17106,7 +17474,7 @@ impl EnableMFADeviceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "EntityAlreadyExistsException" => {
                     EnableMFADeviceError::EntityAlreadyExists(String::from(parsed_error.message))
@@ -17134,6 +17502,14 @@ impl EnableMFADeviceError {
             },
             Err(_) => EnableMFADeviceError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -17201,7 +17577,7 @@ impl GenerateCredentialReportError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "LimitExceededException" => {
                     GenerateCredentialReportError::LimitExceeded(String::from(parsed_error.message))
@@ -17213,6 +17589,14 @@ impl GenerateCredentialReportError {
             },
             Err(_) => GenerateCredentialReportError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -17276,7 +17660,7 @@ impl GetAccessKeyLastUsedError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchEntityException" => {
                     GetAccessKeyLastUsedError::NoSuchEntity(String::from(parsed_error.message))
@@ -17285,6 +17669,14 @@ impl GetAccessKeyLastUsedError {
             },
             Err(_) => GetAccessKeyLastUsedError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -17347,7 +17739,7 @@ impl GetAccountAuthorizationDetailsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ServiceFailureException" => GetAccountAuthorizationDetailsError::ServiceFailure(
                     String::from(parsed_error.message),
@@ -17356,6 +17748,14 @@ impl GetAccountAuthorizationDetailsError {
             },
             Err(_) => GetAccountAuthorizationDetailsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -17420,7 +17820,7 @@ impl GetAccountPasswordPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchEntityException" => {
                     GetAccountPasswordPolicyError::NoSuchEntity(String::from(parsed_error.message))
@@ -17432,6 +17832,14 @@ impl GetAccountPasswordPolicyError {
             },
             Err(_) => GetAccountPasswordPolicyError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -17495,7 +17903,7 @@ impl GetAccountSummaryError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ServiceFailureException" => {
                     GetAccountSummaryError::ServiceFailure(String::from(parsed_error.message))
@@ -17504,6 +17912,14 @@ impl GetAccountSummaryError {
             },
             Err(_) => GetAccountSummaryError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -17566,7 +17982,7 @@ impl GetContextKeysForCustomPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInputException" => GetContextKeysForCustomPolicyError::InvalidInput(
                     String::from(parsed_error.message),
@@ -17575,6 +17991,14 @@ impl GetContextKeysForCustomPolicyError {
             },
             Err(_) => GetContextKeysForCustomPolicyError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -17639,7 +18063,7 @@ impl GetContextKeysForPrincipalPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInputException" => GetContextKeysForPrincipalPolicyError::InvalidInput(
                     String::from(parsed_error.message),
@@ -17651,6 +18075,14 @@ impl GetContextKeysForPrincipalPolicyError {
             },
             Err(_) => GetContextKeysForPrincipalPolicyError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -17720,7 +18152,7 @@ impl GetCredentialReportError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CredentialReportExpiredException" => {
                     GetCredentialReportError::CredentialReportExpired(String::from(
@@ -17744,6 +18176,14 @@ impl GetCredentialReportError {
             },
             Err(_) => GetCredentialReportError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -17811,7 +18251,7 @@ impl GetGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchEntityException" => {
                     GetGroupError::NoSuchEntity(String::from(parsed_error.message))
@@ -17823,6 +18263,14 @@ impl GetGroupError {
             },
             Err(_) => GetGroupError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -17886,7 +18334,7 @@ impl GetGroupPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchEntityException" => {
                     GetGroupPolicyError::NoSuchEntity(String::from(parsed_error.message))
@@ -17898,6 +18346,14 @@ impl GetGroupPolicyError {
             },
             Err(_) => GetGroupPolicyError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -17961,7 +18417,7 @@ impl GetInstanceProfileError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchEntityException" => {
                     GetInstanceProfileError::NoSuchEntity(String::from(parsed_error.message))
@@ -17973,6 +18429,14 @@ impl GetInstanceProfileError {
             },
             Err(_) => GetInstanceProfileError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -18038,7 +18502,7 @@ impl GetLoginProfileError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchEntityException" => {
                     GetLoginProfileError::NoSuchEntity(String::from(parsed_error.message))
@@ -18050,6 +18514,14 @@ impl GetLoginProfileError {
             },
             Err(_) => GetLoginProfileError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -18115,7 +18587,7 @@ impl GetOpenIDConnectProviderError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInputException" => {
                     GetOpenIDConnectProviderError::InvalidInput(String::from(parsed_error.message))
@@ -18130,6 +18602,14 @@ impl GetOpenIDConnectProviderError {
             },
             Err(_) => GetOpenIDConnectProviderError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -18198,7 +18678,7 @@ impl GetPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInputException" => {
                     GetPolicyError::InvalidInput(String::from(parsed_error.message))
@@ -18213,6 +18693,14 @@ impl GetPolicyError {
             },
             Err(_) => GetPolicyError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -18279,7 +18767,7 @@ impl GetPolicyVersionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInputException" => {
                     GetPolicyVersionError::InvalidInput(String::from(parsed_error.message))
@@ -18294,6 +18782,14 @@ impl GetPolicyVersionError {
             },
             Err(_) => GetPolicyVersionError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -18358,7 +18854,7 @@ impl GetRoleError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchEntityException" => {
                     GetRoleError::NoSuchEntity(String::from(parsed_error.message))
@@ -18370,6 +18866,14 @@ impl GetRoleError {
             },
             Err(_) => GetRoleError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -18433,7 +18937,7 @@ impl GetRolePolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchEntityException" => {
                     GetRolePolicyError::NoSuchEntity(String::from(parsed_error.message))
@@ -18445,6 +18949,14 @@ impl GetRolePolicyError {
             },
             Err(_) => GetRolePolicyError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -18510,7 +19022,7 @@ impl GetSAMLProviderError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInputException" => {
                     GetSAMLProviderError::InvalidInput(String::from(parsed_error.message))
@@ -18525,6 +19037,14 @@ impl GetSAMLProviderError {
             },
             Err(_) => GetSAMLProviderError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -18589,7 +19109,7 @@ impl GetSSHPublicKeyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchEntityException" => {
                     GetSSHPublicKeyError::NoSuchEntity(String::from(parsed_error.message))
@@ -18603,6 +19123,14 @@ impl GetSSHPublicKeyError {
             },
             Err(_) => GetSSHPublicKeyError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -18666,7 +19194,7 @@ impl GetServerCertificateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchEntityException" => {
                     GetServerCertificateError::NoSuchEntity(String::from(parsed_error.message))
@@ -18678,6 +19206,14 @@ impl GetServerCertificateError {
             },
             Err(_) => GetServerCertificateError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -18745,7 +19281,7 @@ impl GetServiceLinkedRoleDeletionStatusError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInputException" => GetServiceLinkedRoleDeletionStatusError::InvalidInput(
                     String::from(parsed_error.message),
@@ -18762,6 +19298,14 @@ impl GetServiceLinkedRoleDeletionStatusError {
             },
             Err(_) => GetServiceLinkedRoleDeletionStatusError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -18828,7 +19372,7 @@ impl GetUserError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchEntityException" => {
                     GetUserError::NoSuchEntity(String::from(parsed_error.message))
@@ -18840,6 +19384,14 @@ impl GetUserError {
             },
             Err(_) => GetUserError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -18903,7 +19455,7 @@ impl GetUserPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchEntityException" => {
                     GetUserPolicyError::NoSuchEntity(String::from(parsed_error.message))
@@ -18915,6 +19467,14 @@ impl GetUserPolicyError {
             },
             Err(_) => GetUserPolicyError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -18978,7 +19538,7 @@ impl ListAccessKeysError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchEntityException" => {
                     ListAccessKeysError::NoSuchEntity(String::from(parsed_error.message))
@@ -18990,6 +19550,14 @@ impl ListAccessKeysError {
             },
             Err(_) => ListAccessKeysError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -19051,7 +19619,7 @@ impl ListAccountAliasesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ServiceFailureException" => {
                     ListAccountAliasesError::ServiceFailure(String::from(parsed_error.message))
@@ -19060,6 +19628,14 @@ impl ListAccountAliasesError {
             },
             Err(_) => ListAccountAliasesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -19126,7 +19702,7 @@ impl ListAttachedGroupPoliciesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInputException" => {
                     ListAttachedGroupPoliciesError::InvalidInput(String::from(parsed_error.message))
@@ -19141,6 +19717,14 @@ impl ListAttachedGroupPoliciesError {
             },
             Err(_) => ListAttachedGroupPoliciesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -19209,7 +19793,7 @@ impl ListAttachedRolePoliciesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInputException" => {
                     ListAttachedRolePoliciesError::InvalidInput(String::from(parsed_error.message))
@@ -19224,6 +19808,14 @@ impl ListAttachedRolePoliciesError {
             },
             Err(_) => ListAttachedRolePoliciesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -19292,7 +19884,7 @@ impl ListAttachedUserPoliciesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInputException" => {
                     ListAttachedUserPoliciesError::InvalidInput(String::from(parsed_error.message))
@@ -19307,6 +19899,14 @@ impl ListAttachedUserPoliciesError {
             },
             Err(_) => ListAttachedUserPoliciesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -19375,7 +19975,7 @@ impl ListEntitiesForPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInputException" => {
                     ListEntitiesForPolicyError::InvalidInput(String::from(parsed_error.message))
@@ -19390,6 +19990,14 @@ impl ListEntitiesForPolicyError {
             },
             Err(_) => ListEntitiesForPolicyError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -19456,7 +20064,7 @@ impl ListGroupPoliciesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchEntityException" => {
                     ListGroupPoliciesError::NoSuchEntity(String::from(parsed_error.message))
@@ -19468,6 +20076,14 @@ impl ListGroupPoliciesError {
             },
             Err(_) => ListGroupPoliciesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -19531,7 +20147,7 @@ impl ListGroupsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ServiceFailureException" => {
                     ListGroupsError::ServiceFailure(String::from(parsed_error.message))
@@ -19540,6 +20156,14 @@ impl ListGroupsError {
             },
             Err(_) => ListGroupsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -19602,7 +20226,7 @@ impl ListGroupsForUserError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchEntityException" => {
                     ListGroupsForUserError::NoSuchEntity(String::from(parsed_error.message))
@@ -19614,6 +20238,14 @@ impl ListGroupsForUserError {
             },
             Err(_) => ListGroupsForUserError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -19677,7 +20309,7 @@ impl ListInstanceProfilesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ServiceFailureException" => {
                     ListInstanceProfilesError::ServiceFailure(String::from(parsed_error.message))
@@ -19686,6 +20318,14 @@ impl ListInstanceProfilesError {
             },
             Err(_) => ListInstanceProfilesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -19750,7 +20390,7 @@ impl ListInstanceProfilesForRoleError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchEntityException" => ListInstanceProfilesForRoleError::NoSuchEntity(
                     String::from(parsed_error.message),
@@ -19762,6 +20402,14 @@ impl ListInstanceProfilesForRoleError {
             },
             Err(_) => ListInstanceProfilesForRoleError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -19827,7 +20475,7 @@ impl ListMFADevicesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchEntityException" => {
                     ListMFADevicesError::NoSuchEntity(String::from(parsed_error.message))
@@ -19839,6 +20487,14 @@ impl ListMFADevicesError {
             },
             Err(_) => ListMFADevicesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -19900,7 +20556,7 @@ impl ListOpenIDConnectProvidersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ServiceFailureException" => ListOpenIDConnectProvidersError::ServiceFailure(
                     String::from(parsed_error.message),
@@ -19909,6 +20565,14 @@ impl ListOpenIDConnectProvidersError {
             },
             Err(_) => ListOpenIDConnectProvidersError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -19971,7 +20635,7 @@ impl ListPoliciesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ServiceFailureException" => {
                     ListPoliciesError::ServiceFailure(String::from(parsed_error.message))
@@ -19980,6 +20644,14 @@ impl ListPoliciesError {
             },
             Err(_) => ListPoliciesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -20044,7 +20716,7 @@ impl ListPolicyVersionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInputException" => {
                     ListPolicyVersionsError::InvalidInput(String::from(parsed_error.message))
@@ -20059,6 +20731,14 @@ impl ListPolicyVersionsError {
             },
             Err(_) => ListPolicyVersionsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -20125,7 +20805,7 @@ impl ListRolePoliciesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchEntityException" => {
                     ListRolePoliciesError::NoSuchEntity(String::from(parsed_error.message))
@@ -20137,6 +20817,14 @@ impl ListRolePoliciesError {
             },
             Err(_) => ListRolePoliciesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -20198,7 +20886,7 @@ impl ListRolesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ServiceFailureException" => {
                     ListRolesError::ServiceFailure(String::from(parsed_error.message))
@@ -20207,6 +20895,14 @@ impl ListRolesError {
             },
             Err(_) => ListRolesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -20267,7 +20963,7 @@ impl ListSAMLProvidersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ServiceFailureException" => {
                     ListSAMLProvidersError::ServiceFailure(String::from(parsed_error.message))
@@ -20276,6 +20972,14 @@ impl ListSAMLProvidersError {
             },
             Err(_) => ListSAMLProvidersError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -20338,7 +21042,7 @@ impl ListSSHPublicKeysError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchEntityException" => {
                     ListSSHPublicKeysError::NoSuchEntity(String::from(parsed_error.message))
@@ -20347,6 +21051,14 @@ impl ListSSHPublicKeysError {
             },
             Err(_) => ListSSHPublicKeysError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -20409,7 +21121,7 @@ impl ListServerCertificatesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ServiceFailureException" => {
                     ListServerCertificatesError::ServiceFailure(String::from(parsed_error.message))
@@ -20418,6 +21130,14 @@ impl ListServerCertificatesError {
             },
             Err(_) => ListServerCertificatesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -20482,7 +21202,7 @@ impl ListServiceSpecificCredentialsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchEntityException" => ListServiceSpecificCredentialsError::NoSuchEntity(
                     String::from(parsed_error.message),
@@ -20496,6 +21216,14 @@ impl ListServiceSpecificCredentialsError {
             },
             Err(_) => ListServiceSpecificCredentialsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -20561,7 +21289,7 @@ impl ListSigningCertificatesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchEntityException" => {
                     ListSigningCertificatesError::NoSuchEntity(String::from(parsed_error.message))
@@ -20573,6 +21301,14 @@ impl ListSigningCertificatesError {
             },
             Err(_) => ListSigningCertificatesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -20638,7 +21374,7 @@ impl ListUserPoliciesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchEntityException" => {
                     ListUserPoliciesError::NoSuchEntity(String::from(parsed_error.message))
@@ -20650,6 +21386,14 @@ impl ListUserPoliciesError {
             },
             Err(_) => ListUserPoliciesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -20711,7 +21455,7 @@ impl ListUsersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ServiceFailureException" => {
                     ListUsersError::ServiceFailure(String::from(parsed_error.message))
@@ -20720,6 +21464,14 @@ impl ListUsersError {
             },
             Err(_) => ListUsersError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -20778,12 +21530,20 @@ impl ListVirtualMFADevicesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListVirtualMFADevicesError::Unknown(String::from(body)),
             },
             Err(_) => ListVirtualMFADevicesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -20851,7 +21611,7 @@ impl PutGroupPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "LimitExceededException" => {
                     PutGroupPolicyError::LimitExceeded(String::from(parsed_error.message))
@@ -20869,6 +21629,14 @@ impl PutGroupPolicyError {
             },
             Err(_) => PutGroupPolicyError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -20940,7 +21708,7 @@ impl PutRolePolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "LimitExceededException" => {
                     PutRolePolicyError::LimitExceeded(String::from(parsed_error.message))
@@ -20961,6 +21729,14 @@ impl PutRolePolicyError {
             },
             Err(_) => PutRolePolicyError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -21031,7 +21807,7 @@ impl PutUserPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "LimitExceededException" => {
                     PutUserPolicyError::LimitExceeded(String::from(parsed_error.message))
@@ -21049,6 +21825,14 @@ impl PutUserPolicyError {
             },
             Err(_) => PutUserPolicyError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -21116,7 +21900,7 @@ impl RemoveClientIDFromOpenIDConnectProviderError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInputException" => {
                     RemoveClientIDFromOpenIDConnectProviderError::InvalidInput(String::from(
@@ -21137,6 +21921,14 @@ impl RemoveClientIDFromOpenIDConnectProviderError {
             },
             Err(_) => RemoveClientIDFromOpenIDConnectProviderError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -21207,7 +21999,7 @@ impl RemoveRoleFromInstanceProfileError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "LimitExceededException" => RemoveRoleFromInstanceProfileError::LimitExceeded(
                     String::from(parsed_error.message),
@@ -21227,6 +22019,14 @@ impl RemoveRoleFromInstanceProfileError {
             },
             Err(_) => RemoveRoleFromInstanceProfileError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -21296,7 +22096,7 @@ impl RemoveUserFromGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "LimitExceededException" => {
                     RemoveUserFromGroupError::LimitExceeded(String::from(parsed_error.message))
@@ -21311,6 +22111,14 @@ impl RemoveUserFromGroupError {
             },
             Err(_) => RemoveUserFromGroupError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -21375,7 +22183,7 @@ impl ResetServiceSpecificCredentialError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchEntityException" => ResetServiceSpecificCredentialError::NoSuchEntity(
                     String::from(parsed_error.message),
@@ -21384,6 +22192,14 @@ impl ResetServiceSpecificCredentialError {
             },
             Err(_) => ResetServiceSpecificCredentialError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -21452,7 +22268,7 @@ impl ResyncMFADeviceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidAuthenticationCodeException" => {
                     ResyncMFADeviceError::InvalidAuthenticationCode(String::from(
@@ -21472,6 +22288,14 @@ impl ResyncMFADeviceError {
             },
             Err(_) => ResyncMFADeviceError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -21541,7 +22365,7 @@ impl SetDefaultPolicyVersionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInputException" => {
                     SetDefaultPolicyVersionError::InvalidInput(String::from(parsed_error.message))
@@ -21559,6 +22383,14 @@ impl SetDefaultPolicyVersionError {
             },
             Err(_) => SetDefaultPolicyVersionError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -21626,7 +22458,7 @@ impl SimulateCustomPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInputException" => {
                     SimulateCustomPolicyError::InvalidInput(String::from(parsed_error.message))
@@ -21638,6 +22470,14 @@ impl SimulateCustomPolicyError {
             },
             Err(_) => SimulateCustomPolicyError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -21705,7 +22545,7 @@ impl SimulatePrincipalPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInputException" => {
                     SimulatePrincipalPolicyError::InvalidInput(String::from(parsed_error.message))
@@ -21720,6 +22560,14 @@ impl SimulatePrincipalPolicyError {
             },
             Err(_) => SimulatePrincipalPolicyError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -21788,7 +22636,7 @@ impl UpdateAccessKeyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "LimitExceededException" => {
                     UpdateAccessKeyError::LimitExceeded(String::from(parsed_error.message))
@@ -21803,6 +22651,14 @@ impl UpdateAccessKeyError {
             },
             Err(_) => UpdateAccessKeyError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -21871,7 +22727,7 @@ impl UpdateAccountPasswordPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "LimitExceededException" => UpdateAccountPasswordPolicyError::LimitExceeded(
                     String::from(parsed_error.message),
@@ -21891,6 +22747,14 @@ impl UpdateAccountPasswordPolicyError {
             },
             Err(_) => UpdateAccountPasswordPolicyError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -21964,7 +22828,7 @@ impl UpdateAssumeRolePolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "LimitExceededException" => {
                     UpdateAssumeRolePolicyError::LimitExceeded(String::from(parsed_error.message))
@@ -21987,6 +22851,14 @@ impl UpdateAssumeRolePolicyError {
             },
             Err(_) => UpdateAssumeRolePolicyError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -22059,7 +22931,7 @@ impl UpdateGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "EntityAlreadyExistsException" => {
                     UpdateGroupError::EntityAlreadyExists(String::from(parsed_error.message))
@@ -22077,6 +22949,14 @@ impl UpdateGroupError {
             },
             Err(_) => UpdateGroupError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -22148,7 +23028,7 @@ impl UpdateLoginProfileError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "EntityTemporarilyUnmodifiableException" => {
                     UpdateLoginProfileError::EntityTemporarilyUnmodifiable(String::from(
@@ -22173,6 +23053,14 @@ impl UpdateLoginProfileError {
             },
             Err(_) => UpdateLoginProfileError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -22243,7 +23131,7 @@ impl UpdateOpenIDConnectProviderThumbprintError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInputException" => {
                     UpdateOpenIDConnectProviderThumbprintError::InvalidInput(String::from(
@@ -22264,6 +23152,14 @@ impl UpdateOpenIDConnectProviderThumbprintError {
             },
             Err(_) => UpdateOpenIDConnectProviderThumbprintError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -22332,7 +23228,7 @@ impl UpdateRoleDescriptionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchEntityException" => {
                     UpdateRoleDescriptionError::NoSuchEntity(String::from(parsed_error.message))
@@ -22347,6 +23243,14 @@ impl UpdateRoleDescriptionError {
             },
             Err(_) => UpdateRoleDescriptionError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -22417,7 +23321,7 @@ impl UpdateSAMLProviderError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInputException" => {
                     UpdateSAMLProviderError::InvalidInput(String::from(parsed_error.message))
@@ -22435,6 +23339,14 @@ impl UpdateSAMLProviderError {
             },
             Err(_) => UpdateSAMLProviderError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -22500,7 +23412,7 @@ impl UpdateSSHPublicKeyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchEntityException" => {
                     UpdateSSHPublicKeyError::NoSuchEntity(String::from(parsed_error.message))
@@ -22509,6 +23421,14 @@ impl UpdateSSHPublicKeyError {
             },
             Err(_) => UpdateSSHPublicKeyError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -22577,7 +23497,7 @@ impl UpdateServerCertificateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "EntityAlreadyExistsException" => {
                     UpdateServerCertificateError::EntityAlreadyExists(String::from(
@@ -22597,6 +23517,14 @@ impl UpdateServerCertificateError {
             },
             Err(_) => UpdateServerCertificateError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -22662,7 +23590,7 @@ impl UpdateServiceSpecificCredentialError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchEntityException" => UpdateServiceSpecificCredentialError::NoSuchEntity(
                     String::from(parsed_error.message),
@@ -22671,6 +23599,14 @@ impl UpdateServiceSpecificCredentialError {
             },
             Err(_) => UpdateServiceSpecificCredentialError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -22737,7 +23673,7 @@ impl UpdateSigningCertificateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "LimitExceededException" => {
                     UpdateSigningCertificateError::LimitExceeded(String::from(parsed_error.message))
@@ -22752,6 +23688,14 @@ impl UpdateSigningCertificateError {
             },
             Err(_) => UpdateSigningCertificateError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -22824,7 +23768,7 @@ impl UpdateUserError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "EntityAlreadyExistsException" => {
                     UpdateUserError::EntityAlreadyExists(String::from(parsed_error.message))
@@ -22847,6 +23791,14 @@ impl UpdateUserError {
             },
             Err(_) => UpdateUserError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -22919,7 +23871,7 @@ impl UploadSSHPublicKeyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DuplicateSSHPublicKeyException" => {
                     UploadSSHPublicKeyError::DuplicateSSHPublicKey(String::from(
@@ -22944,6 +23896,14 @@ impl UploadSSHPublicKeyError {
             },
             Err(_) => UploadSSHPublicKeyError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -23018,7 +23978,7 @@ impl UploadServerCertificateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "EntityAlreadyExistsException" => {
                     UploadServerCertificateError::EntityAlreadyExists(String::from(
@@ -23043,6 +24003,14 @@ impl UploadServerCertificateError {
             },
             Err(_) => UploadServerCertificateError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -23121,7 +24089,7 @@ impl UploadSigningCertificateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DuplicateCertificateException" => {
                     UploadSigningCertificateError::DuplicateCertificate(String::from(
@@ -23156,6 +24124,14 @@ impl UploadSigningCertificateError {
             },
             Err(_) => UploadSigningCertificateError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 

--- a/rusoto/services/importexport/src/generated.rs
+++ b/rusoto/services/importexport/src/generated.rs
@@ -1265,8 +1265,8 @@ impl WarningMessageDeserializer {
 /// Errors returned by CancelJob
 #[derive(Debug, PartialEq)]
 pub enum CancelJobError {
-    /// <p>AWS Import/Export cannot cancel the job</p>
-    UnableToCancelJobId(String),
+    /// <p>The specified job ID has been canceled and is no longer valid.</p>
+    CanceledJobId(String),
     /// <p>Indicates that the specified job has expired out of the system.</p>
     ExpiredJobId(String),
     /// <p>The AWS Access Key ID specified in the request did not match the manifest&#39;s accessKeyId value. The manifest and the request authentication must use the same AWS Access Key ID.</p>
@@ -1275,8 +1275,8 @@ pub enum CancelJobError {
     InvalidJobId(String),
     /// <p>The client tool version is invalid.</p>
     InvalidVersion(String),
-    /// <p>The specified job ID has been canceled and is no longer valid.</p>
-    CanceledJobId(String),
+    /// <p>AWS Import/Export cannot cancel the job</p>
+    UnableToCancelJobId(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -1294,8 +1294,8 @@ impl CancelJobError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "UnableToCancelJobIdException" => {
-                    CancelJobError::UnableToCancelJobId(String::from(parsed_error.message))
+                "CanceledJobIdException" => {
+                    CancelJobError::CanceledJobId(String::from(parsed_error.message))
                 }
                 "ExpiredJobIdException" => {
                     CancelJobError::ExpiredJobId(String::from(parsed_error.message))
@@ -1309,8 +1309,8 @@ impl CancelJobError {
                 "InvalidVersionException" => {
                     CancelJobError::InvalidVersion(String::from(parsed_error.message))
                 }
-                "CanceledJobIdException" => {
-                    CancelJobError::CanceledJobId(String::from(parsed_error.message))
+                "UnableToCancelJobIdException" => {
+                    CancelJobError::UnableToCancelJobId(String::from(parsed_error.message))
                 }
                 _ => CancelJobError::Unknown(String::from(body)),
             },
@@ -1356,12 +1356,12 @@ impl fmt::Display for CancelJobError {
 impl Error for CancelJobError {
     fn description(&self) -> &str {
         match *self {
-            CancelJobError::UnableToCancelJobId(ref cause) => cause,
+            CancelJobError::CanceledJobId(ref cause) => cause,
             CancelJobError::ExpiredJobId(ref cause) => cause,
             CancelJobError::InvalidAccessKeyId(ref cause) => cause,
             CancelJobError::InvalidJobId(ref cause) => cause,
             CancelJobError::InvalidVersion(ref cause) => cause,
-            CancelJobError::CanceledJobId(ref cause) => cause,
+            CancelJobError::UnableToCancelJobId(ref cause) => cause,
             CancelJobError::Validation(ref cause) => cause,
             CancelJobError::Credentials(ref err) => err.description(),
             CancelJobError::HttpDispatch(ref dispatch_error) => dispatch_error.description(),
@@ -1372,38 +1372,38 @@ impl Error for CancelJobError {
 /// Errors returned by CreateJob
 #[derive(Debug, PartialEq)]
 pub enum CreateJobError {
+    /// <p>The account specified does not have the appropriate bucket permissions.</p>
+    BucketPermission(String),
     /// <p>Each account can create only a certain number of jobs per day. If you need to create more than this, please contact awsimportexport@amazon.com to explain your particular use case.</p>
     CreateJobQuotaExceeded(String),
-    /// <p>File system specified in export manifest is invalid.</p>
-    InvalidFileSystem(String),
+    /// <p>The AWS Access Key ID specified in the request did not match the manifest&#39;s accessKeyId value. The manifest and the request authentication must use the same AWS Access Key ID.</p>
+    InvalidAccessKeyId(String),
+    /// <p>The address specified in the manifest is invalid.</p>
+    InvalidAddress(String),
     /// <p>One or more customs parameters was invalid. Please correct and resubmit.</p>
     InvalidCustoms(String),
+    /// <p>File system specified in export manifest is invalid.</p>
+    InvalidFileSystem(String),
+    /// <p>The JOBID was missing, not found, or not associated with the AWS account.</p>
+    InvalidJobId(String),
     /// <p>One or more manifest fields was invalid. Please correct and resubmit.</p>
     InvalidManifestField(String),
     /// <p>One or more parameters had an invalid value.</p>
     InvalidParameter(String),
+    /// <p>The client tool version is invalid.</p>
+    InvalidVersion(String),
+    /// <p>Your manifest is not well-formed.</p>
+    MalformedManifest(String),
     /// <p>One or more required customs parameters was missing from the manifest.</p>
     MissingCustoms(String),
     /// <p>One or more required fields were missing from the manifest file. Please correct and resubmit.</p>
     MissingManifestField(String),
     /// <p>One or more required parameters was missing from the request.</p>
     MissingParameter(String),
-    /// <p>The AWS Access Key ID specified in the request did not match the manifest&#39;s accessKeyId value. The manifest and the request authentication must use the same AWS Access Key ID.</p>
-    InvalidAccessKeyId(String),
-    /// <p>The JOBID was missing, not found, or not associated with the AWS account.</p>
-    InvalidJobId(String),
-    /// <p>The account specified does not have the appropriate bucket permissions.</p>
-    BucketPermission(String),
-    /// <p>The address specified in the manifest is invalid.</p>
-    InvalidAddress(String),
-    /// <p>The client tool version is invalid.</p>
-    InvalidVersion(String),
-    /// <p>The specified bucket does not exist. Create the specified bucket or change the manifest&#39;s bucket, exportBucket, or logBucket field to a bucket that the account, as specified by the manifest&#39;s Access Key ID, has write permissions to.</p>
-    NoSuchBucket(String),
     /// <p>Your manifest file contained buckets from multiple regions. A job is restricted to buckets from one region. Please correct and resubmit.</p>
     MultipleRegions(String),
-    /// <p>Your manifest is not well-formed.</p>
-    MalformedManifest(String),
+    /// <p>The specified bucket does not exist. Create the specified bucket or change the manifest&#39;s bucket, exportBucket, or logBucket field to a bucket that the account, as specified by the manifest&#39;s Access Key ID, has write permissions to.</p>
+    NoSuchBucket(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -1421,20 +1421,38 @@ impl CreateJobError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
+                "BucketPermissionException" => {
+                    CreateJobError::BucketPermission(String::from(parsed_error.message))
+                }
                 "CreateJobQuotaExceededException" => {
                     CreateJobError::CreateJobQuotaExceeded(String::from(parsed_error.message))
+                }
+                "InvalidAccessKeyIdException" => {
+                    CreateJobError::InvalidAccessKeyId(String::from(parsed_error.message))
+                }
+                "InvalidAddressException" => {
+                    CreateJobError::InvalidAddress(String::from(parsed_error.message))
+                }
+                "InvalidCustomsException" => {
+                    CreateJobError::InvalidCustoms(String::from(parsed_error.message))
                 }
                 "InvalidFileSystemException" => {
                     CreateJobError::InvalidFileSystem(String::from(parsed_error.message))
                 }
-                "InvalidCustomsException" => {
-                    CreateJobError::InvalidCustoms(String::from(parsed_error.message))
+                "InvalidJobIdException" => {
+                    CreateJobError::InvalidJobId(String::from(parsed_error.message))
                 }
                 "InvalidManifestFieldException" => {
                     CreateJobError::InvalidManifestField(String::from(parsed_error.message))
                 }
                 "InvalidParameterException" => {
                     CreateJobError::InvalidParameter(String::from(parsed_error.message))
+                }
+                "InvalidVersionException" => {
+                    CreateJobError::InvalidVersion(String::from(parsed_error.message))
+                }
+                "MalformedManifestException" => {
+                    CreateJobError::MalformedManifest(String::from(parsed_error.message))
                 }
                 "MissingCustomsException" => {
                     CreateJobError::MissingCustoms(String::from(parsed_error.message))
@@ -1445,29 +1463,11 @@ impl CreateJobError {
                 "MissingParameterException" => {
                     CreateJobError::MissingParameter(String::from(parsed_error.message))
                 }
-                "InvalidAccessKeyIdException" => {
-                    CreateJobError::InvalidAccessKeyId(String::from(parsed_error.message))
-                }
-                "InvalidJobIdException" => {
-                    CreateJobError::InvalidJobId(String::from(parsed_error.message))
-                }
-                "BucketPermissionException" => {
-                    CreateJobError::BucketPermission(String::from(parsed_error.message))
-                }
-                "InvalidAddressException" => {
-                    CreateJobError::InvalidAddress(String::from(parsed_error.message))
-                }
-                "InvalidVersionException" => {
-                    CreateJobError::InvalidVersion(String::from(parsed_error.message))
-                }
-                "NoSuchBucketException" => {
-                    CreateJobError::NoSuchBucket(String::from(parsed_error.message))
-                }
                 "MultipleRegionsException" => {
                     CreateJobError::MultipleRegions(String::from(parsed_error.message))
                 }
-                "MalformedManifestException" => {
-                    CreateJobError::MalformedManifest(String::from(parsed_error.message))
+                "NoSuchBucketException" => {
+                    CreateJobError::NoSuchBucket(String::from(parsed_error.message))
                 }
                 _ => CreateJobError::Unknown(String::from(body)),
             },
@@ -1513,22 +1513,22 @@ impl fmt::Display for CreateJobError {
 impl Error for CreateJobError {
     fn description(&self) -> &str {
         match *self {
+            CreateJobError::BucketPermission(ref cause) => cause,
             CreateJobError::CreateJobQuotaExceeded(ref cause) => cause,
-            CreateJobError::InvalidFileSystem(ref cause) => cause,
+            CreateJobError::InvalidAccessKeyId(ref cause) => cause,
+            CreateJobError::InvalidAddress(ref cause) => cause,
             CreateJobError::InvalidCustoms(ref cause) => cause,
+            CreateJobError::InvalidFileSystem(ref cause) => cause,
+            CreateJobError::InvalidJobId(ref cause) => cause,
             CreateJobError::InvalidManifestField(ref cause) => cause,
             CreateJobError::InvalidParameter(ref cause) => cause,
+            CreateJobError::InvalidVersion(ref cause) => cause,
+            CreateJobError::MalformedManifest(ref cause) => cause,
             CreateJobError::MissingCustoms(ref cause) => cause,
             CreateJobError::MissingManifestField(ref cause) => cause,
             CreateJobError::MissingParameter(ref cause) => cause,
-            CreateJobError::InvalidAccessKeyId(ref cause) => cause,
-            CreateJobError::InvalidJobId(ref cause) => cause,
-            CreateJobError::BucketPermission(ref cause) => cause,
-            CreateJobError::InvalidAddress(ref cause) => cause,
-            CreateJobError::InvalidVersion(ref cause) => cause,
-            CreateJobError::NoSuchBucket(ref cause) => cause,
             CreateJobError::MultipleRegions(ref cause) => cause,
-            CreateJobError::MalformedManifest(ref cause) => cause,
+            CreateJobError::NoSuchBucket(ref cause) => cause,
             CreateJobError::Validation(ref cause) => cause,
             CreateJobError::Credentials(ref err) => err.description(),
             CreateJobError::HttpDispatch(ref dispatch_error) => dispatch_error.description(),
@@ -1539,20 +1539,20 @@ impl Error for CreateJobError {
 /// Errors returned by GetShippingLabel
 #[derive(Debug, PartialEq)]
 pub enum GetShippingLabelError {
-    /// <p>Indicates that the specified job has expired out of the system.</p>
-    ExpiredJobId(String),
-    /// <p>One or more parameters had an invalid value.</p>
-    InvalidParameter(String),
-    /// <p>The AWS Access Key ID specified in the request did not match the manifest&#39;s accessKeyId value. The manifest and the request authentication must use the same AWS Access Key ID.</p>
-    InvalidAccessKeyId(String),
-    /// <p>The JOBID was missing, not found, or not associated with the AWS account.</p>
-    InvalidJobId(String),
-    /// <p>The address specified in the manifest is invalid.</p>
-    InvalidAddress(String),
-    /// <p>The client tool version is invalid.</p>
-    InvalidVersion(String),
     /// <p>The specified job ID has been canceled and is no longer valid.</p>
     CanceledJobId(String),
+    /// <p>Indicates that the specified job has expired out of the system.</p>
+    ExpiredJobId(String),
+    /// <p>The AWS Access Key ID specified in the request did not match the manifest&#39;s accessKeyId value. The manifest and the request authentication must use the same AWS Access Key ID.</p>
+    InvalidAccessKeyId(String),
+    /// <p>The address specified in the manifest is invalid.</p>
+    InvalidAddress(String),
+    /// <p>The JOBID was missing, not found, or not associated with the AWS account.</p>
+    InvalidJobId(String),
+    /// <p>One or more parameters had an invalid value.</p>
+    InvalidParameter(String),
+    /// <p>The client tool version is invalid.</p>
+    InvalidVersion(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -1570,26 +1570,26 @@ impl GetShippingLabelError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
+                "CanceledJobIdException" => {
+                    GetShippingLabelError::CanceledJobId(String::from(parsed_error.message))
+                }
                 "ExpiredJobIdException" => {
                     GetShippingLabelError::ExpiredJobId(String::from(parsed_error.message))
-                }
-                "InvalidParameterException" => {
-                    GetShippingLabelError::InvalidParameter(String::from(parsed_error.message))
                 }
                 "InvalidAccessKeyIdException" => {
                     GetShippingLabelError::InvalidAccessKeyId(String::from(parsed_error.message))
                 }
-                "InvalidJobIdException" => {
-                    GetShippingLabelError::InvalidJobId(String::from(parsed_error.message))
-                }
                 "InvalidAddressException" => {
                     GetShippingLabelError::InvalidAddress(String::from(parsed_error.message))
                 }
+                "InvalidJobIdException" => {
+                    GetShippingLabelError::InvalidJobId(String::from(parsed_error.message))
+                }
+                "InvalidParameterException" => {
+                    GetShippingLabelError::InvalidParameter(String::from(parsed_error.message))
+                }
                 "InvalidVersionException" => {
                     GetShippingLabelError::InvalidVersion(String::from(parsed_error.message))
-                }
-                "CanceledJobIdException" => {
-                    GetShippingLabelError::CanceledJobId(String::from(parsed_error.message))
                 }
                 _ => GetShippingLabelError::Unknown(String::from(body)),
             },
@@ -1635,13 +1635,13 @@ impl fmt::Display for GetShippingLabelError {
 impl Error for GetShippingLabelError {
     fn description(&self) -> &str {
         match *self {
-            GetShippingLabelError::ExpiredJobId(ref cause) => cause,
-            GetShippingLabelError::InvalidParameter(ref cause) => cause,
-            GetShippingLabelError::InvalidAccessKeyId(ref cause) => cause,
-            GetShippingLabelError::InvalidJobId(ref cause) => cause,
-            GetShippingLabelError::InvalidAddress(ref cause) => cause,
-            GetShippingLabelError::InvalidVersion(ref cause) => cause,
             GetShippingLabelError::CanceledJobId(ref cause) => cause,
+            GetShippingLabelError::ExpiredJobId(ref cause) => cause,
+            GetShippingLabelError::InvalidAccessKeyId(ref cause) => cause,
+            GetShippingLabelError::InvalidAddress(ref cause) => cause,
+            GetShippingLabelError::InvalidJobId(ref cause) => cause,
+            GetShippingLabelError::InvalidParameter(ref cause) => cause,
+            GetShippingLabelError::InvalidVersion(ref cause) => cause,
             GetShippingLabelError::Validation(ref cause) => cause,
             GetShippingLabelError::Credentials(ref err) => err.description(),
             GetShippingLabelError::HttpDispatch(ref dispatch_error) => dispatch_error.description(),
@@ -1652,6 +1652,8 @@ impl Error for GetShippingLabelError {
 /// Errors returned by GetStatus
 #[derive(Debug, PartialEq)]
 pub enum GetStatusError {
+    /// <p>The specified job ID has been canceled and is no longer valid.</p>
+    CanceledJobId(String),
     /// <p>Indicates that the specified job has expired out of the system.</p>
     ExpiredJobId(String),
     /// <p>The AWS Access Key ID specified in the request did not match the manifest&#39;s accessKeyId value. The manifest and the request authentication must use the same AWS Access Key ID.</p>
@@ -1660,8 +1662,6 @@ pub enum GetStatusError {
     InvalidJobId(String),
     /// <p>The client tool version is invalid.</p>
     InvalidVersion(String),
-    /// <p>The specified job ID has been canceled and is no longer valid.</p>
-    CanceledJobId(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -1679,6 +1679,9 @@ impl GetStatusError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
+                "CanceledJobIdException" => {
+                    GetStatusError::CanceledJobId(String::from(parsed_error.message))
+                }
                 "ExpiredJobIdException" => {
                     GetStatusError::ExpiredJobId(String::from(parsed_error.message))
                 }
@@ -1690,9 +1693,6 @@ impl GetStatusError {
                 }
                 "InvalidVersionException" => {
                     GetStatusError::InvalidVersion(String::from(parsed_error.message))
-                }
-                "CanceledJobIdException" => {
-                    GetStatusError::CanceledJobId(String::from(parsed_error.message))
                 }
                 _ => GetStatusError::Unknown(String::from(body)),
             },
@@ -1738,11 +1738,11 @@ impl fmt::Display for GetStatusError {
 impl Error for GetStatusError {
     fn description(&self) -> &str {
         match *self {
+            GetStatusError::CanceledJobId(ref cause) => cause,
             GetStatusError::ExpiredJobId(ref cause) => cause,
             GetStatusError::InvalidAccessKeyId(ref cause) => cause,
             GetStatusError::InvalidJobId(ref cause) => cause,
             GetStatusError::InvalidVersion(ref cause) => cause,
-            GetStatusError::CanceledJobId(ref cause) => cause,
             GetStatusError::Validation(ref cause) => cause,
             GetStatusError::Credentials(ref err) => err.description(),
             GetStatusError::HttpDispatch(ref dispatch_error) => dispatch_error.description(),
@@ -1753,10 +1753,10 @@ impl Error for GetStatusError {
 /// Errors returned by ListJobs
 #[derive(Debug, PartialEq)]
 pub enum ListJobsError {
-    /// <p>One or more parameters had an invalid value.</p>
-    InvalidParameter(String),
     /// <p>The AWS Access Key ID specified in the request did not match the manifest&#39;s accessKeyId value. The manifest and the request authentication must use the same AWS Access Key ID.</p>
     InvalidAccessKeyId(String),
+    /// <p>One or more parameters had an invalid value.</p>
+    InvalidParameter(String),
     /// <p>The client tool version is invalid.</p>
     InvalidVersion(String),
     /// An error occurred dispatching the HTTP request
@@ -1776,11 +1776,11 @@ impl ListJobsError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "InvalidParameterException" => {
-                    ListJobsError::InvalidParameter(String::from(parsed_error.message))
-                }
                 "InvalidAccessKeyIdException" => {
                     ListJobsError::InvalidAccessKeyId(String::from(parsed_error.message))
+                }
+                "InvalidParameterException" => {
+                    ListJobsError::InvalidParameter(String::from(parsed_error.message))
                 }
                 "InvalidVersionException" => {
                     ListJobsError::InvalidVersion(String::from(parsed_error.message))
@@ -1829,8 +1829,8 @@ impl fmt::Display for ListJobsError {
 impl Error for ListJobsError {
     fn description(&self) -> &str {
         match *self {
-            ListJobsError::InvalidParameter(ref cause) => cause,
             ListJobsError::InvalidAccessKeyId(ref cause) => cause,
+            ListJobsError::InvalidParameter(ref cause) => cause,
             ListJobsError::InvalidVersion(ref cause) => cause,
             ListJobsError::Validation(ref cause) => cause,
             ListJobsError::Credentials(ref err) => err.description(),
@@ -1842,42 +1842,42 @@ impl Error for ListJobsError {
 /// Errors returned by UpdateJob
 #[derive(Debug, PartialEq)]
 pub enum UpdateJobError {
-    /// <p>AWS Import/Export cannot update the job</p>
-    UnableToUpdateJobId(String),
-    /// <p>File system specified in export manifest is invalid.</p>
-    InvalidFileSystem(String),
+    /// <p>The account specified does not have the appropriate bucket permissions.</p>
+    BucketPermission(String),
+    /// <p>The specified job ID has been canceled and is no longer valid.</p>
+    CanceledJobId(String),
     /// <p>Indicates that the specified job has expired out of the system.</p>
     ExpiredJobId(String),
+    /// <p>The AWS Access Key ID specified in the request did not match the manifest&#39;s accessKeyId value. The manifest and the request authentication must use the same AWS Access Key ID.</p>
+    InvalidAccessKeyId(String),
+    /// <p>The address specified in the manifest is invalid.</p>
+    InvalidAddress(String),
     /// <p>One or more customs parameters was invalid. Please correct and resubmit.</p>
     InvalidCustoms(String),
+    /// <p>File system specified in export manifest is invalid.</p>
+    InvalidFileSystem(String),
+    /// <p>The JOBID was missing, not found, or not associated with the AWS account.</p>
+    InvalidJobId(String),
     /// <p>One or more manifest fields was invalid. Please correct and resubmit.</p>
     InvalidManifestField(String),
     /// <p>One or more parameters had an invalid value.</p>
     InvalidParameter(String),
+    /// <p>The client tool version is invalid.</p>
+    InvalidVersion(String),
+    /// <p>Your manifest is not well-formed.</p>
+    MalformedManifest(String),
     /// <p>One or more required customs parameters was missing from the manifest.</p>
     MissingCustoms(String),
     /// <p>One or more required fields were missing from the manifest file. Please correct and resubmit.</p>
     MissingManifestField(String),
     /// <p>One or more required parameters was missing from the request.</p>
     MissingParameter(String),
-    /// <p>The AWS Access Key ID specified in the request did not match the manifest&#39;s accessKeyId value. The manifest and the request authentication must use the same AWS Access Key ID.</p>
-    InvalidAccessKeyId(String),
-    /// <p>The JOBID was missing, not found, or not associated with the AWS account.</p>
-    InvalidJobId(String),
-    /// <p>The account specified does not have the appropriate bucket permissions.</p>
-    BucketPermission(String),
-    /// <p>The address specified in the manifest is invalid.</p>
-    InvalidAddress(String),
-    /// <p>The client tool version is invalid.</p>
-    InvalidVersion(String),
-    /// <p>The specified bucket does not exist. Create the specified bucket or change the manifest&#39;s bucket, exportBucket, or logBucket field to a bucket that the account, as specified by the manifest&#39;s Access Key ID, has write permissions to.</p>
-    NoSuchBucket(String),
-    /// <p>The specified job ID has been canceled and is no longer valid.</p>
-    CanceledJobId(String),
     /// <p>Your manifest file contained buckets from multiple regions. A job is restricted to buckets from one region. Please correct and resubmit.</p>
     MultipleRegions(String),
-    /// <p>Your manifest is not well-formed.</p>
-    MalformedManifest(String),
+    /// <p>The specified bucket does not exist. Create the specified bucket or change the manifest&#39;s bucket, exportBucket, or logBucket field to a bucket that the account, as specified by the manifest&#39;s Access Key ID, has write permissions to.</p>
+    NoSuchBucket(String),
+    /// <p>AWS Import/Export cannot update the job</p>
+    UnableToUpdateJobId(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -1895,23 +1895,41 @@ impl UpdateJobError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "UnableToUpdateJobIdException" => {
-                    UpdateJobError::UnableToUpdateJobId(String::from(parsed_error.message))
+                "BucketPermissionException" => {
+                    UpdateJobError::BucketPermission(String::from(parsed_error.message))
                 }
-                "InvalidFileSystemException" => {
-                    UpdateJobError::InvalidFileSystem(String::from(parsed_error.message))
+                "CanceledJobIdException" => {
+                    UpdateJobError::CanceledJobId(String::from(parsed_error.message))
                 }
                 "ExpiredJobIdException" => {
                     UpdateJobError::ExpiredJobId(String::from(parsed_error.message))
                 }
+                "InvalidAccessKeyIdException" => {
+                    UpdateJobError::InvalidAccessKeyId(String::from(parsed_error.message))
+                }
+                "InvalidAddressException" => {
+                    UpdateJobError::InvalidAddress(String::from(parsed_error.message))
+                }
                 "InvalidCustomsException" => {
                     UpdateJobError::InvalidCustoms(String::from(parsed_error.message))
+                }
+                "InvalidFileSystemException" => {
+                    UpdateJobError::InvalidFileSystem(String::from(parsed_error.message))
+                }
+                "InvalidJobIdException" => {
+                    UpdateJobError::InvalidJobId(String::from(parsed_error.message))
                 }
                 "InvalidManifestFieldException" => {
                     UpdateJobError::InvalidManifestField(String::from(parsed_error.message))
                 }
                 "InvalidParameterException" => {
                     UpdateJobError::InvalidParameter(String::from(parsed_error.message))
+                }
+                "InvalidVersionException" => {
+                    UpdateJobError::InvalidVersion(String::from(parsed_error.message))
+                }
+                "MalformedManifestException" => {
+                    UpdateJobError::MalformedManifest(String::from(parsed_error.message))
                 }
                 "MissingCustomsException" => {
                     UpdateJobError::MissingCustoms(String::from(parsed_error.message))
@@ -1922,32 +1940,14 @@ impl UpdateJobError {
                 "MissingParameterException" => {
                     UpdateJobError::MissingParameter(String::from(parsed_error.message))
                 }
-                "InvalidAccessKeyIdException" => {
-                    UpdateJobError::InvalidAccessKeyId(String::from(parsed_error.message))
-                }
-                "InvalidJobIdException" => {
-                    UpdateJobError::InvalidJobId(String::from(parsed_error.message))
-                }
-                "BucketPermissionException" => {
-                    UpdateJobError::BucketPermission(String::from(parsed_error.message))
-                }
-                "InvalidAddressException" => {
-                    UpdateJobError::InvalidAddress(String::from(parsed_error.message))
-                }
-                "InvalidVersionException" => {
-                    UpdateJobError::InvalidVersion(String::from(parsed_error.message))
+                "MultipleRegionsException" => {
+                    UpdateJobError::MultipleRegions(String::from(parsed_error.message))
                 }
                 "NoSuchBucketException" => {
                     UpdateJobError::NoSuchBucket(String::from(parsed_error.message))
                 }
-                "CanceledJobIdException" => {
-                    UpdateJobError::CanceledJobId(String::from(parsed_error.message))
-                }
-                "MultipleRegionsException" => {
-                    UpdateJobError::MultipleRegions(String::from(parsed_error.message))
-                }
-                "MalformedManifestException" => {
-                    UpdateJobError::MalformedManifest(String::from(parsed_error.message))
+                "UnableToUpdateJobIdException" => {
+                    UpdateJobError::UnableToUpdateJobId(String::from(parsed_error.message))
                 }
                 _ => UpdateJobError::Unknown(String::from(body)),
             },
@@ -1993,24 +1993,24 @@ impl fmt::Display for UpdateJobError {
 impl Error for UpdateJobError {
     fn description(&self) -> &str {
         match *self {
-            UpdateJobError::UnableToUpdateJobId(ref cause) => cause,
-            UpdateJobError::InvalidFileSystem(ref cause) => cause,
+            UpdateJobError::BucketPermission(ref cause) => cause,
+            UpdateJobError::CanceledJobId(ref cause) => cause,
             UpdateJobError::ExpiredJobId(ref cause) => cause,
+            UpdateJobError::InvalidAccessKeyId(ref cause) => cause,
+            UpdateJobError::InvalidAddress(ref cause) => cause,
             UpdateJobError::InvalidCustoms(ref cause) => cause,
+            UpdateJobError::InvalidFileSystem(ref cause) => cause,
+            UpdateJobError::InvalidJobId(ref cause) => cause,
             UpdateJobError::InvalidManifestField(ref cause) => cause,
             UpdateJobError::InvalidParameter(ref cause) => cause,
+            UpdateJobError::InvalidVersion(ref cause) => cause,
+            UpdateJobError::MalformedManifest(ref cause) => cause,
             UpdateJobError::MissingCustoms(ref cause) => cause,
             UpdateJobError::MissingManifestField(ref cause) => cause,
             UpdateJobError::MissingParameter(ref cause) => cause,
-            UpdateJobError::InvalidAccessKeyId(ref cause) => cause,
-            UpdateJobError::InvalidJobId(ref cause) => cause,
-            UpdateJobError::BucketPermission(ref cause) => cause,
-            UpdateJobError::InvalidAddress(ref cause) => cause,
-            UpdateJobError::InvalidVersion(ref cause) => cause,
-            UpdateJobError::NoSuchBucket(ref cause) => cause,
-            UpdateJobError::CanceledJobId(ref cause) => cause,
             UpdateJobError::MultipleRegions(ref cause) => cause,
-            UpdateJobError::MalformedManifest(ref cause) => cause,
+            UpdateJobError::NoSuchBucket(ref cause) => cause,
+            UpdateJobError::UnableToUpdateJobId(ref cause) => cause,
             UpdateJobError::Validation(ref cause) => cause,
             UpdateJobError::Credentials(ref err) => err.description(),
             UpdateJobError::HttpDispatch(ref dispatch_error) => dispatch_error.description(),

--- a/rusoto/services/importexport/src/generated.rs
+++ b/rusoto/services/importexport/src/generated.rs
@@ -1292,7 +1292,7 @@ impl CancelJobError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "UnableToCancelJobIdException" => {
                     CancelJobError::UnableToCancelJobId(String::from(parsed_error.message))
@@ -1316,6 +1316,14 @@ impl CancelJobError {
             },
             Err(_) => CancelJobError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -1411,7 +1419,7 @@ impl CreateJobError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CreateJobQuotaExceededException" => {
                     CreateJobError::CreateJobQuotaExceeded(String::from(parsed_error.message))
@@ -1465,6 +1473,14 @@ impl CreateJobError {
             },
             Err(_) => CreateJobError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -1552,7 +1568,7 @@ impl GetShippingLabelError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ExpiredJobIdException" => {
                     GetShippingLabelError::ExpiredJobId(String::from(parsed_error.message))
@@ -1579,6 +1595,14 @@ impl GetShippingLabelError {
             },
             Err(_) => GetShippingLabelError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -1653,7 +1677,7 @@ impl GetStatusError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ExpiredJobIdException" => {
                     GetStatusError::ExpiredJobId(String::from(parsed_error.message))
@@ -1674,6 +1698,14 @@ impl GetStatusError {
             },
             Err(_) => GetStatusError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -1742,7 +1774,7 @@ impl ListJobsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidParameterException" => {
                     ListJobsError::InvalidParameter(String::from(parsed_error.message))
@@ -1757,6 +1789,14 @@ impl ListJobsError {
             },
             Err(_) => ListJobsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -1853,7 +1893,7 @@ impl UpdateJobError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "UnableToUpdateJobIdException" => {
                     UpdateJobError::UnableToUpdateJobId(String::from(parsed_error.message))
@@ -1913,6 +1953,14 @@ impl UpdateJobError {
             },
             Err(_) => UpdateJobError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 

--- a/rusoto/services/machinelearning/src/generated.rs
+++ b/rusoto/services/machinelearning/src/generated.rs
@@ -1583,15 +1583,16 @@ pub struct UpdateMLModelOutput {
 /// Errors returned by AddTags
 #[derive(Debug, PartialEq)]
 pub enum AddTagsError {
-    InvalidTag(String),
-
-    TagLimitExceeded(String),
-    /// <p>A specified resource cannot be located.</p>
-    ResourceNotFound(String),
-    /// <p>An error on the client occurred. Typically, the cause is an invalid input value.</p>
-    InvalidInput(String),
     /// <p>An error on the server occurred when trying to process a request.</p>
     InternalServer(String),
+    /// <p>An error on the client occurred. Typically, the cause is an invalid input value.</p>
+    InvalidInput(String),
+
+    InvalidTag(String),
+    /// <p>A specified resource cannot be located.</p>
+    ResourceNotFound(String),
+
+    TagLimitExceeded(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -1615,18 +1616,18 @@ impl AddTagsError {
                 let error_type = pieces.last().expect("Expected error type");
 
                 match *error_type {
-                    "InvalidTagException" => AddTagsError::InvalidTag(String::from(error_message)),
-                    "TagLimitExceededException" => {
-                        AddTagsError::TagLimitExceeded(String::from(error_message))
-                    }
-                    "ResourceNotFoundException" => {
-                        AddTagsError::ResourceNotFound(String::from(error_message))
+                    "InternalServerException" => {
+                        AddTagsError::InternalServer(String::from(error_message))
                     }
                     "InvalidInputException" => {
                         AddTagsError::InvalidInput(String::from(error_message))
                     }
-                    "InternalServerException" => {
-                        AddTagsError::InternalServer(String::from(error_message))
+                    "InvalidTagException" => AddTagsError::InvalidTag(String::from(error_message)),
+                    "ResourceNotFoundException" => {
+                        AddTagsError::ResourceNotFound(String::from(error_message))
+                    }
+                    "TagLimitExceededException" => {
+                        AddTagsError::TagLimitExceeded(String::from(error_message))
                     }
                     "ValidationException" => AddTagsError::Validation(error_message.to_string()),
                     _ => AddTagsError::Unknown(String::from(body)),
@@ -1665,11 +1666,11 @@ impl fmt::Display for AddTagsError {
 impl Error for AddTagsError {
     fn description(&self) -> &str {
         match *self {
-            AddTagsError::InvalidTag(ref cause) => cause,
-            AddTagsError::TagLimitExceeded(ref cause) => cause,
-            AddTagsError::ResourceNotFound(ref cause) => cause,
-            AddTagsError::InvalidInput(ref cause) => cause,
             AddTagsError::InternalServer(ref cause) => cause,
+            AddTagsError::InvalidInput(ref cause) => cause,
+            AddTagsError::InvalidTag(ref cause) => cause,
+            AddTagsError::ResourceNotFound(ref cause) => cause,
+            AddTagsError::TagLimitExceeded(ref cause) => cause,
             AddTagsError::Validation(ref cause) => cause,
             AddTagsError::Credentials(ref err) => err.description(),
             AddTagsError::HttpDispatch(ref dispatch_error) => dispatch_error.description(),
@@ -1682,10 +1683,10 @@ impl Error for AddTagsError {
 pub enum CreateBatchPredictionError {
     /// <p>A second request to use or change an object was not allowed. This can result from retrying a request using a parameter that was not present in the original request.</p>
     IdempotentParameterMismatch(String),
-    /// <p>An error on the client occurred. Typically, the cause is an invalid input value.</p>
-    InvalidInput(String),
     /// <p>An error on the server occurred when trying to process a request.</p>
     InternalServer(String),
+    /// <p>An error on the client occurred. Typically, the cause is an invalid input value.</p>
+    InvalidInput(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -1714,11 +1715,11 @@ impl CreateBatchPredictionError {
                             error_message,
                         ))
                     }
-                    "InvalidInputException" => {
-                        CreateBatchPredictionError::InvalidInput(String::from(error_message))
-                    }
                     "InternalServerException" => {
                         CreateBatchPredictionError::InternalServer(String::from(error_message))
+                    }
+                    "InvalidInputException" => {
+                        CreateBatchPredictionError::InvalidInput(String::from(error_message))
                     }
                     "ValidationException" => {
                         CreateBatchPredictionError::Validation(error_message.to_string())
@@ -1760,8 +1761,8 @@ impl Error for CreateBatchPredictionError {
     fn description(&self) -> &str {
         match *self {
             CreateBatchPredictionError::IdempotentParameterMismatch(ref cause) => cause,
-            CreateBatchPredictionError::InvalidInput(ref cause) => cause,
             CreateBatchPredictionError::InternalServer(ref cause) => cause,
+            CreateBatchPredictionError::InvalidInput(ref cause) => cause,
             CreateBatchPredictionError::Validation(ref cause) => cause,
             CreateBatchPredictionError::Credentials(ref err) => err.description(),
             CreateBatchPredictionError::HttpDispatch(ref dispatch_error) => {
@@ -1776,10 +1777,10 @@ impl Error for CreateBatchPredictionError {
 pub enum CreateDataSourceFromRDSError {
     /// <p>A second request to use or change an object was not allowed. This can result from retrying a request using a parameter that was not present in the original request.</p>
     IdempotentParameterMismatch(String),
-    /// <p>An error on the client occurred. Typically, the cause is an invalid input value.</p>
-    InvalidInput(String),
     /// <p>An error on the server occurred when trying to process a request.</p>
     InternalServer(String),
+    /// <p>An error on the client occurred. Typically, the cause is an invalid input value.</p>
+    InvalidInput(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -1808,11 +1809,11 @@ impl CreateDataSourceFromRDSError {
                             error_message,
                         ))
                     }
-                    "InvalidInputException" => {
-                        CreateDataSourceFromRDSError::InvalidInput(String::from(error_message))
-                    }
                     "InternalServerException" => {
                         CreateDataSourceFromRDSError::InternalServer(String::from(error_message))
+                    }
+                    "InvalidInputException" => {
+                        CreateDataSourceFromRDSError::InvalidInput(String::from(error_message))
                     }
                     "ValidationException" => {
                         CreateDataSourceFromRDSError::Validation(error_message.to_string())
@@ -1854,8 +1855,8 @@ impl Error for CreateDataSourceFromRDSError {
     fn description(&self) -> &str {
         match *self {
             CreateDataSourceFromRDSError::IdempotentParameterMismatch(ref cause) => cause,
-            CreateDataSourceFromRDSError::InvalidInput(ref cause) => cause,
             CreateDataSourceFromRDSError::InternalServer(ref cause) => cause,
+            CreateDataSourceFromRDSError::InvalidInput(ref cause) => cause,
             CreateDataSourceFromRDSError::Validation(ref cause) => cause,
             CreateDataSourceFromRDSError::Credentials(ref err) => err.description(),
             CreateDataSourceFromRDSError::HttpDispatch(ref dispatch_error) => {
@@ -1870,10 +1871,10 @@ impl Error for CreateDataSourceFromRDSError {
 pub enum CreateDataSourceFromRedshiftError {
     /// <p>A second request to use or change an object was not allowed. This can result from retrying a request using a parameter that was not present in the original request.</p>
     IdempotentParameterMismatch(String),
-    /// <p>An error on the client occurred. Typically, the cause is an invalid input value.</p>
-    InvalidInput(String),
     /// <p>An error on the server occurred when trying to process a request.</p>
     InternalServer(String),
+    /// <p>An error on the client occurred. Typically, the cause is an invalid input value.</p>
+    InvalidInput(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -1902,13 +1903,13 @@ impl CreateDataSourceFromRedshiftError {
                             String::from(error_message),
                         )
                     }
-                    "InvalidInputException" => {
-                        CreateDataSourceFromRedshiftError::InvalidInput(String::from(error_message))
-                    }
                     "InternalServerException" => {
                         CreateDataSourceFromRedshiftError::InternalServer(String::from(
                             error_message,
                         ))
+                    }
+                    "InvalidInputException" => {
+                        CreateDataSourceFromRedshiftError::InvalidInput(String::from(error_message))
                     }
                     "ValidationException" => {
                         CreateDataSourceFromRedshiftError::Validation(error_message.to_string())
@@ -1950,8 +1951,8 @@ impl Error for CreateDataSourceFromRedshiftError {
     fn description(&self) -> &str {
         match *self {
             CreateDataSourceFromRedshiftError::IdempotentParameterMismatch(ref cause) => cause,
-            CreateDataSourceFromRedshiftError::InvalidInput(ref cause) => cause,
             CreateDataSourceFromRedshiftError::InternalServer(ref cause) => cause,
+            CreateDataSourceFromRedshiftError::InvalidInput(ref cause) => cause,
             CreateDataSourceFromRedshiftError::Validation(ref cause) => cause,
             CreateDataSourceFromRedshiftError::Credentials(ref err) => err.description(),
             CreateDataSourceFromRedshiftError::HttpDispatch(ref dispatch_error) => {
@@ -1966,10 +1967,10 @@ impl Error for CreateDataSourceFromRedshiftError {
 pub enum CreateDataSourceFromS3Error {
     /// <p>A second request to use or change an object was not allowed. This can result from retrying a request using a parameter that was not present in the original request.</p>
     IdempotentParameterMismatch(String),
-    /// <p>An error on the client occurred. Typically, the cause is an invalid input value.</p>
-    InvalidInput(String),
     /// <p>An error on the server occurred when trying to process a request.</p>
     InternalServer(String),
+    /// <p>An error on the client occurred. Typically, the cause is an invalid input value.</p>
+    InvalidInput(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -1998,11 +1999,11 @@ impl CreateDataSourceFromS3Error {
                             error_message,
                         ))
                     }
-                    "InvalidInputException" => {
-                        CreateDataSourceFromS3Error::InvalidInput(String::from(error_message))
-                    }
                     "InternalServerException" => {
                         CreateDataSourceFromS3Error::InternalServer(String::from(error_message))
+                    }
+                    "InvalidInputException" => {
+                        CreateDataSourceFromS3Error::InvalidInput(String::from(error_message))
                     }
                     "ValidationException" => {
                         CreateDataSourceFromS3Error::Validation(error_message.to_string())
@@ -2044,8 +2045,8 @@ impl Error for CreateDataSourceFromS3Error {
     fn description(&self) -> &str {
         match *self {
             CreateDataSourceFromS3Error::IdempotentParameterMismatch(ref cause) => cause,
-            CreateDataSourceFromS3Error::InvalidInput(ref cause) => cause,
             CreateDataSourceFromS3Error::InternalServer(ref cause) => cause,
+            CreateDataSourceFromS3Error::InvalidInput(ref cause) => cause,
             CreateDataSourceFromS3Error::Validation(ref cause) => cause,
             CreateDataSourceFromS3Error::Credentials(ref err) => err.description(),
             CreateDataSourceFromS3Error::HttpDispatch(ref dispatch_error) => {
@@ -2060,10 +2061,10 @@ impl Error for CreateDataSourceFromS3Error {
 pub enum CreateEvaluationError {
     /// <p>A second request to use or change an object was not allowed. This can result from retrying a request using a parameter that was not present in the original request.</p>
     IdempotentParameterMismatch(String),
-    /// <p>An error on the client occurred. Typically, the cause is an invalid input value.</p>
-    InvalidInput(String),
     /// <p>An error on the server occurred when trying to process a request.</p>
     InternalServer(String),
+    /// <p>An error on the client occurred. Typically, the cause is an invalid input value.</p>
+    InvalidInput(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -2092,11 +2093,11 @@ impl CreateEvaluationError {
                             error_message,
                         ))
                     }
-                    "InvalidInputException" => {
-                        CreateEvaluationError::InvalidInput(String::from(error_message))
-                    }
                     "InternalServerException" => {
                         CreateEvaluationError::InternalServer(String::from(error_message))
+                    }
+                    "InvalidInputException" => {
+                        CreateEvaluationError::InvalidInput(String::from(error_message))
                     }
                     "ValidationException" => {
                         CreateEvaluationError::Validation(error_message.to_string())
@@ -2138,8 +2139,8 @@ impl Error for CreateEvaluationError {
     fn description(&self) -> &str {
         match *self {
             CreateEvaluationError::IdempotentParameterMismatch(ref cause) => cause,
-            CreateEvaluationError::InvalidInput(ref cause) => cause,
             CreateEvaluationError::InternalServer(ref cause) => cause,
+            CreateEvaluationError::InvalidInput(ref cause) => cause,
             CreateEvaluationError::Validation(ref cause) => cause,
             CreateEvaluationError::Credentials(ref err) => err.description(),
             CreateEvaluationError::HttpDispatch(ref dispatch_error) => dispatch_error.description(),
@@ -2152,10 +2153,10 @@ impl Error for CreateEvaluationError {
 pub enum CreateMLModelError {
     /// <p>A second request to use or change an object was not allowed. This can result from retrying a request using a parameter that was not present in the original request.</p>
     IdempotentParameterMismatch(String),
-    /// <p>An error on the client occurred. Typically, the cause is an invalid input value.</p>
-    InvalidInput(String),
     /// <p>An error on the server occurred when trying to process a request.</p>
     InternalServer(String),
+    /// <p>An error on the client occurred. Typically, the cause is an invalid input value.</p>
+    InvalidInput(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -2182,11 +2183,11 @@ impl CreateMLModelError {
                     "IdempotentParameterMismatchException" => {
                         CreateMLModelError::IdempotentParameterMismatch(String::from(error_message))
                     }
-                    "InvalidInputException" => {
-                        CreateMLModelError::InvalidInput(String::from(error_message))
-                    }
                     "InternalServerException" => {
                         CreateMLModelError::InternalServer(String::from(error_message))
+                    }
+                    "InvalidInputException" => {
+                        CreateMLModelError::InvalidInput(String::from(error_message))
                     }
                     "ValidationException" => {
                         CreateMLModelError::Validation(error_message.to_string())
@@ -2228,8 +2229,8 @@ impl Error for CreateMLModelError {
     fn description(&self) -> &str {
         match *self {
             CreateMLModelError::IdempotentParameterMismatch(ref cause) => cause,
-            CreateMLModelError::InvalidInput(ref cause) => cause,
             CreateMLModelError::InternalServer(ref cause) => cause,
+            CreateMLModelError::InvalidInput(ref cause) => cause,
             CreateMLModelError::Validation(ref cause) => cause,
             CreateMLModelError::Credentials(ref err) => err.description(),
             CreateMLModelError::HttpDispatch(ref dispatch_error) => dispatch_error.description(),
@@ -2240,12 +2241,12 @@ impl Error for CreateMLModelError {
 /// Errors returned by CreateRealtimeEndpoint
 #[derive(Debug, PartialEq)]
 pub enum CreateRealtimeEndpointError {
-    /// <p>A specified resource cannot be located.</p>
-    ResourceNotFound(String),
-    /// <p>An error on the client occurred. Typically, the cause is an invalid input value.</p>
-    InvalidInput(String),
     /// <p>An error on the server occurred when trying to process a request.</p>
     InternalServer(String),
+    /// <p>An error on the client occurred. Typically, the cause is an invalid input value.</p>
+    InvalidInput(String),
+    /// <p>A specified resource cannot be located.</p>
+    ResourceNotFound(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -2269,14 +2270,14 @@ impl CreateRealtimeEndpointError {
                 let error_type = pieces.last().expect("Expected error type");
 
                 match *error_type {
-                    "ResourceNotFoundException" => {
-                        CreateRealtimeEndpointError::ResourceNotFound(String::from(error_message))
+                    "InternalServerException" => {
+                        CreateRealtimeEndpointError::InternalServer(String::from(error_message))
                     }
                     "InvalidInputException" => {
                         CreateRealtimeEndpointError::InvalidInput(String::from(error_message))
                     }
-                    "InternalServerException" => {
-                        CreateRealtimeEndpointError::InternalServer(String::from(error_message))
+                    "ResourceNotFoundException" => {
+                        CreateRealtimeEndpointError::ResourceNotFound(String::from(error_message))
                     }
                     "ValidationException" => {
                         CreateRealtimeEndpointError::Validation(error_message.to_string())
@@ -2317,9 +2318,9 @@ impl fmt::Display for CreateRealtimeEndpointError {
 impl Error for CreateRealtimeEndpointError {
     fn description(&self) -> &str {
         match *self {
-            CreateRealtimeEndpointError::ResourceNotFound(ref cause) => cause,
-            CreateRealtimeEndpointError::InvalidInput(ref cause) => cause,
             CreateRealtimeEndpointError::InternalServer(ref cause) => cause,
+            CreateRealtimeEndpointError::InvalidInput(ref cause) => cause,
+            CreateRealtimeEndpointError::ResourceNotFound(ref cause) => cause,
             CreateRealtimeEndpointError::Validation(ref cause) => cause,
             CreateRealtimeEndpointError::Credentials(ref err) => err.description(),
             CreateRealtimeEndpointError::HttpDispatch(ref dispatch_error) => {
@@ -2332,12 +2333,12 @@ impl Error for CreateRealtimeEndpointError {
 /// Errors returned by DeleteBatchPrediction
 #[derive(Debug, PartialEq)]
 pub enum DeleteBatchPredictionError {
-    /// <p>A specified resource cannot be located.</p>
-    ResourceNotFound(String),
-    /// <p>An error on the client occurred. Typically, the cause is an invalid input value.</p>
-    InvalidInput(String),
     /// <p>An error on the server occurred when trying to process a request.</p>
     InternalServer(String),
+    /// <p>An error on the client occurred. Typically, the cause is an invalid input value.</p>
+    InvalidInput(String),
+    /// <p>A specified resource cannot be located.</p>
+    ResourceNotFound(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -2361,14 +2362,14 @@ impl DeleteBatchPredictionError {
                 let error_type = pieces.last().expect("Expected error type");
 
                 match *error_type {
-                    "ResourceNotFoundException" => {
-                        DeleteBatchPredictionError::ResourceNotFound(String::from(error_message))
+                    "InternalServerException" => {
+                        DeleteBatchPredictionError::InternalServer(String::from(error_message))
                     }
                     "InvalidInputException" => {
                         DeleteBatchPredictionError::InvalidInput(String::from(error_message))
                     }
-                    "InternalServerException" => {
-                        DeleteBatchPredictionError::InternalServer(String::from(error_message))
+                    "ResourceNotFoundException" => {
+                        DeleteBatchPredictionError::ResourceNotFound(String::from(error_message))
                     }
                     "ValidationException" => {
                         DeleteBatchPredictionError::Validation(error_message.to_string())
@@ -2409,9 +2410,9 @@ impl fmt::Display for DeleteBatchPredictionError {
 impl Error for DeleteBatchPredictionError {
     fn description(&self) -> &str {
         match *self {
-            DeleteBatchPredictionError::ResourceNotFound(ref cause) => cause,
-            DeleteBatchPredictionError::InvalidInput(ref cause) => cause,
             DeleteBatchPredictionError::InternalServer(ref cause) => cause,
+            DeleteBatchPredictionError::InvalidInput(ref cause) => cause,
+            DeleteBatchPredictionError::ResourceNotFound(ref cause) => cause,
             DeleteBatchPredictionError::Validation(ref cause) => cause,
             DeleteBatchPredictionError::Credentials(ref err) => err.description(),
             DeleteBatchPredictionError::HttpDispatch(ref dispatch_error) => {
@@ -2424,12 +2425,12 @@ impl Error for DeleteBatchPredictionError {
 /// Errors returned by DeleteDataSource
 #[derive(Debug, PartialEq)]
 pub enum DeleteDataSourceError {
-    /// <p>A specified resource cannot be located.</p>
-    ResourceNotFound(String),
-    /// <p>An error on the client occurred. Typically, the cause is an invalid input value.</p>
-    InvalidInput(String),
     /// <p>An error on the server occurred when trying to process a request.</p>
     InternalServer(String),
+    /// <p>An error on the client occurred. Typically, the cause is an invalid input value.</p>
+    InvalidInput(String),
+    /// <p>A specified resource cannot be located.</p>
+    ResourceNotFound(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -2453,14 +2454,14 @@ impl DeleteDataSourceError {
                 let error_type = pieces.last().expect("Expected error type");
 
                 match *error_type {
-                    "ResourceNotFoundException" => {
-                        DeleteDataSourceError::ResourceNotFound(String::from(error_message))
+                    "InternalServerException" => {
+                        DeleteDataSourceError::InternalServer(String::from(error_message))
                     }
                     "InvalidInputException" => {
                         DeleteDataSourceError::InvalidInput(String::from(error_message))
                     }
-                    "InternalServerException" => {
-                        DeleteDataSourceError::InternalServer(String::from(error_message))
+                    "ResourceNotFoundException" => {
+                        DeleteDataSourceError::ResourceNotFound(String::from(error_message))
                     }
                     "ValidationException" => {
                         DeleteDataSourceError::Validation(error_message.to_string())
@@ -2501,9 +2502,9 @@ impl fmt::Display for DeleteDataSourceError {
 impl Error for DeleteDataSourceError {
     fn description(&self) -> &str {
         match *self {
-            DeleteDataSourceError::ResourceNotFound(ref cause) => cause,
-            DeleteDataSourceError::InvalidInput(ref cause) => cause,
             DeleteDataSourceError::InternalServer(ref cause) => cause,
+            DeleteDataSourceError::InvalidInput(ref cause) => cause,
+            DeleteDataSourceError::ResourceNotFound(ref cause) => cause,
             DeleteDataSourceError::Validation(ref cause) => cause,
             DeleteDataSourceError::Credentials(ref err) => err.description(),
             DeleteDataSourceError::HttpDispatch(ref dispatch_error) => dispatch_error.description(),
@@ -2514,12 +2515,12 @@ impl Error for DeleteDataSourceError {
 /// Errors returned by DeleteEvaluation
 #[derive(Debug, PartialEq)]
 pub enum DeleteEvaluationError {
-    /// <p>A specified resource cannot be located.</p>
-    ResourceNotFound(String),
-    /// <p>An error on the client occurred. Typically, the cause is an invalid input value.</p>
-    InvalidInput(String),
     /// <p>An error on the server occurred when trying to process a request.</p>
     InternalServer(String),
+    /// <p>An error on the client occurred. Typically, the cause is an invalid input value.</p>
+    InvalidInput(String),
+    /// <p>A specified resource cannot be located.</p>
+    ResourceNotFound(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -2543,14 +2544,14 @@ impl DeleteEvaluationError {
                 let error_type = pieces.last().expect("Expected error type");
 
                 match *error_type {
-                    "ResourceNotFoundException" => {
-                        DeleteEvaluationError::ResourceNotFound(String::from(error_message))
+                    "InternalServerException" => {
+                        DeleteEvaluationError::InternalServer(String::from(error_message))
                     }
                     "InvalidInputException" => {
                         DeleteEvaluationError::InvalidInput(String::from(error_message))
                     }
-                    "InternalServerException" => {
-                        DeleteEvaluationError::InternalServer(String::from(error_message))
+                    "ResourceNotFoundException" => {
+                        DeleteEvaluationError::ResourceNotFound(String::from(error_message))
                     }
                     "ValidationException" => {
                         DeleteEvaluationError::Validation(error_message.to_string())
@@ -2591,9 +2592,9 @@ impl fmt::Display for DeleteEvaluationError {
 impl Error for DeleteEvaluationError {
     fn description(&self) -> &str {
         match *self {
-            DeleteEvaluationError::ResourceNotFound(ref cause) => cause,
-            DeleteEvaluationError::InvalidInput(ref cause) => cause,
             DeleteEvaluationError::InternalServer(ref cause) => cause,
+            DeleteEvaluationError::InvalidInput(ref cause) => cause,
+            DeleteEvaluationError::ResourceNotFound(ref cause) => cause,
             DeleteEvaluationError::Validation(ref cause) => cause,
             DeleteEvaluationError::Credentials(ref err) => err.description(),
             DeleteEvaluationError::HttpDispatch(ref dispatch_error) => dispatch_error.description(),
@@ -2604,12 +2605,12 @@ impl Error for DeleteEvaluationError {
 /// Errors returned by DeleteMLModel
 #[derive(Debug, PartialEq)]
 pub enum DeleteMLModelError {
-    /// <p>A specified resource cannot be located.</p>
-    ResourceNotFound(String),
-    /// <p>An error on the client occurred. Typically, the cause is an invalid input value.</p>
-    InvalidInput(String),
     /// <p>An error on the server occurred when trying to process a request.</p>
     InternalServer(String),
+    /// <p>An error on the client occurred. Typically, the cause is an invalid input value.</p>
+    InvalidInput(String),
+    /// <p>A specified resource cannot be located.</p>
+    ResourceNotFound(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -2633,14 +2634,14 @@ impl DeleteMLModelError {
                 let error_type = pieces.last().expect("Expected error type");
 
                 match *error_type {
-                    "ResourceNotFoundException" => {
-                        DeleteMLModelError::ResourceNotFound(String::from(error_message))
+                    "InternalServerException" => {
+                        DeleteMLModelError::InternalServer(String::from(error_message))
                     }
                     "InvalidInputException" => {
                         DeleteMLModelError::InvalidInput(String::from(error_message))
                     }
-                    "InternalServerException" => {
-                        DeleteMLModelError::InternalServer(String::from(error_message))
+                    "ResourceNotFoundException" => {
+                        DeleteMLModelError::ResourceNotFound(String::from(error_message))
                     }
                     "ValidationException" => {
                         DeleteMLModelError::Validation(error_message.to_string())
@@ -2681,9 +2682,9 @@ impl fmt::Display for DeleteMLModelError {
 impl Error for DeleteMLModelError {
     fn description(&self) -> &str {
         match *self {
-            DeleteMLModelError::ResourceNotFound(ref cause) => cause,
-            DeleteMLModelError::InvalidInput(ref cause) => cause,
             DeleteMLModelError::InternalServer(ref cause) => cause,
+            DeleteMLModelError::InvalidInput(ref cause) => cause,
+            DeleteMLModelError::ResourceNotFound(ref cause) => cause,
             DeleteMLModelError::Validation(ref cause) => cause,
             DeleteMLModelError::Credentials(ref err) => err.description(),
             DeleteMLModelError::HttpDispatch(ref dispatch_error) => dispatch_error.description(),
@@ -2694,12 +2695,12 @@ impl Error for DeleteMLModelError {
 /// Errors returned by DeleteRealtimeEndpoint
 #[derive(Debug, PartialEq)]
 pub enum DeleteRealtimeEndpointError {
-    /// <p>A specified resource cannot be located.</p>
-    ResourceNotFound(String),
-    /// <p>An error on the client occurred. Typically, the cause is an invalid input value.</p>
-    InvalidInput(String),
     /// <p>An error on the server occurred when trying to process a request.</p>
     InternalServer(String),
+    /// <p>An error on the client occurred. Typically, the cause is an invalid input value.</p>
+    InvalidInput(String),
+    /// <p>A specified resource cannot be located.</p>
+    ResourceNotFound(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -2723,14 +2724,14 @@ impl DeleteRealtimeEndpointError {
                 let error_type = pieces.last().expect("Expected error type");
 
                 match *error_type {
-                    "ResourceNotFoundException" => {
-                        DeleteRealtimeEndpointError::ResourceNotFound(String::from(error_message))
+                    "InternalServerException" => {
+                        DeleteRealtimeEndpointError::InternalServer(String::from(error_message))
                     }
                     "InvalidInputException" => {
                         DeleteRealtimeEndpointError::InvalidInput(String::from(error_message))
                     }
-                    "InternalServerException" => {
-                        DeleteRealtimeEndpointError::InternalServer(String::from(error_message))
+                    "ResourceNotFoundException" => {
+                        DeleteRealtimeEndpointError::ResourceNotFound(String::from(error_message))
                     }
                     "ValidationException" => {
                         DeleteRealtimeEndpointError::Validation(error_message.to_string())
@@ -2771,9 +2772,9 @@ impl fmt::Display for DeleteRealtimeEndpointError {
 impl Error for DeleteRealtimeEndpointError {
     fn description(&self) -> &str {
         match *self {
-            DeleteRealtimeEndpointError::ResourceNotFound(ref cause) => cause,
-            DeleteRealtimeEndpointError::InvalidInput(ref cause) => cause,
             DeleteRealtimeEndpointError::InternalServer(ref cause) => cause,
+            DeleteRealtimeEndpointError::InvalidInput(ref cause) => cause,
+            DeleteRealtimeEndpointError::ResourceNotFound(ref cause) => cause,
             DeleteRealtimeEndpointError::Validation(ref cause) => cause,
             DeleteRealtimeEndpointError::Credentials(ref err) => err.description(),
             DeleteRealtimeEndpointError::HttpDispatch(ref dispatch_error) => {
@@ -2786,13 +2787,14 @@ impl Error for DeleteRealtimeEndpointError {
 /// Errors returned by DeleteTags
 #[derive(Debug, PartialEq)]
 pub enum DeleteTagsError {
+    /// <p>An error on the server occurred when trying to process a request.</p>
+    InternalServer(String),
+    /// <p>An error on the client occurred. Typically, the cause is an invalid input value.</p>
+    InvalidInput(String),
+
     InvalidTag(String),
     /// <p>A specified resource cannot be located.</p>
     ResourceNotFound(String),
-    /// <p>An error on the client occurred. Typically, the cause is an invalid input value.</p>
-    InvalidInput(String),
-    /// <p>An error on the server occurred when trying to process a request.</p>
-    InternalServer(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -2816,17 +2818,17 @@ impl DeleteTagsError {
                 let error_type = pieces.last().expect("Expected error type");
 
                 match *error_type {
+                    "InternalServerException" => {
+                        DeleteTagsError::InternalServer(String::from(error_message))
+                    }
+                    "InvalidInputException" => {
+                        DeleteTagsError::InvalidInput(String::from(error_message))
+                    }
                     "InvalidTagException" => {
                         DeleteTagsError::InvalidTag(String::from(error_message))
                     }
                     "ResourceNotFoundException" => {
                         DeleteTagsError::ResourceNotFound(String::from(error_message))
-                    }
-                    "InvalidInputException" => {
-                        DeleteTagsError::InvalidInput(String::from(error_message))
-                    }
-                    "InternalServerException" => {
-                        DeleteTagsError::InternalServer(String::from(error_message))
                     }
                     "ValidationException" => DeleteTagsError::Validation(error_message.to_string()),
                     _ => DeleteTagsError::Unknown(String::from(body)),
@@ -2865,10 +2867,10 @@ impl fmt::Display for DeleteTagsError {
 impl Error for DeleteTagsError {
     fn description(&self) -> &str {
         match *self {
+            DeleteTagsError::InternalServer(ref cause) => cause,
+            DeleteTagsError::InvalidInput(ref cause) => cause,
             DeleteTagsError::InvalidTag(ref cause) => cause,
             DeleteTagsError::ResourceNotFound(ref cause) => cause,
-            DeleteTagsError::InvalidInput(ref cause) => cause,
-            DeleteTagsError::InternalServer(ref cause) => cause,
             DeleteTagsError::Validation(ref cause) => cause,
             DeleteTagsError::Credentials(ref err) => err.description(),
             DeleteTagsError::HttpDispatch(ref dispatch_error) => dispatch_error.description(),
@@ -2879,10 +2881,10 @@ impl Error for DeleteTagsError {
 /// Errors returned by DescribeBatchPredictions
 #[derive(Debug, PartialEq)]
 pub enum DescribeBatchPredictionsError {
-    /// <p>An error on the client occurred. Typically, the cause is an invalid input value.</p>
-    InvalidInput(String),
     /// <p>An error on the server occurred when trying to process a request.</p>
     InternalServer(String),
+    /// <p>An error on the client occurred. Typically, the cause is an invalid input value.</p>
+    InvalidInput(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -2906,11 +2908,11 @@ impl DescribeBatchPredictionsError {
                 let error_type = pieces.last().expect("Expected error type");
 
                 match *error_type {
-                    "InvalidInputException" => {
-                        DescribeBatchPredictionsError::InvalidInput(String::from(error_message))
-                    }
                     "InternalServerException" => {
                         DescribeBatchPredictionsError::InternalServer(String::from(error_message))
+                    }
+                    "InvalidInputException" => {
+                        DescribeBatchPredictionsError::InvalidInput(String::from(error_message))
                     }
                     "ValidationException" => {
                         DescribeBatchPredictionsError::Validation(error_message.to_string())
@@ -2951,8 +2953,8 @@ impl fmt::Display for DescribeBatchPredictionsError {
 impl Error for DescribeBatchPredictionsError {
     fn description(&self) -> &str {
         match *self {
-            DescribeBatchPredictionsError::InvalidInput(ref cause) => cause,
             DescribeBatchPredictionsError::InternalServer(ref cause) => cause,
+            DescribeBatchPredictionsError::InvalidInput(ref cause) => cause,
             DescribeBatchPredictionsError::Validation(ref cause) => cause,
             DescribeBatchPredictionsError::Credentials(ref err) => err.description(),
             DescribeBatchPredictionsError::HttpDispatch(ref dispatch_error) => {
@@ -2965,10 +2967,10 @@ impl Error for DescribeBatchPredictionsError {
 /// Errors returned by DescribeDataSources
 #[derive(Debug, PartialEq)]
 pub enum DescribeDataSourcesError {
-    /// <p>An error on the client occurred. Typically, the cause is an invalid input value.</p>
-    InvalidInput(String),
     /// <p>An error on the server occurred when trying to process a request.</p>
     InternalServer(String),
+    /// <p>An error on the client occurred. Typically, the cause is an invalid input value.</p>
+    InvalidInput(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -2992,11 +2994,11 @@ impl DescribeDataSourcesError {
                 let error_type = pieces.last().expect("Expected error type");
 
                 match *error_type {
-                    "InvalidInputException" => {
-                        DescribeDataSourcesError::InvalidInput(String::from(error_message))
-                    }
                     "InternalServerException" => {
                         DescribeDataSourcesError::InternalServer(String::from(error_message))
+                    }
+                    "InvalidInputException" => {
+                        DescribeDataSourcesError::InvalidInput(String::from(error_message))
                     }
                     "ValidationException" => {
                         DescribeDataSourcesError::Validation(error_message.to_string())
@@ -3037,8 +3039,8 @@ impl fmt::Display for DescribeDataSourcesError {
 impl Error for DescribeDataSourcesError {
     fn description(&self) -> &str {
         match *self {
-            DescribeDataSourcesError::InvalidInput(ref cause) => cause,
             DescribeDataSourcesError::InternalServer(ref cause) => cause,
+            DescribeDataSourcesError::InvalidInput(ref cause) => cause,
             DescribeDataSourcesError::Validation(ref cause) => cause,
             DescribeDataSourcesError::Credentials(ref err) => err.description(),
             DescribeDataSourcesError::HttpDispatch(ref dispatch_error) => {
@@ -3051,10 +3053,10 @@ impl Error for DescribeDataSourcesError {
 /// Errors returned by DescribeEvaluations
 #[derive(Debug, PartialEq)]
 pub enum DescribeEvaluationsError {
-    /// <p>An error on the client occurred. Typically, the cause is an invalid input value.</p>
-    InvalidInput(String),
     /// <p>An error on the server occurred when trying to process a request.</p>
     InternalServer(String),
+    /// <p>An error on the client occurred. Typically, the cause is an invalid input value.</p>
+    InvalidInput(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -3078,11 +3080,11 @@ impl DescribeEvaluationsError {
                 let error_type = pieces.last().expect("Expected error type");
 
                 match *error_type {
-                    "InvalidInputException" => {
-                        DescribeEvaluationsError::InvalidInput(String::from(error_message))
-                    }
                     "InternalServerException" => {
                         DescribeEvaluationsError::InternalServer(String::from(error_message))
+                    }
+                    "InvalidInputException" => {
+                        DescribeEvaluationsError::InvalidInput(String::from(error_message))
                     }
                     "ValidationException" => {
                         DescribeEvaluationsError::Validation(error_message.to_string())
@@ -3123,8 +3125,8 @@ impl fmt::Display for DescribeEvaluationsError {
 impl Error for DescribeEvaluationsError {
     fn description(&self) -> &str {
         match *self {
-            DescribeEvaluationsError::InvalidInput(ref cause) => cause,
             DescribeEvaluationsError::InternalServer(ref cause) => cause,
+            DescribeEvaluationsError::InvalidInput(ref cause) => cause,
             DescribeEvaluationsError::Validation(ref cause) => cause,
             DescribeEvaluationsError::Credentials(ref err) => err.description(),
             DescribeEvaluationsError::HttpDispatch(ref dispatch_error) => {
@@ -3137,10 +3139,10 @@ impl Error for DescribeEvaluationsError {
 /// Errors returned by DescribeMLModels
 #[derive(Debug, PartialEq)]
 pub enum DescribeMLModelsError {
-    /// <p>An error on the client occurred. Typically, the cause is an invalid input value.</p>
-    InvalidInput(String),
     /// <p>An error on the server occurred when trying to process a request.</p>
     InternalServer(String),
+    /// <p>An error on the client occurred. Typically, the cause is an invalid input value.</p>
+    InvalidInput(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -3164,11 +3166,11 @@ impl DescribeMLModelsError {
                 let error_type = pieces.last().expect("Expected error type");
 
                 match *error_type {
-                    "InvalidInputException" => {
-                        DescribeMLModelsError::InvalidInput(String::from(error_message))
-                    }
                     "InternalServerException" => {
                         DescribeMLModelsError::InternalServer(String::from(error_message))
+                    }
+                    "InvalidInputException" => {
+                        DescribeMLModelsError::InvalidInput(String::from(error_message))
                     }
                     "ValidationException" => {
                         DescribeMLModelsError::Validation(error_message.to_string())
@@ -3209,8 +3211,8 @@ impl fmt::Display for DescribeMLModelsError {
 impl Error for DescribeMLModelsError {
     fn description(&self) -> &str {
         match *self {
-            DescribeMLModelsError::InvalidInput(ref cause) => cause,
             DescribeMLModelsError::InternalServer(ref cause) => cause,
+            DescribeMLModelsError::InvalidInput(ref cause) => cause,
             DescribeMLModelsError::Validation(ref cause) => cause,
             DescribeMLModelsError::Credentials(ref err) => err.description(),
             DescribeMLModelsError::HttpDispatch(ref dispatch_error) => dispatch_error.description(),
@@ -3221,12 +3223,12 @@ impl Error for DescribeMLModelsError {
 /// Errors returned by DescribeTags
 #[derive(Debug, PartialEq)]
 pub enum DescribeTagsError {
-    /// <p>A specified resource cannot be located.</p>
-    ResourceNotFound(String),
-    /// <p>An error on the client occurred. Typically, the cause is an invalid input value.</p>
-    InvalidInput(String),
     /// <p>An error on the server occurred when trying to process a request.</p>
     InternalServer(String),
+    /// <p>An error on the client occurred. Typically, the cause is an invalid input value.</p>
+    InvalidInput(String),
+    /// <p>A specified resource cannot be located.</p>
+    ResourceNotFound(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -3250,14 +3252,14 @@ impl DescribeTagsError {
                 let error_type = pieces.last().expect("Expected error type");
 
                 match *error_type {
-                    "ResourceNotFoundException" => {
-                        DescribeTagsError::ResourceNotFound(String::from(error_message))
+                    "InternalServerException" => {
+                        DescribeTagsError::InternalServer(String::from(error_message))
                     }
                     "InvalidInputException" => {
                         DescribeTagsError::InvalidInput(String::from(error_message))
                     }
-                    "InternalServerException" => {
-                        DescribeTagsError::InternalServer(String::from(error_message))
+                    "ResourceNotFoundException" => {
+                        DescribeTagsError::ResourceNotFound(String::from(error_message))
                     }
                     "ValidationException" => {
                         DescribeTagsError::Validation(error_message.to_string())
@@ -3298,9 +3300,9 @@ impl fmt::Display for DescribeTagsError {
 impl Error for DescribeTagsError {
     fn description(&self) -> &str {
         match *self {
-            DescribeTagsError::ResourceNotFound(ref cause) => cause,
-            DescribeTagsError::InvalidInput(ref cause) => cause,
             DescribeTagsError::InternalServer(ref cause) => cause,
+            DescribeTagsError::InvalidInput(ref cause) => cause,
+            DescribeTagsError::ResourceNotFound(ref cause) => cause,
             DescribeTagsError::Validation(ref cause) => cause,
             DescribeTagsError::Credentials(ref err) => err.description(),
             DescribeTagsError::HttpDispatch(ref dispatch_error) => dispatch_error.description(),
@@ -3311,12 +3313,12 @@ impl Error for DescribeTagsError {
 /// Errors returned by GetBatchPrediction
 #[derive(Debug, PartialEq)]
 pub enum GetBatchPredictionError {
-    /// <p>A specified resource cannot be located.</p>
-    ResourceNotFound(String),
-    /// <p>An error on the client occurred. Typically, the cause is an invalid input value.</p>
-    InvalidInput(String),
     /// <p>An error on the server occurred when trying to process a request.</p>
     InternalServer(String),
+    /// <p>An error on the client occurred. Typically, the cause is an invalid input value.</p>
+    InvalidInput(String),
+    /// <p>A specified resource cannot be located.</p>
+    ResourceNotFound(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -3340,14 +3342,14 @@ impl GetBatchPredictionError {
                 let error_type = pieces.last().expect("Expected error type");
 
                 match *error_type {
-                    "ResourceNotFoundException" => {
-                        GetBatchPredictionError::ResourceNotFound(String::from(error_message))
+                    "InternalServerException" => {
+                        GetBatchPredictionError::InternalServer(String::from(error_message))
                     }
                     "InvalidInputException" => {
                         GetBatchPredictionError::InvalidInput(String::from(error_message))
                     }
-                    "InternalServerException" => {
-                        GetBatchPredictionError::InternalServer(String::from(error_message))
+                    "ResourceNotFoundException" => {
+                        GetBatchPredictionError::ResourceNotFound(String::from(error_message))
                     }
                     "ValidationException" => {
                         GetBatchPredictionError::Validation(error_message.to_string())
@@ -3388,9 +3390,9 @@ impl fmt::Display for GetBatchPredictionError {
 impl Error for GetBatchPredictionError {
     fn description(&self) -> &str {
         match *self {
-            GetBatchPredictionError::ResourceNotFound(ref cause) => cause,
-            GetBatchPredictionError::InvalidInput(ref cause) => cause,
             GetBatchPredictionError::InternalServer(ref cause) => cause,
+            GetBatchPredictionError::InvalidInput(ref cause) => cause,
+            GetBatchPredictionError::ResourceNotFound(ref cause) => cause,
             GetBatchPredictionError::Validation(ref cause) => cause,
             GetBatchPredictionError::Credentials(ref err) => err.description(),
             GetBatchPredictionError::HttpDispatch(ref dispatch_error) => {
@@ -3403,12 +3405,12 @@ impl Error for GetBatchPredictionError {
 /// Errors returned by GetDataSource
 #[derive(Debug, PartialEq)]
 pub enum GetDataSourceError {
-    /// <p>A specified resource cannot be located.</p>
-    ResourceNotFound(String),
-    /// <p>An error on the client occurred. Typically, the cause is an invalid input value.</p>
-    InvalidInput(String),
     /// <p>An error on the server occurred when trying to process a request.</p>
     InternalServer(String),
+    /// <p>An error on the client occurred. Typically, the cause is an invalid input value.</p>
+    InvalidInput(String),
+    /// <p>A specified resource cannot be located.</p>
+    ResourceNotFound(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -3432,14 +3434,14 @@ impl GetDataSourceError {
                 let error_type = pieces.last().expect("Expected error type");
 
                 match *error_type {
-                    "ResourceNotFoundException" => {
-                        GetDataSourceError::ResourceNotFound(String::from(error_message))
+                    "InternalServerException" => {
+                        GetDataSourceError::InternalServer(String::from(error_message))
                     }
                     "InvalidInputException" => {
                         GetDataSourceError::InvalidInput(String::from(error_message))
                     }
-                    "InternalServerException" => {
-                        GetDataSourceError::InternalServer(String::from(error_message))
+                    "ResourceNotFoundException" => {
+                        GetDataSourceError::ResourceNotFound(String::from(error_message))
                     }
                     "ValidationException" => {
                         GetDataSourceError::Validation(error_message.to_string())
@@ -3480,9 +3482,9 @@ impl fmt::Display for GetDataSourceError {
 impl Error for GetDataSourceError {
     fn description(&self) -> &str {
         match *self {
-            GetDataSourceError::ResourceNotFound(ref cause) => cause,
-            GetDataSourceError::InvalidInput(ref cause) => cause,
             GetDataSourceError::InternalServer(ref cause) => cause,
+            GetDataSourceError::InvalidInput(ref cause) => cause,
+            GetDataSourceError::ResourceNotFound(ref cause) => cause,
             GetDataSourceError::Validation(ref cause) => cause,
             GetDataSourceError::Credentials(ref err) => err.description(),
             GetDataSourceError::HttpDispatch(ref dispatch_error) => dispatch_error.description(),
@@ -3493,12 +3495,12 @@ impl Error for GetDataSourceError {
 /// Errors returned by GetEvaluation
 #[derive(Debug, PartialEq)]
 pub enum GetEvaluationError {
-    /// <p>A specified resource cannot be located.</p>
-    ResourceNotFound(String),
-    /// <p>An error on the client occurred. Typically, the cause is an invalid input value.</p>
-    InvalidInput(String),
     /// <p>An error on the server occurred when trying to process a request.</p>
     InternalServer(String),
+    /// <p>An error on the client occurred. Typically, the cause is an invalid input value.</p>
+    InvalidInput(String),
+    /// <p>A specified resource cannot be located.</p>
+    ResourceNotFound(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -3522,14 +3524,14 @@ impl GetEvaluationError {
                 let error_type = pieces.last().expect("Expected error type");
 
                 match *error_type {
-                    "ResourceNotFoundException" => {
-                        GetEvaluationError::ResourceNotFound(String::from(error_message))
+                    "InternalServerException" => {
+                        GetEvaluationError::InternalServer(String::from(error_message))
                     }
                     "InvalidInputException" => {
                         GetEvaluationError::InvalidInput(String::from(error_message))
                     }
-                    "InternalServerException" => {
-                        GetEvaluationError::InternalServer(String::from(error_message))
+                    "ResourceNotFoundException" => {
+                        GetEvaluationError::ResourceNotFound(String::from(error_message))
                     }
                     "ValidationException" => {
                         GetEvaluationError::Validation(error_message.to_string())
@@ -3570,9 +3572,9 @@ impl fmt::Display for GetEvaluationError {
 impl Error for GetEvaluationError {
     fn description(&self) -> &str {
         match *self {
-            GetEvaluationError::ResourceNotFound(ref cause) => cause,
-            GetEvaluationError::InvalidInput(ref cause) => cause,
             GetEvaluationError::InternalServer(ref cause) => cause,
+            GetEvaluationError::InvalidInput(ref cause) => cause,
+            GetEvaluationError::ResourceNotFound(ref cause) => cause,
             GetEvaluationError::Validation(ref cause) => cause,
             GetEvaluationError::Credentials(ref err) => err.description(),
             GetEvaluationError::HttpDispatch(ref dispatch_error) => dispatch_error.description(),
@@ -3583,12 +3585,12 @@ impl Error for GetEvaluationError {
 /// Errors returned by GetMLModel
 #[derive(Debug, PartialEq)]
 pub enum GetMLModelError {
-    /// <p>A specified resource cannot be located.</p>
-    ResourceNotFound(String),
-    /// <p>An error on the client occurred. Typically, the cause is an invalid input value.</p>
-    InvalidInput(String),
     /// <p>An error on the server occurred when trying to process a request.</p>
     InternalServer(String),
+    /// <p>An error on the client occurred. Typically, the cause is an invalid input value.</p>
+    InvalidInput(String),
+    /// <p>A specified resource cannot be located.</p>
+    ResourceNotFound(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -3612,14 +3614,14 @@ impl GetMLModelError {
                 let error_type = pieces.last().expect("Expected error type");
 
                 match *error_type {
-                    "ResourceNotFoundException" => {
-                        GetMLModelError::ResourceNotFound(String::from(error_message))
+                    "InternalServerException" => {
+                        GetMLModelError::InternalServer(String::from(error_message))
                     }
                     "InvalidInputException" => {
                         GetMLModelError::InvalidInput(String::from(error_message))
                     }
-                    "InternalServerException" => {
-                        GetMLModelError::InternalServer(String::from(error_message))
+                    "ResourceNotFoundException" => {
+                        GetMLModelError::ResourceNotFound(String::from(error_message))
                     }
                     "ValidationException" => GetMLModelError::Validation(error_message.to_string()),
                     _ => GetMLModelError::Unknown(String::from(body)),
@@ -3658,9 +3660,9 @@ impl fmt::Display for GetMLModelError {
 impl Error for GetMLModelError {
     fn description(&self) -> &str {
         match *self {
-            GetMLModelError::ResourceNotFound(ref cause) => cause,
-            GetMLModelError::InvalidInput(ref cause) => cause,
             GetMLModelError::InternalServer(ref cause) => cause,
+            GetMLModelError::InvalidInput(ref cause) => cause,
+            GetMLModelError::ResourceNotFound(ref cause) => cause,
             GetMLModelError::Validation(ref cause) => cause,
             GetMLModelError::Credentials(ref err) => err.description(),
             GetMLModelError::HttpDispatch(ref dispatch_error) => dispatch_error.description(),
@@ -3671,16 +3673,16 @@ impl Error for GetMLModelError {
 /// Errors returned by Predict
 #[derive(Debug, PartialEq)]
 pub enum PredictError {
-    /// <p>A specified resource cannot be located.</p>
-    ResourceNotFound(String),
-    /// <p>An error on the client occurred. Typically, the cause is an invalid input value.</p>
-    InvalidInput(String),
     /// <p>An error on the server occurred when trying to process a request.</p>
     InternalServer(String),
-    /// <p>The exception is thrown when a predict request is made to an unmounted <code>MLModel</code>.</p>
-    PredictorNotMounted(String),
+    /// <p>An error on the client occurred. Typically, the cause is an invalid input value.</p>
+    InvalidInput(String),
     /// <p>The subscriber exceeded the maximum number of operations. This exception can occur when listing objects such as <code>DataSource</code>.</p>
     LimitExceeded(String),
+    /// <p>The exception is thrown when a predict request is made to an unmounted <code>MLModel</code>.</p>
+    PredictorNotMounted(String),
+    /// <p>A specified resource cannot be located.</p>
+    ResourceNotFound(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -3704,20 +3706,20 @@ impl PredictError {
                 let error_type = pieces.last().expect("Expected error type");
 
                 match *error_type {
-                    "ResourceNotFoundException" => {
-                        PredictError::ResourceNotFound(String::from(error_message))
+                    "InternalServerException" => {
+                        PredictError::InternalServer(String::from(error_message))
                     }
                     "InvalidInputException" => {
                         PredictError::InvalidInput(String::from(error_message))
                     }
-                    "InternalServerException" => {
-                        PredictError::InternalServer(String::from(error_message))
+                    "LimitExceededException" => {
+                        PredictError::LimitExceeded(String::from(error_message))
                     }
                     "PredictorNotMountedException" => {
                         PredictError::PredictorNotMounted(String::from(error_message))
                     }
-                    "LimitExceededException" => {
-                        PredictError::LimitExceeded(String::from(error_message))
+                    "ResourceNotFoundException" => {
+                        PredictError::ResourceNotFound(String::from(error_message))
                     }
                     "ValidationException" => PredictError::Validation(error_message.to_string()),
                     _ => PredictError::Unknown(String::from(body)),
@@ -3756,11 +3758,11 @@ impl fmt::Display for PredictError {
 impl Error for PredictError {
     fn description(&self) -> &str {
         match *self {
-            PredictError::ResourceNotFound(ref cause) => cause,
-            PredictError::InvalidInput(ref cause) => cause,
             PredictError::InternalServer(ref cause) => cause,
-            PredictError::PredictorNotMounted(ref cause) => cause,
+            PredictError::InvalidInput(ref cause) => cause,
             PredictError::LimitExceeded(ref cause) => cause,
+            PredictError::PredictorNotMounted(ref cause) => cause,
+            PredictError::ResourceNotFound(ref cause) => cause,
             PredictError::Validation(ref cause) => cause,
             PredictError::Credentials(ref err) => err.description(),
             PredictError::HttpDispatch(ref dispatch_error) => dispatch_error.description(),
@@ -3771,12 +3773,12 @@ impl Error for PredictError {
 /// Errors returned by UpdateBatchPrediction
 #[derive(Debug, PartialEq)]
 pub enum UpdateBatchPredictionError {
-    /// <p>A specified resource cannot be located.</p>
-    ResourceNotFound(String),
-    /// <p>An error on the client occurred. Typically, the cause is an invalid input value.</p>
-    InvalidInput(String),
     /// <p>An error on the server occurred when trying to process a request.</p>
     InternalServer(String),
+    /// <p>An error on the client occurred. Typically, the cause is an invalid input value.</p>
+    InvalidInput(String),
+    /// <p>A specified resource cannot be located.</p>
+    ResourceNotFound(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -3800,14 +3802,14 @@ impl UpdateBatchPredictionError {
                 let error_type = pieces.last().expect("Expected error type");
 
                 match *error_type {
-                    "ResourceNotFoundException" => {
-                        UpdateBatchPredictionError::ResourceNotFound(String::from(error_message))
+                    "InternalServerException" => {
+                        UpdateBatchPredictionError::InternalServer(String::from(error_message))
                     }
                     "InvalidInputException" => {
                         UpdateBatchPredictionError::InvalidInput(String::from(error_message))
                     }
-                    "InternalServerException" => {
-                        UpdateBatchPredictionError::InternalServer(String::from(error_message))
+                    "ResourceNotFoundException" => {
+                        UpdateBatchPredictionError::ResourceNotFound(String::from(error_message))
                     }
                     "ValidationException" => {
                         UpdateBatchPredictionError::Validation(error_message.to_string())
@@ -3848,9 +3850,9 @@ impl fmt::Display for UpdateBatchPredictionError {
 impl Error for UpdateBatchPredictionError {
     fn description(&self) -> &str {
         match *self {
-            UpdateBatchPredictionError::ResourceNotFound(ref cause) => cause,
-            UpdateBatchPredictionError::InvalidInput(ref cause) => cause,
             UpdateBatchPredictionError::InternalServer(ref cause) => cause,
+            UpdateBatchPredictionError::InvalidInput(ref cause) => cause,
+            UpdateBatchPredictionError::ResourceNotFound(ref cause) => cause,
             UpdateBatchPredictionError::Validation(ref cause) => cause,
             UpdateBatchPredictionError::Credentials(ref err) => err.description(),
             UpdateBatchPredictionError::HttpDispatch(ref dispatch_error) => {
@@ -3863,12 +3865,12 @@ impl Error for UpdateBatchPredictionError {
 /// Errors returned by UpdateDataSource
 #[derive(Debug, PartialEq)]
 pub enum UpdateDataSourceError {
-    /// <p>A specified resource cannot be located.</p>
-    ResourceNotFound(String),
-    /// <p>An error on the client occurred. Typically, the cause is an invalid input value.</p>
-    InvalidInput(String),
     /// <p>An error on the server occurred when trying to process a request.</p>
     InternalServer(String),
+    /// <p>An error on the client occurred. Typically, the cause is an invalid input value.</p>
+    InvalidInput(String),
+    /// <p>A specified resource cannot be located.</p>
+    ResourceNotFound(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -3892,14 +3894,14 @@ impl UpdateDataSourceError {
                 let error_type = pieces.last().expect("Expected error type");
 
                 match *error_type {
-                    "ResourceNotFoundException" => {
-                        UpdateDataSourceError::ResourceNotFound(String::from(error_message))
+                    "InternalServerException" => {
+                        UpdateDataSourceError::InternalServer(String::from(error_message))
                     }
                     "InvalidInputException" => {
                         UpdateDataSourceError::InvalidInput(String::from(error_message))
                     }
-                    "InternalServerException" => {
-                        UpdateDataSourceError::InternalServer(String::from(error_message))
+                    "ResourceNotFoundException" => {
+                        UpdateDataSourceError::ResourceNotFound(String::from(error_message))
                     }
                     "ValidationException" => {
                         UpdateDataSourceError::Validation(error_message.to_string())
@@ -3940,9 +3942,9 @@ impl fmt::Display for UpdateDataSourceError {
 impl Error for UpdateDataSourceError {
     fn description(&self) -> &str {
         match *self {
-            UpdateDataSourceError::ResourceNotFound(ref cause) => cause,
-            UpdateDataSourceError::InvalidInput(ref cause) => cause,
             UpdateDataSourceError::InternalServer(ref cause) => cause,
+            UpdateDataSourceError::InvalidInput(ref cause) => cause,
+            UpdateDataSourceError::ResourceNotFound(ref cause) => cause,
             UpdateDataSourceError::Validation(ref cause) => cause,
             UpdateDataSourceError::Credentials(ref err) => err.description(),
             UpdateDataSourceError::HttpDispatch(ref dispatch_error) => dispatch_error.description(),
@@ -3953,12 +3955,12 @@ impl Error for UpdateDataSourceError {
 /// Errors returned by UpdateEvaluation
 #[derive(Debug, PartialEq)]
 pub enum UpdateEvaluationError {
-    /// <p>A specified resource cannot be located.</p>
-    ResourceNotFound(String),
-    /// <p>An error on the client occurred. Typically, the cause is an invalid input value.</p>
-    InvalidInput(String),
     /// <p>An error on the server occurred when trying to process a request.</p>
     InternalServer(String),
+    /// <p>An error on the client occurred. Typically, the cause is an invalid input value.</p>
+    InvalidInput(String),
+    /// <p>A specified resource cannot be located.</p>
+    ResourceNotFound(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -3982,14 +3984,14 @@ impl UpdateEvaluationError {
                 let error_type = pieces.last().expect("Expected error type");
 
                 match *error_type {
-                    "ResourceNotFoundException" => {
-                        UpdateEvaluationError::ResourceNotFound(String::from(error_message))
+                    "InternalServerException" => {
+                        UpdateEvaluationError::InternalServer(String::from(error_message))
                     }
                     "InvalidInputException" => {
                         UpdateEvaluationError::InvalidInput(String::from(error_message))
                     }
-                    "InternalServerException" => {
-                        UpdateEvaluationError::InternalServer(String::from(error_message))
+                    "ResourceNotFoundException" => {
+                        UpdateEvaluationError::ResourceNotFound(String::from(error_message))
                     }
                     "ValidationException" => {
                         UpdateEvaluationError::Validation(error_message.to_string())
@@ -4030,9 +4032,9 @@ impl fmt::Display for UpdateEvaluationError {
 impl Error for UpdateEvaluationError {
     fn description(&self) -> &str {
         match *self {
-            UpdateEvaluationError::ResourceNotFound(ref cause) => cause,
-            UpdateEvaluationError::InvalidInput(ref cause) => cause,
             UpdateEvaluationError::InternalServer(ref cause) => cause,
+            UpdateEvaluationError::InvalidInput(ref cause) => cause,
+            UpdateEvaluationError::ResourceNotFound(ref cause) => cause,
             UpdateEvaluationError::Validation(ref cause) => cause,
             UpdateEvaluationError::Credentials(ref err) => err.description(),
             UpdateEvaluationError::HttpDispatch(ref dispatch_error) => dispatch_error.description(),
@@ -4043,12 +4045,12 @@ impl Error for UpdateEvaluationError {
 /// Errors returned by UpdateMLModel
 #[derive(Debug, PartialEq)]
 pub enum UpdateMLModelError {
-    /// <p>A specified resource cannot be located.</p>
-    ResourceNotFound(String),
-    /// <p>An error on the client occurred. Typically, the cause is an invalid input value.</p>
-    InvalidInput(String),
     /// <p>An error on the server occurred when trying to process a request.</p>
     InternalServer(String),
+    /// <p>An error on the client occurred. Typically, the cause is an invalid input value.</p>
+    InvalidInput(String),
+    /// <p>A specified resource cannot be located.</p>
+    ResourceNotFound(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -4072,14 +4074,14 @@ impl UpdateMLModelError {
                 let error_type = pieces.last().expect("Expected error type");
 
                 match *error_type {
-                    "ResourceNotFoundException" => {
-                        UpdateMLModelError::ResourceNotFound(String::from(error_message))
+                    "InternalServerException" => {
+                        UpdateMLModelError::InternalServer(String::from(error_message))
                     }
                     "InvalidInputException" => {
                         UpdateMLModelError::InvalidInput(String::from(error_message))
                     }
-                    "InternalServerException" => {
-                        UpdateMLModelError::InternalServer(String::from(error_message))
+                    "ResourceNotFoundException" => {
+                        UpdateMLModelError::ResourceNotFound(String::from(error_message))
                     }
                     "ValidationException" => {
                         UpdateMLModelError::Validation(error_message.to_string())
@@ -4120,9 +4122,9 @@ impl fmt::Display for UpdateMLModelError {
 impl Error for UpdateMLModelError {
     fn description(&self) -> &str {
         match *self {
-            UpdateMLModelError::ResourceNotFound(ref cause) => cause,
-            UpdateMLModelError::InvalidInput(ref cause) => cause,
             UpdateMLModelError::InternalServer(ref cause) => cause,
+            UpdateMLModelError::InvalidInput(ref cause) => cause,
+            UpdateMLModelError::ResourceNotFound(ref cause) => cause,
             UpdateMLModelError::Validation(ref cause) => cause,
             UpdateMLModelError::Credentials(ref err) => err.description(),
             UpdateMLModelError::HttpDispatch(ref dispatch_error) => dispatch_error.description(),

--- a/rusoto/services/rds/src/generated.rs
+++ b/rusoto/services/rds/src/generated.rs
@@ -17966,12 +17966,12 @@ impl AddRoleToDBClusterError {
                 "DBClusterNotFoundFault" => AddRoleToDBClusterError::DBClusterNotFoundFault(
                     String::from(parsed_error.message),
                 ),
-                "DBClusterRoleAlreadyExistsFault" => {
+                "DBClusterRoleAlreadyExists" => {
                     AddRoleToDBClusterError::DBClusterRoleAlreadyExistsFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "DBClusterRoleQuotaExceededFault" => {
+                "DBClusterRoleQuotaExceeded" => {
                     AddRoleToDBClusterError::DBClusterRoleQuotaExceededFault(String::from(
                         parsed_error.message,
                     ))
@@ -18062,12 +18062,10 @@ impl AddSourceIdentifierToSubscriptionError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "SourceNotFoundFault" => {
-                    AddSourceIdentifierToSubscriptionError::SourceNotFoundFault(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "SubscriptionNotFoundFault" => {
+                "SourceNotFound" => AddSourceIdentifierToSubscriptionError::SourceNotFoundFault(
+                    String::from(parsed_error.message),
+                ),
+                "SubscriptionNotFound" => {
                     AddSourceIdentifierToSubscriptionError::SubscriptionNotFoundFault(
                         String::from(parsed_error.message),
                     )
@@ -18156,10 +18154,10 @@ impl AddTagsToResourceError {
                 "DBClusterNotFoundFault" => AddTagsToResourceError::DBClusterNotFoundFault(
                     String::from(parsed_error.message),
                 ),
-                "DBInstanceNotFoundFault" => AddTagsToResourceError::DBInstanceNotFoundFault(
+                "DBInstanceNotFound" => AddTagsToResourceError::DBInstanceNotFoundFault(
                     String::from(parsed_error.message),
                 ),
-                "DBSnapshotNotFoundFault" => AddTagsToResourceError::DBSnapshotNotFoundFault(
+                "DBSnapshotNotFound" => AddTagsToResourceError::DBSnapshotNotFoundFault(
                     String::from(parsed_error.message),
                 ),
                 _ => AddTagsToResourceError::Unknown(String::from(body)),
@@ -18327,22 +18325,22 @@ impl AuthorizeDBSecurityGroupIngressError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AuthorizationAlreadyExistsFault" => {
+                "AuthorizationAlreadyExists" => {
                     AuthorizeDBSecurityGroupIngressError::AuthorizationAlreadyExistsFault(
                         String::from(parsed_error.message),
                     )
                 }
-                "AuthorizationQuotaExceededFault" => {
+                "AuthorizationQuotaExceeded" => {
                     AuthorizeDBSecurityGroupIngressError::AuthorizationQuotaExceededFault(
                         String::from(parsed_error.message),
                     )
                 }
-                "DBSecurityGroupNotFoundFault" => {
+                "DBSecurityGroupNotFound" => {
                     AuthorizeDBSecurityGroupIngressError::DBSecurityGroupNotFoundFault(
                         String::from(parsed_error.message),
                     )
                 }
-                "InvalidDBSecurityGroupStateFault" => {
+                "InvalidDBSecurityGroupState" => {
                     AuthorizeDBSecurityGroupIngressError::InvalidDBSecurityGroupStateFault(
                         String::from(parsed_error.message),
                     )
@@ -18436,17 +18434,17 @@ impl CopyDBClusterParameterGroupError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "DBParameterGroupAlreadyExistsFault" => {
+                "DBParameterGroupAlreadyExists" => {
                     CopyDBClusterParameterGroupError::DBParameterGroupAlreadyExistsFault(
                         String::from(parsed_error.message),
                     )
                 }
-                "DBParameterGroupNotFoundFault" => {
+                "DBParameterGroupNotFound" => {
                     CopyDBClusterParameterGroupError::DBParameterGroupNotFoundFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "DBParameterGroupQuotaExceededFault" => {
+                "DBParameterGroupQuotaExceeded" => {
                     CopyDBClusterParameterGroupError::DBParameterGroupQuotaExceededFault(
                         String::from(parsed_error.message),
                     )
@@ -18568,11 +18566,9 @@ impl CopyDBClusterSnapshotError {
                         parsed_error.message,
                     ))
                 }
-                "SnapshotQuotaExceededFault" => {
-                    CopyDBClusterSnapshotError::SnapshotQuotaExceededFault(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "SnapshotQuotaExceeded" => CopyDBClusterSnapshotError::SnapshotQuotaExceededFault(
+                    String::from(parsed_error.message),
+                ),
                 _ => CopyDBClusterSnapshotError::Unknown(String::from(body)),
             },
             Err(_) => CopyDBClusterSnapshotError::Unknown(body.to_string()),
@@ -18658,17 +18654,17 @@ impl CopyDBParameterGroupError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "DBParameterGroupAlreadyExistsFault" => {
+                "DBParameterGroupAlreadyExists" => {
                     CopyDBParameterGroupError::DBParameterGroupAlreadyExistsFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "DBParameterGroupNotFoundFault" => {
+                "DBParameterGroupNotFound" => {
                     CopyDBParameterGroupError::DBParameterGroupNotFoundFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "DBParameterGroupQuotaExceededFault" => {
+                "DBParameterGroupQuotaExceeded" => {
                     CopyDBParameterGroupError::DBParameterGroupQuotaExceededFault(String::from(
                         parsed_error.message,
                     ))
@@ -18759,21 +18755,19 @@ impl CopyDBSnapshotError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "DBSnapshotAlreadyExistsFault" => {
-                    CopyDBSnapshotError::DBSnapshotAlreadyExistsFault(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "DBSnapshotNotFoundFault" => {
+                "DBSnapshotAlreadyExists" => CopyDBSnapshotError::DBSnapshotAlreadyExistsFault(
+                    String::from(parsed_error.message),
+                ),
+                "DBSnapshotNotFound" => {
                     CopyDBSnapshotError::DBSnapshotNotFoundFault(String::from(parsed_error.message))
                 }
-                "InvalidDBSnapshotStateFault" => CopyDBSnapshotError::InvalidDBSnapshotStateFault(
+                "InvalidDBSnapshotState" => CopyDBSnapshotError::InvalidDBSnapshotStateFault(
                     String::from(parsed_error.message),
                 ),
                 "KMSKeyNotAccessibleFault" => CopyDBSnapshotError::KMSKeyNotAccessibleFault(
                     String::from(parsed_error.message),
                 ),
-                "SnapshotQuotaExceededFault" => CopyDBSnapshotError::SnapshotQuotaExceededFault(
+                "SnapshotQuotaExceeded" => CopyDBSnapshotError::SnapshotQuotaExceededFault(
                     String::from(parsed_error.message),
                 ),
                 _ => CopyDBSnapshotError::Unknown(String::from(body)),
@@ -18983,7 +18977,7 @@ impl CreateDBClusterError {
                 "DBClusterNotFoundFault" => {
                     CreateDBClusterError::DBClusterNotFoundFault(String::from(parsed_error.message))
                 }
-                "DBClusterParameterGroupNotFoundFault" => {
+                "DBClusterParameterGroupNotFound" => {
                     CreateDBClusterError::DBClusterParameterGroupNotFoundFault(String::from(
                         parsed_error.message,
                     ))
@@ -18993,7 +18987,7 @@ impl CreateDBClusterError {
                         parsed_error.message,
                     ))
                 }
-                "DBInstanceNotFoundFault" => CreateDBClusterError::DBInstanceNotFoundFault(
+                "DBInstanceNotFound" => CreateDBClusterError::DBInstanceNotFoundFault(
                     String::from(parsed_error.message),
                 ),
                 "DBSubnetGroupDoesNotCoverEnoughAZs" => {
@@ -19004,7 +18998,7 @@ impl CreateDBClusterError {
                 "DBSubnetGroupNotFoundFault" => CreateDBClusterError::DBSubnetGroupNotFoundFault(
                     String::from(parsed_error.message),
                 ),
-                "InsufficientStorageClusterCapacityFault" => {
+                "InsufficientStorageClusterCapacity" => {
                     CreateDBClusterError::InsufficientStorageClusterCapacityFault(String::from(
                         parsed_error.message,
                     ))
@@ -19012,11 +19006,9 @@ impl CreateDBClusterError {
                 "InvalidDBClusterStateFault" => CreateDBClusterError::InvalidDBClusterStateFault(
                     String::from(parsed_error.message),
                 ),
-                "InvalidDBInstanceStateFault" => {
-                    CreateDBClusterError::InvalidDBInstanceStateFault(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "InvalidDBInstanceState" => CreateDBClusterError::InvalidDBInstanceStateFault(
+                    String::from(parsed_error.message),
+                ),
                 "InvalidDBSubnetGroupStateFault" => {
                     CreateDBClusterError::InvalidDBSubnetGroupStateFault(String::from(
                         parsed_error.message,
@@ -19033,7 +19025,7 @@ impl CreateDBClusterError {
                 "KMSKeyNotAccessibleFault" => CreateDBClusterError::KMSKeyNotAccessibleFault(
                     String::from(parsed_error.message),
                 ),
-                "StorageQuotaExceededFault" => CreateDBClusterError::StorageQuotaExceededFault(
+                "StorageQuotaExceeded" => CreateDBClusterError::StorageQuotaExceededFault(
                     String::from(parsed_error.message),
                 ),
                 _ => CreateDBClusterError::Unknown(String::from(body)),
@@ -19126,12 +19118,12 @@ impl CreateDBClusterParameterGroupError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "DBParameterGroupAlreadyExistsFault" => {
+                "DBParameterGroupAlreadyExists" => {
                     CreateDBClusterParameterGroupError::DBParameterGroupAlreadyExistsFault(
                         String::from(parsed_error.message),
                     )
                 }
-                "DBParameterGroupQuotaExceededFault" => {
+                "DBParameterGroupQuotaExceeded" => {
                     CreateDBClusterParameterGroupError::DBParameterGroupQuotaExceededFault(
                         String::from(parsed_error.message),
                     )
@@ -19243,7 +19235,7 @@ impl CreateDBClusterSnapshotError {
                         parsed_error.message,
                     ))
                 }
-                "SnapshotQuotaExceededFault" => {
+                "SnapshotQuotaExceeded" => {
                     CreateDBClusterSnapshotError::SnapshotQuotaExceededFault(String::from(
                         parsed_error.message,
                     ))
@@ -19362,27 +19354,23 @@ impl CreateDBInstanceError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AuthorizationNotFoundFault" => CreateDBInstanceError::AuthorizationNotFoundFault(
+                "AuthorizationNotFound" => CreateDBInstanceError::AuthorizationNotFoundFault(
                     String::from(parsed_error.message),
                 ),
                 "DBClusterNotFoundFault" => CreateDBInstanceError::DBClusterNotFoundFault(
                     String::from(parsed_error.message),
                 ),
-                "DBInstanceAlreadyExistsFault" => {
-                    CreateDBInstanceError::DBInstanceAlreadyExistsFault(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "DBParameterGroupNotFoundFault" => {
+                "DBInstanceAlreadyExists" => CreateDBInstanceError::DBInstanceAlreadyExistsFault(
+                    String::from(parsed_error.message),
+                ),
+                "DBParameterGroupNotFound" => {
                     CreateDBInstanceError::DBParameterGroupNotFoundFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "DBSecurityGroupNotFoundFault" => {
-                    CreateDBInstanceError::DBSecurityGroupNotFoundFault(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "DBSecurityGroupNotFound" => CreateDBInstanceError::DBSecurityGroupNotFoundFault(
+                    String::from(parsed_error.message),
+                ),
                 "DBSubnetGroupDoesNotCoverEnoughAZs" => {
                     CreateDBInstanceError::DBSubnetGroupDoesNotCoverEnoughAZs(String::from(
                         parsed_error.message,
@@ -19394,10 +19382,10 @@ impl CreateDBInstanceError {
                 "DomainNotFoundFault" => {
                     CreateDBInstanceError::DomainNotFoundFault(String::from(parsed_error.message))
                 }
-                "InstanceQuotaExceededFault" => CreateDBInstanceError::InstanceQuotaExceededFault(
+                "InstanceQuotaExceeded" => CreateDBInstanceError::InstanceQuotaExceededFault(
                     String::from(parsed_error.message),
                 ),
-                "InsufficientDBInstanceCapacityFault" => {
+                "InsufficientDBInstanceCapacity" => {
                     CreateDBInstanceError::InsufficientDBInstanceCapacityFault(String::from(
                         parsed_error.message,
                     ))
@@ -19424,14 +19412,12 @@ impl CreateDBInstanceError {
                         parsed_error.message,
                     ))
                 }
-                "StorageQuotaExceededFault" => CreateDBInstanceError::StorageQuotaExceededFault(
+                "StorageQuotaExceeded" => CreateDBInstanceError::StorageQuotaExceededFault(
                     String::from(parsed_error.message),
                 ),
-                "StorageTypeNotSupportedFault" => {
-                    CreateDBInstanceError::StorageTypeNotSupportedFault(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "StorageTypeNotSupported" => CreateDBInstanceError::StorageTypeNotSupportedFault(
+                    String::from(parsed_error.message),
+                ),
                 _ => CreateDBInstanceError::Unknown(String::from(body)),
             },
             Err(_) => CreateDBInstanceError::Unknown(body.to_string()),
@@ -19557,22 +19543,20 @@ impl CreateDBInstanceReadReplicaError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "DBInstanceAlreadyExistsFault" => {
+                "DBInstanceAlreadyExists" => {
                     CreateDBInstanceReadReplicaError::DBInstanceAlreadyExistsFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "DBInstanceNotFoundFault" => {
-                    CreateDBInstanceReadReplicaError::DBInstanceNotFoundFault(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "DBParameterGroupNotFoundFault" => {
+                "DBInstanceNotFound" => CreateDBInstanceReadReplicaError::DBInstanceNotFoundFault(
+                    String::from(parsed_error.message),
+                ),
+                "DBParameterGroupNotFound" => {
                     CreateDBInstanceReadReplicaError::DBParameterGroupNotFoundFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "DBSecurityGroupNotFoundFault" => {
+                "DBSecurityGroupNotFound" => {
                     CreateDBInstanceReadReplicaError::DBSecurityGroupNotFoundFault(String::from(
                         parsed_error.message,
                     ))
@@ -19592,17 +19576,17 @@ impl CreateDBInstanceReadReplicaError {
                         parsed_error.message,
                     ))
                 }
-                "InstanceQuotaExceededFault" => {
+                "InstanceQuotaExceeded" => {
                     CreateDBInstanceReadReplicaError::InstanceQuotaExceededFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InsufficientDBInstanceCapacityFault" => {
+                "InsufficientDBInstanceCapacity" => {
                     CreateDBInstanceReadReplicaError::InsufficientDBInstanceCapacityFault(
                         String::from(parsed_error.message),
                     )
                 }
-                "InvalidDBInstanceStateFault" => {
+                "InvalidDBInstanceState" => {
                     CreateDBInstanceReadReplicaError::InvalidDBInstanceStateFault(String::from(
                         parsed_error.message,
                     ))
@@ -19635,12 +19619,12 @@ impl CreateDBInstanceReadReplicaError {
                         String::from(parsed_error.message),
                     )
                 }
-                "StorageQuotaExceededFault" => {
+                "StorageQuotaExceeded" => {
                     CreateDBInstanceReadReplicaError::StorageQuotaExceededFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "StorageTypeNotSupportedFault" => {
+                "StorageTypeNotSupported" => {
                     CreateDBInstanceReadReplicaError::StorageTypeNotSupportedFault(String::from(
                         parsed_error.message,
                     ))
@@ -19746,12 +19730,12 @@ impl CreateDBParameterGroupError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "DBParameterGroupAlreadyExistsFault" => {
+                "DBParameterGroupAlreadyExists" => {
                     CreateDBParameterGroupError::DBParameterGroupAlreadyExistsFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "DBParameterGroupQuotaExceededFault" => {
+                "DBParameterGroupQuotaExceeded" => {
                     CreateDBParameterGroupError::DBParameterGroupQuotaExceededFault(String::from(
                         parsed_error.message,
                     ))
@@ -19837,17 +19821,17 @@ impl CreateDBSecurityGroupError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "DBSecurityGroupAlreadyExistsFault" => {
+                "DBSecurityGroupAlreadyExists" => {
                     CreateDBSecurityGroupError::DBSecurityGroupAlreadyExistsFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "DBSecurityGroupNotSupportedFault" => {
+                "DBSecurityGroupNotSupported" => {
                     CreateDBSecurityGroupError::DBSecurityGroupNotSupportedFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "DBSecurityGroupQuotaExceededFault" => {
+                "QuotaExceeded.DBSecurityGroup" => {
                     CreateDBSecurityGroupError::DBSecurityGroupQuotaExceededFault(String::from(
                         parsed_error.message,
                     ))
@@ -19936,20 +19920,16 @@ impl CreateDBSnapshotError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "DBInstanceNotFoundFault" => CreateDBSnapshotError::DBInstanceNotFoundFault(
+                "DBInstanceNotFound" => CreateDBSnapshotError::DBInstanceNotFoundFault(
                     String::from(parsed_error.message),
                 ),
-                "DBSnapshotAlreadyExistsFault" => {
-                    CreateDBSnapshotError::DBSnapshotAlreadyExistsFault(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "InvalidDBInstanceStateFault" => {
-                    CreateDBSnapshotError::InvalidDBInstanceStateFault(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "SnapshotQuotaExceededFault" => CreateDBSnapshotError::SnapshotQuotaExceededFault(
+                "DBSnapshotAlreadyExists" => CreateDBSnapshotError::DBSnapshotAlreadyExistsFault(
+                    String::from(parsed_error.message),
+                ),
+                "InvalidDBInstanceState" => CreateDBSnapshotError::InvalidDBInstanceStateFault(
+                    String::from(parsed_error.message),
+                ),
+                "SnapshotQuotaExceeded" => CreateDBSnapshotError::SnapshotQuotaExceededFault(
                     String::from(parsed_error.message),
                 ),
                 _ => CreateDBSnapshotError::Unknown(String::from(body)),
@@ -20037,7 +20017,7 @@ impl CreateDBSubnetGroupError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "DBSubnetGroupAlreadyExistsFault" => {
+                "DBSubnetGroupAlreadyExists" => {
                     CreateDBSubnetGroupError::DBSubnetGroupAlreadyExistsFault(String::from(
                         parsed_error.message,
                     ))
@@ -20047,7 +20027,7 @@ impl CreateDBSubnetGroupError {
                         parsed_error.message,
                     ))
                 }
-                "DBSubnetGroupQuotaExceededFault" => {
+                "DBSubnetGroupQuotaExceeded" => {
                     CreateDBSubnetGroupError::DBSubnetGroupQuotaExceededFault(String::from(
                         parsed_error.message,
                     ))
@@ -20152,33 +20132,29 @@ impl CreateEventSubscriptionError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "EventSubscriptionQuotaExceededFault" => {
+                "EventSubscriptionQuotaExceeded" => {
                     CreateEventSubscriptionError::EventSubscriptionQuotaExceededFault(
                         String::from(parsed_error.message),
                     )
                 }
-                "SNSInvalidTopicFault" => CreateEventSubscriptionError::SNSInvalidTopicFault(
+                "SNSInvalidTopic" => CreateEventSubscriptionError::SNSInvalidTopicFault(
                     String::from(parsed_error.message),
                 ),
-                "SNSNoAuthorizationFault" => {
-                    CreateEventSubscriptionError::SNSNoAuthorizationFault(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "SNSTopicArnNotFoundFault" => {
-                    CreateEventSubscriptionError::SNSTopicArnNotFoundFault(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "SourceNotFoundFault" => CreateEventSubscriptionError::SourceNotFoundFault(
+                "SNSNoAuthorization" => CreateEventSubscriptionError::SNSNoAuthorizationFault(
                     String::from(parsed_error.message),
                 ),
-                "SubscriptionAlreadyExistFault" => {
+                "SNSTopicArnNotFound" => CreateEventSubscriptionError::SNSTopicArnNotFoundFault(
+                    String::from(parsed_error.message),
+                ),
+                "SourceNotFound" => CreateEventSubscriptionError::SourceNotFoundFault(
+                    String::from(parsed_error.message),
+                ),
+                "SubscriptionAlreadyExist" => {
                     CreateEventSubscriptionError::SubscriptionAlreadyExistFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "SubscriptionCategoryNotFoundFault" => {
+                "SubscriptionCategoryNotFound" => {
                     CreateEventSubscriptionError::SubscriptionCategoryNotFoundFault(String::from(
                         parsed_error.message,
                     ))
@@ -20378,7 +20354,7 @@ impl DeleteDBClusterError {
                 "InvalidDBClusterStateFault" => DeleteDBClusterError::InvalidDBClusterStateFault(
                     String::from(parsed_error.message),
                 ),
-                "SnapshotQuotaExceededFault" => DeleteDBClusterError::SnapshotQuotaExceededFault(
+                "SnapshotQuotaExceeded" => DeleteDBClusterError::SnapshotQuotaExceededFault(
                     String::from(parsed_error.message),
                 ),
                 _ => DeleteDBClusterError::Unknown(String::from(body)),
@@ -20461,12 +20437,12 @@ impl DeleteDBClusterParameterGroupError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "DBParameterGroupNotFoundFault" => {
+                "DBParameterGroupNotFound" => {
                     DeleteDBClusterParameterGroupError::DBParameterGroupNotFoundFault(
                         String::from(parsed_error.message),
                     )
                 }
-                "InvalidDBParameterGroupStateFault" => {
+                "InvalidDBParameterGroupState" => {
                     DeleteDBClusterParameterGroupError::InvalidDBParameterGroupStateFault(
                         String::from(parsed_error.message),
                     )
@@ -20647,23 +20623,19 @@ impl DeleteDBInstanceError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "DBInstanceNotFoundFault" => DeleteDBInstanceError::DBInstanceNotFoundFault(
+                "DBInstanceNotFound" => DeleteDBInstanceError::DBInstanceNotFoundFault(
                     String::from(parsed_error.message),
                 ),
-                "DBSnapshotAlreadyExistsFault" => {
-                    DeleteDBInstanceError::DBSnapshotAlreadyExistsFault(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "DBSnapshotAlreadyExists" => DeleteDBInstanceError::DBSnapshotAlreadyExistsFault(
+                    String::from(parsed_error.message),
+                ),
                 "InvalidDBClusterStateFault" => DeleteDBInstanceError::InvalidDBClusterStateFault(
                     String::from(parsed_error.message),
                 ),
-                "InvalidDBInstanceStateFault" => {
-                    DeleteDBInstanceError::InvalidDBInstanceStateFault(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "SnapshotQuotaExceededFault" => DeleteDBInstanceError::SnapshotQuotaExceededFault(
+                "InvalidDBInstanceState" => DeleteDBInstanceError::InvalidDBInstanceStateFault(
+                    String::from(parsed_error.message),
+                ),
+                "SnapshotQuotaExceeded" => DeleteDBInstanceError::SnapshotQuotaExceededFault(
                     String::from(parsed_error.message),
                 ),
                 _ => DeleteDBInstanceError::Unknown(String::from(body)),
@@ -20746,12 +20718,12 @@ impl DeleteDBParameterGroupError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "DBParameterGroupNotFoundFault" => {
+                "DBParameterGroupNotFound" => {
                     DeleteDBParameterGroupError::DBParameterGroupNotFoundFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InvalidDBParameterGroupStateFault" => {
+                "InvalidDBParameterGroupState" => {
                     DeleteDBParameterGroupError::InvalidDBParameterGroupStateFault(String::from(
                         parsed_error.message,
                     ))
@@ -20835,12 +20807,12 @@ impl DeleteDBSecurityGroupError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "DBSecurityGroupNotFoundFault" => {
+                "DBSecurityGroupNotFound" => {
                     DeleteDBSecurityGroupError::DBSecurityGroupNotFoundFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InvalidDBSecurityGroupStateFault" => {
+                "InvalidDBSecurityGroupState" => {
                     DeleteDBSecurityGroupError::InvalidDBSecurityGroupStateFault(String::from(
                         parsed_error.message,
                     ))
@@ -20924,14 +20896,12 @@ impl DeleteDBSnapshotError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "DBSnapshotNotFoundFault" => DeleteDBSnapshotError::DBSnapshotNotFoundFault(
+                "DBSnapshotNotFound" => DeleteDBSnapshotError::DBSnapshotNotFoundFault(
                     String::from(parsed_error.message),
                 ),
-                "InvalidDBSnapshotStateFault" => {
-                    DeleteDBSnapshotError::InvalidDBSnapshotStateFault(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "InvalidDBSnapshotState" => DeleteDBSnapshotError::InvalidDBSnapshotStateFault(
+                    String::from(parsed_error.message),
+                ),
                 _ => DeleteDBSnapshotError::Unknown(String::from(body)),
             },
             Err(_) => DeleteDBSnapshotError::Unknown(body.to_string()),
@@ -21106,16 +21076,14 @@ impl DeleteEventSubscriptionError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "InvalidEventSubscriptionStateFault" => {
+                "InvalidEventSubscriptionState" => {
                     DeleteEventSubscriptionError::InvalidEventSubscriptionStateFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "SubscriptionNotFoundFault" => {
-                    DeleteEventSubscriptionError::SubscriptionNotFoundFault(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "SubscriptionNotFound" => DeleteEventSubscriptionError::SubscriptionNotFoundFault(
+                    String::from(parsed_error.message),
+                ),
                 _ => DeleteEventSubscriptionError::Unknown(String::from(body)),
             },
             Err(_) => DeleteEventSubscriptionError::Unknown(body.to_string()),
@@ -21353,7 +21321,7 @@ impl DescribeCertificatesError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "CertificateNotFoundFault" => DescribeCertificatesError::CertificateNotFoundFault(
+                "CertificateNotFound" => DescribeCertificatesError::CertificateNotFoundFault(
                     String::from(parsed_error.message),
                 ),
                 _ => DescribeCertificatesError::Unknown(String::from(body)),
@@ -21432,7 +21400,7 @@ impl DescribeDBClusterParameterGroupsError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "DBParameterGroupNotFoundFault" => {
+                "DBParameterGroupNotFound" => {
                     DescribeDBClusterParameterGroupsError::DBParameterGroupNotFoundFault(
                         String::from(parsed_error.message),
                     )
@@ -21515,7 +21483,7 @@ impl DescribeDBClusterParametersError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "DBParameterGroupNotFoundFault" => {
+                "DBParameterGroupNotFound" => {
                     DescribeDBClusterParametersError::DBParameterGroupNotFoundFault(String::from(
                         parsed_error.message,
                     ))
@@ -21912,7 +21880,7 @@ impl DescribeDBInstancesError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "DBInstanceNotFoundFault" => DescribeDBInstancesError::DBInstanceNotFoundFault(
+                "DBInstanceNotFound" => DescribeDBInstancesError::DBInstanceNotFoundFault(
                     String::from(parsed_error.message),
                 ),
                 _ => DescribeDBInstancesError::Unknown(String::from(body)),
@@ -21991,7 +21959,7 @@ impl DescribeDBLogFilesError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "DBInstanceNotFoundFault" => DescribeDBLogFilesError::DBInstanceNotFoundFault(
+                "DBInstanceNotFound" => DescribeDBLogFilesError::DBInstanceNotFoundFault(
                     String::from(parsed_error.message),
                 ),
                 _ => DescribeDBLogFilesError::Unknown(String::from(body)),
@@ -22070,7 +22038,7 @@ impl DescribeDBParameterGroupsError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "DBParameterGroupNotFoundFault" => {
+                "DBParameterGroupNotFound" => {
                     DescribeDBParameterGroupsError::DBParameterGroupNotFoundFault(String::from(
                         parsed_error.message,
                     ))
@@ -22151,7 +22119,7 @@ impl DescribeDBParametersError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "DBParameterGroupNotFoundFault" => {
+                "DBParameterGroupNotFound" => {
                     DescribeDBParametersError::DBParameterGroupNotFoundFault(String::from(
                         parsed_error.message,
                     ))
@@ -22232,7 +22200,7 @@ impl DescribeDBSecurityGroupsError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "DBSecurityGroupNotFoundFault" => {
+                "DBSecurityGroupNotFound" => {
                     DescribeDBSecurityGroupsError::DBSecurityGroupNotFoundFault(String::from(
                         parsed_error.message,
                     ))
@@ -22313,7 +22281,7 @@ impl DescribeDBSnapshotAttributesError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "DBSnapshotNotFoundFault" => {
+                "DBSnapshotNotFound" => {
                     DescribeDBSnapshotAttributesError::DBSnapshotNotFoundFault(String::from(
                         parsed_error.message,
                     ))
@@ -22394,7 +22362,7 @@ impl DescribeDBSnapshotsError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "DBSnapshotNotFoundFault" => DescribeDBSnapshotsError::DBSnapshotNotFoundFault(
+                "DBSnapshotNotFound" => DescribeDBSnapshotsError::DBSnapshotNotFoundFault(
                     String::from(parsed_error.message),
                 ),
                 _ => DescribeDBSnapshotsError::Unknown(String::from(body)),
@@ -22773,7 +22741,7 @@ impl DescribeEventSubscriptionsError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "SubscriptionNotFoundFault" => {
+                "SubscriptionNotFound" => {
                     DescribeEventSubscriptionsError::SubscriptionNotFoundFault(String::from(
                         parsed_error.message,
                     ))
@@ -23231,7 +23199,7 @@ impl DescribeReservedDBInstancesError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ReservedDBInstanceNotFoundFault" => {
+                "ReservedDBInstanceNotFound" => {
                     DescribeReservedDBInstancesError::ReservedDBInstanceNotFoundFault(
                         String::from(parsed_error.message),
                     )
@@ -23313,7 +23281,7 @@ impl DescribeReservedDBInstancesOfferingsError {
         match Self::deserialize(&mut stack) {
                             Ok(parsed_error) => {
                                 match &parsed_error.code[..] {
-                                    "ReservedDBInstancesOfferingNotFoundFault" => DescribeReservedDBInstancesOfferingsError::ReservedDBInstancesOfferingNotFoundFault(String::from(parsed_error.message)),_ => DescribeReservedDBInstancesOfferingsError::Unknown(String::from(body))
+                                    "ReservedDBInstancesOfferingNotFound" => DescribeReservedDBInstancesOfferingsError::ReservedDBInstancesOfferingNotFoundFault(String::from(parsed_error.message)),_ => DescribeReservedDBInstancesOfferingsError::Unknown(String::from(body))
                                 }
                            },
                            Err(_) => DescribeReservedDBInstancesOfferingsError::Unknown(body.to_string())
@@ -23463,12 +23431,12 @@ impl DescribeValidDBInstanceModificationsError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "DBInstanceNotFoundFault" => {
+                "DBInstanceNotFound" => {
                     DescribeValidDBInstanceModificationsError::DBInstanceNotFoundFault(
                         String::from(parsed_error.message),
                     )
                 }
-                "InvalidDBInstanceStateFault" => {
+                "InvalidDBInstanceState" => {
                     DescribeValidDBInstanceModificationsError::InvalidDBInstanceStateFault(
                         String::from(parsed_error.message),
                     )
@@ -23554,11 +23522,9 @@ impl DownloadDBLogFilePortionError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "DBInstanceNotFoundFault" => {
-                    DownloadDBLogFilePortionError::DBInstanceNotFoundFault(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "DBInstanceNotFound" => DownloadDBLogFilePortionError::DBInstanceNotFoundFault(
+                    String::from(parsed_error.message),
+                ),
                 "DBLogFileNotFoundFault" => DownloadDBLogFilePortionError::DBLogFileNotFoundFault(
                     String::from(parsed_error.message),
                 ),
@@ -23651,11 +23617,9 @@ impl FailoverDBClusterError {
                         parsed_error.message,
                     ))
                 }
-                "InvalidDBInstanceStateFault" => {
-                    FailoverDBClusterError::InvalidDBInstanceStateFault(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "InvalidDBInstanceState" => FailoverDBClusterError::InvalidDBInstanceStateFault(
+                    String::from(parsed_error.message),
+                ),
                 _ => FailoverDBClusterError::Unknown(String::from(body)),
             },
             Err(_) => FailoverDBClusterError::Unknown(body.to_string()),
@@ -23741,10 +23705,10 @@ impl ListTagsForResourceError {
                 "DBClusterNotFoundFault" => ListTagsForResourceError::DBClusterNotFoundFault(
                     String::from(parsed_error.message),
                 ),
-                "DBInstanceNotFoundFault" => ListTagsForResourceError::DBInstanceNotFoundFault(
+                "DBInstanceNotFound" => ListTagsForResourceError::DBInstanceNotFoundFault(
                     String::from(parsed_error.message),
                 ),
-                "DBSnapshotNotFoundFault" => ListTagsForResourceError::DBSnapshotNotFoundFault(
+                "DBSnapshotNotFound" => ListTagsForResourceError::DBSnapshotNotFoundFault(
                     String::from(parsed_error.message),
                 ),
                 _ => ListTagsForResourceError::Unknown(String::from(body)),
@@ -23853,7 +23817,7 @@ impl ModifyDBClusterError {
                 "DBClusterNotFoundFault" => {
                     ModifyDBClusterError::DBClusterNotFoundFault(String::from(parsed_error.message))
                 }
-                "DBClusterParameterGroupNotFoundFault" => {
+                "DBClusterParameterGroupNotFound" => {
                     ModifyDBClusterError::DBClusterParameterGroupNotFoundFault(String::from(
                         parsed_error.message,
                     ))
@@ -23864,12 +23828,10 @@ impl ModifyDBClusterError {
                 "InvalidDBClusterStateFault" => ModifyDBClusterError::InvalidDBClusterStateFault(
                     String::from(parsed_error.message),
                 ),
-                "InvalidDBInstanceStateFault" => {
-                    ModifyDBClusterError::InvalidDBInstanceStateFault(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "InvalidDBSecurityGroupStateFault" => {
+                "InvalidDBInstanceState" => ModifyDBClusterError::InvalidDBInstanceStateFault(
+                    String::from(parsed_error.message),
+                ),
+                "InvalidDBSecurityGroupState" => {
                     ModifyDBClusterError::InvalidDBSecurityGroupStateFault(String::from(
                         parsed_error.message,
                     ))
@@ -23887,7 +23849,7 @@ impl ModifyDBClusterError {
                         parsed_error.message,
                     ))
                 }
-                "StorageQuotaExceededFault" => ModifyDBClusterError::StorageQuotaExceededFault(
+                "StorageQuotaExceeded" => ModifyDBClusterError::StorageQuotaExceededFault(
                     String::from(parsed_error.message),
                 ),
                 _ => ModifyDBClusterError::Unknown(String::from(body)),
@@ -23976,12 +23938,12 @@ impl ModifyDBClusterParameterGroupError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "DBParameterGroupNotFoundFault" => {
+                "DBParameterGroupNotFound" => {
                     ModifyDBClusterParameterGroupError::DBParameterGroupNotFoundFault(
                         String::from(parsed_error.message),
                     )
                 }
-                "InvalidDBParameterGroupStateFault" => {
+                "InvalidDBParameterGroupState" => {
                     ModifyDBClusterParameterGroupError::InvalidDBParameterGroupStateFault(
                         String::from(parsed_error.message),
                     )
@@ -24079,7 +24041,7 @@ impl ModifyDBClusterSnapshotAttributeError {
                         String::from(parsed_error.message),
                     )
                 }
-                "SharedSnapshotQuotaExceededFault" => {
+                "SharedSnapshotQuotaExceeded" => {
                     ModifyDBClusterSnapshotAttributeError::SharedSnapshotQuotaExceededFault(
                         String::from(parsed_error.message),
                     )
@@ -24198,31 +24160,27 @@ impl ModifyDBInstanceError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AuthorizationNotFoundFault" => ModifyDBInstanceError::AuthorizationNotFoundFault(
+                "AuthorizationNotFound" => ModifyDBInstanceError::AuthorizationNotFoundFault(
                     String::from(parsed_error.message),
                 ),
-                "CertificateNotFoundFault" => ModifyDBInstanceError::CertificateNotFoundFault(
+                "CertificateNotFound" => ModifyDBInstanceError::CertificateNotFoundFault(
                     String::from(parsed_error.message),
                 ),
-                "DBInstanceAlreadyExistsFault" => {
-                    ModifyDBInstanceError::DBInstanceAlreadyExistsFault(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "DBInstanceNotFoundFault" => ModifyDBInstanceError::DBInstanceNotFoundFault(
+                "DBInstanceAlreadyExists" => ModifyDBInstanceError::DBInstanceAlreadyExistsFault(
                     String::from(parsed_error.message),
                 ),
-                "DBParameterGroupNotFoundFault" => {
+                "DBInstanceNotFound" => ModifyDBInstanceError::DBInstanceNotFoundFault(
+                    String::from(parsed_error.message),
+                ),
+                "DBParameterGroupNotFound" => {
                     ModifyDBInstanceError::DBParameterGroupNotFoundFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "DBSecurityGroupNotFoundFault" => {
-                    ModifyDBInstanceError::DBSecurityGroupNotFoundFault(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "DBUpgradeDependencyFailureFault" => {
+                "DBSecurityGroupNotFound" => ModifyDBInstanceError::DBSecurityGroupNotFoundFault(
+                    String::from(parsed_error.message),
+                ),
+                "DBUpgradeDependencyFailure" => {
                     ModifyDBInstanceError::DBUpgradeDependencyFailureFault(String::from(
                         parsed_error.message,
                     ))
@@ -24230,17 +24188,15 @@ impl ModifyDBInstanceError {
                 "DomainNotFoundFault" => {
                     ModifyDBInstanceError::DomainNotFoundFault(String::from(parsed_error.message))
                 }
-                "InsufficientDBInstanceCapacityFault" => {
+                "InsufficientDBInstanceCapacity" => {
                     ModifyDBInstanceError::InsufficientDBInstanceCapacityFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InvalidDBInstanceStateFault" => {
-                    ModifyDBInstanceError::InvalidDBInstanceStateFault(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "InvalidDBSecurityGroupStateFault" => {
+                "InvalidDBInstanceState" => ModifyDBInstanceError::InvalidDBInstanceStateFault(
+                    String::from(parsed_error.message),
+                ),
+                "InvalidDBSecurityGroupState" => {
                     ModifyDBInstanceError::InvalidDBSecurityGroupStateFault(String::from(
                         parsed_error.message,
                     ))
@@ -24258,14 +24214,12 @@ impl ModifyDBInstanceError {
                         parsed_error.message,
                     ))
                 }
-                "StorageQuotaExceededFault" => ModifyDBInstanceError::StorageQuotaExceededFault(
+                "StorageQuotaExceeded" => ModifyDBInstanceError::StorageQuotaExceededFault(
                     String::from(parsed_error.message),
                 ),
-                "StorageTypeNotSupportedFault" => {
-                    ModifyDBInstanceError::StorageTypeNotSupportedFault(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "StorageTypeNotSupported" => ModifyDBInstanceError::StorageTypeNotSupportedFault(
+                    String::from(parsed_error.message),
+                ),
                 _ => ModifyDBInstanceError::Unknown(String::from(body)),
             },
             Err(_) => ModifyDBInstanceError::Unknown(body.to_string()),
@@ -24357,12 +24311,12 @@ impl ModifyDBParameterGroupError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "DBParameterGroupNotFoundFault" => {
+                "DBParameterGroupNotFound" => {
                     ModifyDBParameterGroupError::DBParameterGroupNotFoundFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InvalidDBParameterGroupStateFault" => {
+                "InvalidDBParameterGroupState" => {
                     ModifyDBParameterGroupError::InvalidDBParameterGroupStateFault(String::from(
                         parsed_error.message,
                     ))
@@ -24444,7 +24398,7 @@ impl ModifyDBSnapshotError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "DBSnapshotNotFoundFault" => ModifyDBSnapshotError::DBSnapshotNotFoundFault(
+                "DBSnapshotNotFound" => ModifyDBSnapshotError::DBSnapshotNotFoundFault(
                     String::from(parsed_error.message),
                 ),
                 _ => ModifyDBSnapshotError::Unknown(String::from(body)),
@@ -24525,17 +24479,15 @@ impl ModifyDBSnapshotAttributeError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "DBSnapshotNotFoundFault" => {
-                    ModifyDBSnapshotAttributeError::DBSnapshotNotFoundFault(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "InvalidDBSnapshotStateFault" => {
+                "DBSnapshotNotFound" => ModifyDBSnapshotAttributeError::DBSnapshotNotFoundFault(
+                    String::from(parsed_error.message),
+                ),
+                "InvalidDBSnapshotState" => {
                     ModifyDBSnapshotAttributeError::InvalidDBSnapshotStateFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "SharedSnapshotQuotaExceededFault" => {
+                "SharedSnapshotQuotaExceeded" => {
                     ModifyDBSnapshotAttributeError::SharedSnapshotQuotaExceededFault(String::from(
                         parsed_error.message,
                     ))
@@ -24737,34 +24689,28 @@ impl ModifyEventSubscriptionError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "EventSubscriptionQuotaExceededFault" => {
+                "EventSubscriptionQuotaExceeded" => {
                     ModifyEventSubscriptionError::EventSubscriptionQuotaExceededFault(
                         String::from(parsed_error.message),
                     )
                 }
-                "SNSInvalidTopicFault" => ModifyEventSubscriptionError::SNSInvalidTopicFault(
+                "SNSInvalidTopic" => ModifyEventSubscriptionError::SNSInvalidTopicFault(
                     String::from(parsed_error.message),
                 ),
-                "SNSNoAuthorizationFault" => {
-                    ModifyEventSubscriptionError::SNSNoAuthorizationFault(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "SNSTopicArnNotFoundFault" => {
-                    ModifyEventSubscriptionError::SNSTopicArnNotFoundFault(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "SubscriptionCategoryNotFoundFault" => {
+                "SNSNoAuthorization" => ModifyEventSubscriptionError::SNSNoAuthorizationFault(
+                    String::from(parsed_error.message),
+                ),
+                "SNSTopicArnNotFound" => ModifyEventSubscriptionError::SNSTopicArnNotFoundFault(
+                    String::from(parsed_error.message),
+                ),
+                "SubscriptionCategoryNotFound" => {
                     ModifyEventSubscriptionError::SubscriptionCategoryNotFoundFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "SubscriptionNotFoundFault" => {
-                    ModifyEventSubscriptionError::SubscriptionNotFoundFault(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "SubscriptionNotFound" => ModifyEventSubscriptionError::SubscriptionNotFoundFault(
+                    String::from(parsed_error.message),
+                ),
                 _ => ModifyEventSubscriptionError::Unknown(String::from(body)),
             },
             Err(_) => ModifyEventSubscriptionError::Unknown(body.to_string()),
@@ -24935,14 +24881,12 @@ impl PromoteReadReplicaError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "DBInstanceNotFoundFault" => PromoteReadReplicaError::DBInstanceNotFoundFault(
+                "DBInstanceNotFound" => PromoteReadReplicaError::DBInstanceNotFoundFault(
                     String::from(parsed_error.message),
                 ),
-                "InvalidDBInstanceStateFault" => {
-                    PromoteReadReplicaError::InvalidDBInstanceStateFault(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "InvalidDBInstanceState" => PromoteReadReplicaError::InvalidDBInstanceStateFault(
+                    String::from(parsed_error.message),
+                ),
                 _ => PromoteReadReplicaError::Unknown(String::from(body)),
             },
             Err(_) => PromoteReadReplicaError::Unknown(body.to_string()),
@@ -25114,7 +25058,7 @@ impl PurchaseReservedDBInstancesOfferingError {
         match Self::deserialize(&mut stack) {
                             Ok(parsed_error) => {
                                 match &parsed_error.code[..] {
-                                    "ReservedDBInstanceAlreadyExistsFault" => PurchaseReservedDBInstancesOfferingError::ReservedDBInstanceAlreadyExistsFault(String::from(parsed_error.message)),"ReservedDBInstanceQuotaExceededFault" => PurchaseReservedDBInstancesOfferingError::ReservedDBInstanceQuotaExceededFault(String::from(parsed_error.message)),"ReservedDBInstancesOfferingNotFoundFault" => PurchaseReservedDBInstancesOfferingError::ReservedDBInstancesOfferingNotFoundFault(String::from(parsed_error.message)),_ => PurchaseReservedDBInstancesOfferingError::Unknown(String::from(body))
+                                    "ReservedDBInstanceAlreadyExists" => PurchaseReservedDBInstancesOfferingError::ReservedDBInstanceAlreadyExistsFault(String::from(parsed_error.message)),"ReservedDBInstanceQuotaExceeded" => PurchaseReservedDBInstancesOfferingError::ReservedDBInstanceQuotaExceededFault(String::from(parsed_error.message)),"ReservedDBInstancesOfferingNotFound" => PurchaseReservedDBInstancesOfferingError::ReservedDBInstancesOfferingNotFoundFault(String::from(parsed_error.message)),_ => PurchaseReservedDBInstancesOfferingError::Unknown(String::from(body))
                                 }
                            },
                            Err(_) => PurchaseReservedDBInstancesOfferingError::Unknown(body.to_string())
@@ -25193,14 +25137,12 @@ impl RebootDBInstanceError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "DBInstanceNotFoundFault" => RebootDBInstanceError::DBInstanceNotFoundFault(
+                "DBInstanceNotFound" => RebootDBInstanceError::DBInstanceNotFoundFault(
                     String::from(parsed_error.message),
                 ),
-                "InvalidDBInstanceStateFault" => {
-                    RebootDBInstanceError::InvalidDBInstanceStateFault(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "InvalidDBInstanceState" => RebootDBInstanceError::InvalidDBInstanceStateFault(
+                    String::from(parsed_error.message),
+                ),
                 _ => RebootDBInstanceError::Unknown(String::from(body)),
             },
             Err(_) => RebootDBInstanceError::Unknown(body.to_string()),
@@ -25283,7 +25225,7 @@ impl RemoveRoleFromDBClusterError {
                 "DBClusterNotFoundFault" => RemoveRoleFromDBClusterError::DBClusterNotFoundFault(
                     String::from(parsed_error.message),
                 ),
-                "DBClusterRoleNotFoundFault" => {
+                "DBClusterRoleNotFound" => {
                     RemoveRoleFromDBClusterError::DBClusterRoleNotFoundFault(String::from(
                         parsed_error.message,
                     ))
@@ -25373,12 +25315,12 @@ impl RemoveSourceIdentifierFromSubscriptionError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "SourceNotFoundFault" => {
+                "SourceNotFound" => {
                     RemoveSourceIdentifierFromSubscriptionError::SourceNotFoundFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "SubscriptionNotFoundFault" => {
+                "SubscriptionNotFound" => {
                     RemoveSourceIdentifierFromSubscriptionError::SubscriptionNotFoundFault(
                         String::from(parsed_error.message),
                     )
@@ -25469,10 +25411,10 @@ impl RemoveTagsFromResourceError {
                 "DBClusterNotFoundFault" => RemoveTagsFromResourceError::DBClusterNotFoundFault(
                     String::from(parsed_error.message),
                 ),
-                "DBInstanceNotFoundFault" => RemoveTagsFromResourceError::DBInstanceNotFoundFault(
+                "DBInstanceNotFound" => RemoveTagsFromResourceError::DBInstanceNotFoundFault(
                     String::from(parsed_error.message),
                 ),
-                "DBSnapshotNotFoundFault" => RemoveTagsFromResourceError::DBSnapshotNotFoundFault(
+                "DBSnapshotNotFound" => RemoveTagsFromResourceError::DBSnapshotNotFoundFault(
                     String::from(parsed_error.message),
                 ),
                 _ => RemoveTagsFromResourceError::Unknown(String::from(body)),
@@ -25555,12 +25497,12 @@ impl ResetDBClusterParameterGroupError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "DBParameterGroupNotFoundFault" => {
+                "DBParameterGroupNotFound" => {
                     ResetDBClusterParameterGroupError::DBParameterGroupNotFoundFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InvalidDBParameterGroupStateFault" => {
+                "InvalidDBParameterGroupState" => {
                     ResetDBClusterParameterGroupError::InvalidDBParameterGroupStateFault(
                         String::from(parsed_error.message),
                     )
@@ -25646,12 +25588,12 @@ impl ResetDBParameterGroupError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "DBParameterGroupNotFoundFault" => {
+                "DBParameterGroupNotFound" => {
                     ResetDBParameterGroupError::DBParameterGroupNotFoundFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InvalidDBParameterGroupStateFault" => {
+                "InvalidDBParameterGroupState" => {
                     ResetDBParameterGroupError::InvalidDBParameterGroupStateFault(String::from(
                         parsed_error.message,
                     ))
@@ -25765,7 +25707,7 @@ impl RestoreDBClusterFromS3Error {
                 "DBClusterNotFoundFault" => RestoreDBClusterFromS3Error::DBClusterNotFoundFault(
                     String::from(parsed_error.message),
                 ),
-                "DBClusterParameterGroupNotFoundFault" => {
+                "DBClusterParameterGroupNotFound" => {
                     RestoreDBClusterFromS3Error::DBClusterParameterGroupNotFoundFault(
                         String::from(parsed_error.message),
                     )
@@ -25780,7 +25722,7 @@ impl RestoreDBClusterFromS3Error {
                         parsed_error.message,
                     ))
                 }
-                "InsufficientStorageClusterCapacityFault" => {
+                "InsufficientStorageClusterCapacity" => {
                     RestoreDBClusterFromS3Error::InsufficientStorageClusterCapacityFault(
                         String::from(parsed_error.message),
                     )
@@ -25811,11 +25753,9 @@ impl RestoreDBClusterFromS3Error {
                         parsed_error.message,
                     ))
                 }
-                "StorageQuotaExceededFault" => {
-                    RestoreDBClusterFromS3Error::StorageQuotaExceededFault(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "StorageQuotaExceeded" => RestoreDBClusterFromS3Error::StorageQuotaExceededFault(
+                    String::from(parsed_error.message),
+                ),
                 _ => RestoreDBClusterFromS3Error::Unknown(String::from(body)),
             },
             Err(_) => RestoreDBClusterFromS3Error::Unknown(body.to_string()),
@@ -25949,7 +25889,7 @@ impl RestoreDBClusterFromSnapshotError {
                         String::from(parsed_error.message),
                     )
                 }
-                "DBSnapshotNotFoundFault" => {
+                "DBSnapshotNotFound" => {
                     RestoreDBClusterFromSnapshotError::DBSnapshotNotFoundFault(String::from(
                         parsed_error.message,
                     ))
@@ -25964,7 +25904,7 @@ impl RestoreDBClusterFromSnapshotError {
                         String::from(parsed_error.message),
                     )
                 }
-                "InsufficientStorageClusterCapacityFault" => {
+                "InsufficientStorageClusterCapacity" => {
                     RestoreDBClusterFromSnapshotError::InsufficientStorageClusterCapacityFault(
                         String::from(parsed_error.message),
                     )
@@ -25974,7 +25914,7 @@ impl RestoreDBClusterFromSnapshotError {
                         String::from(parsed_error.message),
                     )
                 }
-                "InvalidDBSnapshotStateFault" => {
+                "InvalidDBSnapshotState" => {
                     RestoreDBClusterFromSnapshotError::InvalidDBSnapshotStateFault(String::from(
                         parsed_error.message,
                     ))
@@ -26000,7 +25940,7 @@ impl RestoreDBClusterFromSnapshotError {
                         parsed_error.message,
                     ))
                 }
-                "StorageQuotaExceededFault" => {
+                "StorageQuotaExceeded" => {
                     RestoreDBClusterFromSnapshotError::StorageQuotaExceededFault(String::from(
                         parsed_error.message,
                     ))
@@ -26161,7 +26101,7 @@ impl RestoreDBClusterToPointInTimeError {
                         String::from(parsed_error.message),
                     )
                 }
-                "InsufficientStorageClusterCapacityFault" => {
+                "InsufficientStorageClusterCapacity" => {
                     RestoreDBClusterToPointInTimeError::InsufficientStorageClusterCapacityFault(
                         String::from(parsed_error.message),
                     )
@@ -26176,7 +26116,7 @@ impl RestoreDBClusterToPointInTimeError {
                         parsed_error.message,
                     ))
                 }
-                "InvalidDBSnapshotStateFault" => {
+                "InvalidDBSnapshotState" => {
                     RestoreDBClusterToPointInTimeError::InvalidDBSnapshotStateFault(String::from(
                         parsed_error.message,
                     ))
@@ -26202,7 +26142,7 @@ impl RestoreDBClusterToPointInTimeError {
                         parsed_error.message,
                     ))
                 }
-                "StorageQuotaExceededFault" => {
+                "StorageQuotaExceeded" => {
                     RestoreDBClusterToPointInTimeError::StorageQuotaExceededFault(String::from(
                         parsed_error.message,
                     ))
@@ -26338,22 +26278,22 @@ impl RestoreDBInstanceFromDBSnapshotError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AuthorizationNotFoundFault" => {
+                "AuthorizationNotFound" => {
                     RestoreDBInstanceFromDBSnapshotError::AuthorizationNotFoundFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "DBInstanceAlreadyExistsFault" => {
+                "DBInstanceAlreadyExists" => {
                     RestoreDBInstanceFromDBSnapshotError::DBInstanceAlreadyExistsFault(
                         String::from(parsed_error.message),
                     )
                 }
-                "DBSecurityGroupNotFoundFault" => {
+                "DBSecurityGroupNotFound" => {
                     RestoreDBInstanceFromDBSnapshotError::DBSecurityGroupNotFoundFault(
                         String::from(parsed_error.message),
                     )
                 }
-                "DBSnapshotNotFoundFault" => {
+                "DBSnapshotNotFound" => {
                     RestoreDBInstanceFromDBSnapshotError::DBSnapshotNotFoundFault(String::from(
                         parsed_error.message,
                     ))
@@ -26373,17 +26313,17 @@ impl RestoreDBInstanceFromDBSnapshotError {
                         parsed_error.message,
                     ))
                 }
-                "InstanceQuotaExceededFault" => {
+                "InstanceQuotaExceeded" => {
                     RestoreDBInstanceFromDBSnapshotError::InstanceQuotaExceededFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InsufficientDBInstanceCapacityFault" => {
+                "InsufficientDBInstanceCapacity" => {
                     RestoreDBInstanceFromDBSnapshotError::InsufficientDBInstanceCapacityFault(
                         String::from(parsed_error.message),
                     )
                 }
-                "InvalidDBSnapshotStateFault" => {
+                "InvalidDBSnapshotState" => {
                     RestoreDBInstanceFromDBSnapshotError::InvalidDBSnapshotStateFault(
                         String::from(parsed_error.message),
                     )
@@ -26416,12 +26356,12 @@ impl RestoreDBInstanceFromDBSnapshotError {
                         String::from(parsed_error.message),
                     )
                 }
-                "StorageQuotaExceededFault" => {
+                "StorageQuotaExceeded" => {
                     RestoreDBInstanceFromDBSnapshotError::StorageQuotaExceededFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "StorageTypeNotSupportedFault" => {
+                "StorageTypeNotSupported" => {
                     RestoreDBInstanceFromDBSnapshotError::StorageTypeNotSupportedFault(
                         String::from(parsed_error.message),
                     )
@@ -26555,22 +26495,22 @@ impl RestoreDBInstanceFromS3Error {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AuthorizationNotFoundFault" => {
+                "AuthorizationNotFound" => {
                     RestoreDBInstanceFromS3Error::AuthorizationNotFoundFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "DBInstanceAlreadyExistsFault" => {
+                "DBInstanceAlreadyExists" => {
                     RestoreDBInstanceFromS3Error::DBInstanceAlreadyExistsFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "DBParameterGroupNotFoundFault" => {
+                "DBParameterGroupNotFound" => {
                     RestoreDBInstanceFromS3Error::DBParameterGroupNotFoundFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "DBSecurityGroupNotFoundFault" => {
+                "DBSecurityGroupNotFound" => {
                     RestoreDBInstanceFromS3Error::DBSecurityGroupNotFoundFault(String::from(
                         parsed_error.message,
                     ))
@@ -26585,12 +26525,12 @@ impl RestoreDBInstanceFromS3Error {
                         parsed_error.message,
                     ))
                 }
-                "InstanceQuotaExceededFault" => {
+                "InstanceQuotaExceeded" => {
                     RestoreDBInstanceFromS3Error::InstanceQuotaExceededFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InsufficientDBInstanceCapacityFault" => {
+                "InsufficientDBInstanceCapacity" => {
                     RestoreDBInstanceFromS3Error::InsufficientDBInstanceCapacityFault(
                         String::from(parsed_error.message),
                     )
@@ -26621,12 +26561,10 @@ impl RestoreDBInstanceFromS3Error {
                         String::from(parsed_error.message),
                     )
                 }
-                "StorageQuotaExceededFault" => {
-                    RestoreDBInstanceFromS3Error::StorageQuotaExceededFault(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "StorageTypeNotSupportedFault" => {
+                "StorageQuotaExceeded" => RestoreDBInstanceFromS3Error::StorageQuotaExceededFault(
+                    String::from(parsed_error.message),
+                ),
+                "StorageTypeNotSupported" => {
                     RestoreDBInstanceFromS3Error::StorageTypeNotSupportedFault(String::from(
                         parsed_error.message,
                     ))
@@ -26758,22 +26696,22 @@ impl RestoreDBInstanceToPointInTimeError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AuthorizationNotFoundFault" => {
+                "AuthorizationNotFound" => {
                     RestoreDBInstanceToPointInTimeError::AuthorizationNotFoundFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "DBInstanceAlreadyExistsFault" => {
+                "DBInstanceAlreadyExists" => {
                     RestoreDBInstanceToPointInTimeError::DBInstanceAlreadyExistsFault(
                         String::from(parsed_error.message),
                     )
                 }
-                "DBInstanceNotFoundFault" => {
+                "DBInstanceNotFound" => {
                     RestoreDBInstanceToPointInTimeError::DBInstanceNotFoundFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "DBSecurityGroupNotFoundFault" => {
+                "DBSecurityGroupNotFound" => {
                     RestoreDBInstanceToPointInTimeError::DBSecurityGroupNotFoundFault(
                         String::from(parsed_error.message),
                     )
@@ -26791,17 +26729,17 @@ impl RestoreDBInstanceToPointInTimeError {
                 "DomainNotFoundFault" => RestoreDBInstanceToPointInTimeError::DomainNotFoundFault(
                     String::from(parsed_error.message),
                 ),
-                "InstanceQuotaExceededFault" => {
+                "InstanceQuotaExceeded" => {
                     RestoreDBInstanceToPointInTimeError::InstanceQuotaExceededFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InsufficientDBInstanceCapacityFault" => {
+                "InsufficientDBInstanceCapacity" => {
                     RestoreDBInstanceToPointInTimeError::InsufficientDBInstanceCapacityFault(
                         String::from(parsed_error.message),
                     )
                 }
-                "InvalidDBInstanceStateFault" => {
+                "InvalidDBInstanceState" => {
                     RestoreDBInstanceToPointInTimeError::InvalidDBInstanceStateFault(String::from(
                         parsed_error.message,
                     ))
@@ -26827,7 +26765,7 @@ impl RestoreDBInstanceToPointInTimeError {
                         parsed_error.message,
                     ))
                 }
-                "PointInTimeRestoreNotEnabledFault" => {
+                "PointInTimeRestoreNotEnabled" => {
                     RestoreDBInstanceToPointInTimeError::PointInTimeRestoreNotEnabledFault(
                         String::from(parsed_error.message),
                     )
@@ -26837,12 +26775,12 @@ impl RestoreDBInstanceToPointInTimeError {
                         String::from(parsed_error.message),
                     )
                 }
-                "StorageQuotaExceededFault" => {
+                "StorageQuotaExceeded" => {
                     RestoreDBInstanceToPointInTimeError::StorageQuotaExceededFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "StorageTypeNotSupportedFault" => {
+                "StorageTypeNotSupported" => {
                     RestoreDBInstanceToPointInTimeError::StorageTypeNotSupportedFault(
                         String::from(parsed_error.message),
                     )
@@ -26953,17 +26891,17 @@ impl RevokeDBSecurityGroupIngressError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AuthorizationNotFoundFault" => {
+                "AuthorizationNotFound" => {
                     RevokeDBSecurityGroupIngressError::AuthorizationNotFoundFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "DBSecurityGroupNotFoundFault" => {
+                "DBSecurityGroupNotFound" => {
                     RevokeDBSecurityGroupIngressError::DBSecurityGroupNotFoundFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InvalidDBSecurityGroupStateFault" => {
+                "InvalidDBSecurityGroupState" => {
                     RevokeDBSecurityGroupIngressError::InvalidDBSecurityGroupStateFault(
                         String::from(parsed_error.message),
                     )
@@ -27066,13 +27004,13 @@ impl StartDBInstanceError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AuthorizationNotFoundFault" => StartDBInstanceError::AuthorizationNotFoundFault(
+                "AuthorizationNotFound" => StartDBInstanceError::AuthorizationNotFoundFault(
                     String::from(parsed_error.message),
                 ),
                 "DBClusterNotFoundFault" => {
                     StartDBInstanceError::DBClusterNotFoundFault(String::from(parsed_error.message))
                 }
-                "DBInstanceNotFoundFault" => StartDBInstanceError::DBInstanceNotFoundFault(
+                "DBInstanceNotFound" => StartDBInstanceError::DBInstanceNotFoundFault(
                     String::from(parsed_error.message),
                 ),
                 "DBSubnetGroupDoesNotCoverEnoughAZs" => {
@@ -27083,7 +27021,7 @@ impl StartDBInstanceError {
                 "DBSubnetGroupNotFoundFault" => StartDBInstanceError::DBSubnetGroupNotFoundFault(
                     String::from(parsed_error.message),
                 ),
-                "InsufficientDBInstanceCapacityFault" => {
+                "InsufficientDBInstanceCapacity" => {
                     StartDBInstanceError::InsufficientDBInstanceCapacityFault(String::from(
                         parsed_error.message,
                     ))
@@ -27091,11 +27029,9 @@ impl StartDBInstanceError {
                 "InvalidDBClusterStateFault" => StartDBInstanceError::InvalidDBClusterStateFault(
                     String::from(parsed_error.message),
                 ),
-                "InvalidDBInstanceStateFault" => {
-                    StartDBInstanceError::InvalidDBInstanceStateFault(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "InvalidDBInstanceState" => StartDBInstanceError::InvalidDBInstanceStateFault(
+                    String::from(parsed_error.message),
+                ),
                 "InvalidSubnet" => {
                     StartDBInstanceError::InvalidSubnet(String::from(parsed_error.message))
                 }
@@ -27199,21 +27135,19 @@ impl StopDBInstanceError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "DBInstanceNotFoundFault" => {
+                "DBInstanceNotFound" => {
                     StopDBInstanceError::DBInstanceNotFoundFault(String::from(parsed_error.message))
                 }
-                "DBSnapshotAlreadyExistsFault" => {
-                    StopDBInstanceError::DBSnapshotAlreadyExistsFault(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "DBSnapshotAlreadyExists" => StopDBInstanceError::DBSnapshotAlreadyExistsFault(
+                    String::from(parsed_error.message),
+                ),
                 "InvalidDBClusterStateFault" => StopDBInstanceError::InvalidDBClusterStateFault(
                     String::from(parsed_error.message),
                 ),
-                "InvalidDBInstanceStateFault" => StopDBInstanceError::InvalidDBInstanceStateFault(
+                "InvalidDBInstanceState" => StopDBInstanceError::InvalidDBInstanceStateFault(
                     String::from(parsed_error.message),
                 ),
-                "SnapshotQuotaExceededFault" => StopDBInstanceError::SnapshotQuotaExceededFault(
+                "SnapshotQuotaExceeded" => StopDBInstanceError::SnapshotQuotaExceededFault(
                     String::from(parsed_error.message),
                 ),
                 _ => StopDBInstanceError::Unknown(String::from(body)),

--- a/rusoto/services/rds/src/generated.rs
+++ b/rusoto/services/rds/src/generated.rs
@@ -17961,7 +17961,7 @@ impl AddRoleToDBClusterError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBClusterNotFoundFault" => AddRoleToDBClusterError::DBClusterNotFoundFault(
                     String::from(parsed_error.message),
@@ -17985,6 +17985,14 @@ impl AddRoleToDBClusterError {
             },
             Err(_) => AddRoleToDBClusterError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -18052,7 +18060,7 @@ impl AddSourceIdentifierToSubscriptionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "SourceNotFoundFault" => {
                     AddSourceIdentifierToSubscriptionError::SourceNotFoundFault(String::from(
@@ -18068,6 +18076,14 @@ impl AddSourceIdentifierToSubscriptionError {
             },
             Err(_) => AddSourceIdentifierToSubscriptionError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -18135,7 +18151,7 @@ impl AddTagsToResourceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBClusterNotFoundFault" => AddTagsToResourceError::DBClusterNotFoundFault(
                     String::from(parsed_error.message),
@@ -18150,6 +18166,14 @@ impl AddTagsToResourceError {
             },
             Err(_) => AddTagsToResourceError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -18214,7 +18238,7 @@ impl ApplyPendingMaintenanceActionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceNotFoundFault" => {
                     ApplyPendingMaintenanceActionError::ResourceNotFoundFault(String::from(
@@ -18225,6 +18249,14 @@ impl ApplyPendingMaintenanceActionError {
             },
             Err(_) => ApplyPendingMaintenanceActionError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -18293,7 +18325,7 @@ impl AuthorizeDBSecurityGroupIngressError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationAlreadyExistsFault" => {
                     AuthorizeDBSecurityGroupIngressError::AuthorizationAlreadyExistsFault(
@@ -18319,6 +18351,14 @@ impl AuthorizeDBSecurityGroupIngressError {
             },
             Err(_) => AuthorizeDBSecurityGroupIngressError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -18394,7 +18434,7 @@ impl CopyDBClusterParameterGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBParameterGroupAlreadyExistsFault" => {
                     CopyDBClusterParameterGroupError::DBParameterGroupAlreadyExistsFault(
@@ -18415,6 +18455,14 @@ impl CopyDBClusterParameterGroupError {
             },
             Err(_) => CopyDBClusterParameterGroupError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -18493,7 +18541,7 @@ impl CopyDBClusterSnapshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBClusterSnapshotAlreadyExistsFault" => {
                     CopyDBClusterSnapshotError::DBClusterSnapshotAlreadyExistsFault(String::from(
@@ -18529,6 +18577,14 @@ impl CopyDBClusterSnapshotError {
             },
             Err(_) => CopyDBClusterSnapshotError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -18600,7 +18656,7 @@ impl CopyDBParameterGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBParameterGroupAlreadyExistsFault" => {
                     CopyDBParameterGroupError::DBParameterGroupAlreadyExistsFault(String::from(
@@ -18621,6 +18677,14 @@ impl CopyDBParameterGroupError {
             },
             Err(_) => CopyDBParameterGroupError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -18693,7 +18757,7 @@ impl CopyDBSnapshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBSnapshotAlreadyExistsFault" => {
                     CopyDBSnapshotError::DBSnapshotAlreadyExistsFault(String::from(
@@ -18716,6 +18780,14 @@ impl CopyDBSnapshotError {
             },
             Err(_) => CopyDBSnapshotError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -18784,7 +18856,7 @@ impl CopyOptionGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "OptionGroupAlreadyExistsFault" => {
                     CopyOptionGroupError::OptionGroupAlreadyExistsFault(String::from(
@@ -18803,6 +18875,14 @@ impl CopyOptionGroupError {
             },
             Err(_) => CopyOptionGroupError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -18893,7 +18973,7 @@ impl CreateDBClusterError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBClusterAlreadyExistsFault" => {
                     CreateDBClusterError::DBClusterAlreadyExistsFault(String::from(
@@ -18960,6 +19040,14 @@ impl CreateDBClusterError {
             },
             Err(_) => CreateDBClusterError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -19036,7 +19124,7 @@ impl CreateDBClusterParameterGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBParameterGroupAlreadyExistsFault" => {
                     CreateDBClusterParameterGroupError::DBParameterGroupAlreadyExistsFault(
@@ -19052,6 +19140,14 @@ impl CreateDBClusterParameterGroupError {
             },
             Err(_) => CreateDBClusterParameterGroupError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -19127,7 +19223,7 @@ impl CreateDBClusterSnapshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBClusterNotFoundFault" => CreateDBClusterSnapshotError::DBClusterNotFoundFault(
                     String::from(parsed_error.message),
@@ -19156,6 +19252,14 @@ impl CreateDBClusterSnapshotError {
             },
             Err(_) => CreateDBClusterSnapshotError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -19256,7 +19360,7 @@ impl CreateDBInstanceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationNotFoundFault" => CreateDBInstanceError::AuthorizationNotFoundFault(
                     String::from(parsed_error.message),
@@ -19332,6 +19436,14 @@ impl CreateDBInstanceError {
             },
             Err(_) => CreateDBInstanceError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -19443,7 +19555,7 @@ impl CreateDBInstanceReadReplicaError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBInstanceAlreadyExistsFault" => {
                     CreateDBInstanceReadReplicaError::DBInstanceAlreadyExistsFault(String::from(
@@ -19538,6 +19650,14 @@ impl CreateDBInstanceReadReplicaError {
             Err(_) => CreateDBInstanceReadReplicaError::Unknown(body.to_string()),
         }
     }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
+    }
 }
 
 impl From<XmlParseError> for CreateDBInstanceReadReplicaError {
@@ -19624,7 +19744,7 @@ impl CreateDBParameterGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBParameterGroupAlreadyExistsFault" => {
                     CreateDBParameterGroupError::DBParameterGroupAlreadyExistsFault(String::from(
@@ -19640,6 +19760,14 @@ impl CreateDBParameterGroupError {
             },
             Err(_) => CreateDBParameterGroupError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -19707,7 +19835,7 @@ impl CreateDBSecurityGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBSecurityGroupAlreadyExistsFault" => {
                     CreateDBSecurityGroupError::DBSecurityGroupAlreadyExistsFault(String::from(
@@ -19728,6 +19856,14 @@ impl CreateDBSecurityGroupError {
             },
             Err(_) => CreateDBSecurityGroupError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -19798,7 +19934,7 @@ impl CreateDBSnapshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBInstanceNotFoundFault" => CreateDBSnapshotError::DBInstanceNotFoundFault(
                     String::from(parsed_error.message),
@@ -19820,6 +19956,14 @@ impl CreateDBSnapshotError {
             },
             Err(_) => CreateDBSnapshotError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -19891,7 +20035,7 @@ impl CreateDBSubnetGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBSubnetGroupAlreadyExistsFault" => {
                     CreateDBSubnetGroupError::DBSubnetGroupAlreadyExistsFault(String::from(
@@ -19920,6 +20064,14 @@ impl CreateDBSubnetGroupError {
             },
             Err(_) => CreateDBSubnetGroupError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -19998,7 +20150,7 @@ impl CreateEventSubscriptionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "EventSubscriptionQuotaExceededFault" => {
                     CreateEventSubscriptionError::EventSubscriptionQuotaExceededFault(
@@ -20035,6 +20187,14 @@ impl CreateEventSubscriptionError {
             },
             Err(_) => CreateEventSubscriptionError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -20105,7 +20265,7 @@ impl CreateOptionGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "OptionGroupAlreadyExistsFault" => {
                     CreateOptionGroupError::OptionGroupAlreadyExistsFault(String::from(
@@ -20121,6 +20281,14 @@ impl CreateOptionGroupError {
             },
             Err(_) => CreateOptionGroupError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -20192,7 +20360,7 @@ impl DeleteDBClusterError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBClusterNotFoundFault" => {
                     DeleteDBClusterError::DBClusterNotFoundFault(String::from(parsed_error.message))
@@ -20217,6 +20385,14 @@ impl DeleteDBClusterError {
             },
             Err(_) => DeleteDBClusterError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -20283,7 +20459,7 @@ impl DeleteDBClusterParameterGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBParameterGroupNotFoundFault" => {
                     DeleteDBClusterParameterGroupError::DBParameterGroupNotFoundFault(
@@ -20299,6 +20475,14 @@ impl DeleteDBClusterParameterGroupError {
             },
             Err(_) => DeleteDBClusterParameterGroupError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -20366,7 +20550,7 @@ impl DeleteDBClusterSnapshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBClusterSnapshotNotFoundFault" => {
                     DeleteDBClusterSnapshotError::DBClusterSnapshotNotFoundFault(String::from(
@@ -20382,6 +20566,14 @@ impl DeleteDBClusterSnapshotError {
             },
             Err(_) => DeleteDBClusterSnapshotError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -20453,7 +20645,7 @@ impl DeleteDBInstanceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBInstanceNotFoundFault" => DeleteDBInstanceError::DBInstanceNotFoundFault(
                     String::from(parsed_error.message),
@@ -20478,6 +20670,14 @@ impl DeleteDBInstanceError {
             },
             Err(_) => DeleteDBInstanceError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -20544,7 +20744,7 @@ impl DeleteDBParameterGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBParameterGroupNotFoundFault" => {
                     DeleteDBParameterGroupError::DBParameterGroupNotFoundFault(String::from(
@@ -20560,6 +20760,14 @@ impl DeleteDBParameterGroupError {
             },
             Err(_) => DeleteDBParameterGroupError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -20625,7 +20833,7 @@ impl DeleteDBSecurityGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBSecurityGroupNotFoundFault" => {
                     DeleteDBSecurityGroupError::DBSecurityGroupNotFoundFault(String::from(
@@ -20641,6 +20849,14 @@ impl DeleteDBSecurityGroupError {
             },
             Err(_) => DeleteDBSecurityGroupError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -20706,7 +20922,7 @@ impl DeleteDBSnapshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBSnapshotNotFoundFault" => DeleteDBSnapshotError::DBSnapshotNotFoundFault(
                     String::from(parsed_error.message),
@@ -20720,6 +20936,14 @@ impl DeleteDBSnapshotError {
             },
             Err(_) => DeleteDBSnapshotError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -20785,7 +21009,7 @@ impl DeleteDBSubnetGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBSubnetGroupNotFoundFault" => {
                     DeleteDBSubnetGroupError::DBSubnetGroupNotFoundFault(String::from(
@@ -20806,6 +21030,14 @@ impl DeleteDBSubnetGroupError {
             },
             Err(_) => DeleteDBSubnetGroupError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -20872,7 +21104,7 @@ impl DeleteEventSubscriptionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidEventSubscriptionStateFault" => {
                     DeleteEventSubscriptionError::InvalidEventSubscriptionStateFault(String::from(
@@ -20888,6 +21120,14 @@ impl DeleteEventSubscriptionError {
             },
             Err(_) => DeleteEventSubscriptionError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -20953,7 +21193,7 @@ impl DeleteOptionGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidOptionGroupStateFault" => {
                     DeleteOptionGroupError::InvalidOptionGroupStateFault(String::from(
@@ -20967,6 +21207,14 @@ impl DeleteOptionGroupError {
             },
             Err(_) => DeleteOptionGroupError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -21028,12 +21276,20 @@ impl DescribeAccountAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeAccountAttributesError::Unknown(String::from(body)),
             },
             Err(_) => DescribeAccountAttributesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -21095,7 +21351,7 @@ impl DescribeCertificatesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CertificateNotFoundFault" => DescribeCertificatesError::CertificateNotFoundFault(
                     String::from(parsed_error.message),
@@ -21104,6 +21360,14 @@ impl DescribeCertificatesError {
             },
             Err(_) => DescribeCertificatesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -21166,7 +21430,7 @@ impl DescribeDBClusterParameterGroupsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBParameterGroupNotFoundFault" => {
                     DescribeDBClusterParameterGroupsError::DBParameterGroupNotFoundFault(
@@ -21177,6 +21441,14 @@ impl DescribeDBClusterParameterGroupsError {
             },
             Err(_) => DescribeDBClusterParameterGroupsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -21241,7 +21513,7 @@ impl DescribeDBClusterParametersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBParameterGroupNotFoundFault" => {
                     DescribeDBClusterParametersError::DBParameterGroupNotFoundFault(String::from(
@@ -21252,6 +21524,14 @@ impl DescribeDBClusterParametersError {
             },
             Err(_) => DescribeDBClusterParametersError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -21314,7 +21594,7 @@ impl DescribeDBClusterSnapshotAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBClusterSnapshotNotFoundFault" => {
                     DescribeDBClusterSnapshotAttributesError::DBClusterSnapshotNotFoundFault(
@@ -21325,6 +21605,14 @@ impl DescribeDBClusterSnapshotAttributesError {
             },
             Err(_) => DescribeDBClusterSnapshotAttributesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -21389,7 +21677,7 @@ impl DescribeDBClusterSnapshotsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBClusterSnapshotNotFoundFault" => {
                     DescribeDBClusterSnapshotsError::DBClusterSnapshotNotFoundFault(String::from(
@@ -21400,6 +21688,14 @@ impl DescribeDBClusterSnapshotsError {
             },
             Err(_) => DescribeDBClusterSnapshotsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -21462,7 +21758,7 @@ impl DescribeDBClustersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBClusterNotFoundFault" => DescribeDBClustersError::DBClusterNotFoundFault(
                     String::from(parsed_error.message),
@@ -21471,6 +21767,14 @@ impl DescribeDBClustersError {
             },
             Err(_) => DescribeDBClustersError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -21531,12 +21835,20 @@ impl DescribeDBEngineVersionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeDBEngineVersionsError::Unknown(String::from(body)),
             },
             Err(_) => DescribeDBEngineVersionsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -21598,7 +21910,7 @@ impl DescribeDBInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBInstanceNotFoundFault" => DescribeDBInstancesError::DBInstanceNotFoundFault(
                     String::from(parsed_error.message),
@@ -21607,6 +21919,14 @@ impl DescribeDBInstancesError {
             },
             Err(_) => DescribeDBInstancesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -21669,7 +21989,7 @@ impl DescribeDBLogFilesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBInstanceNotFoundFault" => DescribeDBLogFilesError::DBInstanceNotFoundFault(
                     String::from(parsed_error.message),
@@ -21678,6 +21998,14 @@ impl DescribeDBLogFilesError {
             },
             Err(_) => DescribeDBLogFilesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -21740,7 +22068,7 @@ impl DescribeDBParameterGroupsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBParameterGroupNotFoundFault" => {
                     DescribeDBParameterGroupsError::DBParameterGroupNotFoundFault(String::from(
@@ -21751,6 +22079,14 @@ impl DescribeDBParameterGroupsError {
             },
             Err(_) => DescribeDBParameterGroupsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -21813,7 +22149,7 @@ impl DescribeDBParametersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBParameterGroupNotFoundFault" => {
                     DescribeDBParametersError::DBParameterGroupNotFoundFault(String::from(
@@ -21824,6 +22160,14 @@ impl DescribeDBParametersError {
             },
             Err(_) => DescribeDBParametersError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -21886,7 +22230,7 @@ impl DescribeDBSecurityGroupsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBSecurityGroupNotFoundFault" => {
                     DescribeDBSecurityGroupsError::DBSecurityGroupNotFoundFault(String::from(
@@ -21897,6 +22241,14 @@ impl DescribeDBSecurityGroupsError {
             },
             Err(_) => DescribeDBSecurityGroupsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -21959,7 +22311,7 @@ impl DescribeDBSnapshotAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBSnapshotNotFoundFault" => {
                     DescribeDBSnapshotAttributesError::DBSnapshotNotFoundFault(String::from(
@@ -21970,6 +22322,14 @@ impl DescribeDBSnapshotAttributesError {
             },
             Err(_) => DescribeDBSnapshotAttributesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -22032,7 +22392,7 @@ impl DescribeDBSnapshotsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBSnapshotNotFoundFault" => DescribeDBSnapshotsError::DBSnapshotNotFoundFault(
                     String::from(parsed_error.message),
@@ -22041,6 +22401,14 @@ impl DescribeDBSnapshotsError {
             },
             Err(_) => DescribeDBSnapshotsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -22103,7 +22471,7 @@ impl DescribeDBSubnetGroupsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBSubnetGroupNotFoundFault" => {
                     DescribeDBSubnetGroupsError::DBSubnetGroupNotFoundFault(String::from(
@@ -22114,6 +22482,14 @@ impl DescribeDBSubnetGroupsError {
             },
             Err(_) => DescribeDBSubnetGroupsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -22174,12 +22550,20 @@ impl DescribeEngineDefaultClusterParametersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeEngineDefaultClusterParametersError::Unknown(String::from(body)),
             },
             Err(_) => DescribeEngineDefaultClusterParametersError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -22239,12 +22623,20 @@ impl DescribeEngineDefaultParametersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeEngineDefaultParametersError::Unknown(String::from(body)),
             },
             Err(_) => DescribeEngineDefaultParametersError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -22304,12 +22696,20 @@ impl DescribeEventCategoriesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeEventCategoriesError::Unknown(String::from(body)),
             },
             Err(_) => DescribeEventCategoriesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -22371,7 +22771,7 @@ impl DescribeEventSubscriptionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "SubscriptionNotFoundFault" => {
                     DescribeEventSubscriptionsError::SubscriptionNotFoundFault(String::from(
@@ -22382,6 +22782,14 @@ impl DescribeEventSubscriptionsError {
             },
             Err(_) => DescribeEventSubscriptionsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -22442,12 +22850,20 @@ impl DescribeEventsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeEventsError::Unknown(String::from(body)),
             },
             Err(_) => DescribeEventsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -22505,12 +22921,20 @@ impl DescribeOptionGroupOptionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeOptionGroupOptionsError::Unknown(String::from(body)),
             },
             Err(_) => DescribeOptionGroupOptionsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -22572,7 +22996,7 @@ impl DescribeOptionGroupsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "OptionGroupNotFoundFault" => DescribeOptionGroupsError::OptionGroupNotFoundFault(
                     String::from(parsed_error.message),
@@ -22581,6 +23005,14 @@ impl DescribeOptionGroupsError {
             },
             Err(_) => DescribeOptionGroupsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -22641,12 +23073,20 @@ impl DescribeOrderableDBInstanceOptionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeOrderableDBInstanceOptionsError::Unknown(String::from(body)),
             },
             Err(_) => DescribeOrderableDBInstanceOptionsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -22708,7 +23148,7 @@ impl DescribePendingMaintenanceActionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ResourceNotFoundFault" => {
                     DescribePendingMaintenanceActionsError::ResourceNotFoundFault(String::from(
@@ -22719,6 +23159,14 @@ impl DescribePendingMaintenanceActionsError {
             },
             Err(_) => DescribePendingMaintenanceActionsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -22781,7 +23229,7 @@ impl DescribeReservedDBInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ReservedDBInstanceNotFoundFault" => {
                     DescribeReservedDBInstancesError::ReservedDBInstanceNotFoundFault(
@@ -22792,6 +23240,14 @@ impl DescribeReservedDBInstancesError {
             },
             Err(_) => DescribeReservedDBInstancesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -22854,7 +23310,7 @@ impl DescribeReservedDBInstancesOfferingsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
                             Ok(parsed_error) => {
                                 match &parsed_error.code[..] {
                                     "ReservedDBInstancesOfferingNotFoundFault" => DescribeReservedDBInstancesOfferingsError::ReservedDBInstancesOfferingNotFoundFault(String::from(parsed_error.message)),_ => DescribeReservedDBInstancesOfferingsError::Unknown(String::from(body))
@@ -22862,6 +23318,14 @@ impl DescribeReservedDBInstancesOfferingsError {
                            },
                            Err(_) => DescribeReservedDBInstancesOfferingsError::Unknown(body.to_string())
                        }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -22920,12 +23384,20 @@ impl DescribeSourceRegionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeSourceRegionsError::Unknown(String::from(body)),
             },
             Err(_) => DescribeSourceRegionsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -22989,7 +23461,7 @@ impl DescribeValidDBInstanceModificationsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBInstanceNotFoundFault" => {
                     DescribeValidDBInstanceModificationsError::DBInstanceNotFoundFault(
@@ -23005,6 +23477,14 @@ impl DescribeValidDBInstanceModificationsError {
             },
             Err(_) => DescribeValidDBInstanceModificationsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -23072,7 +23552,7 @@ impl DownloadDBLogFilePortionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBInstanceNotFoundFault" => {
                     DownloadDBLogFilePortionError::DBInstanceNotFoundFault(String::from(
@@ -23086,6 +23566,14 @@ impl DownloadDBLogFilePortionError {
             },
             Err(_) => DownloadDBLogFilePortionError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -23153,7 +23641,7 @@ impl FailoverDBClusterError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBClusterNotFoundFault" => FailoverDBClusterError::DBClusterNotFoundFault(
                     String::from(parsed_error.message),
@@ -23172,6 +23660,14 @@ impl FailoverDBClusterError {
             },
             Err(_) => FailoverDBClusterError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -23240,7 +23736,7 @@ impl ListTagsForResourceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBClusterNotFoundFault" => ListTagsForResourceError::DBClusterNotFoundFault(
                     String::from(parsed_error.message),
@@ -23255,6 +23751,14 @@ impl ListTagsForResourceError {
             },
             Err(_) => ListTagsForResourceError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -23339,7 +23843,7 @@ impl ModifyDBClusterError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBClusterAlreadyExistsFault" => {
                     ModifyDBClusterError::DBClusterAlreadyExistsFault(String::from(
@@ -23390,6 +23894,14 @@ impl ModifyDBClusterError {
             },
             Err(_) => ModifyDBClusterError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -23462,7 +23974,7 @@ impl ModifyDBClusterParameterGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBParameterGroupNotFoundFault" => {
                     ModifyDBClusterParameterGroupError::DBParameterGroupNotFoundFault(
@@ -23478,6 +23990,14 @@ impl ModifyDBClusterParameterGroupError {
             },
             Err(_) => ModifyDBClusterParameterGroupError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -23547,7 +24067,7 @@ impl ModifyDBClusterSnapshotAttributeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBClusterSnapshotNotFoundFault" => {
                     ModifyDBClusterSnapshotAttributeError::DBClusterSnapshotNotFoundFault(
@@ -23568,6 +24088,14 @@ impl ModifyDBClusterSnapshotAttributeError {
             },
             Err(_) => ModifyDBClusterSnapshotAttributeError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -23668,7 +24196,7 @@ impl ModifyDBInstanceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationNotFoundFault" => ModifyDBInstanceError::AuthorizationNotFoundFault(
                     String::from(parsed_error.message),
@@ -23742,6 +24270,14 @@ impl ModifyDBInstanceError {
             },
             Err(_) => ModifyDBInstanceError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -23819,7 +24355,7 @@ impl ModifyDBParameterGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBParameterGroupNotFoundFault" => {
                     ModifyDBParameterGroupError::DBParameterGroupNotFoundFault(String::from(
@@ -23835,6 +24371,14 @@ impl ModifyDBParameterGroupError {
             },
             Err(_) => ModifyDBParameterGroupError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -23898,7 +24442,7 @@ impl ModifyDBSnapshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBSnapshotNotFoundFault" => ModifyDBSnapshotError::DBSnapshotNotFoundFault(
                     String::from(parsed_error.message),
@@ -23907,6 +24451,14 @@ impl ModifyDBSnapshotError {
             },
             Err(_) => ModifyDBSnapshotError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -23971,7 +24523,7 @@ impl ModifyDBSnapshotAttributeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBSnapshotNotFoundFault" => {
                     ModifyDBSnapshotAttributeError::DBSnapshotNotFoundFault(String::from(
@@ -23992,6 +24544,14 @@ impl ModifyDBSnapshotAttributeError {
             },
             Err(_) => ModifyDBSnapshotAttributeError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -24064,7 +24624,7 @@ impl ModifyDBSubnetGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBSubnetGroupDoesNotCoverEnoughAZs" => {
                     ModifyDBSubnetGroupError::DBSubnetGroupDoesNotCoverEnoughAZs(String::from(
@@ -24091,6 +24651,14 @@ impl ModifyDBSubnetGroupError {
             },
             Err(_) => ModifyDBSubnetGroupError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -24167,7 +24735,7 @@ impl ModifyEventSubscriptionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "EventSubscriptionQuotaExceededFault" => {
                     ModifyEventSubscriptionError::EventSubscriptionQuotaExceededFault(
@@ -24201,6 +24769,14 @@ impl ModifyEventSubscriptionError {
             },
             Err(_) => ModifyEventSubscriptionError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -24270,7 +24846,7 @@ impl ModifyOptionGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidOptionGroupStateFault" => {
                     ModifyOptionGroupError::InvalidOptionGroupStateFault(String::from(
@@ -24284,6 +24860,14 @@ impl ModifyOptionGroupError {
             },
             Err(_) => ModifyOptionGroupError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -24349,7 +24933,7 @@ impl PromoteReadReplicaError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBInstanceNotFoundFault" => PromoteReadReplicaError::DBInstanceNotFoundFault(
                     String::from(parsed_error.message),
@@ -24363,6 +24947,14 @@ impl PromoteReadReplicaError {
             },
             Err(_) => PromoteReadReplicaError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -24428,7 +25020,7 @@ impl PromoteReadReplicaDBClusterError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBClusterNotFoundFault" => {
                     PromoteReadReplicaDBClusterError::DBClusterNotFoundFault(String::from(
@@ -24444,6 +25036,14 @@ impl PromoteReadReplicaDBClusterError {
             },
             Err(_) => PromoteReadReplicaDBClusterError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -24511,7 +25111,7 @@ impl PurchaseReservedDBInstancesOfferingError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
                             Ok(parsed_error) => {
                                 match &parsed_error.code[..] {
                                     "ReservedDBInstanceAlreadyExistsFault" => PurchaseReservedDBInstancesOfferingError::ReservedDBInstanceAlreadyExistsFault(String::from(parsed_error.message)),"ReservedDBInstanceQuotaExceededFault" => PurchaseReservedDBInstancesOfferingError::ReservedDBInstanceQuotaExceededFault(String::from(parsed_error.message)),"ReservedDBInstancesOfferingNotFoundFault" => PurchaseReservedDBInstancesOfferingError::ReservedDBInstancesOfferingNotFoundFault(String::from(parsed_error.message)),_ => PurchaseReservedDBInstancesOfferingError::Unknown(String::from(body))
@@ -24519,6 +25119,14 @@ impl PurchaseReservedDBInstancesOfferingError {
                            },
                            Err(_) => PurchaseReservedDBInstancesOfferingError::Unknown(body.to_string())
                        }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -24583,7 +25191,7 @@ impl RebootDBInstanceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBInstanceNotFoundFault" => RebootDBInstanceError::DBInstanceNotFoundFault(
                     String::from(parsed_error.message),
@@ -24597,6 +25205,14 @@ impl RebootDBInstanceError {
             },
             Err(_) => RebootDBInstanceError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -24662,7 +25278,7 @@ impl RemoveRoleFromDBClusterError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBClusterNotFoundFault" => RemoveRoleFromDBClusterError::DBClusterNotFoundFault(
                     String::from(parsed_error.message),
@@ -24681,6 +25297,14 @@ impl RemoveRoleFromDBClusterError {
             },
             Err(_) => RemoveRoleFromDBClusterError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -24747,7 +25371,7 @@ impl RemoveSourceIdentifierFromSubscriptionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "SourceNotFoundFault" => {
                     RemoveSourceIdentifierFromSubscriptionError::SourceNotFoundFault(String::from(
@@ -24763,6 +25387,14 @@ impl RemoveSourceIdentifierFromSubscriptionError {
             },
             Err(_) => RemoveSourceIdentifierFromSubscriptionError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -24832,7 +25464,7 @@ impl RemoveTagsFromResourceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBClusterNotFoundFault" => RemoveTagsFromResourceError::DBClusterNotFoundFault(
                     String::from(parsed_error.message),
@@ -24847,6 +25479,14 @@ impl RemoveTagsFromResourceError {
             },
             Err(_) => RemoveTagsFromResourceError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -24913,7 +25553,7 @@ impl ResetDBClusterParameterGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBParameterGroupNotFoundFault" => {
                     ResetDBClusterParameterGroupError::DBParameterGroupNotFoundFault(String::from(
@@ -24929,6 +25569,14 @@ impl ResetDBClusterParameterGroupError {
             },
             Err(_) => ResetDBClusterParameterGroupError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -24996,7 +25644,7 @@ impl ResetDBParameterGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBParameterGroupNotFoundFault" => {
                     ResetDBParameterGroupError::DBParameterGroupNotFoundFault(String::from(
@@ -25012,6 +25660,14 @@ impl ResetDBParameterGroupError {
             },
             Err(_) => ResetDBParameterGroupError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -25099,7 +25755,7 @@ impl RestoreDBClusterFromS3Error {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBClusterAlreadyExistsFault" => {
                     RestoreDBClusterFromS3Error::DBClusterAlreadyExistsFault(String::from(
@@ -25164,6 +25820,14 @@ impl RestoreDBClusterFromS3Error {
             },
             Err(_) => RestoreDBClusterFromS3Error::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -25268,7 +25932,7 @@ impl RestoreDBClusterFromSnapshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBClusterAlreadyExistsFault" => {
                     RestoreDBClusterFromSnapshotError::DBClusterAlreadyExistsFault(String::from(
@@ -25345,6 +26009,14 @@ impl RestoreDBClusterFromSnapshotError {
             },
             Err(_) => RestoreDBClusterFromSnapshotError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -25457,7 +26129,7 @@ impl RestoreDBClusterToPointInTimeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBClusterAlreadyExistsFault" => {
                     RestoreDBClusterToPointInTimeError::DBClusterAlreadyExistsFault(String::from(
@@ -25539,6 +26211,14 @@ impl RestoreDBClusterToPointInTimeError {
             },
             Err(_) => RestoreDBClusterToPointInTimeError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -25656,7 +26336,7 @@ impl RestoreDBInstanceFromDBSnapshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationNotFoundFault" => {
                     RestoreDBInstanceFromDBSnapshotError::AuthorizationNotFoundFault(String::from(
@@ -25750,6 +26430,14 @@ impl RestoreDBInstanceFromDBSnapshotError {
             },
             Err(_) => RestoreDBInstanceFromDBSnapshotError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -25865,7 +26553,7 @@ impl RestoreDBInstanceFromS3Error {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationNotFoundFault" => {
                     RestoreDBInstanceFromS3Error::AuthorizationNotFoundFault(String::from(
@@ -25947,6 +26635,14 @@ impl RestoreDBInstanceFromS3Error {
             },
             Err(_) => RestoreDBInstanceFromS3Error::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -26060,7 +26756,7 @@ impl RestoreDBInstanceToPointInTimeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationNotFoundFault" => {
                     RestoreDBInstanceToPointInTimeError::AuthorizationNotFoundFault(String::from(
@@ -26156,6 +26852,14 @@ impl RestoreDBInstanceToPointInTimeError {
             Err(_) => RestoreDBInstanceToPointInTimeError::Unknown(body.to_string()),
         }
     }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
+    }
 }
 
 impl From<XmlParseError> for RestoreDBInstanceToPointInTimeError {
@@ -26247,7 +26951,7 @@ impl RevokeDBSecurityGroupIngressError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationNotFoundFault" => {
                     RevokeDBSecurityGroupIngressError::AuthorizationNotFoundFault(String::from(
@@ -26268,6 +26972,14 @@ impl RevokeDBSecurityGroupIngressError {
             },
             Err(_) => RevokeDBSecurityGroupIngressError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -26352,7 +27064,7 @@ impl StartDBInstanceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationNotFoundFault" => StartDBInstanceError::AuthorizationNotFoundFault(
                     String::from(parsed_error.message),
@@ -26399,6 +27111,14 @@ impl StartDBInstanceError {
             },
             Err(_) => StartDBInstanceError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -26477,7 +27197,7 @@ impl StopDBInstanceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DBInstanceNotFoundFault" => {
                     StopDBInstanceError::DBInstanceNotFoundFault(String::from(parsed_error.message))
@@ -26500,6 +27220,14 @@ impl StopDBInstanceError {
             },
             Err(_) => StopDBInstanceError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 

--- a/rusoto/services/redshift/src/generated.rs
+++ b/rusoto/services/redshift/src/generated.rs
@@ -10989,7 +10989,7 @@ impl AuthorizeClusterSecurityGroupIngressError {
         match Self::deserialize(&mut stack) {
                             Ok(parsed_error) => {
                                 match &parsed_error.code[..] {
-                                    "AuthorizationAlreadyExistsFault" => AuthorizeClusterSecurityGroupIngressError::AuthorizationAlreadyExistsFault(String::from(parsed_error.message)),"AuthorizationQuotaExceededFault" => AuthorizeClusterSecurityGroupIngressError::AuthorizationQuotaExceededFault(String::from(parsed_error.message)),"ClusterSecurityGroupNotFoundFault" => AuthorizeClusterSecurityGroupIngressError::ClusterSecurityGroupNotFoundFault(String::from(parsed_error.message)),"InvalidClusterSecurityGroupStateFault" => AuthorizeClusterSecurityGroupIngressError::InvalidClusterSecurityGroupStateFault(String::from(parsed_error.message)),_ => AuthorizeClusterSecurityGroupIngressError::Unknown(String::from(body))
+                                    "AuthorizationAlreadyExists" => AuthorizeClusterSecurityGroupIngressError::AuthorizationAlreadyExistsFault(String::from(parsed_error.message)),"AuthorizationQuotaExceeded" => AuthorizeClusterSecurityGroupIngressError::AuthorizationQuotaExceededFault(String::from(parsed_error.message)),"ClusterSecurityGroupNotFound" => AuthorizeClusterSecurityGroupIngressError::ClusterSecurityGroupNotFoundFault(String::from(parsed_error.message)),"InvalidClusterSecurityGroupState" => AuthorizeClusterSecurityGroupIngressError::InvalidClusterSecurityGroupStateFault(String::from(parsed_error.message)),_ => AuthorizeClusterSecurityGroupIngressError::Unknown(String::from(body))
                                 }
                            },
                            Err(_) => AuthorizeClusterSecurityGroupIngressError::Unknown(body.to_string())
@@ -11087,17 +11087,17 @@ impl AuthorizeSnapshotAccessError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AuthorizationAlreadyExistsFault" => {
+                "AuthorizationAlreadyExists" => {
                     AuthorizeSnapshotAccessError::AuthorizationAlreadyExistsFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "AuthorizationQuotaExceededFault" => {
+                "AuthorizationQuotaExceeded" => {
                     AuthorizeSnapshotAccessError::AuthorizationQuotaExceededFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "ClusterSnapshotNotFoundFault" => {
+                "ClusterSnapshotNotFound" => {
                     AuthorizeSnapshotAccessError::ClusterSnapshotNotFoundFault(String::from(
                         parsed_error.message,
                     ))
@@ -11107,7 +11107,7 @@ impl AuthorizeSnapshotAccessError {
                         String::from(parsed_error.message),
                     )
                 }
-                "InvalidClusterSnapshotStateFault" => {
+                "InvalidClusterSnapshotState" => {
                     AuthorizeSnapshotAccessError::InvalidClusterSnapshotStateFault(String::from(
                         parsed_error.message,
                     ))
@@ -11204,22 +11204,22 @@ impl CopyClusterSnapshotError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ClusterSnapshotAlreadyExistsFault" => {
+                "ClusterSnapshotAlreadyExists" => {
                     CopyClusterSnapshotError::ClusterSnapshotAlreadyExistsFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "ClusterSnapshotNotFoundFault" => {
+                "ClusterSnapshotNotFound" => {
                     CopyClusterSnapshotError::ClusterSnapshotNotFoundFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "ClusterSnapshotQuotaExceededFault" => {
+                "ClusterSnapshotQuotaExceeded" => {
                     CopyClusterSnapshotError::ClusterSnapshotQuotaExceededFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InvalidClusterSnapshotStateFault" => {
+                "InvalidClusterSnapshotState" => {
                     CopyClusterSnapshotError::InvalidClusterSnapshotStateFault(String::from(
                         parsed_error.message,
                     ))
@@ -11339,18 +11339,18 @@ impl CreateClusterError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ClusterAlreadyExistsFault" => CreateClusterError::ClusterAlreadyExistsFault(
+                "ClusterAlreadyExists" => CreateClusterError::ClusterAlreadyExistsFault(
                     String::from(parsed_error.message),
                 ),
-                "ClusterParameterGroupNotFoundFault" => {
+                "ClusterParameterGroupNotFound" => {
                     CreateClusterError::ClusterParameterGroupNotFoundFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "ClusterQuotaExceededFault" => CreateClusterError::ClusterQuotaExceededFault(
+                "ClusterQuotaExceeded" => CreateClusterError::ClusterQuotaExceededFault(
                     String::from(parsed_error.message),
                 ),
-                "ClusterSecurityGroupNotFoundFault" => {
+                "ClusterSecurityGroupNotFound" => {
                     CreateClusterError::ClusterSecurityGroupNotFoundFault(String::from(
                         parsed_error.message,
                     ))
@@ -11375,7 +11375,7 @@ impl CreateClusterError {
                         parsed_error.message,
                     ))
                 }
-                "InsufficientClusterCapacityFault" => {
+                "InsufficientClusterCapacity" => {
                     CreateClusterError::InsufficientClusterCapacityFault(String::from(
                         parsed_error.message,
                     ))
@@ -11400,12 +11400,12 @@ impl CreateClusterError {
                 "LimitExceededFault" => {
                     CreateClusterError::LimitExceededFault(String::from(parsed_error.message))
                 }
-                "NumberOfNodesPerClusterLimitExceededFault" => {
+                "NumberOfNodesPerClusterLimitExceeded" => {
                     CreateClusterError::NumberOfNodesPerClusterLimitExceededFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "NumberOfNodesQuotaExceededFault" => {
+                "NumberOfNodesQuotaExceeded" => {
                     CreateClusterError::NumberOfNodesQuotaExceededFault(String::from(
                         parsed_error.message,
                     ))
@@ -11514,12 +11514,12 @@ impl CreateClusterParameterGroupError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ClusterParameterGroupAlreadyExistsFault" => {
+                "ClusterParameterGroupAlreadyExists" => {
                     CreateClusterParameterGroupError::ClusterParameterGroupAlreadyExistsFault(
                         String::from(parsed_error.message),
                     )
                 }
-                "ClusterParameterGroupQuotaExceededFault" => {
+                "ClusterParameterGroupQuotaExceeded" => {
                     CreateClusterParameterGroupError::ClusterParameterGroupQuotaExceededFault(
                         String::from(parsed_error.message),
                     )
@@ -11621,12 +11621,12 @@ impl CreateClusterSecurityGroupError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ClusterSecurityGroupAlreadyExistsFault" => {
+                "ClusterSecurityGroupAlreadyExists" => {
                     CreateClusterSecurityGroupError::ClusterSecurityGroupAlreadyExistsFault(
                         String::from(parsed_error.message),
                     )
                 }
-                "ClusterSecurityGroupQuotaExceededFault" => {
+                "QuotaExceeded.ClusterSecurityGroup" => {
                     CreateClusterSecurityGroupError::ClusterSecurityGroupQuotaExceededFault(
                         String::from(parsed_error.message),
                     )
@@ -11730,24 +11730,22 @@ impl CreateClusterSnapshotError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ClusterNotFoundFault" => CreateClusterSnapshotError::ClusterNotFoundFault(
+                "ClusterNotFound" => CreateClusterSnapshotError::ClusterNotFoundFault(
                     String::from(parsed_error.message),
                 ),
-                "ClusterSnapshotAlreadyExistsFault" => {
+                "ClusterSnapshotAlreadyExists" => {
                     CreateClusterSnapshotError::ClusterSnapshotAlreadyExistsFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "ClusterSnapshotQuotaExceededFault" => {
+                "ClusterSnapshotQuotaExceeded" => {
                     CreateClusterSnapshotError::ClusterSnapshotQuotaExceededFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InvalidClusterStateFault" => {
-                    CreateClusterSnapshotError::InvalidClusterStateFault(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "InvalidClusterState" => CreateClusterSnapshotError::InvalidClusterStateFault(
+                    String::from(parsed_error.message),
+                ),
                 "InvalidTagFault" => {
                     CreateClusterSnapshotError::InvalidTagFault(String::from(parsed_error.message))
                 }
@@ -11849,12 +11847,12 @@ impl CreateClusterSubnetGroupError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ClusterSubnetGroupAlreadyExistsFault" => {
+                "ClusterSubnetGroupAlreadyExists" => {
                     CreateClusterSubnetGroupError::ClusterSubnetGroupAlreadyExistsFault(
                         String::from(parsed_error.message),
                     )
                 }
-                "ClusterSubnetGroupQuotaExceededFault" => {
+                "ClusterSubnetGroupQuotaExceeded" => {
                     CreateClusterSubnetGroupError::ClusterSubnetGroupQuotaExceededFault(
                         String::from(parsed_error.message),
                     )
@@ -11986,7 +11984,7 @@ impl CreateEventSubscriptionError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "EventSubscriptionQuotaExceededFault" => {
+                "EventSubscriptionQuotaExceeded" => {
                     CreateEventSubscriptionError::EventSubscriptionQuotaExceededFault(
                         String::from(parsed_error.message),
                     )
@@ -11994,38 +11992,34 @@ impl CreateEventSubscriptionError {
                 "InvalidTagFault" => CreateEventSubscriptionError::InvalidTagFault(String::from(
                     parsed_error.message,
                 )),
-                "SNSInvalidTopicFault" => CreateEventSubscriptionError::SNSInvalidTopicFault(
+                "SNSInvalidTopic" => CreateEventSubscriptionError::SNSInvalidTopicFault(
                     String::from(parsed_error.message),
                 ),
-                "SNSNoAuthorizationFault" => {
-                    CreateEventSubscriptionError::SNSNoAuthorizationFault(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "SNSTopicArnNotFoundFault" => {
-                    CreateEventSubscriptionError::SNSTopicArnNotFoundFault(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "SourceNotFoundFault" => CreateEventSubscriptionError::SourceNotFoundFault(
+                "SNSNoAuthorization" => CreateEventSubscriptionError::SNSNoAuthorizationFault(
                     String::from(parsed_error.message),
                 ),
-                "SubscriptionAlreadyExistFault" => {
+                "SNSTopicArnNotFound" => CreateEventSubscriptionError::SNSTopicArnNotFoundFault(
+                    String::from(parsed_error.message),
+                ),
+                "SourceNotFound" => CreateEventSubscriptionError::SourceNotFoundFault(
+                    String::from(parsed_error.message),
+                ),
+                "SubscriptionAlreadyExist" => {
                     CreateEventSubscriptionError::SubscriptionAlreadyExistFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "SubscriptionCategoryNotFoundFault" => {
+                "SubscriptionCategoryNotFound" => {
                     CreateEventSubscriptionError::SubscriptionCategoryNotFoundFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "SubscriptionEventIdNotFoundFault" => {
+                "SubscriptionEventIdNotFound" => {
                     CreateEventSubscriptionError::SubscriptionEventIdNotFoundFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "SubscriptionSeverityNotFoundFault" => {
+                "SubscriptionSeverityNotFound" => {
                     CreateEventSubscriptionError::SubscriptionSeverityNotFoundFault(String::from(
                         parsed_error.message,
                     ))
@@ -12537,20 +12531,20 @@ impl DeleteClusterError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ClusterNotFoundFault" => {
+                "ClusterNotFound" => {
                     DeleteClusterError::ClusterNotFoundFault(String::from(parsed_error.message))
                 }
-                "ClusterSnapshotAlreadyExistsFault" => {
+                "ClusterSnapshotAlreadyExists" => {
                     DeleteClusterError::ClusterSnapshotAlreadyExistsFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "ClusterSnapshotQuotaExceededFault" => {
+                "ClusterSnapshotQuotaExceeded" => {
                     DeleteClusterError::ClusterSnapshotQuotaExceededFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InvalidClusterStateFault" => {
+                "InvalidClusterState" => {
                     DeleteClusterError::InvalidClusterStateFault(String::from(parsed_error.message))
                 }
                 _ => DeleteClusterError::Unknown(String::from(body)),
@@ -12632,12 +12626,12 @@ impl DeleteClusterParameterGroupError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ClusterParameterGroupNotFoundFault" => {
+                "ClusterParameterGroupNotFound" => {
                     DeleteClusterParameterGroupError::ClusterParameterGroupNotFoundFault(
                         String::from(parsed_error.message),
                     )
                 }
-                "InvalidClusterParameterGroupStateFault" => {
+                "InvalidClusterParameterGroupState" => {
                     DeleteClusterParameterGroupError::InvalidClusterParameterGroupStateFault(
                         String::from(parsed_error.message),
                     )
@@ -12725,12 +12719,12 @@ impl DeleteClusterSecurityGroupError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ClusterSecurityGroupNotFoundFault" => {
+                "ClusterSecurityGroupNotFound" => {
                     DeleteClusterSecurityGroupError::ClusterSecurityGroupNotFoundFault(
                         String::from(parsed_error.message),
                     )
                 }
-                "InvalidClusterSecurityGroupStateFault" => {
+                "InvalidClusterSecurityGroupState" => {
                     DeleteClusterSecurityGroupError::InvalidClusterSecurityGroupStateFault(
                         String::from(parsed_error.message),
                     )
@@ -12816,12 +12810,12 @@ impl DeleteClusterSnapshotError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ClusterSnapshotNotFoundFault" => {
+                "ClusterSnapshotNotFound" => {
                     DeleteClusterSnapshotError::ClusterSnapshotNotFoundFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InvalidClusterSnapshotStateFault" => {
+                "InvalidClusterSnapshotState" => {
                     DeleteClusterSnapshotError::InvalidClusterSnapshotStateFault(String::from(
                         parsed_error.message,
                     ))
@@ -13007,11 +13001,9 @@ impl DeleteEventSubscriptionError {
                         parsed_error.message,
                     ))
                 }
-                "SubscriptionNotFoundFault" => {
-                    DeleteEventSubscriptionError::SubscriptionNotFoundFault(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "SubscriptionNotFound" => DeleteEventSubscriptionError::SubscriptionNotFoundFault(
+                    String::from(parsed_error.message),
+                ),
                 _ => DeleteEventSubscriptionError::Unknown(String::from(body)),
             },
             Err(_) => DeleteEventSubscriptionError::Unknown(body.to_string()),
@@ -13443,7 +13435,7 @@ impl DescribeClusterParameterGroupsError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ClusterParameterGroupNotFoundFault" => {
+                "ClusterParameterGroupNotFound" => {
                     DescribeClusterParameterGroupsError::ClusterParameterGroupNotFoundFault(
                         String::from(parsed_error.message),
                     )
@@ -13530,7 +13522,7 @@ impl DescribeClusterParametersError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ClusterParameterGroupNotFoundFault" => {
+                "ClusterParameterGroupNotFound" => {
                     DescribeClusterParametersError::ClusterParameterGroupNotFoundFault(
                         String::from(parsed_error.message),
                     )
@@ -13613,7 +13605,7 @@ impl DescribeClusterSecurityGroupsError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ClusterSecurityGroupNotFoundFault" => {
+                "ClusterSecurityGroupNotFound" => {
                     DescribeClusterSecurityGroupsError::ClusterSecurityGroupNotFoundFault(
                         String::from(parsed_error.message),
                     )
@@ -13702,7 +13694,7 @@ impl DescribeClusterSnapshotsError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ClusterSnapshotNotFoundFault" => {
+                "ClusterSnapshotNotFound" => {
                     DescribeClusterSnapshotsError::ClusterSnapshotNotFoundFault(String::from(
                         parsed_error.message,
                     ))
@@ -13949,7 +13941,7 @@ impl DescribeClustersError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ClusterNotFoundFault" => {
+                "ClusterNotFound" => {
                     DescribeClustersError::ClusterNotFoundFault(String::from(parsed_error.message))
                 }
                 "InvalidTagFault" => {
@@ -14181,7 +14173,7 @@ impl DescribeEventSubscriptionsError {
                 "InvalidTagFault" => DescribeEventSubscriptionsError::InvalidTagFault(
                     String::from(parsed_error.message),
                 ),
-                "SubscriptionNotFoundFault" => {
+                "SubscriptionNotFound" => {
                     DescribeEventSubscriptionsError::SubscriptionNotFoundFault(String::from(
                         parsed_error.message,
                     ))
@@ -14510,7 +14502,7 @@ impl DescribeLoggingStatusError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ClusterNotFoundFault" => DescribeLoggingStatusError::ClusterNotFoundFault(
+                "ClusterNotFound" => DescribeLoggingStatusError::ClusterNotFoundFault(
                     String::from(parsed_error.message),
                 ),
                 _ => DescribeLoggingStatusError::Unknown(String::from(body)),
@@ -14671,12 +14663,12 @@ impl DescribeReservedNodeOfferingsError {
                         String::from(parsed_error.message),
                     )
                 }
-                "ReservedNodeOfferingNotFoundFault" => {
+                "ReservedNodeOfferingNotFound" => {
                     DescribeReservedNodeOfferingsError::ReservedNodeOfferingNotFoundFault(
                         String::from(parsed_error.message),
                     )
                 }
-                "UnsupportedOperationFault" => {
+                "UnsupportedOperation" => {
                     DescribeReservedNodeOfferingsError::UnsupportedOperationFault(String::from(
                         parsed_error.message,
                     ))
@@ -14770,11 +14762,9 @@ impl DescribeReservedNodesError {
                         parsed_error.message,
                     ))
                 }
-                "ReservedNodeNotFoundFault" => {
-                    DescribeReservedNodesError::ReservedNodeNotFoundFault(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "ReservedNodeNotFound" => DescribeReservedNodesError::ReservedNodeNotFoundFault(
+                    String::from(parsed_error.message),
+                ),
                 _ => DescribeReservedNodesError::Unknown(String::from(body)),
             },
             Err(_) => DescribeReservedNodesError::Unknown(body.to_string()),
@@ -14854,10 +14844,10 @@ impl DescribeResizeError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ClusterNotFoundFault" => {
+                "ClusterNotFound" => {
                     DescribeResizeError::ClusterNotFoundFault(String::from(parsed_error.message))
                 }
-                "ResizeNotFoundFault" => {
+                "ResizeNotFound" => {
                     DescribeResizeError::ResizeNotFoundFault(String::from(parsed_error.message))
                 }
                 _ => DescribeResizeError::Unknown(String::from(body)),
@@ -15024,7 +15014,7 @@ impl DescribeTableRestoreStatusError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ClusterNotFoundFault" => DescribeTableRestoreStatusError::ClusterNotFoundFault(
+                "ClusterNotFound" => DescribeTableRestoreStatusError::ClusterNotFoundFault(
                     String::from(parsed_error.message),
                 ),
                 "TableRestoreNotFoundFault" => {
@@ -15192,7 +15182,7 @@ impl DisableLoggingError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ClusterNotFoundFault" => {
+                "ClusterNotFound" => {
                     DisableLoggingError::ClusterNotFoundFault(String::from(parsed_error.message))
                 }
                 _ => DisableLoggingError::Unknown(String::from(body)),
@@ -15275,10 +15265,10 @@ impl DisableSnapshotCopyError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ClusterNotFoundFault" => DisableSnapshotCopyError::ClusterNotFoundFault(
-                    String::from(parsed_error.message),
-                ),
-                "InvalidClusterStateFault" => DisableSnapshotCopyError::InvalidClusterStateFault(
+                "ClusterNotFound" => DisableSnapshotCopyError::ClusterNotFoundFault(String::from(
+                    parsed_error.message,
+                )),
+                "InvalidClusterState" => DisableSnapshotCopyError::InvalidClusterStateFault(
                     String::from(parsed_error.message),
                 ),
                 "SnapshotCopyAlreadyDisabledFault" => {
@@ -15379,7 +15369,7 @@ impl EnableLoggingError {
                 "BucketNotFoundFault" => {
                     EnableLoggingError::BucketNotFoundFault(String::from(parsed_error.message))
                 }
-                "ClusterNotFoundFault" => {
+                "ClusterNotFound" => {
                     EnableLoggingError::ClusterNotFoundFault(String::from(parsed_error.message))
                 }
                 "InsufficientS3BucketPolicyFault" => {
@@ -15489,9 +15479,9 @@ impl EnableSnapshotCopyError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ClusterNotFoundFault" => EnableSnapshotCopyError::ClusterNotFoundFault(
-                    String::from(parsed_error.message),
-                ),
+                "ClusterNotFound" => EnableSnapshotCopyError::ClusterNotFoundFault(String::from(
+                    parsed_error.message,
+                )),
                 "CopyToRegionDisabledFault" => EnableSnapshotCopyError::CopyToRegionDisabledFault(
                     String::from(parsed_error.message),
                 ),
@@ -15505,7 +15495,7 @@ impl EnableSnapshotCopyError {
                         parsed_error.message,
                     ))
                 }
-                "InvalidClusterStateFault" => EnableSnapshotCopyError::InvalidClusterStateFault(
+                "InvalidClusterState" => EnableSnapshotCopyError::InvalidClusterStateFault(
                     String::from(parsed_error.message),
                 ),
                 "LimitExceededFault" => {
@@ -15616,14 +15606,12 @@ impl GetClusterCredentialsError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ClusterNotFoundFault" => GetClusterCredentialsError::ClusterNotFoundFault(
+                "ClusterNotFound" => GetClusterCredentialsError::ClusterNotFoundFault(
                     String::from(parsed_error.message),
                 ),
-                "UnsupportedOperationFault" => {
-                    GetClusterCredentialsError::UnsupportedOperationFault(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "UnsupportedOperation" => GetClusterCredentialsError::UnsupportedOperationFault(
+                    String::from(parsed_error.message),
+                ),
                 _ => GetClusterCredentialsError::Unknown(String::from(body)),
             },
             Err(_) => GetClusterCredentialsError::Unknown(body.to_string()),
@@ -15731,18 +15719,18 @@ impl ModifyClusterError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ClusterAlreadyExistsFault" => ModifyClusterError::ClusterAlreadyExistsFault(
+                "ClusterAlreadyExists" => ModifyClusterError::ClusterAlreadyExistsFault(
                     String::from(parsed_error.message),
                 ),
-                "ClusterNotFoundFault" => {
+                "ClusterNotFound" => {
                     ModifyClusterError::ClusterNotFoundFault(String::from(parsed_error.message))
                 }
-                "ClusterParameterGroupNotFoundFault" => {
+                "ClusterParameterGroupNotFound" => {
                     ModifyClusterError::ClusterParameterGroupNotFoundFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "ClusterSecurityGroupNotFoundFault" => {
+                "ClusterSecurityGroupNotFound" => {
                     ModifyClusterError::ClusterSecurityGroupNotFoundFault(String::from(
                         parsed_error.message,
                     ))
@@ -15762,17 +15750,17 @@ impl ModifyClusterError {
                         parsed_error.message,
                     ))
                 }
-                "InsufficientClusterCapacityFault" => {
+                "InsufficientClusterCapacity" => {
                     ModifyClusterError::InsufficientClusterCapacityFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InvalidClusterSecurityGroupStateFault" => {
+                "InvalidClusterSecurityGroupState" => {
                     ModifyClusterError::InvalidClusterSecurityGroupStateFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InvalidClusterStateFault" => {
+                "InvalidClusterState" => {
                     ModifyClusterError::InvalidClusterStateFault(String::from(parsed_error.message))
                 }
                 "InvalidElasticIpFault" => {
@@ -15781,12 +15769,12 @@ impl ModifyClusterError {
                 "LimitExceededFault" => {
                     ModifyClusterError::LimitExceededFault(String::from(parsed_error.message))
                 }
-                "NumberOfNodesPerClusterLimitExceededFault" => {
+                "NumberOfNodesPerClusterLimitExceeded" => {
                     ModifyClusterError::NumberOfNodesPerClusterLimitExceededFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "NumberOfNodesQuotaExceededFault" => {
+                "NumberOfNodesQuotaExceeded" => {
                     ModifyClusterError::NumberOfNodesQuotaExceededFault(String::from(
                         parsed_error.message,
                     ))
@@ -15888,14 +15876,12 @@ impl ModifyClusterIamRolesError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ClusterNotFoundFault" => ModifyClusterIamRolesError::ClusterNotFoundFault(
+                "ClusterNotFound" => ModifyClusterIamRolesError::ClusterNotFoundFault(
                     String::from(parsed_error.message),
                 ),
-                "InvalidClusterStateFault" => {
-                    ModifyClusterIamRolesError::InvalidClusterStateFault(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "InvalidClusterState" => ModifyClusterIamRolesError::InvalidClusterStateFault(
+                    String::from(parsed_error.message),
+                ),
                 _ => ModifyClusterIamRolesError::Unknown(String::from(body)),
             },
             Err(_) => ModifyClusterIamRolesError::Unknown(body.to_string()),
@@ -15975,12 +15961,12 @@ impl ModifyClusterParameterGroupError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ClusterParameterGroupNotFoundFault" => {
+                "ClusterParameterGroupNotFound" => {
                     ModifyClusterParameterGroupError::ClusterParameterGroupNotFoundFault(
                         String::from(parsed_error.message),
                     )
                 }
-                "InvalidClusterParameterGroupStateFault" => {
+                "InvalidClusterParameterGroupState" => {
                     ModifyClusterParameterGroupError::InvalidClusterParameterGroupStateFault(
                         String::from(parsed_error.message),
                     )
@@ -16204,38 +16190,32 @@ impl ModifyEventSubscriptionError {
                         parsed_error.message,
                     ))
                 }
-                "SNSInvalidTopicFault" => ModifyEventSubscriptionError::SNSInvalidTopicFault(
+                "SNSInvalidTopic" => ModifyEventSubscriptionError::SNSInvalidTopicFault(
                     String::from(parsed_error.message),
                 ),
-                "SNSNoAuthorizationFault" => {
-                    ModifyEventSubscriptionError::SNSNoAuthorizationFault(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "SNSTopicArnNotFoundFault" => {
-                    ModifyEventSubscriptionError::SNSTopicArnNotFoundFault(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "SourceNotFoundFault" => ModifyEventSubscriptionError::SourceNotFoundFault(
+                "SNSNoAuthorization" => ModifyEventSubscriptionError::SNSNoAuthorizationFault(
                     String::from(parsed_error.message),
                 ),
-                "SubscriptionCategoryNotFoundFault" => {
+                "SNSTopicArnNotFound" => ModifyEventSubscriptionError::SNSTopicArnNotFoundFault(
+                    String::from(parsed_error.message),
+                ),
+                "SourceNotFound" => ModifyEventSubscriptionError::SourceNotFoundFault(
+                    String::from(parsed_error.message),
+                ),
+                "SubscriptionCategoryNotFound" => {
                     ModifyEventSubscriptionError::SubscriptionCategoryNotFoundFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "SubscriptionEventIdNotFoundFault" => {
+                "SubscriptionEventIdNotFound" => {
                     ModifyEventSubscriptionError::SubscriptionEventIdNotFoundFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "SubscriptionNotFoundFault" => {
-                    ModifyEventSubscriptionError::SubscriptionNotFoundFault(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "SubscriptionSeverityNotFoundFault" => {
+                "SubscriptionNotFound" => ModifyEventSubscriptionError::SubscriptionNotFoundFault(
+                    String::from(parsed_error.message),
+                ),
+                "SubscriptionSeverityNotFound" => {
                     ModifyEventSubscriptionError::SubscriptionSeverityNotFoundFault(String::from(
                         parsed_error.message,
                     ))
@@ -16330,12 +16310,10 @@ impl ModifySnapshotCopyRetentionPeriodError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ClusterNotFoundFault" => {
-                    ModifySnapshotCopyRetentionPeriodError::ClusterNotFoundFault(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "InvalidClusterStateFault" => {
+                "ClusterNotFound" => ModifySnapshotCopyRetentionPeriodError::ClusterNotFoundFault(
+                    String::from(parsed_error.message),
+                ),
+                "InvalidClusterState" => {
                     ModifySnapshotCopyRetentionPeriodError::InvalidClusterStateFault(String::from(
                         parsed_error.message,
                     ))
@@ -16435,22 +16413,22 @@ impl PurchaseReservedNodeOfferingError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ReservedNodeAlreadyExistsFault" => {
+                "ReservedNodeAlreadyExists" => {
                     PurchaseReservedNodeOfferingError::ReservedNodeAlreadyExistsFault(
                         String::from(parsed_error.message),
                     )
                 }
-                "ReservedNodeOfferingNotFoundFault" => {
+                "ReservedNodeOfferingNotFound" => {
                     PurchaseReservedNodeOfferingError::ReservedNodeOfferingNotFoundFault(
                         String::from(parsed_error.message),
                     )
                 }
-                "ReservedNodeQuotaExceededFault" => {
+                "ReservedNodeQuotaExceeded" => {
                     PurchaseReservedNodeOfferingError::ReservedNodeQuotaExceededFault(
                         String::from(parsed_error.message),
                     )
                 }
-                "UnsupportedOperationFault" => {
+                "UnsupportedOperation" => {
                     PurchaseReservedNodeOfferingError::UnsupportedOperationFault(String::from(
                         parsed_error.message,
                     ))
@@ -16538,10 +16516,10 @@ impl RebootClusterError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ClusterNotFoundFault" => {
+                "ClusterNotFound" => {
                     RebootClusterError::ClusterNotFoundFault(String::from(parsed_error.message))
                 }
-                "InvalidClusterStateFault" => {
+                "InvalidClusterState" => {
                     RebootClusterError::InvalidClusterStateFault(String::from(parsed_error.message))
                 }
                 _ => RebootClusterError::Unknown(String::from(body)),
@@ -16621,12 +16599,12 @@ impl ResetClusterParameterGroupError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ClusterParameterGroupNotFoundFault" => {
+                "ClusterParameterGroupNotFound" => {
                     ResetClusterParameterGroupError::ClusterParameterGroupNotFoundFault(
                         String::from(parsed_error.message),
                     )
                 }
-                "InvalidClusterParameterGroupStateFault" => {
+                "InvalidClusterParameterGroupState" => {
                     ResetClusterParameterGroupError::InvalidClusterParameterGroupStateFault(
                         String::from(parsed_error.message),
                     )
@@ -16750,32 +16728,32 @@ impl RestoreFromClusterSnapshotError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AccessToSnapshotDeniedFault" => {
+                "AccessToSnapshotDenied" => {
                     RestoreFromClusterSnapshotError::AccessToSnapshotDeniedFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "ClusterAlreadyExistsFault" => {
+                "ClusterAlreadyExists" => {
                     RestoreFromClusterSnapshotError::ClusterAlreadyExistsFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "ClusterParameterGroupNotFoundFault" => {
+                "ClusterParameterGroupNotFound" => {
                     RestoreFromClusterSnapshotError::ClusterParameterGroupNotFoundFault(
                         String::from(parsed_error.message),
                     )
                 }
-                "ClusterQuotaExceededFault" => {
+                "ClusterQuotaExceeded" => {
                     RestoreFromClusterSnapshotError::ClusterQuotaExceededFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "ClusterSecurityGroupNotFoundFault" => {
+                "ClusterSecurityGroupNotFound" => {
                     RestoreFromClusterSnapshotError::ClusterSecurityGroupNotFoundFault(
                         String::from(parsed_error.message),
                     )
                 }
-                "ClusterSnapshotNotFoundFault" => {
+                "ClusterSnapshotNotFound" => {
                     RestoreFromClusterSnapshotError::ClusterSnapshotNotFoundFault(String::from(
                         parsed_error.message,
                     ))
@@ -16800,12 +16778,12 @@ impl RestoreFromClusterSnapshotError {
                         parsed_error.message,
                     ))
                 }
-                "InsufficientClusterCapacityFault" => {
+                "InsufficientClusterCapacity" => {
                     RestoreFromClusterSnapshotError::InsufficientClusterCapacityFault(
                         String::from(parsed_error.message),
                     )
                 }
-                "InvalidClusterSnapshotStateFault" => {
+                "InvalidClusterSnapshotState" => {
                     RestoreFromClusterSnapshotError::InvalidClusterSnapshotStateFault(
                         String::from(parsed_error.message),
                     )
@@ -16818,7 +16796,7 @@ impl RestoreFromClusterSnapshotError {
                 "InvalidElasticIpFault" => RestoreFromClusterSnapshotError::InvalidElasticIpFault(
                     String::from(parsed_error.message),
                 ),
-                "InvalidRestoreFault" => RestoreFromClusterSnapshotError::InvalidRestoreFault(
+                "InvalidRestore" => RestoreFromClusterSnapshotError::InvalidRestoreFault(
                     String::from(parsed_error.message),
                 ),
                 "InvalidSubnet" => RestoreFromClusterSnapshotError::InvalidSubnet(String::from(
@@ -16832,12 +16810,12 @@ impl RestoreFromClusterSnapshotError {
                 "LimitExceededFault" => RestoreFromClusterSnapshotError::LimitExceededFault(
                     String::from(parsed_error.message),
                 ),
-                "NumberOfNodesPerClusterLimitExceededFault" => {
+                "NumberOfNodesPerClusterLimitExceeded" => {
                     RestoreFromClusterSnapshotError::NumberOfNodesPerClusterLimitExceededFault(
                         String::from(parsed_error.message),
                     )
                 }
-                "NumberOfNodesQuotaExceededFault" => {
+                "NumberOfNodesQuotaExceeded" => {
                     RestoreFromClusterSnapshotError::NumberOfNodesQuotaExceededFault(String::from(
                         parsed_error.message,
                     ))
@@ -16959,12 +16937,10 @@ impl RestoreTableFromClusterSnapshotError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ClusterNotFoundFault" => {
-                    RestoreTableFromClusterSnapshotError::ClusterNotFoundFault(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "ClusterSnapshotNotFoundFault" => {
+                "ClusterNotFound" => RestoreTableFromClusterSnapshotError::ClusterNotFoundFault(
+                    String::from(parsed_error.message),
+                ),
+                "ClusterSnapshotNotFound" => {
                     RestoreTableFromClusterSnapshotError::ClusterSnapshotNotFoundFault(
                         String::from(parsed_error.message),
                     )
@@ -16974,22 +16950,22 @@ impl RestoreTableFromClusterSnapshotError {
                         String::from(parsed_error.message),
                     )
                 }
-                "InvalidClusterSnapshotStateFault" => {
+                "InvalidClusterSnapshotState" => {
                     RestoreTableFromClusterSnapshotError::InvalidClusterSnapshotStateFault(
                         String::from(parsed_error.message),
                     )
                 }
-                "InvalidClusterStateFault" => {
+                "InvalidClusterState" => {
                     RestoreTableFromClusterSnapshotError::InvalidClusterStateFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InvalidTableRestoreArgumentFault" => {
+                "InvalidTableRestoreArgument" => {
                     RestoreTableFromClusterSnapshotError::InvalidTableRestoreArgumentFault(
                         String::from(parsed_error.message),
                     )
                 }
-                "UnsupportedOperationFault" => {
+                "UnsupportedOperation" => {
                     RestoreTableFromClusterSnapshotError::UnsupportedOperationFault(String::from(
                         parsed_error.message,
                     ))
@@ -17086,17 +17062,17 @@ impl RevokeClusterSecurityGroupIngressError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AuthorizationNotFoundFault" => {
+                "AuthorizationNotFound" => {
                     RevokeClusterSecurityGroupIngressError::AuthorizationNotFoundFault(
                         String::from(parsed_error.message),
                     )
                 }
-                "ClusterSecurityGroupNotFoundFault" => {
+                "ClusterSecurityGroupNotFound" => {
                     RevokeClusterSecurityGroupIngressError::ClusterSecurityGroupNotFoundFault(
                         String::from(parsed_error.message),
                     )
                 }
-                "InvalidClusterSecurityGroupStateFault" => {
+                "InvalidClusterSecurityGroupState" => {
                     RevokeClusterSecurityGroupIngressError::InvalidClusterSecurityGroupStateFault(
                         String::from(parsed_error.message),
                     )
@@ -17187,17 +17163,15 @@ impl RevokeSnapshotAccessError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AccessToSnapshotDeniedFault" => {
+                "AccessToSnapshotDenied" => {
                     RevokeSnapshotAccessError::AccessToSnapshotDeniedFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "AuthorizationNotFoundFault" => {
-                    RevokeSnapshotAccessError::AuthorizationNotFoundFault(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "ClusterSnapshotNotFoundFault" => {
+                "AuthorizationNotFound" => RevokeSnapshotAccessError::AuthorizationNotFoundFault(
+                    String::from(parsed_error.message),
+                ),
+                "ClusterSnapshotNotFound" => {
                     RevokeSnapshotAccessError::ClusterSnapshotNotFoundFault(String::from(
                         parsed_error.message,
                     ))
@@ -17284,15 +17258,15 @@ impl RotateEncryptionKeyError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ClusterNotFoundFault" => RotateEncryptionKeyError::ClusterNotFoundFault(
-                    String::from(parsed_error.message),
-                ),
+                "ClusterNotFound" => RotateEncryptionKeyError::ClusterNotFoundFault(String::from(
+                    parsed_error.message,
+                )),
                 "DependentServiceRequestThrottlingFault" => {
                     RotateEncryptionKeyError::DependentServiceRequestThrottlingFault(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InvalidClusterStateFault" => RotateEncryptionKeyError::InvalidClusterStateFault(
+                "InvalidClusterState" => RotateEncryptionKeyError::InvalidClusterStateFault(
                     String::from(parsed_error.message),
                 ),
                 _ => RotateEncryptionKeyError::Unknown(String::from(body)),

--- a/rusoto/services/redshift/src/generated.rs
+++ b/rusoto/services/redshift/src/generated.rs
@@ -10986,7 +10986,7 @@ impl AuthorizeClusterSecurityGroupIngressError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
                             Ok(parsed_error) => {
                                 match &parsed_error.code[..] {
                                     "AuthorizationAlreadyExistsFault" => AuthorizeClusterSecurityGroupIngressError::AuthorizationAlreadyExistsFault(String::from(parsed_error.message)),"AuthorizationQuotaExceededFault" => AuthorizeClusterSecurityGroupIngressError::AuthorizationQuotaExceededFault(String::from(parsed_error.message)),"ClusterSecurityGroupNotFoundFault" => AuthorizeClusterSecurityGroupIngressError::ClusterSecurityGroupNotFoundFault(String::from(parsed_error.message)),"InvalidClusterSecurityGroupStateFault" => AuthorizeClusterSecurityGroupIngressError::InvalidClusterSecurityGroupStateFault(String::from(parsed_error.message)),_ => AuthorizeClusterSecurityGroupIngressError::Unknown(String::from(body))
@@ -10994,6 +10994,14 @@ impl AuthorizeClusterSecurityGroupIngressError {
                            },
                            Err(_) => AuthorizeClusterSecurityGroupIngressError::Unknown(body.to_string())
                        }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11077,7 +11085,7 @@ impl AuthorizeSnapshotAccessError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationAlreadyExistsFault" => {
                     AuthorizeSnapshotAccessError::AuthorizationAlreadyExistsFault(String::from(
@@ -11111,6 +11119,14 @@ impl AuthorizeSnapshotAccessError {
             },
             Err(_) => AuthorizeSnapshotAccessError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11186,7 +11202,7 @@ impl CopyClusterSnapshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ClusterSnapshotAlreadyExistsFault" => {
                     CopyClusterSnapshotError::ClusterSnapshotAlreadyExistsFault(String::from(
@@ -11212,6 +11228,14 @@ impl CopyClusterSnapshotError {
             },
             Err(_) => CopyClusterSnapshotError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11313,7 +11337,7 @@ impl CreateClusterError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ClusterAlreadyExistsFault" => CreateClusterError::ClusterAlreadyExistsFault(
                     String::from(parsed_error.message),
@@ -11396,6 +11420,14 @@ impl CreateClusterError {
             },
             Err(_) => CreateClusterError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11480,7 +11512,7 @@ impl CreateClusterParameterGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ClusterParameterGroupAlreadyExistsFault" => {
                     CreateClusterParameterGroupError::ClusterParameterGroupAlreadyExistsFault(
@@ -11504,6 +11536,14 @@ impl CreateClusterParameterGroupError {
             },
             Err(_) => CreateClusterParameterGroupError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11579,7 +11619,7 @@ impl CreateClusterSecurityGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ClusterSecurityGroupAlreadyExistsFault" => {
                     CreateClusterSecurityGroupError::ClusterSecurityGroupAlreadyExistsFault(
@@ -11601,6 +11641,14 @@ impl CreateClusterSecurityGroupError {
             },
             Err(_) => CreateClusterSecurityGroupError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11680,7 +11728,7 @@ impl CreateClusterSnapshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ClusterNotFoundFault" => CreateClusterSnapshotError::ClusterNotFoundFault(
                     String::from(parsed_error.message),
@@ -11710,6 +11758,14 @@ impl CreateClusterSnapshotError {
             },
             Err(_) => CreateClusterSnapshotError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11791,7 +11847,7 @@ impl CreateClusterSubnetGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ClusterSubnetGroupAlreadyExistsFault" => {
                     CreateClusterSubnetGroupError::ClusterSubnetGroupAlreadyExistsFault(
@@ -11829,6 +11885,14 @@ impl CreateClusterSubnetGroupError {
             },
             Err(_) => CreateClusterSubnetGroupError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11920,7 +11984,7 @@ impl CreateEventSubscriptionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "EventSubscriptionQuotaExceededFault" => {
                     CreateEventSubscriptionError::EventSubscriptionQuotaExceededFault(
@@ -11973,6 +12037,14 @@ impl CreateEventSubscriptionError {
             },
             Err(_) => CreateEventSubscriptionError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -12051,7 +12123,7 @@ impl CreateHsmClientCertificateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "HsmClientCertificateAlreadyExistsFault" => {
                     CreateHsmClientCertificateError::HsmClientCertificateAlreadyExistsFault(
@@ -12073,6 +12145,14 @@ impl CreateHsmClientCertificateError {
             },
             Err(_) => CreateHsmClientCertificateError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -12148,7 +12228,7 @@ impl CreateHsmConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "HsmConfigurationAlreadyExistsFault" => {
                     CreateHsmConfigurationError::HsmConfigurationAlreadyExistsFault(String::from(
@@ -12170,6 +12250,14 @@ impl CreateHsmConfigurationError {
             },
             Err(_) => CreateHsmConfigurationError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -12245,7 +12333,7 @@ impl CreateSnapshotCopyGrantError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DependentServiceRequestThrottlingFault" => {
                     CreateSnapshotCopyGrantError::DependentServiceRequestThrottlingFault(
@@ -12275,6 +12363,14 @@ impl CreateSnapshotCopyGrantError {
             },
             Err(_) => CreateSnapshotCopyGrantError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -12348,7 +12444,7 @@ impl CreateTagsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidTagFault" => {
                     CreateTagsError::InvalidTagFault(String::from(parsed_error.message))
@@ -12363,6 +12459,14 @@ impl CreateTagsError {
             },
             Err(_) => CreateTagsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -12431,7 +12535,7 @@ impl DeleteClusterError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ClusterNotFoundFault" => {
                     DeleteClusterError::ClusterNotFoundFault(String::from(parsed_error.message))
@@ -12453,6 +12557,14 @@ impl DeleteClusterError {
             },
             Err(_) => DeleteClusterError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -12518,7 +12630,7 @@ impl DeleteClusterParameterGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ClusterParameterGroupNotFoundFault" => {
                     DeleteClusterParameterGroupError::ClusterParameterGroupNotFoundFault(
@@ -12534,6 +12646,14 @@ impl DeleteClusterParameterGroupError {
             },
             Err(_) => DeleteClusterParameterGroupError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -12603,7 +12723,7 @@ impl DeleteClusterSecurityGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ClusterSecurityGroupNotFoundFault" => {
                     DeleteClusterSecurityGroupError::ClusterSecurityGroupNotFoundFault(
@@ -12619,6 +12739,14 @@ impl DeleteClusterSecurityGroupError {
             },
             Err(_) => DeleteClusterSecurityGroupError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -12686,7 +12814,7 @@ impl DeleteClusterSnapshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ClusterSnapshotNotFoundFault" => {
                     DeleteClusterSnapshotError::ClusterSnapshotNotFoundFault(String::from(
@@ -12702,6 +12830,14 @@ impl DeleteClusterSnapshotError {
             },
             Err(_) => DeleteClusterSnapshotError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -12769,7 +12905,7 @@ impl DeleteClusterSubnetGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ClusterSubnetGroupNotFoundFault" => {
                     DeleteClusterSubnetGroupError::ClusterSubnetGroupNotFoundFault(String::from(
@@ -12790,6 +12926,14 @@ impl DeleteClusterSubnetGroupError {
             },
             Err(_) => DeleteClusterSubnetGroupError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -12856,7 +13000,7 @@ impl DeleteEventSubscriptionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidSubscriptionStateFault" => {
                     DeleteEventSubscriptionError::InvalidSubscriptionStateFault(String::from(
@@ -12872,6 +13016,14 @@ impl DeleteEventSubscriptionError {
             },
             Err(_) => DeleteEventSubscriptionError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -12937,7 +13089,7 @@ impl DeleteHsmClientCertificateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "HsmClientCertificateNotFoundFault" => {
                     DeleteHsmClientCertificateError::HsmClientCertificateNotFoundFault(
@@ -12953,6 +13105,14 @@ impl DeleteHsmClientCertificateError {
             },
             Err(_) => DeleteHsmClientCertificateError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -13020,7 +13180,7 @@ impl DeleteHsmConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "HsmConfigurationNotFoundFault" => {
                     DeleteHsmConfigurationError::HsmConfigurationNotFoundFault(String::from(
@@ -13036,6 +13196,14 @@ impl DeleteHsmConfigurationError {
             },
             Err(_) => DeleteHsmConfigurationError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -13101,7 +13269,7 @@ impl DeleteSnapshotCopyGrantError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidSnapshotCopyGrantStateFault" => {
                     DeleteSnapshotCopyGrantError::InvalidSnapshotCopyGrantStateFault(String::from(
@@ -13117,6 +13285,14 @@ impl DeleteSnapshotCopyGrantError {
             },
             Err(_) => DeleteSnapshotCopyGrantError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -13182,7 +13358,7 @@ impl DeleteTagsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidTagFault" => {
                     DeleteTagsError::InvalidTagFault(String::from(parsed_error.message))
@@ -13194,6 +13370,14 @@ impl DeleteTagsError {
             },
             Err(_) => DeleteTagsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -13257,7 +13441,7 @@ impl DescribeClusterParameterGroupsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ClusterParameterGroupNotFoundFault" => {
                     DescribeClusterParameterGroupsError::ClusterParameterGroupNotFoundFault(
@@ -13271,6 +13455,14 @@ impl DescribeClusterParameterGroupsError {
             },
             Err(_) => DescribeClusterParameterGroupsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -13336,7 +13528,7 @@ impl DescribeClusterParametersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ClusterParameterGroupNotFoundFault" => {
                     DescribeClusterParametersError::ClusterParameterGroupNotFoundFault(
@@ -13347,6 +13539,14 @@ impl DescribeClusterParametersError {
             },
             Err(_) => DescribeClusterParametersError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -13411,7 +13611,7 @@ impl DescribeClusterSecurityGroupsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ClusterSecurityGroupNotFoundFault" => {
                     DescribeClusterSecurityGroupsError::ClusterSecurityGroupNotFoundFault(
@@ -13425,6 +13625,14 @@ impl DescribeClusterSecurityGroupsError {
             },
             Err(_) => DescribeClusterSecurityGroupsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -13492,7 +13700,7 @@ impl DescribeClusterSnapshotsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ClusterSnapshotNotFoundFault" => {
                     DescribeClusterSnapshotsError::ClusterSnapshotNotFoundFault(String::from(
@@ -13506,6 +13714,14 @@ impl DescribeClusterSnapshotsError {
             },
             Err(_) => DescribeClusterSnapshotsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -13571,7 +13787,7 @@ impl DescribeClusterSubnetGroupsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ClusterSubnetGroupNotFoundFault" => {
                     DescribeClusterSubnetGroupsError::ClusterSubnetGroupNotFoundFault(
@@ -13585,6 +13801,14 @@ impl DescribeClusterSubnetGroupsError {
             },
             Err(_) => DescribeClusterSubnetGroupsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -13646,12 +13870,20 @@ impl DescribeClusterVersionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeClusterVersionsError::Unknown(String::from(body)),
             },
             Err(_) => DescribeClusterVersionsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -13715,7 +13947,7 @@ impl DescribeClustersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ClusterNotFoundFault" => {
                     DescribeClustersError::ClusterNotFoundFault(String::from(parsed_error.message))
@@ -13727,6 +13959,14 @@ impl DescribeClustersError {
             },
             Err(_) => DescribeClustersError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -13786,12 +14026,20 @@ impl DescribeDefaultClusterParametersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeDefaultClusterParametersError::Unknown(String::from(body)),
             },
             Err(_) => DescribeDefaultClusterParametersError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -13851,12 +14099,20 @@ impl DescribeEventCategoriesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeEventCategoriesError::Unknown(String::from(body)),
             },
             Err(_) => DescribeEventCategoriesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -13920,7 +14176,7 @@ impl DescribeEventSubscriptionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidTagFault" => DescribeEventSubscriptionsError::InvalidTagFault(
                     String::from(parsed_error.message),
@@ -13934,6 +14190,14 @@ impl DescribeEventSubscriptionsError {
             },
             Err(_) => DescribeEventSubscriptionsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -13995,12 +14259,20 @@ impl DescribeEventsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeEventsError::Unknown(String::from(body)),
             },
             Err(_) => DescribeEventsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -14062,7 +14334,7 @@ impl DescribeHsmClientCertificatesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "HsmClientCertificateNotFoundFault" => {
                     DescribeHsmClientCertificatesError::HsmClientCertificateNotFoundFault(
@@ -14076,6 +14348,14 @@ impl DescribeHsmClientCertificatesError {
             },
             Err(_) => DescribeHsmClientCertificatesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -14143,7 +14423,7 @@ impl DescribeHsmConfigurationsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "HsmConfigurationNotFoundFault" => {
                     DescribeHsmConfigurationsError::HsmConfigurationNotFoundFault(String::from(
@@ -14157,6 +14437,14 @@ impl DescribeHsmConfigurationsError {
             },
             Err(_) => DescribeHsmConfigurationsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -14220,7 +14508,7 @@ impl DescribeLoggingStatusError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ClusterNotFoundFault" => DescribeLoggingStatusError::ClusterNotFoundFault(
                     String::from(parsed_error.message),
@@ -14229,6 +14517,14 @@ impl DescribeLoggingStatusError {
             },
             Err(_) => DescribeLoggingStatusError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -14289,12 +14585,20 @@ impl DescribeOrderableClusterOptionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeOrderableClusterOptionsError::Unknown(String::from(body)),
             },
             Err(_) => DescribeOrderableClusterOptionsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -14360,7 +14664,7 @@ impl DescribeReservedNodeOfferingsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DependentServiceUnavailableFault" => {
                     DescribeReservedNodeOfferingsError::DependentServiceUnavailableFault(
@@ -14381,6 +14685,14 @@ impl DescribeReservedNodeOfferingsError {
             },
             Err(_) => DescribeReservedNodeOfferingsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -14451,7 +14763,7 @@ impl DescribeReservedNodesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DependentServiceUnavailableFault" => {
                     DescribeReservedNodesError::DependentServiceUnavailableFault(String::from(
@@ -14467,6 +14779,14 @@ impl DescribeReservedNodesError {
             },
             Err(_) => DescribeReservedNodesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -14532,7 +14852,7 @@ impl DescribeResizeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ClusterNotFoundFault" => {
                     DescribeResizeError::ClusterNotFoundFault(String::from(parsed_error.message))
@@ -14544,6 +14864,14 @@ impl DescribeResizeError {
             },
             Err(_) => DescribeResizeError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -14607,7 +14935,7 @@ impl DescribeSnapshotCopyGrantsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidTagFault" => DescribeSnapshotCopyGrantsError::InvalidTagFault(
                     String::from(parsed_error.message),
@@ -14621,6 +14949,14 @@ impl DescribeSnapshotCopyGrantsError {
             },
             Err(_) => DescribeSnapshotCopyGrantsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -14686,7 +15022,7 @@ impl DescribeTableRestoreStatusError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ClusterNotFoundFault" => DescribeTableRestoreStatusError::ClusterNotFoundFault(
                     String::from(parsed_error.message),
@@ -14700,6 +15036,14 @@ impl DescribeTableRestoreStatusError {
             },
             Err(_) => DescribeTableRestoreStatusError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -14765,7 +15109,7 @@ impl DescribeTagsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidTagFault" => {
                     DescribeTagsError::InvalidTagFault(String::from(parsed_error.message))
@@ -14777,6 +15121,14 @@ impl DescribeTagsError {
             },
             Err(_) => DescribeTagsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -14838,7 +15190,7 @@ impl DisableLoggingError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ClusterNotFoundFault" => {
                     DisableLoggingError::ClusterNotFoundFault(String::from(parsed_error.message))
@@ -14847,6 +15199,14 @@ impl DisableLoggingError {
             },
             Err(_) => DisableLoggingError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -14913,7 +15273,7 @@ impl DisableSnapshotCopyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ClusterNotFoundFault" => DisableSnapshotCopyError::ClusterNotFoundFault(
                     String::from(parsed_error.message),
@@ -14933,6 +15293,14 @@ impl DisableSnapshotCopyError {
             },
             Err(_) => DisableSnapshotCopyError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -15006,7 +15374,7 @@ impl EnableLoggingError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "BucketNotFoundFault" => {
                     EnableLoggingError::BucketNotFoundFault(String::from(parsed_error.message))
@@ -15029,6 +15397,14 @@ impl EnableLoggingError {
             },
             Err(_) => EnableLoggingError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -15111,7 +15487,7 @@ impl EnableSnapshotCopyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ClusterNotFoundFault" => EnableSnapshotCopyError::ClusterNotFoundFault(
                     String::from(parsed_error.message),
@@ -15157,6 +15533,14 @@ impl EnableSnapshotCopyError {
             },
             Err(_) => EnableSnapshotCopyError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -15230,7 +15614,7 @@ impl GetClusterCredentialsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ClusterNotFoundFault" => GetClusterCredentialsError::ClusterNotFoundFault(
                     String::from(parsed_error.message),
@@ -15244,6 +15628,14 @@ impl GetClusterCredentialsError {
             },
             Err(_) => GetClusterCredentialsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -15337,7 +15729,7 @@ impl ModifyClusterError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ClusterAlreadyExistsFault" => ModifyClusterError::ClusterAlreadyExistsFault(
                     String::from(parsed_error.message),
@@ -15409,6 +15801,14 @@ impl ModifyClusterError {
             },
             Err(_) => ModifyClusterError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -15486,7 +15886,7 @@ impl ModifyClusterIamRolesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ClusterNotFoundFault" => ModifyClusterIamRolesError::ClusterNotFoundFault(
                     String::from(parsed_error.message),
@@ -15500,6 +15900,14 @@ impl ModifyClusterIamRolesError {
             },
             Err(_) => ModifyClusterIamRolesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -15565,7 +15973,7 @@ impl ModifyClusterParameterGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ClusterParameterGroupNotFoundFault" => {
                     ModifyClusterParameterGroupError::ClusterParameterGroupNotFoundFault(
@@ -15581,6 +15989,14 @@ impl ModifyClusterParameterGroupError {
             },
             Err(_) => ModifyClusterParameterGroupError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -15658,7 +16074,7 @@ impl ModifyClusterSubnetGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ClusterSubnetGroupNotFoundFault" => {
                     ModifyClusterSubnetGroupError::ClusterSubnetGroupNotFoundFault(String::from(
@@ -15688,6 +16104,14 @@ impl ModifyClusterSubnetGroupError {
             },
             Err(_) => ModifyClusterSubnetGroupError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -15773,7 +16197,7 @@ impl ModifyEventSubscriptionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidSubscriptionStateFault" => {
                     ModifyEventSubscriptionError::InvalidSubscriptionStateFault(String::from(
@@ -15820,6 +16244,14 @@ impl ModifyEventSubscriptionError {
             },
             Err(_) => ModifyEventSubscriptionError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -15896,7 +16328,7 @@ impl ModifySnapshotCopyRetentionPeriodError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ClusterNotFoundFault" => {
                     ModifySnapshotCopyRetentionPeriodError::ClusterNotFoundFault(String::from(
@@ -15922,6 +16354,14 @@ impl ModifySnapshotCopyRetentionPeriodError {
             },
             Err(_) => ModifySnapshotCopyRetentionPeriodError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -15993,7 +16433,7 @@ impl PurchaseReservedNodeOfferingError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ReservedNodeAlreadyExistsFault" => {
                     PurchaseReservedNodeOfferingError::ReservedNodeAlreadyExistsFault(
@@ -16019,6 +16459,14 @@ impl PurchaseReservedNodeOfferingError {
             },
             Err(_) => PurchaseReservedNodeOfferingError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -16088,7 +16536,7 @@ impl RebootClusterError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ClusterNotFoundFault" => {
                     RebootClusterError::ClusterNotFoundFault(String::from(parsed_error.message))
@@ -16100,6 +16548,14 @@ impl RebootClusterError {
             },
             Err(_) => RebootClusterError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -16163,7 +16619,7 @@ impl ResetClusterParameterGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ClusterParameterGroupNotFoundFault" => {
                     ResetClusterParameterGroupError::ClusterParameterGroupNotFoundFault(
@@ -16179,6 +16635,14 @@ impl ResetClusterParameterGroupError {
             },
             Err(_) => ResetClusterParameterGroupError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -16284,7 +16748,7 @@ impl RestoreFromClusterSnapshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessToSnapshotDeniedFault" => {
                     RestoreFromClusterSnapshotError::AccessToSnapshotDeniedFault(String::from(
@@ -16386,6 +16850,14 @@ impl RestoreFromClusterSnapshotError {
             Err(_) => RestoreFromClusterSnapshotError::Unknown(body.to_string()),
         }
     }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
+    }
 }
 
 impl From<XmlParseError> for RestoreFromClusterSnapshotError {
@@ -16485,7 +16957,7 @@ impl RestoreTableFromClusterSnapshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ClusterNotFoundFault" => {
                     RestoreTableFromClusterSnapshotError::ClusterNotFoundFault(String::from(
@@ -16526,6 +16998,14 @@ impl RestoreTableFromClusterSnapshotError {
             },
             Err(_) => RestoreTableFromClusterSnapshotError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -16604,7 +17084,7 @@ impl RevokeClusterSecurityGroupIngressError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationNotFoundFault" => {
                     RevokeClusterSecurityGroupIngressError::AuthorizationNotFoundFault(
@@ -16625,6 +17105,14 @@ impl RevokeClusterSecurityGroupIngressError {
             },
             Err(_) => RevokeClusterSecurityGroupIngressError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -16697,7 +17185,7 @@ impl RevokeSnapshotAccessError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccessToSnapshotDeniedFault" => {
                     RevokeSnapshotAccessError::AccessToSnapshotDeniedFault(String::from(
@@ -16718,6 +17206,14 @@ impl RevokeSnapshotAccessError {
             },
             Err(_) => RevokeSnapshotAccessError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -16786,7 +17282,7 @@ impl RotateEncryptionKeyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ClusterNotFoundFault" => RotateEncryptionKeyError::ClusterNotFoundFault(
                     String::from(parsed_error.message),
@@ -16803,6 +17299,14 @@ impl RotateEncryptionKeyError {
             },
             Err(_) => RotateEncryptionKeyError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 

--- a/rusoto/services/route53/src/custom/custom_tests.rs
+++ b/rusoto/services/route53/src/custom/custom_tests.rs
@@ -1,6 +1,7 @@
 extern crate rusoto_mock;
 
 use ::{Route53, Route53Client, ListResourceRecordSetsRequest, ListResourceRecordSetsError};
+use rusoto_core::Region;
 
 use self::rusoto_mock::*;
 

--- a/rusoto/services/route53/src/custom/custom_tests.rs
+++ b/rusoto/services/route53/src/custom/custom_tests.rs
@@ -1,0 +1,30 @@
+extern crate rusoto_mock;
+
+use ::{Route53, Route53Client, ListResourceRecordSetsRequest, ListResourceRecordSetsError};
+
+use self::rusoto_mock::*;
+
+#[test]
+fn test_parse_no_such_hosted_zone_error() {
+    let mock = MockRequestDispatcher::with_status(404)
+        .with_body(r#"<?xml version="1.0"?>
+            <ErrorResponse xmlns="https://route53.amazonaws.com/doc/2013-04-01/">
+                <Error>
+                    <Type>Sender</Type>
+                    <Code>NoSuchHostedZone</Code>
+                    <Message>No hosted zone found with ID: NO-SUCH-ZONE</Message>
+                </Error>
+                <RequestId>20c2984f-279e-11e8-9a16-83e7725d8022</RequestId>
+            </ErrorResponse>"#);
+
+    let request = ListResourceRecordSetsRequest {
+        hosted_zone_id: "NO-SUCH-ZONE".to_owned(),
+        ..Default::default()
+    };
+
+    let client = Route53Client::new(mock, MockCredentialsProvider, Region::UsEast1);
+    let result = client.list_resource_record_sets(&request).sync();
+    assert!(result.is_err());
+    let err = result.err().unwrap();
+    assert_eq!(ListResourceRecordSetsError::NoSuchHostedZone("No hosted zone found with ID: NO-SUCH-ZONE".to_owned()), err);
+}

--- a/rusoto/services/route53/src/custom/mod.rs
+++ b/rusoto/services/route53/src/custom/mod.rs
@@ -1,0 +1,2 @@
+#[cfg(test)]
+mod custom_tests;

--- a/rusoto/services/route53/src/generated.rs
+++ b/rusoto/services/route53/src/generated.rs
@@ -10006,7 +10006,7 @@ impl AssociateVPCWithHostedZoneError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ConflictingDomainExists" => {
                     AssociateVPCWithHostedZoneError::ConflictingDomainExists(String::from(
@@ -10037,6 +10037,14 @@ impl AssociateVPCWithHostedZoneError {
             },
             Err(_) => AssociateVPCWithHostedZoneError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10113,7 +10121,7 @@ impl ChangeResourceRecordSetsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidChangeBatch" => ChangeResourceRecordSetsError::InvalidChangeBatch(
                     String::from(parsed_error.message),
@@ -10136,6 +10144,14 @@ impl ChangeResourceRecordSetsError {
             },
             Err(_) => ChangeResourceRecordSetsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10210,7 +10226,7 @@ impl ChangeTagsForResourceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInput" => {
                     ChangeTagsForResourceError::InvalidInput(String::from(parsed_error.message))
@@ -10231,6 +10247,14 @@ impl ChangeTagsForResourceError {
             },
             Err(_) => ChangeTagsForResourceError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10301,7 +10325,7 @@ impl CreateHealthCheckError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "HealthCheckAlreadyExists" => CreateHealthCheckError::HealthCheckAlreadyExists(
                     String::from(parsed_error.message),
@@ -10316,6 +10340,14 @@ impl CreateHealthCheckError {
             },
             Err(_) => CreateHealthCheckError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10396,7 +10428,7 @@ impl CreateHostedZoneError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ConflictingDomainExists" => CreateHostedZoneError::ConflictingDomainExists(
                     String::from(parsed_error.message),
@@ -10429,6 +10461,14 @@ impl CreateHostedZoneError {
             },
             Err(_) => CreateHostedZoneError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10507,7 +10547,7 @@ impl CreateQueryLoggingConfigError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ConcurrentModification" => CreateQueryLoggingConfigError::ConcurrentModification(
                     String::from(parsed_error.message),
@@ -10537,6 +10577,14 @@ impl CreateQueryLoggingConfigError {
             },
             Err(_) => CreateQueryLoggingConfigError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10618,7 +10666,7 @@ impl CreateReusableDelegationSetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DelegationSetAlreadyCreated" => {
                     CreateReusableDelegationSetError::DelegationSetAlreadyCreated(String::from(
@@ -10651,6 +10699,14 @@ impl CreateReusableDelegationSetError {
             },
             Err(_) => CreateReusableDelegationSetError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10725,7 +10781,7 @@ impl CreateTrafficPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInput" => {
                     CreateTrafficPolicyError::InvalidInput(String::from(parsed_error.message))
@@ -10747,6 +10803,14 @@ impl CreateTrafficPolicyError {
             },
             Err(_) => CreateTrafficPolicyError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10820,7 +10884,7 @@ impl CreateTrafficPolicyInstanceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInput" => CreateTrafficPolicyInstanceError::InvalidInput(String::from(
                     parsed_error.message,
@@ -10845,6 +10909,14 @@ impl CreateTrafficPolicyInstanceError {
             },
             Err(_) => CreateTrafficPolicyInstanceError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10919,7 +10991,7 @@ impl CreateTrafficPolicyVersionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ConcurrentModification" => {
                     CreateTrafficPolicyVersionError::ConcurrentModification(String::from(
@@ -10941,6 +11013,14 @@ impl CreateTrafficPolicyVersionError {
             },
             Err(_) => CreateTrafficPolicyVersionError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11014,7 +11094,7 @@ impl CreateVPCAssociationAuthorizationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ConcurrentModification" => {
                     CreateVPCAssociationAuthorizationError::ConcurrentModification(String::from(
@@ -11039,6 +11119,14 @@ impl CreateVPCAssociationAuthorizationError {
             },
             Err(_) => CreateVPCAssociationAuthorizationError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11111,7 +11199,7 @@ impl DeleteHealthCheckError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "HealthCheckInUse" => {
                     DeleteHealthCheckError::HealthCheckInUse(String::from(parsed_error.message))
@@ -11126,6 +11214,14 @@ impl DeleteHealthCheckError {
             },
             Err(_) => DeleteHealthCheckError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11198,7 +11294,7 @@ impl DeleteHostedZoneError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "HostedZoneNotEmpty" => {
                     DeleteHostedZoneError::HostedZoneNotEmpty(String::from(parsed_error.message))
@@ -11219,6 +11315,14 @@ impl DeleteHostedZoneError {
             },
             Err(_) => DeleteHostedZoneError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11287,7 +11391,7 @@ impl DeleteQueryLoggingConfigError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ConcurrentModification" => DeleteQueryLoggingConfigError::ConcurrentModification(
                     String::from(parsed_error.message),
@@ -11304,6 +11408,14 @@ impl DeleteQueryLoggingConfigError {
             },
             Err(_) => DeleteQueryLoggingConfigError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11374,7 +11486,7 @@ impl DeleteReusableDelegationSetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DelegationSetInUse" => DeleteReusableDelegationSetError::DelegationSetInUse(
                     String::from(parsed_error.message),
@@ -11394,6 +11506,14 @@ impl DeleteReusableDelegationSetError {
             },
             Err(_) => DeleteReusableDelegationSetError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11465,7 +11585,7 @@ impl DeleteTrafficPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ConcurrentModification" => DeleteTrafficPolicyError::ConcurrentModification(
                     String::from(parsed_error.message),
@@ -11483,6 +11603,14 @@ impl DeleteTrafficPolicyError {
             },
             Err(_) => DeleteTrafficPolicyError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11552,7 +11680,7 @@ impl DeleteTrafficPolicyInstanceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInput" => DeleteTrafficPolicyInstanceError::InvalidInput(String::from(
                     parsed_error.message,
@@ -11571,6 +11699,14 @@ impl DeleteTrafficPolicyInstanceError {
             },
             Err(_) => DeleteTrafficPolicyInstanceError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11643,7 +11779,7 @@ impl DeleteVPCAssociationAuthorizationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ConcurrentModification" => {
                     DeleteVPCAssociationAuthorizationError::ConcurrentModification(String::from(
@@ -11668,6 +11804,14 @@ impl DeleteVPCAssociationAuthorizationError {
             },
             Err(_) => DeleteVPCAssociationAuthorizationError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11744,7 +11888,7 @@ impl DisassociateVPCFromHostedZoneError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInput" => DisassociateVPCFromHostedZoneError::InvalidInput(String::from(
                     parsed_error.message,
@@ -11767,6 +11911,14 @@ impl DisassociateVPCFromHostedZoneError {
             },
             Err(_) => DisassociateVPCFromHostedZoneError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11833,7 +11985,7 @@ impl GetAccountLimitError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInput" => {
                     GetAccountLimitError::InvalidInput(String::from(parsed_error.message))
@@ -11842,6 +11994,14 @@ impl GetAccountLimitError {
             },
             Err(_) => GetAccountLimitError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11904,7 +12064,7 @@ impl GetChangeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInput" => GetChangeError::InvalidInput(String::from(parsed_error.message)),
                 "NoSuchChange" => GetChangeError::NoSuchChange(String::from(parsed_error.message)),
@@ -11912,6 +12072,14 @@ impl GetChangeError {
             },
             Err(_) => GetChangeError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11971,12 +12139,20 @@ impl GetCheckerIpRangesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetCheckerIpRangesError::Unknown(String::from(body)),
             },
             Err(_) => GetCheckerIpRangesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -12040,7 +12216,7 @@ impl GetGeoLocationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInput" => {
                     GetGeoLocationError::InvalidInput(String::from(parsed_error.message))
@@ -12052,6 +12228,14 @@ impl GetGeoLocationError {
             },
             Err(_) => GetGeoLocationError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -12117,7 +12301,7 @@ impl GetHealthCheckError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "IncompatibleVersion" => {
                     GetHealthCheckError::IncompatibleVersion(String::from(parsed_error.message))
@@ -12132,6 +12316,14 @@ impl GetHealthCheckError {
             },
             Err(_) => GetHealthCheckError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -12192,12 +12384,20 @@ impl GetHealthCheckCountError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetHealthCheckCountError::Unknown(String::from(body)),
             },
             Err(_) => GetHealthCheckCountError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -12261,7 +12461,7 @@ impl GetHealthCheckLastFailureReasonError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInput" => GetHealthCheckLastFailureReasonError::InvalidInput(
                     String::from(parsed_error.message),
@@ -12273,6 +12473,14 @@ impl GetHealthCheckLastFailureReasonError {
             },
             Err(_) => GetHealthCheckLastFailureReasonError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -12338,7 +12546,7 @@ impl GetHealthCheckStatusError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInput" => {
                     GetHealthCheckStatusError::InvalidInput(String::from(parsed_error.message))
@@ -12350,6 +12558,14 @@ impl GetHealthCheckStatusError {
             },
             Err(_) => GetHealthCheckStatusError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -12415,7 +12631,7 @@ impl GetHostedZoneError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInput" => {
                     GetHostedZoneError::InvalidInput(String::from(parsed_error.message))
@@ -12427,6 +12643,14 @@ impl GetHostedZoneError {
             },
             Err(_) => GetHostedZoneError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -12488,7 +12712,7 @@ impl GetHostedZoneCountError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInput" => {
                     GetHostedZoneCountError::InvalidInput(String::from(parsed_error.message))
@@ -12497,6 +12721,14 @@ impl GetHostedZoneCountError {
             },
             Err(_) => GetHostedZoneCountError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -12563,7 +12795,7 @@ impl GetHostedZoneLimitError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "HostedZoneNotPrivate" => GetHostedZoneLimitError::HostedZoneNotPrivate(
                     String::from(parsed_error.message),
@@ -12578,6 +12810,14 @@ impl GetHostedZoneLimitError {
             },
             Err(_) => GetHostedZoneLimitError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -12644,7 +12884,7 @@ impl GetQueryLoggingConfigError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInput" => {
                     GetQueryLoggingConfigError::InvalidInput(String::from(parsed_error.message))
@@ -12658,6 +12898,14 @@ impl GetQueryLoggingConfigError {
             },
             Err(_) => GetQueryLoggingConfigError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -12725,7 +12973,7 @@ impl GetReusableDelegationSetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DelegationSetNotReusable" => {
                     GetReusableDelegationSetError::DelegationSetNotReusable(String::from(
@@ -12742,6 +12990,14 @@ impl GetReusableDelegationSetError {
             },
             Err(_) => GetReusableDelegationSetError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -12808,7 +13064,7 @@ impl GetReusableDelegationSetLimitError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInput" => GetReusableDelegationSetLimitError::InvalidInput(String::from(
                     parsed_error.message,
@@ -12820,6 +13076,14 @@ impl GetReusableDelegationSetLimitError {
             },
             Err(_) => GetReusableDelegationSetLimitError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -12885,7 +13149,7 @@ impl GetTrafficPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInput" => {
                     GetTrafficPolicyError::InvalidInput(String::from(parsed_error.message))
@@ -12897,6 +13161,14 @@ impl GetTrafficPolicyError {
             },
             Err(_) => GetTrafficPolicyError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -12960,7 +13232,7 @@ impl GetTrafficPolicyInstanceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInput" => {
                     GetTrafficPolicyInstanceError::InvalidInput(String::from(parsed_error.message))
@@ -12974,6 +13246,14 @@ impl GetTrafficPolicyInstanceError {
             },
             Err(_) => GetTrafficPolicyInstanceError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -13035,12 +13315,20 @@ impl GetTrafficPolicyInstanceCountError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetTrafficPolicyInstanceCountError::Unknown(String::from(body)),
             },
             Err(_) => GetTrafficPolicyInstanceCountError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -13102,7 +13390,7 @@ impl ListGeoLocationsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInput" => {
                     ListGeoLocationsError::InvalidInput(String::from(parsed_error.message))
@@ -13111,6 +13399,14 @@ impl ListGeoLocationsError {
             },
             Err(_) => ListGeoLocationsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -13173,7 +13469,7 @@ impl ListHealthChecksError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "IncompatibleVersion" => {
                     ListHealthChecksError::IncompatibleVersion(String::from(parsed_error.message))
@@ -13185,6 +13481,14 @@ impl ListHealthChecksError {
             },
             Err(_) => ListHealthChecksError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -13250,7 +13554,7 @@ impl ListHostedZonesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DelegationSetNotReusable" => ListHostedZonesError::DelegationSetNotReusable(
                     String::from(parsed_error.message),
@@ -13265,6 +13569,14 @@ impl ListHostedZonesError {
             },
             Err(_) => ListHostedZonesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -13329,7 +13641,7 @@ impl ListHostedZonesByNameError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidDomainName" => ListHostedZonesByNameError::InvalidDomainName(
                     String::from(parsed_error.message),
@@ -13341,6 +13653,14 @@ impl ListHostedZonesByNameError {
             },
             Err(_) => ListHostedZonesByNameError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -13408,7 +13728,7 @@ impl ListQueryLoggingConfigsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInput" => {
                     ListQueryLoggingConfigsError::InvalidInput(String::from(parsed_error.message))
@@ -13423,6 +13743,14 @@ impl ListQueryLoggingConfigsError {
             },
             Err(_) => ListQueryLoggingConfigsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -13489,7 +13817,7 @@ impl ListResourceRecordSetsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInput" => {
                     ListResourceRecordSetsError::InvalidInput(String::from(parsed_error.message))
@@ -13501,6 +13829,14 @@ impl ListResourceRecordSetsError {
             },
             Err(_) => ListResourceRecordSetsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -13564,7 +13900,7 @@ impl ListReusableDelegationSetsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInput" => ListReusableDelegationSetsError::InvalidInput(String::from(
                     parsed_error.message,
@@ -13573,6 +13909,14 @@ impl ListReusableDelegationSetsError {
             },
             Err(_) => ListReusableDelegationSetsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -13643,7 +13987,7 @@ impl ListTagsForResourceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInput" => {
                     ListTagsForResourceError::InvalidInput(String::from(parsed_error.message))
@@ -13664,6 +14008,14 @@ impl ListTagsForResourceError {
             },
             Err(_) => ListTagsForResourceError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -13738,7 +14090,7 @@ impl ListTagsForResourcesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInput" => {
                     ListTagsForResourcesError::InvalidInput(String::from(parsed_error.message))
@@ -13759,6 +14111,14 @@ impl ListTagsForResourcesError {
             },
             Err(_) => ListTagsForResourcesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -13825,7 +14185,7 @@ impl ListTrafficPoliciesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInput" => {
                     ListTrafficPoliciesError::InvalidInput(String::from(parsed_error.message))
@@ -13834,6 +14194,14 @@ impl ListTrafficPoliciesError {
             },
             Err(_) => ListTrafficPoliciesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -13898,7 +14266,7 @@ impl ListTrafficPolicyInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInput" => ListTrafficPolicyInstancesError::InvalidInput(String::from(
                     parsed_error.message,
@@ -13912,6 +14280,14 @@ impl ListTrafficPolicyInstancesError {
             },
             Err(_) => ListTrafficPolicyInstancesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -13979,7 +14355,7 @@ impl ListTrafficPolicyInstancesByHostedZoneError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInput" => ListTrafficPolicyInstancesByHostedZoneError::InvalidInput(
                     String::from(parsed_error.message),
@@ -13998,6 +14374,14 @@ impl ListTrafficPolicyInstancesByHostedZoneError {
             },
             Err(_) => ListTrafficPolicyInstancesByHostedZoneError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -14068,7 +14452,7 @@ impl ListTrafficPolicyInstancesByPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInput" => ListTrafficPolicyInstancesByPolicyError::InvalidInput(
                     String::from(parsed_error.message),
@@ -14087,6 +14471,14 @@ impl ListTrafficPolicyInstancesByPolicyError {
             },
             Err(_) => ListTrafficPolicyInstancesByPolicyError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -14155,7 +14547,7 @@ impl ListTrafficPolicyVersionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInput" => {
                     ListTrafficPolicyVersionsError::InvalidInput(String::from(parsed_error.message))
@@ -14167,6 +14559,14 @@ impl ListTrafficPolicyVersionsError {
             },
             Err(_) => ListTrafficPolicyVersionsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -14234,7 +14634,7 @@ impl ListVPCAssociationAuthorizationsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInput" => ListVPCAssociationAuthorizationsError::InvalidInput(
                     String::from(parsed_error.message),
@@ -14251,6 +14651,14 @@ impl ListVPCAssociationAuthorizationsError {
             },
             Err(_) => ListVPCAssociationAuthorizationsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -14317,7 +14725,7 @@ impl TestDNSAnswerError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInput" => {
                     TestDNSAnswerError::InvalidInput(String::from(parsed_error.message))
@@ -14329,6 +14737,14 @@ impl TestDNSAnswerError {
             },
             Err(_) => TestDNSAnswerError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -14394,7 +14810,7 @@ impl UpdateHealthCheckError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "HealthCheckVersionMismatch" => {
                     UpdateHealthCheckError::HealthCheckVersionMismatch(String::from(
@@ -14411,6 +14827,14 @@ impl UpdateHealthCheckError {
             },
             Err(_) => UpdateHealthCheckError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -14477,7 +14901,7 @@ impl UpdateHostedZoneCommentError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidInput" => {
                     UpdateHostedZoneCommentError::InvalidInput(String::from(parsed_error.message))
@@ -14489,6 +14913,14 @@ impl UpdateHostedZoneCommentError {
             },
             Err(_) => UpdateHostedZoneCommentError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -14556,7 +14988,7 @@ impl UpdateTrafficPolicyCommentError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ConcurrentModification" => {
                     UpdateTrafficPolicyCommentError::ConcurrentModification(String::from(
@@ -14573,6 +15005,14 @@ impl UpdateTrafficPolicyCommentError {
             },
             Err(_) => UpdateTrafficPolicyCommentError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -14645,7 +15085,7 @@ impl UpdateTrafficPolicyInstanceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ConflictingTypes" => UpdateTrafficPolicyInstanceError::ConflictingTypes(
                     String::from(parsed_error.message),
@@ -14670,6 +15110,14 @@ impl UpdateTrafficPolicyInstanceError {
             },
             Err(_) => UpdateTrafficPolicyInstanceError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 

--- a/rusoto/services/s3/src/generated.rs
+++ b/rusoto/services/s3/src/generated.rs
@@ -15580,7 +15580,7 @@ impl AbortMultipartUploadError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchUpload" => {
                     AbortMultipartUploadError::NoSuchUpload(String::from(parsed_error.message))
@@ -15589,6 +15589,13 @@ impl AbortMultipartUploadError {
             },
             Err(_) => AbortMultipartUploadError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -15649,12 +15656,19 @@ impl CompleteMultipartUploadError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CompleteMultipartUploadError::Unknown(String::from(body)),
             },
             Err(_) => CompleteMultipartUploadError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -15716,7 +15730,7 @@ impl CopyObjectError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ObjectNotInActiveTierError" => {
                     CopyObjectError::ObjectNotInActiveTierError(String::from(parsed_error.message))
@@ -15725,6 +15739,13 @@ impl CopyObjectError {
             },
             Err(_) => CopyObjectError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -15787,7 +15808,7 @@ impl CreateBucketError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "BucketAlreadyExists" => {
                     CreateBucketError::BucketAlreadyExists(String::from(parsed_error.message))
@@ -15799,6 +15820,13 @@ impl CreateBucketError {
             },
             Err(_) => CreateBucketError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -15858,12 +15886,19 @@ impl CreateMultipartUploadError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateMultipartUploadError::Unknown(String::from(body)),
             },
             Err(_) => CreateMultipartUploadError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -15923,12 +15958,19 @@ impl DeleteBucketError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteBucketError::Unknown(String::from(body)),
             },
             Err(_) => DeleteBucketError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -15986,12 +16028,19 @@ impl DeleteBucketAnalyticsConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteBucketAnalyticsConfigurationError::Unknown(String::from(body)),
             },
             Err(_) => DeleteBucketAnalyticsConfigurationError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -16051,12 +16100,19 @@ impl DeleteBucketCorsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteBucketCorsError::Unknown(String::from(body)),
             },
             Err(_) => DeleteBucketCorsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -16114,12 +16170,19 @@ impl DeleteBucketEncryptionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteBucketEncryptionError::Unknown(String::from(body)),
             },
             Err(_) => DeleteBucketEncryptionError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -16179,12 +16242,19 @@ impl DeleteBucketInventoryConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteBucketInventoryConfigurationError::Unknown(String::from(body)),
             },
             Err(_) => DeleteBucketInventoryConfigurationError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -16244,12 +16314,19 @@ impl DeleteBucketLifecycleError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteBucketLifecycleError::Unknown(String::from(body)),
             },
             Err(_) => DeleteBucketLifecycleError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -16309,12 +16386,19 @@ impl DeleteBucketMetricsConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteBucketMetricsConfigurationError::Unknown(String::from(body)),
             },
             Err(_) => DeleteBucketMetricsConfigurationError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -16374,12 +16458,19 @@ impl DeleteBucketPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteBucketPolicyError::Unknown(String::from(body)),
             },
             Err(_) => DeleteBucketPolicyError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -16439,12 +16530,19 @@ impl DeleteBucketReplicationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteBucketReplicationError::Unknown(String::from(body)),
             },
             Err(_) => DeleteBucketReplicationError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -16504,12 +16602,19 @@ impl DeleteBucketTaggingError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteBucketTaggingError::Unknown(String::from(body)),
             },
             Err(_) => DeleteBucketTaggingError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -16569,12 +16674,19 @@ impl DeleteBucketWebsiteError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteBucketWebsiteError::Unknown(String::from(body)),
             },
             Err(_) => DeleteBucketWebsiteError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -16634,12 +16746,19 @@ impl DeleteObjectError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteObjectError::Unknown(String::from(body)),
             },
             Err(_) => DeleteObjectError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -16697,12 +16816,19 @@ impl DeleteObjectTaggingError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteObjectTaggingError::Unknown(String::from(body)),
             },
             Err(_) => DeleteObjectTaggingError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -16762,12 +16888,19 @@ impl DeleteObjectsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteObjectsError::Unknown(String::from(body)),
             },
             Err(_) => DeleteObjectsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -16825,12 +16958,19 @@ impl GetBucketAccelerateConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketAccelerateConfigurationError::Unknown(String::from(body)),
             },
             Err(_) => GetBucketAccelerateConfigurationError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -16890,12 +17030,19 @@ impl GetBucketAclError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketAclError::Unknown(String::from(body)),
             },
             Err(_) => GetBucketAclError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -16953,12 +17100,19 @@ impl GetBucketAnalyticsConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketAnalyticsConfigurationError::Unknown(String::from(body)),
             },
             Err(_) => GetBucketAnalyticsConfigurationError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -17018,12 +17172,19 @@ impl GetBucketCorsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketCorsError::Unknown(String::from(body)),
             },
             Err(_) => GetBucketCorsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -17081,12 +17242,19 @@ impl GetBucketEncryptionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketEncryptionError::Unknown(String::from(body)),
             },
             Err(_) => GetBucketEncryptionError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -17146,12 +17314,19 @@ impl GetBucketInventoryConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketInventoryConfigurationError::Unknown(String::from(body)),
             },
             Err(_) => GetBucketInventoryConfigurationError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -17211,12 +17386,19 @@ impl GetBucketLifecycleError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketLifecycleError::Unknown(String::from(body)),
             },
             Err(_) => GetBucketLifecycleError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -17276,12 +17458,19 @@ impl GetBucketLifecycleConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketLifecycleConfigurationError::Unknown(String::from(body)),
             },
             Err(_) => GetBucketLifecycleConfigurationError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -17341,12 +17530,19 @@ impl GetBucketLocationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketLocationError::Unknown(String::from(body)),
             },
             Err(_) => GetBucketLocationError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -17406,12 +17602,19 @@ impl GetBucketLoggingError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketLoggingError::Unknown(String::from(body)),
             },
             Err(_) => GetBucketLoggingError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -17469,12 +17672,19 @@ impl GetBucketMetricsConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketMetricsConfigurationError::Unknown(String::from(body)),
             },
             Err(_) => GetBucketMetricsConfigurationError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -17534,12 +17744,19 @@ impl GetBucketNotificationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketNotificationError::Unknown(String::from(body)),
             },
             Err(_) => GetBucketNotificationError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -17599,12 +17816,19 @@ impl GetBucketNotificationConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketNotificationConfigurationError::Unknown(String::from(body)),
             },
             Err(_) => GetBucketNotificationConfigurationError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -17664,12 +17888,19 @@ impl GetBucketPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketPolicyError::Unknown(String::from(body)),
             },
             Err(_) => GetBucketPolicyError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -17727,12 +17958,19 @@ impl GetBucketReplicationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketReplicationError::Unknown(String::from(body)),
             },
             Err(_) => GetBucketReplicationError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -17792,12 +18030,19 @@ impl GetBucketRequestPaymentError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketRequestPaymentError::Unknown(String::from(body)),
             },
             Err(_) => GetBucketRequestPaymentError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -17857,12 +18102,19 @@ impl GetBucketTaggingError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketTaggingError::Unknown(String::from(body)),
             },
             Err(_) => GetBucketTaggingError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -17920,12 +18172,19 @@ impl GetBucketVersioningError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketVersioningError::Unknown(String::from(body)),
             },
             Err(_) => GetBucketVersioningError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -17985,12 +18244,19 @@ impl GetBucketWebsiteError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketWebsiteError::Unknown(String::from(body)),
             },
             Err(_) => GetBucketWebsiteError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -18050,13 +18316,20 @@ impl GetObjectError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchKey" => GetObjectError::NoSuchKey(String::from(parsed_error.message)),
                 _ => GetObjectError::Unknown(String::from(body)),
             },
             Err(_) => GetObjectError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -18117,13 +18390,20 @@ impl GetObjectAclError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchKey" => GetObjectAclError::NoSuchKey(String::from(parsed_error.message)),
                 _ => GetObjectAclError::Unknown(String::from(body)),
             },
             Err(_) => GetObjectAclError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -18182,12 +18462,19 @@ impl GetObjectTaggingError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetObjectTaggingError::Unknown(String::from(body)),
             },
             Err(_) => GetObjectTaggingError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -18245,12 +18532,19 @@ impl GetObjectTorrentError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetObjectTorrentError::Unknown(String::from(body)),
             },
             Err(_) => GetObjectTorrentError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -18310,13 +18604,20 @@ impl HeadBucketError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchBucket" => HeadBucketError::NoSuchBucket(String::from(parsed_error.message)),
                 _ => HeadBucketError::Unknown(String::from(body)),
             },
             Err(_) => HeadBucketError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -18377,13 +18678,20 @@ impl HeadObjectError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchKey" => HeadObjectError::NoSuchKey(String::from(parsed_error.message)),
                 _ => HeadObjectError::Unknown(String::from(body)),
             },
             Err(_) => HeadObjectError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -18442,12 +18750,19 @@ impl ListBucketAnalyticsConfigurationsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListBucketAnalyticsConfigurationsError::Unknown(String::from(body)),
             },
             Err(_) => ListBucketAnalyticsConfigurationsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -18507,12 +18822,19 @@ impl ListBucketInventoryConfigurationsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListBucketInventoryConfigurationsError::Unknown(String::from(body)),
             },
             Err(_) => ListBucketInventoryConfigurationsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -18572,12 +18894,19 @@ impl ListBucketMetricsConfigurationsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListBucketMetricsConfigurationsError::Unknown(String::from(body)),
             },
             Err(_) => ListBucketMetricsConfigurationsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -18637,12 +18966,19 @@ impl ListBucketsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListBucketsError::Unknown(String::from(body)),
             },
             Err(_) => ListBucketsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -18700,12 +19036,19 @@ impl ListMultipartUploadsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListMultipartUploadsError::Unknown(String::from(body)),
             },
             Err(_) => ListMultipartUploadsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -18765,12 +19108,19 @@ impl ListObjectVersionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListObjectVersionsError::Unknown(String::from(body)),
             },
             Err(_) => ListObjectVersionsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -18832,7 +19182,7 @@ impl ListObjectsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchBucket" => {
                     ListObjectsError::NoSuchBucket(String::from(parsed_error.message))
@@ -18841,6 +19191,13 @@ impl ListObjectsError {
             },
             Err(_) => ListObjectsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -18901,7 +19258,7 @@ impl ListObjectsV2Error {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchBucket" => {
                     ListObjectsV2Error::NoSuchBucket(String::from(parsed_error.message))
@@ -18910,6 +19267,13 @@ impl ListObjectsV2Error {
             },
             Err(_) => ListObjectsV2Error::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -18968,12 +19332,19 @@ impl ListPartsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListPartsError::Unknown(String::from(body)),
             },
             Err(_) => ListPartsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -19031,12 +19402,19 @@ impl PutBucketAccelerateConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutBucketAccelerateConfigurationError::Unknown(String::from(body)),
             },
             Err(_) => PutBucketAccelerateConfigurationError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -19096,12 +19474,19 @@ impl PutBucketAclError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutBucketAclError::Unknown(String::from(body)),
             },
             Err(_) => PutBucketAclError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -19159,12 +19544,19 @@ impl PutBucketAnalyticsConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutBucketAnalyticsConfigurationError::Unknown(String::from(body)),
             },
             Err(_) => PutBucketAnalyticsConfigurationError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -19224,12 +19616,19 @@ impl PutBucketCorsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutBucketCorsError::Unknown(String::from(body)),
             },
             Err(_) => PutBucketCorsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -19287,12 +19686,19 @@ impl PutBucketEncryptionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutBucketEncryptionError::Unknown(String::from(body)),
             },
             Err(_) => PutBucketEncryptionError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -19352,12 +19758,19 @@ impl PutBucketInventoryConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutBucketInventoryConfigurationError::Unknown(String::from(body)),
             },
             Err(_) => PutBucketInventoryConfigurationError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -19417,12 +19830,19 @@ impl PutBucketLifecycleError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutBucketLifecycleError::Unknown(String::from(body)),
             },
             Err(_) => PutBucketLifecycleError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -19482,12 +19902,19 @@ impl PutBucketLifecycleConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutBucketLifecycleConfigurationError::Unknown(String::from(body)),
             },
             Err(_) => PutBucketLifecycleConfigurationError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -19547,12 +19974,19 @@ impl PutBucketLoggingError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutBucketLoggingError::Unknown(String::from(body)),
             },
             Err(_) => PutBucketLoggingError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -19610,12 +20044,19 @@ impl PutBucketMetricsConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutBucketMetricsConfigurationError::Unknown(String::from(body)),
             },
             Err(_) => PutBucketMetricsConfigurationError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -19675,12 +20116,19 @@ impl PutBucketNotificationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutBucketNotificationError::Unknown(String::from(body)),
             },
             Err(_) => PutBucketNotificationError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -19740,12 +20188,19 @@ impl PutBucketNotificationConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutBucketNotificationConfigurationError::Unknown(String::from(body)),
             },
             Err(_) => PutBucketNotificationConfigurationError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -19805,12 +20260,19 @@ impl PutBucketPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutBucketPolicyError::Unknown(String::from(body)),
             },
             Err(_) => PutBucketPolicyError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -19868,12 +20330,19 @@ impl PutBucketReplicationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutBucketReplicationError::Unknown(String::from(body)),
             },
             Err(_) => PutBucketReplicationError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -19933,12 +20402,19 @@ impl PutBucketRequestPaymentError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutBucketRequestPaymentError::Unknown(String::from(body)),
             },
             Err(_) => PutBucketRequestPaymentError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -19998,12 +20474,19 @@ impl PutBucketTaggingError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutBucketTaggingError::Unknown(String::from(body)),
             },
             Err(_) => PutBucketTaggingError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -20061,12 +20544,19 @@ impl PutBucketVersioningError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutBucketVersioningError::Unknown(String::from(body)),
             },
             Err(_) => PutBucketVersioningError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -20126,12 +20616,19 @@ impl PutBucketWebsiteError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutBucketWebsiteError::Unknown(String::from(body)),
             },
             Err(_) => PutBucketWebsiteError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -20189,12 +20686,19 @@ impl PutObjectError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutObjectError::Unknown(String::from(body)),
             },
             Err(_) => PutObjectError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -20254,13 +20758,20 @@ impl PutObjectAclError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "NoSuchKey" => PutObjectAclError::NoSuchKey(String::from(parsed_error.message)),
                 _ => PutObjectAclError::Unknown(String::from(body)),
             },
             Err(_) => PutObjectAclError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -20319,12 +20830,19 @@ impl PutObjectTaggingError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutObjectTaggingError::Unknown(String::from(body)),
             },
             Err(_) => PutObjectTaggingError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -20384,7 +20902,7 @@ impl RestoreObjectError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ObjectAlreadyInActiveTierError" => {
                     RestoreObjectError::ObjectAlreadyInActiveTierError(String::from(
@@ -20395,6 +20913,13 @@ impl RestoreObjectError {
             },
             Err(_) => RestoreObjectError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -20453,12 +20978,19 @@ impl UploadPartError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => UploadPartError::Unknown(String::from(body)),
             },
             Err(_) => UploadPartError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -20516,12 +21048,19 @@ impl UploadPartCopyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => UploadPartCopyError::Unknown(String::from(body)),
             },
             Err(_) => UploadPartCopyError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 

--- a/rusoto/services/sdb/src/generated.rs
+++ b/rusoto/services/sdb/src/generated.rs
@@ -1101,12 +1101,20 @@ impl BatchDeleteAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => BatchDeleteAttributesError::Unknown(String::from(body)),
             },
             Err(_) => BatchDeleteAttributesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -1184,7 +1192,7 @@ impl BatchPutAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "DuplicateItemName" => {
                     BatchPutAttributesError::DuplicateItemName(String::from(parsed_error.message))
@@ -1225,6 +1233,14 @@ impl BatchPutAttributesError {
             },
             Err(_) => BatchPutAttributesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -1299,7 +1315,7 @@ impl CreateDomainError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "MissingParameter" => {
                     CreateDomainError::MissingParameter(String::from(parsed_error.message))
@@ -1314,6 +1330,14 @@ impl CreateDomainError {
             },
             Err(_) => CreateDomainError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -1382,7 +1406,7 @@ impl DeleteAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "MissingParameter" => {
                     DeleteAttributesError::MissingParameter(String::from(parsed_error.message))
@@ -1400,6 +1424,14 @@ impl DeleteAttributesError {
             },
             Err(_) => DeleteAttributesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -1463,7 +1495,7 @@ impl DeleteDomainError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "MissingParameter" => {
                     DeleteDomainError::MissingParameter(String::from(parsed_error.message))
@@ -1472,6 +1504,14 @@ impl DeleteDomainError {
             },
             Err(_) => DeleteDomainError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -1534,7 +1574,7 @@ impl DomainMetadataError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "MissingParameter" => {
                     DomainMetadataError::MissingParameter(String::from(parsed_error.message))
@@ -1546,6 +1586,14 @@ impl DomainMetadataError {
             },
             Err(_) => DomainMetadataError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -1611,7 +1659,7 @@ impl GetAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "MissingParameter" => {
                     GetAttributesError::MissingParameter(String::from(parsed_error.message))
@@ -1626,6 +1674,14 @@ impl GetAttributesError {
             },
             Err(_) => GetAttributesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -1690,7 +1746,7 @@ impl ListDomainsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidNextToken" => {
                     ListDomainsError::InvalidNextToken(String::from(parsed_error.message))
@@ -1702,6 +1758,14 @@ impl ListDomainsError {
             },
             Err(_) => ListDomainsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -1775,7 +1839,7 @@ impl PutAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "MissingParameter" => {
                     PutAttributesError::MissingParameter(String::from(parsed_error.message))
@@ -1806,6 +1870,14 @@ impl PutAttributesError {
             },
             Err(_) => PutAttributesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -1888,7 +1960,7 @@ impl SelectError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "RequestTimeout" => SelectError::RequestTimeout(String::from(parsed_error.message)),
                 "MissingParameter" => {
@@ -1917,6 +1989,14 @@ impl SelectError {
             },
             Err(_) => SelectError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 

--- a/rusoto/services/sdb/src/generated.rs
+++ b/rusoto/services/sdb/src/generated.rs
@@ -1161,20 +1161,20 @@ impl Error for BatchDeleteAttributesError {
 pub enum BatchPutAttributesError {
     /// <p>The item name was specified more than once. </p>
     DuplicateItemName(String),
+    /// <p>The value for a parameter is invalid.</p>
+    InvalidParameterValue(String),
     /// <p>The request must contain the specified missing parameter.</p>
     MissingParameter(String),
     /// <p>The specified domain does not exist.</p>
     NoSuchDomain(String),
-    /// <p>The value for a parameter is invalid.</p>
-    InvalidParameterValue(String),
-    /// <p>Too many attributes exist in a single call.</p>
-    NumberSubmittedAttributesExceeded(String),
     /// <p>Too many attributes in this domain.</p>
     NumberDomainAttributesExceeded(String),
-    /// <p>Too many attributes in this item.</p>
-    NumberItemAttributesExceeded(String),
     /// <p>Too many bytes in this domain.</p>
     NumberDomainBytesExceeded(String),
+    /// <p>Too many attributes in this item.</p>
+    NumberItemAttributesExceeded(String),
+    /// <p>Too many attributes exist in a single call.</p>
+    NumberSubmittedAttributesExceeded(String),
     /// <p>Too many items exist in a single call.</p>
     NumberSubmittedItemsExceeded(String),
     /// An error occurred dispatching the HTTP request
@@ -1197,33 +1197,33 @@ impl BatchPutAttributesError {
                 "DuplicateItemName" => {
                     BatchPutAttributesError::DuplicateItemName(String::from(parsed_error.message))
                 }
+                "InvalidParameterValue" => BatchPutAttributesError::InvalidParameterValue(
+                    String::from(parsed_error.message),
+                ),
                 "MissingParameter" => {
                     BatchPutAttributesError::MissingParameter(String::from(parsed_error.message))
                 }
                 "NoSuchDomain" => {
                     BatchPutAttributesError::NoSuchDomain(String::from(parsed_error.message))
                 }
-                "InvalidParameterValue" => BatchPutAttributesError::InvalidParameterValue(
-                    String::from(parsed_error.message),
-                ),
-                "NumberSubmittedAttributesExceeded" => {
-                    BatchPutAttributesError::NumberSubmittedAttributesExceeded(String::from(
-                        parsed_error.message,
-                    ))
-                }
                 "NumberDomainAttributesExceeded" => {
                     BatchPutAttributesError::NumberDomainAttributesExceeded(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "NumberItemAttributesExceeded" => {
-                    BatchPutAttributesError::NumberItemAttributesExceeded(String::from(
                         parsed_error.message,
                     ))
                 }
                 "NumberDomainBytesExceeded" => BatchPutAttributesError::NumberDomainBytesExceeded(
                     String::from(parsed_error.message),
                 ),
+                "NumberItemAttributesExceeded" => {
+                    BatchPutAttributesError::NumberItemAttributesExceeded(String::from(
+                        parsed_error.message,
+                    ))
+                }
+                "NumberSubmittedAttributesExceeded" => {
+                    BatchPutAttributesError::NumberSubmittedAttributesExceeded(String::from(
+                        parsed_error.message,
+                    ))
+                }
                 "NumberSubmittedItemsExceeded" => {
                     BatchPutAttributesError::NumberSubmittedItemsExceeded(String::from(
                         parsed_error.message,
@@ -1274,13 +1274,13 @@ impl Error for BatchPutAttributesError {
     fn description(&self) -> &str {
         match *self {
             BatchPutAttributesError::DuplicateItemName(ref cause) => cause,
+            BatchPutAttributesError::InvalidParameterValue(ref cause) => cause,
             BatchPutAttributesError::MissingParameter(ref cause) => cause,
             BatchPutAttributesError::NoSuchDomain(ref cause) => cause,
-            BatchPutAttributesError::InvalidParameterValue(ref cause) => cause,
-            BatchPutAttributesError::NumberSubmittedAttributesExceeded(ref cause) => cause,
             BatchPutAttributesError::NumberDomainAttributesExceeded(ref cause) => cause,
-            BatchPutAttributesError::NumberItemAttributesExceeded(ref cause) => cause,
             BatchPutAttributesError::NumberDomainBytesExceeded(ref cause) => cause,
+            BatchPutAttributesError::NumberItemAttributesExceeded(ref cause) => cause,
+            BatchPutAttributesError::NumberSubmittedAttributesExceeded(ref cause) => cause,
             BatchPutAttributesError::NumberSubmittedItemsExceeded(ref cause) => cause,
             BatchPutAttributesError::Validation(ref cause) => cause,
             BatchPutAttributesError::Credentials(ref err) => err.description(),
@@ -1294,10 +1294,10 @@ impl Error for BatchPutAttributesError {
 /// Errors returned by CreateDomain
 #[derive(Debug, PartialEq)]
 pub enum CreateDomainError {
-    /// <p>The request must contain the specified missing parameter.</p>
-    MissingParameter(String),
     /// <p>The value for a parameter is invalid.</p>
     InvalidParameterValue(String),
+    /// <p>The request must contain the specified missing parameter.</p>
+    MissingParameter(String),
     /// <p>Too many domains exist per this account.</p>
     NumberDomainsExceeded(String),
     /// An error occurred dispatching the HTTP request
@@ -1317,11 +1317,11 @@ impl CreateDomainError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "MissingParameter" => {
-                    CreateDomainError::MissingParameter(String::from(parsed_error.message))
-                }
                 "InvalidParameterValue" => {
                     CreateDomainError::InvalidParameterValue(String::from(parsed_error.message))
+                }
+                "MissingParameter" => {
+                    CreateDomainError::MissingParameter(String::from(parsed_error.message))
                 }
                 "NumberDomainsExceeded" => {
                     CreateDomainError::NumberDomainsExceeded(String::from(parsed_error.message))
@@ -1370,8 +1370,8 @@ impl fmt::Display for CreateDomainError {
 impl Error for CreateDomainError {
     fn description(&self) -> &str {
         match *self {
-            CreateDomainError::MissingParameter(ref cause) => cause,
             CreateDomainError::InvalidParameterValue(ref cause) => cause,
+            CreateDomainError::MissingParameter(ref cause) => cause,
             CreateDomainError::NumberDomainsExceeded(ref cause) => cause,
             CreateDomainError::Validation(ref cause) => cause,
             CreateDomainError::Credentials(ref err) => err.description(),
@@ -1383,14 +1383,14 @@ impl Error for CreateDomainError {
 /// Errors returned by DeleteAttributes
 #[derive(Debug, PartialEq)]
 pub enum DeleteAttributesError {
-    /// <p>The request must contain the specified missing parameter.</p>
-    MissingParameter(String),
     /// <p>The specified attribute does not exist.</p>
     AttributeDoesNotExist(String),
-    /// <p>The specified domain does not exist.</p>
-    NoSuchDomain(String),
     /// <p>The value for a parameter is invalid.</p>
     InvalidParameterValue(String),
+    /// <p>The request must contain the specified missing parameter.</p>
+    MissingParameter(String),
+    /// <p>The specified domain does not exist.</p>
+    NoSuchDomain(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -1408,17 +1408,17 @@ impl DeleteAttributesError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "MissingParameter" => {
-                    DeleteAttributesError::MissingParameter(String::from(parsed_error.message))
-                }
                 "AttributeDoesNotExist" => {
                     DeleteAttributesError::AttributeDoesNotExist(String::from(parsed_error.message))
                 }
-                "NoSuchDomain" => {
-                    DeleteAttributesError::NoSuchDomain(String::from(parsed_error.message))
-                }
                 "InvalidParameterValue" => {
                     DeleteAttributesError::InvalidParameterValue(String::from(parsed_error.message))
+                }
+                "MissingParameter" => {
+                    DeleteAttributesError::MissingParameter(String::from(parsed_error.message))
+                }
+                "NoSuchDomain" => {
+                    DeleteAttributesError::NoSuchDomain(String::from(parsed_error.message))
                 }
                 _ => DeleteAttributesError::Unknown(String::from(body)),
             },
@@ -1464,10 +1464,10 @@ impl fmt::Display for DeleteAttributesError {
 impl Error for DeleteAttributesError {
     fn description(&self) -> &str {
         match *self {
-            DeleteAttributesError::MissingParameter(ref cause) => cause,
             DeleteAttributesError::AttributeDoesNotExist(ref cause) => cause,
-            DeleteAttributesError::NoSuchDomain(ref cause) => cause,
             DeleteAttributesError::InvalidParameterValue(ref cause) => cause,
+            DeleteAttributesError::MissingParameter(ref cause) => cause,
+            DeleteAttributesError::NoSuchDomain(ref cause) => cause,
             DeleteAttributesError::Validation(ref cause) => cause,
             DeleteAttributesError::Credentials(ref err) => err.description(),
             DeleteAttributesError::HttpDispatch(ref dispatch_error) => dispatch_error.description(),
@@ -1638,12 +1638,12 @@ impl Error for DomainMetadataError {
 /// Errors returned by GetAttributes
 #[derive(Debug, PartialEq)]
 pub enum GetAttributesError {
+    /// <p>The value for a parameter is invalid.</p>
+    InvalidParameterValue(String),
     /// <p>The request must contain the specified missing parameter.</p>
     MissingParameter(String),
     /// <p>The specified domain does not exist.</p>
     NoSuchDomain(String),
-    /// <p>The value for a parameter is invalid.</p>
-    InvalidParameterValue(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -1661,14 +1661,14 @@ impl GetAttributesError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
+                "InvalidParameterValue" => {
+                    GetAttributesError::InvalidParameterValue(String::from(parsed_error.message))
+                }
                 "MissingParameter" => {
                     GetAttributesError::MissingParameter(String::from(parsed_error.message))
                 }
                 "NoSuchDomain" => {
                     GetAttributesError::NoSuchDomain(String::from(parsed_error.message))
-                }
-                "InvalidParameterValue" => {
-                    GetAttributesError::InvalidParameterValue(String::from(parsed_error.message))
                 }
                 _ => GetAttributesError::Unknown(String::from(body)),
             },
@@ -1714,9 +1714,9 @@ impl fmt::Display for GetAttributesError {
 impl Error for GetAttributesError {
     fn description(&self) -> &str {
         match *self {
+            GetAttributesError::InvalidParameterValue(ref cause) => cause,
             GetAttributesError::MissingParameter(ref cause) => cause,
             GetAttributesError::NoSuchDomain(ref cause) => cause,
-            GetAttributesError::InvalidParameterValue(ref cause) => cause,
             GetAttributesError::Validation(ref cause) => cause,
             GetAttributesError::Credentials(ref err) => err.description(),
             GetAttributesError::HttpDispatch(ref dispatch_error) => dispatch_error.description(),
@@ -1810,20 +1810,20 @@ impl Error for ListDomainsError {
 /// Errors returned by PutAttributes
 #[derive(Debug, PartialEq)]
 pub enum PutAttributesError {
-    /// <p>The request must contain the specified missing parameter.</p>
-    MissingParameter(String),
     /// <p>The specified attribute does not exist.</p>
     AttributeDoesNotExist(String),
-    /// <p>The specified domain does not exist.</p>
-    NoSuchDomain(String),
     /// <p>The value for a parameter is invalid.</p>
     InvalidParameterValue(String),
+    /// <p>The request must contain the specified missing parameter.</p>
+    MissingParameter(String),
+    /// <p>The specified domain does not exist.</p>
+    NoSuchDomain(String),
     /// <p>Too many attributes in this domain.</p>
     NumberDomainAttributesExceeded(String),
-    /// <p>Too many attributes in this item.</p>
-    NumberItemAttributesExceeded(String),
     /// <p>Too many bytes in this domain.</p>
     NumberDomainBytesExceeded(String),
+    /// <p>Too many attributes in this item.</p>
+    NumberItemAttributesExceeded(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -1841,31 +1841,31 @@ impl PutAttributesError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "MissingParameter" => {
-                    PutAttributesError::MissingParameter(String::from(parsed_error.message))
-                }
                 "AttributeDoesNotExist" => {
                     PutAttributesError::AttributeDoesNotExist(String::from(parsed_error.message))
                 }
-                "NoSuchDomain" => {
-                    PutAttributesError::NoSuchDomain(String::from(parsed_error.message))
-                }
                 "InvalidParameterValue" => {
                     PutAttributesError::InvalidParameterValue(String::from(parsed_error.message))
+                }
+                "MissingParameter" => {
+                    PutAttributesError::MissingParameter(String::from(parsed_error.message))
+                }
+                "NoSuchDomain" => {
+                    PutAttributesError::NoSuchDomain(String::from(parsed_error.message))
                 }
                 "NumberDomainAttributesExceeded" => {
                     PutAttributesError::NumberDomainAttributesExceeded(String::from(
                         parsed_error.message,
                     ))
                 }
+                "NumberDomainBytesExceeded" => PutAttributesError::NumberDomainBytesExceeded(
+                    String::from(parsed_error.message),
+                ),
                 "NumberItemAttributesExceeded" => {
                     PutAttributesError::NumberItemAttributesExceeded(String::from(
                         parsed_error.message,
                     ))
                 }
-                "NumberDomainBytesExceeded" => PutAttributesError::NumberDomainBytesExceeded(
-                    String::from(parsed_error.message),
-                ),
                 _ => PutAttributesError::Unknown(String::from(body)),
             },
             Err(_) => PutAttributesError::Unknown(body.to_string()),
@@ -1910,13 +1910,13 @@ impl fmt::Display for PutAttributesError {
 impl Error for PutAttributesError {
     fn description(&self) -> &str {
         match *self {
-            PutAttributesError::MissingParameter(ref cause) => cause,
             PutAttributesError::AttributeDoesNotExist(ref cause) => cause,
-            PutAttributesError::NoSuchDomain(ref cause) => cause,
             PutAttributesError::InvalidParameterValue(ref cause) => cause,
+            PutAttributesError::MissingParameter(ref cause) => cause,
+            PutAttributesError::NoSuchDomain(ref cause) => cause,
             PutAttributesError::NumberDomainAttributesExceeded(ref cause) => cause,
-            PutAttributesError::NumberItemAttributesExceeded(ref cause) => cause,
             PutAttributesError::NumberDomainBytesExceeded(ref cause) => cause,
+            PutAttributesError::NumberItemAttributesExceeded(ref cause) => cause,
             PutAttributesError::Validation(ref cause) => cause,
             PutAttributesError::Credentials(ref err) => err.description(),
             PutAttributesError::HttpDispatch(ref dispatch_error) => dispatch_error.description(),
@@ -1927,24 +1927,24 @@ impl Error for PutAttributesError {
 /// Errors returned by Select
 #[derive(Debug, PartialEq)]
 pub enum SelectError {
-    /// <p>A timeout occurred when attempting to query the specified domain with specified query expression.</p>
-    RequestTimeout(String),
-    /// <p>The request must contain the specified missing parameter.</p>
-    MissingParameter(String),
     /// <p>The specified NextToken is not valid. </p>
     InvalidNextToken(String),
-    /// <p>The specified domain does not exist.</p>
-    NoSuchDomain(String),
-    /// <p>The specified query expression syntax is not valid.</p>
-    InvalidQueryExpression(String),
-    /// <p>The value for a parameter is invalid.</p>
-    InvalidParameterValue(String),
-    /// <p>Too many attributes requested.</p>
-    TooManyRequestedAttributes(String),
     /// <p>Too many predicates exist in the query expression.</p>
     InvalidNumberPredicates(String),
     /// <p>Too many predicates exist in the query expression.</p>
     InvalidNumberValueTests(String),
+    /// <p>The value for a parameter is invalid.</p>
+    InvalidParameterValue(String),
+    /// <p>The specified query expression syntax is not valid.</p>
+    InvalidQueryExpression(String),
+    /// <p>The request must contain the specified missing parameter.</p>
+    MissingParameter(String),
+    /// <p>The specified domain does not exist.</p>
+    NoSuchDomain(String),
+    /// <p>A timeout occurred when attempting to query the specified domain with specified query expression.</p>
+    RequestTimeout(String),
+    /// <p>Too many attributes requested.</p>
+    TooManyRequestedAttributes(String),
     /// An error occurred dispatching the HTTP request
     HttpDispatch(HttpDispatchError),
     /// An error was encountered with AWS credentials.
@@ -1962,28 +1962,28 @@ impl SelectError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "RequestTimeout" => SelectError::RequestTimeout(String::from(parsed_error.message)),
-                "MissingParameter" => {
-                    SelectError::MissingParameter(String::from(parsed_error.message))
-                }
                 "InvalidNextToken" => {
                     SelectError::InvalidNextToken(String::from(parsed_error.message))
-                }
-                "NoSuchDomain" => SelectError::NoSuchDomain(String::from(parsed_error.message)),
-                "InvalidQueryExpression" => {
-                    SelectError::InvalidQueryExpression(String::from(parsed_error.message))
-                }
-                "InvalidParameterValue" => {
-                    SelectError::InvalidParameterValue(String::from(parsed_error.message))
-                }
-                "TooManyRequestedAttributes" => {
-                    SelectError::TooManyRequestedAttributes(String::from(parsed_error.message))
                 }
                 "InvalidNumberPredicates" => {
                     SelectError::InvalidNumberPredicates(String::from(parsed_error.message))
                 }
                 "InvalidNumberValueTests" => {
                     SelectError::InvalidNumberValueTests(String::from(parsed_error.message))
+                }
+                "InvalidParameterValue" => {
+                    SelectError::InvalidParameterValue(String::from(parsed_error.message))
+                }
+                "InvalidQueryExpression" => {
+                    SelectError::InvalidQueryExpression(String::from(parsed_error.message))
+                }
+                "MissingParameter" => {
+                    SelectError::MissingParameter(String::from(parsed_error.message))
+                }
+                "NoSuchDomain" => SelectError::NoSuchDomain(String::from(parsed_error.message)),
+                "RequestTimeout" => SelectError::RequestTimeout(String::from(parsed_error.message)),
+                "TooManyRequestedAttributes" => {
+                    SelectError::TooManyRequestedAttributes(String::from(parsed_error.message))
                 }
                 _ => SelectError::Unknown(String::from(body)),
             },
@@ -2029,15 +2029,15 @@ impl fmt::Display for SelectError {
 impl Error for SelectError {
     fn description(&self) -> &str {
         match *self {
-            SelectError::RequestTimeout(ref cause) => cause,
-            SelectError::MissingParameter(ref cause) => cause,
             SelectError::InvalidNextToken(ref cause) => cause,
-            SelectError::NoSuchDomain(ref cause) => cause,
-            SelectError::InvalidQueryExpression(ref cause) => cause,
-            SelectError::InvalidParameterValue(ref cause) => cause,
-            SelectError::TooManyRequestedAttributes(ref cause) => cause,
             SelectError::InvalidNumberPredicates(ref cause) => cause,
             SelectError::InvalidNumberValueTests(ref cause) => cause,
+            SelectError::InvalidParameterValue(ref cause) => cause,
+            SelectError::InvalidQueryExpression(ref cause) => cause,
+            SelectError::MissingParameter(ref cause) => cause,
+            SelectError::NoSuchDomain(ref cause) => cause,
+            SelectError::RequestTimeout(ref cause) => cause,
+            SelectError::TooManyRequestedAttributes(ref cause) => cause,
             SelectError::Validation(ref cause) => cause,
             SelectError::Credentials(ref err) => err.description(),
             SelectError::HttpDispatch(ref dispatch_error) => dispatch_error.description(),

--- a/rusoto/services/ses/src/generated.rs
+++ b/rusoto/services/ses/src/generated.rs
@@ -9087,7 +9087,7 @@ impl CloneReceiptRuleSetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AlreadyExistsException" => {
                     CloneReceiptRuleSetError::AlreadyExists(String::from(parsed_error.message))
@@ -9102,6 +9102,14 @@ impl CloneReceiptRuleSetError {
             },
             Err(_) => CloneReceiptRuleSetError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -9170,7 +9178,7 @@ impl CreateConfigurationSetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ConfigurationSetAlreadyExistsException" => {
                     CreateConfigurationSetError::ConfigurationSetAlreadyExists(String::from(
@@ -9189,6 +9197,14 @@ impl CreateConfigurationSetError {
             },
             Err(_) => CreateConfigurationSetError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -9263,7 +9279,7 @@ impl CreateConfigurationSetEventDestinationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ConfigurationSetDoesNotExistException" => {
                     CreateConfigurationSetEventDestinationError::ConfigurationSetDoesNotExist(
@@ -9299,6 +9315,14 @@ impl CreateConfigurationSetEventDestinationError {
             },
             Err(_) => CreateConfigurationSetEventDestinationError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -9378,7 +9402,7 @@ impl CreateConfigurationSetTrackingOptionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ConfigurationSetDoesNotExistException" => {
                     CreateConfigurationSetTrackingOptionsError::ConfigurationSetDoesNotExist(
@@ -9399,6 +9423,14 @@ impl CreateConfigurationSetTrackingOptionsError {
             },
             Err(_) => CreateConfigurationSetTrackingOptionsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -9473,7 +9505,7 @@ impl CreateCustomVerificationEmailTemplateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
                             Ok(parsed_error) => {
                                 match &parsed_error.code[..] {
                                     "CustomVerificationEmailInvalidContentException" => CreateCustomVerificationEmailTemplateError::CustomVerificationEmailInvalidContent(String::from(parsed_error.message)),"CustomVerificationEmailTemplateAlreadyExistsException" => CreateCustomVerificationEmailTemplateError::CustomVerificationEmailTemplateAlreadyExists(String::from(parsed_error.message)),"FromEmailAddressNotVerifiedException" => CreateCustomVerificationEmailTemplateError::FromEmailAddressNotVerified(String::from(parsed_error.message)),"LimitExceededException" => CreateCustomVerificationEmailTemplateError::LimitExceeded(String::from(parsed_error.message)),_ => CreateCustomVerificationEmailTemplateError::Unknown(String::from(body))
@@ -9481,6 +9513,14 @@ impl CreateCustomVerificationEmailTemplateError {
                            },
                            Err(_) => CreateCustomVerificationEmailTemplateError::Unknown(body.to_string())
                        }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -9546,7 +9586,7 @@ impl CreateReceiptFilterError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AlreadyExistsException" => {
                     CreateReceiptFilterError::AlreadyExists(String::from(parsed_error.message))
@@ -9558,6 +9598,14 @@ impl CreateReceiptFilterError {
             },
             Err(_) => CreateReceiptFilterError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -9633,7 +9681,7 @@ impl CreateReceiptRuleError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AlreadyExistsException" => {
                     CreateReceiptRuleError::AlreadyExists(String::from(parsed_error.message))
@@ -9662,6 +9710,14 @@ impl CreateReceiptRuleError {
             },
             Err(_) => CreateReceiptRuleError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -9732,7 +9788,7 @@ impl CreateReceiptRuleSetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AlreadyExistsException" => {
                     CreateReceiptRuleSetError::AlreadyExists(String::from(parsed_error.message))
@@ -9744,6 +9800,14 @@ impl CreateReceiptRuleSetError {
             },
             Err(_) => CreateReceiptRuleSetError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -9811,7 +9875,7 @@ impl CreateTemplateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AlreadyExistsException" => {
                     CreateTemplateError::AlreadyExists(String::from(parsed_error.message))
@@ -9826,6 +9890,14 @@ impl CreateTemplateError {
             },
             Err(_) => CreateTemplateError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -9888,7 +9960,7 @@ impl DeleteConfigurationSetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ConfigurationSetDoesNotExistException" => {
                     DeleteConfigurationSetError::ConfigurationSetDoesNotExist(String::from(
@@ -9899,6 +9971,14 @@ impl DeleteConfigurationSetError {
             },
             Err(_) => DeleteConfigurationSetError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -9963,7 +10043,7 @@ impl DeleteConfigurationSetEventDestinationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ConfigurationSetDoesNotExistException" => {
                     DeleteConfigurationSetEventDestinationError::ConfigurationSetDoesNotExist(
@@ -9979,6 +10059,14 @@ impl DeleteConfigurationSetEventDestinationError {
             },
             Err(_) => DeleteConfigurationSetEventDestinationError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10048,7 +10136,7 @@ impl DeleteConfigurationSetTrackingOptionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ConfigurationSetDoesNotExistException" => {
                     DeleteConfigurationSetTrackingOptionsError::ConfigurationSetDoesNotExist(
@@ -10064,6 +10152,14 @@ impl DeleteConfigurationSetTrackingOptionsError {
             },
             Err(_) => DeleteConfigurationSetTrackingOptionsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10129,12 +10225,20 @@ impl DeleteCustomVerificationEmailTemplateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteCustomVerificationEmailTemplateError::Unknown(String::from(body)),
             },
             Err(_) => DeleteCustomVerificationEmailTemplateError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10194,12 +10298,20 @@ impl DeleteIdentityError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteIdentityError::Unknown(String::from(body)),
             },
             Err(_) => DeleteIdentityError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10257,12 +10369,20 @@ impl DeleteIdentityPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteIdentityPolicyError::Unknown(String::from(body)),
             },
             Err(_) => DeleteIdentityPolicyError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10322,12 +10442,20 @@ impl DeleteReceiptFilterError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteReceiptFilterError::Unknown(String::from(body)),
             },
             Err(_) => DeleteReceiptFilterError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10389,7 +10517,7 @@ impl DeleteReceiptRuleError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "RuleSetDoesNotExistException" => {
                     DeleteReceiptRuleError::RuleSetDoesNotExist(String::from(parsed_error.message))
@@ -10398,6 +10526,14 @@ impl DeleteReceiptRuleError {
             },
             Err(_) => DeleteReceiptRuleError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10460,7 +10596,7 @@ impl DeleteReceiptRuleSetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "CannotDeleteException" => {
                     DeleteReceiptRuleSetError::CannotDelete(String::from(parsed_error.message))
@@ -10469,6 +10605,14 @@ impl DeleteReceiptRuleSetError {
             },
             Err(_) => DeleteReceiptRuleSetError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10529,12 +10673,20 @@ impl DeleteTemplateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteTemplateError::Unknown(String::from(body)),
             },
             Err(_) => DeleteTemplateError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10592,12 +10744,20 @@ impl DeleteVerifiedEmailAddressError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteVerifiedEmailAddressError::Unknown(String::from(body)),
             },
             Err(_) => DeleteVerifiedEmailAddressError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10657,12 +10817,20 @@ impl DescribeActiveReceiptRuleSetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeActiveReceiptRuleSetError::Unknown(String::from(body)),
             },
             Err(_) => DescribeActiveReceiptRuleSetError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10724,7 +10892,7 @@ impl DescribeConfigurationSetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ConfigurationSetDoesNotExistException" => {
                     DescribeConfigurationSetError::ConfigurationSetDoesNotExist(String::from(
@@ -10735,6 +10903,14 @@ impl DescribeConfigurationSetError {
             },
             Err(_) => DescribeConfigurationSetError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10799,7 +10975,7 @@ impl DescribeReceiptRuleError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "RuleDoesNotExistException" => {
                     DescribeReceiptRuleError::RuleDoesNotExist(String::from(parsed_error.message))
@@ -10811,6 +10987,14 @@ impl DescribeReceiptRuleError {
             },
             Err(_) => DescribeReceiptRuleError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10874,7 +11058,7 @@ impl DescribeReceiptRuleSetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "RuleSetDoesNotExistException" => {
                     DescribeReceiptRuleSetError::RuleSetDoesNotExist(String::from(
@@ -10885,6 +11069,14 @@ impl DescribeReceiptRuleSetError {
             },
             Err(_) => DescribeReceiptRuleSetError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -10945,12 +11137,20 @@ impl GetAccountSendingEnabledError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetAccountSendingEnabledError::Unknown(String::from(body)),
             },
             Err(_) => GetAccountSendingEnabledError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11012,7 +11212,7 @@ impl GetCustomVerificationEmailTemplateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
                             Ok(parsed_error) => {
                                 match &parsed_error.code[..] {
                                     "CustomVerificationEmailTemplateDoesNotExistException" => GetCustomVerificationEmailTemplateError::CustomVerificationEmailTemplateDoesNotExist(String::from(parsed_error.message)),_ => GetCustomVerificationEmailTemplateError::Unknown(String::from(body))
@@ -11020,6 +11220,14 @@ impl GetCustomVerificationEmailTemplateError {
                            },
                            Err(_) => GetCustomVerificationEmailTemplateError::Unknown(body.to_string())
                        }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11078,12 +11286,20 @@ impl GetIdentityDkimAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetIdentityDkimAttributesError::Unknown(String::from(body)),
             },
             Err(_) => GetIdentityDkimAttributesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11143,12 +11359,20 @@ impl GetIdentityMailFromDomainAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetIdentityMailFromDomainAttributesError::Unknown(String::from(body)),
             },
             Err(_) => GetIdentityMailFromDomainAttributesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11208,12 +11432,20 @@ impl GetIdentityNotificationAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetIdentityNotificationAttributesError::Unknown(String::from(body)),
             },
             Err(_) => GetIdentityNotificationAttributesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11273,12 +11505,20 @@ impl GetIdentityPoliciesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetIdentityPoliciesError::Unknown(String::from(body)),
             },
             Err(_) => GetIdentityPoliciesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11338,12 +11578,20 @@ impl GetIdentityVerificationAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetIdentityVerificationAttributesError::Unknown(String::from(body)),
             },
             Err(_) => GetIdentityVerificationAttributesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11403,12 +11651,20 @@ impl GetSendQuotaError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetSendQuotaError::Unknown(String::from(body)),
             },
             Err(_) => GetSendQuotaError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11466,12 +11722,20 @@ impl GetSendStatisticsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetSendStatisticsError::Unknown(String::from(body)),
             },
             Err(_) => GetSendStatisticsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11533,7 +11797,7 @@ impl GetTemplateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "TemplateDoesNotExistException" => {
                     GetTemplateError::TemplateDoesNotExist(String::from(parsed_error.message))
@@ -11542,6 +11806,14 @@ impl GetTemplateError {
             },
             Err(_) => GetTemplateError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11600,12 +11872,20 @@ impl ListConfigurationSetsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListConfigurationSetsError::Unknown(String::from(body)),
             },
             Err(_) => ListConfigurationSetsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11665,12 +11945,20 @@ impl ListCustomVerificationEmailTemplatesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListCustomVerificationEmailTemplatesError::Unknown(String::from(body)),
             },
             Err(_) => ListCustomVerificationEmailTemplatesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11730,12 +12018,20 @@ impl ListIdentitiesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListIdentitiesError::Unknown(String::from(body)),
             },
             Err(_) => ListIdentitiesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11793,12 +12089,20 @@ impl ListIdentityPoliciesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListIdentityPoliciesError::Unknown(String::from(body)),
             },
             Err(_) => ListIdentityPoliciesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11858,12 +12162,20 @@ impl ListReceiptFiltersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListReceiptFiltersError::Unknown(String::from(body)),
             },
             Err(_) => ListReceiptFiltersError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11923,12 +12235,20 @@ impl ListReceiptRuleSetsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListReceiptRuleSetsError::Unknown(String::from(body)),
             },
             Err(_) => ListReceiptRuleSetsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -11988,12 +12308,20 @@ impl ListTemplatesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListTemplatesError::Unknown(String::from(body)),
             },
             Err(_) => ListTemplatesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -12051,12 +12379,20 @@ impl ListVerifiedEmailAddressesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListVerifiedEmailAddressesError::Unknown(String::from(body)),
             },
             Err(_) => ListVerifiedEmailAddressesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -12118,7 +12454,7 @@ impl PutIdentityPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidPolicyException" => {
                     PutIdentityPolicyError::InvalidPolicy(String::from(parsed_error.message))
@@ -12127,6 +12463,14 @@ impl PutIdentityPolicyError {
             },
             Err(_) => PutIdentityPolicyError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -12191,7 +12535,7 @@ impl ReorderReceiptRuleSetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "RuleDoesNotExistException" => {
                     ReorderReceiptRuleSetError::RuleDoesNotExist(String::from(parsed_error.message))
@@ -12203,6 +12547,14 @@ impl ReorderReceiptRuleSetError {
             },
             Err(_) => ReorderReceiptRuleSetError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -12266,7 +12618,7 @@ impl SendBounceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "MessageRejected" => {
                     SendBounceError::MessageRejected(String::from(parsed_error.message))
@@ -12275,6 +12627,14 @@ impl SendBounceError {
             },
             Err(_) => SendBounceError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -12345,7 +12705,7 @@ impl SendBulkTemplatedEmailError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccountSendingPausedException" => {
                     SendBulkTemplatedEmailError::AccountSendingPaused(String::from(
@@ -12379,6 +12739,14 @@ impl SendBulkTemplatedEmailError {
             },
             Err(_) => SendBulkTemplatedEmailError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -12454,7 +12822,7 @@ impl SendCustomVerificationEmailError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ConfigurationSetDoesNotExistException" => {
                     SendCustomVerificationEmailError::ConfigurationSetDoesNotExist(String::from(
@@ -12483,6 +12851,14 @@ impl SendCustomVerificationEmailError {
             },
             Err(_) => SendCustomVerificationEmailError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -12559,7 +12935,7 @@ impl SendEmailError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccountSendingPausedException" => {
                     SendEmailError::AccountSendingPaused(String::from(parsed_error.message))
@@ -12582,6 +12958,14 @@ impl SendEmailError {
             },
             Err(_) => SendEmailError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -12654,7 +13038,7 @@ impl SendRawEmailError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccountSendingPausedException" => {
                     SendRawEmailError::AccountSendingPaused(String::from(parsed_error.message))
@@ -12679,6 +13063,14 @@ impl SendRawEmailError {
             },
             Err(_) => SendRawEmailError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -12753,7 +13145,7 @@ impl SendTemplatedEmailError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AccountSendingPausedException" => SendTemplatedEmailError::AccountSendingPaused(
                     String::from(parsed_error.message),
@@ -12783,6 +13175,14 @@ impl SendTemplatedEmailError {
             },
             Err(_) => SendTemplatedEmailError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -12850,7 +13250,7 @@ impl SetActiveReceiptRuleSetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "RuleSetDoesNotExistException" => {
                     SetActiveReceiptRuleSetError::RuleSetDoesNotExist(String::from(
@@ -12861,6 +13261,14 @@ impl SetActiveReceiptRuleSetError {
             },
             Err(_) => SetActiveReceiptRuleSetError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -12921,12 +13329,20 @@ impl SetIdentityDkimEnabledError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => SetIdentityDkimEnabledError::Unknown(String::from(body)),
             },
             Err(_) => SetIdentityDkimEnabledError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -12986,12 +13402,20 @@ impl SetIdentityFeedbackForwardingEnabledError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => SetIdentityFeedbackForwardingEnabledError::Unknown(String::from(body)),
             },
             Err(_) => SetIdentityFeedbackForwardingEnabledError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -13051,12 +13475,20 @@ impl SetIdentityHeadersInNotificationsEnabledError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => SetIdentityHeadersInNotificationsEnabledError::Unknown(String::from(body)),
             },
             Err(_) => SetIdentityHeadersInNotificationsEnabledError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -13118,12 +13550,20 @@ impl SetIdentityMailFromDomainError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => SetIdentityMailFromDomainError::Unknown(String::from(body)),
             },
             Err(_) => SetIdentityMailFromDomainError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -13183,12 +13623,20 @@ impl SetIdentityNotificationTopicError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => SetIdentityNotificationTopicError::Unknown(String::from(body)),
             },
             Err(_) => SetIdentityNotificationTopicError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -13252,7 +13700,7 @@ impl SetReceiptRulePositionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "RuleDoesNotExistException" => SetReceiptRulePositionError::RuleDoesNotExist(
                     String::from(parsed_error.message),
@@ -13266,6 +13714,14 @@ impl SetReceiptRulePositionError {
             },
             Err(_) => SetReceiptRulePositionError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -13333,7 +13789,7 @@ impl TestRenderTemplateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidRenderingParameterException" => {
                     TestRenderTemplateError::InvalidRenderingParameter(String::from(
@@ -13352,6 +13808,14 @@ impl TestRenderTemplateError {
             },
             Err(_) => TestRenderTemplateError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -13414,12 +13878,20 @@ impl UpdateAccountSendingEnabledError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => UpdateAccountSendingEnabledError::Unknown(String::from(body)),
             },
             Err(_) => UpdateAccountSendingEnabledError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -13489,7 +13961,7 @@ impl UpdateConfigurationSetEventDestinationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ConfigurationSetDoesNotExistException" => {
                     UpdateConfigurationSetEventDestinationError::ConfigurationSetDoesNotExist(
@@ -13520,6 +13992,14 @@ impl UpdateConfigurationSetEventDestinationError {
             },
             Err(_) => UpdateConfigurationSetEventDestinationError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -13594,7 +14074,7 @@ impl UpdateConfigurationSetReputationMetricsEnabledError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
                             Ok(parsed_error) => {
                                 match &parsed_error.code[..] {
                                     "ConfigurationSetDoesNotExistException" => UpdateConfigurationSetReputationMetricsEnabledError::ConfigurationSetDoesNotExist(String::from(parsed_error.message)),_ => UpdateConfigurationSetReputationMetricsEnabledError::Unknown(String::from(body))
@@ -13602,6 +14082,14 @@ impl UpdateConfigurationSetReputationMetricsEnabledError {
                            },
                            Err(_) => UpdateConfigurationSetReputationMetricsEnabledError::Unknown(body.to_string())
                        }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -13670,7 +14158,7 @@ impl UpdateConfigurationSetSendingEnabledError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ConfigurationSetDoesNotExistException" => {
                     UpdateConfigurationSetSendingEnabledError::ConfigurationSetDoesNotExist(
@@ -13681,6 +14169,14 @@ impl UpdateConfigurationSetSendingEnabledError {
             },
             Err(_) => UpdateConfigurationSetSendingEnabledError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -13749,7 +14245,7 @@ impl UpdateConfigurationSetTrackingOptionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ConfigurationSetDoesNotExistException" => {
                     UpdateConfigurationSetTrackingOptionsError::ConfigurationSetDoesNotExist(
@@ -13770,6 +14266,14 @@ impl UpdateConfigurationSetTrackingOptionsError {
             },
             Err(_) => UpdateConfigurationSetTrackingOptionsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -13842,7 +14346,7 @@ impl UpdateCustomVerificationEmailTemplateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
                             Ok(parsed_error) => {
                                 match &parsed_error.code[..] {
                                     "CustomVerificationEmailInvalidContentException" => UpdateCustomVerificationEmailTemplateError::CustomVerificationEmailInvalidContent(String::from(parsed_error.message)),"CustomVerificationEmailTemplateDoesNotExistException" => UpdateCustomVerificationEmailTemplateError::CustomVerificationEmailTemplateDoesNotExist(String::from(parsed_error.message)),"FromEmailAddressNotVerifiedException" => UpdateCustomVerificationEmailTemplateError::FromEmailAddressNotVerified(String::from(parsed_error.message)),_ => UpdateCustomVerificationEmailTemplateError::Unknown(String::from(body))
@@ -13850,6 +14354,14 @@ impl UpdateCustomVerificationEmailTemplateError {
                            },
                            Err(_) => UpdateCustomVerificationEmailTemplateError::Unknown(body.to_string())
                        }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -13922,7 +14434,7 @@ impl UpdateReceiptRuleError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidLambdaFunctionException" => UpdateReceiptRuleError::InvalidLambdaFunction(
                     String::from(parsed_error.message),
@@ -13948,6 +14460,14 @@ impl UpdateReceiptRuleError {
             },
             Err(_) => UpdateReceiptRuleError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -14017,7 +14537,7 @@ impl UpdateTemplateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidTemplateException" => {
                     UpdateTemplateError::InvalidTemplate(String::from(parsed_error.message))
@@ -14029,6 +14549,14 @@ impl UpdateTemplateError {
             },
             Err(_) => UpdateTemplateError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -14088,12 +14616,20 @@ impl VerifyDomainDkimError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => VerifyDomainDkimError::Unknown(String::from(body)),
             },
             Err(_) => VerifyDomainDkimError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -14151,12 +14687,20 @@ impl VerifyDomainIdentityError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => VerifyDomainIdentityError::Unknown(String::from(body)),
             },
             Err(_) => VerifyDomainIdentityError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -14216,12 +14760,20 @@ impl VerifyEmailAddressError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => VerifyEmailAddressError::Unknown(String::from(body)),
             },
             Err(_) => VerifyEmailAddressError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -14281,12 +14833,20 @@ impl VerifyEmailIdentityError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => VerifyEmailIdentityError::Unknown(String::from(body)),
             },
             Err(_) => VerifyEmailIdentityError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 

--- a/rusoto/services/ses/src/generated.rs
+++ b/rusoto/services/ses/src/generated.rs
@@ -9089,13 +9089,13 @@ impl CloneReceiptRuleSetError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AlreadyExistsException" => {
+                "AlreadyExists" => {
                     CloneReceiptRuleSetError::AlreadyExists(String::from(parsed_error.message))
                 }
-                "LimitExceededException" => {
+                "LimitExceeded" => {
                     CloneReceiptRuleSetError::LimitExceeded(String::from(parsed_error.message))
                 }
-                "RuleSetDoesNotExistException" => CloneReceiptRuleSetError::RuleSetDoesNotExist(
+                "RuleSetDoesNotExist" => CloneReceiptRuleSetError::RuleSetDoesNotExist(
                     String::from(parsed_error.message),
                 ),
                 _ => CloneReceiptRuleSetError::Unknown(String::from(body)),
@@ -9180,17 +9180,15 @@ impl CreateConfigurationSetError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ConfigurationSetAlreadyExistsException" => {
+                "ConfigurationSetAlreadyExists" => {
                     CreateConfigurationSetError::ConfigurationSetAlreadyExists(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InvalidConfigurationSetException" => {
-                    CreateConfigurationSetError::InvalidConfigurationSet(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "LimitExceededException" => {
+                "InvalidConfigurationSet" => CreateConfigurationSetError::InvalidConfigurationSet(
+                    String::from(parsed_error.message),
+                ),
+                "LimitExceeded" => {
                     CreateConfigurationSetError::LimitExceeded(String::from(parsed_error.message))
                 }
                 _ => CreateConfigurationSetError::Unknown(String::from(body)),
@@ -9281,36 +9279,34 @@ impl CreateConfigurationSetEventDestinationError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ConfigurationSetDoesNotExistException" => {
+                "ConfigurationSetDoesNotExist" => {
                     CreateConfigurationSetEventDestinationError::ConfigurationSetDoesNotExist(
                         String::from(parsed_error.message),
                     )
                 }
-                "EventDestinationAlreadyExistsException" => {
+                "EventDestinationAlreadyExists" => {
                     CreateConfigurationSetEventDestinationError::EventDestinationAlreadyExists(
                         String::from(parsed_error.message),
                     )
                 }
-                "InvalidCloudWatchDestinationException" => {
+                "InvalidCloudWatchDestination" => {
                     CreateConfigurationSetEventDestinationError::InvalidCloudWatchDestination(
                         String::from(parsed_error.message),
                     )
                 }
-                "InvalidFirehoseDestinationException" => {
+                "InvalidFirehoseDestination" => {
                     CreateConfigurationSetEventDestinationError::InvalidFirehoseDestination(
                         String::from(parsed_error.message),
                     )
                 }
-                "InvalidSNSDestinationException" => {
+                "InvalidSNSDestination" => {
                     CreateConfigurationSetEventDestinationError::InvalidSNSDestination(
                         String::from(parsed_error.message),
                     )
                 }
-                "LimitExceededException" => {
-                    CreateConfigurationSetEventDestinationError::LimitExceeded(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "LimitExceeded" => CreateConfigurationSetEventDestinationError::LimitExceeded(
+                    String::from(parsed_error.message),
+                ),
                 _ => CreateConfigurationSetEventDestinationError::Unknown(String::from(body)),
             },
             Err(_) => CreateConfigurationSetEventDestinationError::Unknown(body.to_string()),
@@ -9404,12 +9400,12 @@ impl CreateConfigurationSetTrackingOptionsError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ConfigurationSetDoesNotExistException" => {
+                "ConfigurationSetDoesNotExist" => {
                     CreateConfigurationSetTrackingOptionsError::ConfigurationSetDoesNotExist(
                         String::from(parsed_error.message),
                     )
                 }
-                "InvalidTrackingOptionsException" => {
+                "InvalidTrackingOptions" => {
                     CreateConfigurationSetTrackingOptionsError::InvalidTrackingOptions(
                         String::from(parsed_error.message),
                     )
@@ -9508,7 +9504,7 @@ impl CreateCustomVerificationEmailTemplateError {
         match Self::deserialize(&mut stack) {
                             Ok(parsed_error) => {
                                 match &parsed_error.code[..] {
-                                    "CustomVerificationEmailInvalidContentException" => CreateCustomVerificationEmailTemplateError::CustomVerificationEmailInvalidContent(String::from(parsed_error.message)),"CustomVerificationEmailTemplateAlreadyExistsException" => CreateCustomVerificationEmailTemplateError::CustomVerificationEmailTemplateAlreadyExists(String::from(parsed_error.message)),"FromEmailAddressNotVerifiedException" => CreateCustomVerificationEmailTemplateError::FromEmailAddressNotVerified(String::from(parsed_error.message)),"LimitExceededException" => CreateCustomVerificationEmailTemplateError::LimitExceeded(String::from(parsed_error.message)),_ => CreateCustomVerificationEmailTemplateError::Unknown(String::from(body))
+                                    "CustomVerificationEmailInvalidContent" => CreateCustomVerificationEmailTemplateError::CustomVerificationEmailInvalidContent(String::from(parsed_error.message)),"CustomVerificationEmailTemplateAlreadyExists" => CreateCustomVerificationEmailTemplateError::CustomVerificationEmailTemplateAlreadyExists(String::from(parsed_error.message)),"FromEmailAddressNotVerified" => CreateCustomVerificationEmailTemplateError::FromEmailAddressNotVerified(String::from(parsed_error.message)),"LimitExceeded" => CreateCustomVerificationEmailTemplateError::LimitExceeded(String::from(parsed_error.message)),_ => CreateCustomVerificationEmailTemplateError::Unknown(String::from(body))
                                 }
                            },
                            Err(_) => CreateCustomVerificationEmailTemplateError::Unknown(body.to_string())
@@ -9588,10 +9584,10 @@ impl CreateReceiptFilterError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AlreadyExistsException" => {
+                "AlreadyExists" => {
                     CreateReceiptFilterError::AlreadyExists(String::from(parsed_error.message))
                 }
-                "LimitExceededException" => {
+                "LimitExceeded" => {
                     CreateReceiptFilterError::LimitExceeded(String::from(parsed_error.message))
                 }
                 _ => CreateReceiptFilterError::Unknown(String::from(body)),
@@ -9683,27 +9679,25 @@ impl CreateReceiptRuleError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AlreadyExistsException" => {
+                "AlreadyExists" => {
                     CreateReceiptRuleError::AlreadyExists(String::from(parsed_error.message))
                 }
-                "InvalidLambdaFunctionException" => CreateReceiptRuleError::InvalidLambdaFunction(
+                "InvalidLambdaFunction" => CreateReceiptRuleError::InvalidLambdaFunction(
                     String::from(parsed_error.message),
                 ),
-                "InvalidS3ConfigurationException" => {
-                    CreateReceiptRuleError::InvalidS3Configuration(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "InvalidSnsTopicException" => {
+                "InvalidS3Configuration" => CreateReceiptRuleError::InvalidS3Configuration(
+                    String::from(parsed_error.message),
+                ),
+                "InvalidSnsTopic" => {
                     CreateReceiptRuleError::InvalidSnsTopic(String::from(parsed_error.message))
                 }
-                "LimitExceededException" => {
+                "LimitExceeded" => {
                     CreateReceiptRuleError::LimitExceeded(String::from(parsed_error.message))
                 }
-                "RuleDoesNotExistException" => {
+                "RuleDoesNotExist" => {
                     CreateReceiptRuleError::RuleDoesNotExist(String::from(parsed_error.message))
                 }
-                "RuleSetDoesNotExistException" => {
+                "RuleSetDoesNotExist" => {
                     CreateReceiptRuleError::RuleSetDoesNotExist(String::from(parsed_error.message))
                 }
                 _ => CreateReceiptRuleError::Unknown(String::from(body)),
@@ -9790,10 +9784,10 @@ impl CreateReceiptRuleSetError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AlreadyExistsException" => {
+                "AlreadyExists" => {
                     CreateReceiptRuleSetError::AlreadyExists(String::from(parsed_error.message))
                 }
-                "LimitExceededException" => {
+                "LimitExceeded" => {
                     CreateReceiptRuleSetError::LimitExceeded(String::from(parsed_error.message))
                 }
                 _ => CreateReceiptRuleSetError::Unknown(String::from(body)),
@@ -9877,13 +9871,13 @@ impl CreateTemplateError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AlreadyExistsException" => {
+                "AlreadyExists" => {
                     CreateTemplateError::AlreadyExists(String::from(parsed_error.message))
                 }
-                "InvalidTemplateException" => {
+                "InvalidTemplate" => {
                     CreateTemplateError::InvalidTemplate(String::from(parsed_error.message))
                 }
-                "LimitExceededException" => {
+                "LimitExceeded" => {
                     CreateTemplateError::LimitExceeded(String::from(parsed_error.message))
                 }
                 _ => CreateTemplateError::Unknown(String::from(body)),
@@ -9962,7 +9956,7 @@ impl DeleteConfigurationSetError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ConfigurationSetDoesNotExistException" => {
+                "ConfigurationSetDoesNotExist" => {
                     DeleteConfigurationSetError::ConfigurationSetDoesNotExist(String::from(
                         parsed_error.message,
                     ))
@@ -10045,12 +10039,12 @@ impl DeleteConfigurationSetEventDestinationError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ConfigurationSetDoesNotExistException" => {
+                "ConfigurationSetDoesNotExist" => {
                     DeleteConfigurationSetEventDestinationError::ConfigurationSetDoesNotExist(
                         String::from(parsed_error.message),
                     )
                 }
-                "EventDestinationDoesNotExistException" => {
+                "EventDestinationDoesNotExist" => {
                     DeleteConfigurationSetEventDestinationError::EventDestinationDoesNotExist(
                         String::from(parsed_error.message),
                     )
@@ -10138,7 +10132,7 @@ impl DeleteConfigurationSetTrackingOptionsError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ConfigurationSetDoesNotExistException" => {
+                "ConfigurationSetDoesNotExist" => {
                     DeleteConfigurationSetTrackingOptionsError::ConfigurationSetDoesNotExist(
                         String::from(parsed_error.message),
                     )
@@ -10519,7 +10513,7 @@ impl DeleteReceiptRuleError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "RuleSetDoesNotExistException" => {
+                "RuleSetDoesNotExist" => {
                     DeleteReceiptRuleError::RuleSetDoesNotExist(String::from(parsed_error.message))
                 }
                 _ => DeleteReceiptRuleError::Unknown(String::from(body)),
@@ -10598,7 +10592,7 @@ impl DeleteReceiptRuleSetError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "CannotDeleteException" => {
+                "CannotDelete" => {
                     DeleteReceiptRuleSetError::CannotDelete(String::from(parsed_error.message))
                 }
                 _ => DeleteReceiptRuleSetError::Unknown(String::from(body)),
@@ -10894,7 +10888,7 @@ impl DescribeConfigurationSetError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ConfigurationSetDoesNotExistException" => {
+                "ConfigurationSetDoesNotExist" => {
                     DescribeConfigurationSetError::ConfigurationSetDoesNotExist(String::from(
                         parsed_error.message,
                     ))
@@ -10977,10 +10971,10 @@ impl DescribeReceiptRuleError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "RuleDoesNotExistException" => {
+                "RuleDoesNotExist" => {
                     DescribeReceiptRuleError::RuleDoesNotExist(String::from(parsed_error.message))
                 }
-                "RuleSetDoesNotExistException" => DescribeReceiptRuleError::RuleSetDoesNotExist(
+                "RuleSetDoesNotExist" => DescribeReceiptRuleError::RuleSetDoesNotExist(
                     String::from(parsed_error.message),
                 ),
                 _ => DescribeReceiptRuleError::Unknown(String::from(body)),
@@ -11060,11 +11054,9 @@ impl DescribeReceiptRuleSetError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "RuleSetDoesNotExistException" => {
-                    DescribeReceiptRuleSetError::RuleSetDoesNotExist(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "RuleSetDoesNotExist" => DescribeReceiptRuleSetError::RuleSetDoesNotExist(
+                    String::from(parsed_error.message),
+                ),
                 _ => DescribeReceiptRuleSetError::Unknown(String::from(body)),
             },
             Err(_) => DescribeReceiptRuleSetError::Unknown(body.to_string()),
@@ -11215,7 +11207,7 @@ impl GetCustomVerificationEmailTemplateError {
         match Self::deserialize(&mut stack) {
                             Ok(parsed_error) => {
                                 match &parsed_error.code[..] {
-                                    "CustomVerificationEmailTemplateDoesNotExistException" => GetCustomVerificationEmailTemplateError::CustomVerificationEmailTemplateDoesNotExist(String::from(parsed_error.message)),_ => GetCustomVerificationEmailTemplateError::Unknown(String::from(body))
+                                    "CustomVerificationEmailTemplateDoesNotExist" => GetCustomVerificationEmailTemplateError::CustomVerificationEmailTemplateDoesNotExist(String::from(parsed_error.message)),_ => GetCustomVerificationEmailTemplateError::Unknown(String::from(body))
                                 }
                            },
                            Err(_) => GetCustomVerificationEmailTemplateError::Unknown(body.to_string())
@@ -11799,7 +11791,7 @@ impl GetTemplateError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "TemplateDoesNotExistException" => {
+                "TemplateDoesNotExist" => {
                     GetTemplateError::TemplateDoesNotExist(String::from(parsed_error.message))
                 }
                 _ => GetTemplateError::Unknown(String::from(body)),
@@ -12456,7 +12448,7 @@ impl PutIdentityPolicyError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "InvalidPolicyException" => {
+                "InvalidPolicy" => {
                     PutIdentityPolicyError::InvalidPolicy(String::from(parsed_error.message))
                 }
                 _ => PutIdentityPolicyError::Unknown(String::from(body)),
@@ -12537,10 +12529,10 @@ impl ReorderReceiptRuleSetError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "RuleDoesNotExistException" => {
+                "RuleDoesNotExist" => {
                     ReorderReceiptRuleSetError::RuleDoesNotExist(String::from(parsed_error.message))
                 }
-                "RuleSetDoesNotExistException" => ReorderReceiptRuleSetError::RuleSetDoesNotExist(
+                "RuleSetDoesNotExist" => ReorderReceiptRuleSetError::RuleSetDoesNotExist(
                     String::from(parsed_error.message),
                 ),
                 _ => ReorderReceiptRuleSetError::Unknown(String::from(body)),
@@ -12712,7 +12704,7 @@ impl SendBulkTemplatedEmailError {
                         parsed_error.message,
                     ))
                 }
-                "ConfigurationSetDoesNotExistException" => {
+                "ConfigurationSetDoesNotExist" => {
                     SendBulkTemplatedEmailError::ConfigurationSetDoesNotExist(String::from(
                         parsed_error.message,
                     ))
@@ -12730,11 +12722,9 @@ impl SendBulkTemplatedEmailError {
                 "MessageRejected" => {
                     SendBulkTemplatedEmailError::MessageRejected(String::from(parsed_error.message))
                 }
-                "TemplateDoesNotExistException" => {
-                    SendBulkTemplatedEmailError::TemplateDoesNotExist(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "TemplateDoesNotExist" => SendBulkTemplatedEmailError::TemplateDoesNotExist(
+                    String::from(parsed_error.message),
+                ),
                 _ => SendBulkTemplatedEmailError::Unknown(String::from(body)),
             },
             Err(_) => SendBulkTemplatedEmailError::Unknown(body.to_string()),
@@ -12824,17 +12814,17 @@ impl SendCustomVerificationEmailError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ConfigurationSetDoesNotExistException" => {
+                "ConfigurationSetDoesNotExist" => {
                     SendCustomVerificationEmailError::ConfigurationSetDoesNotExist(String::from(
                         parsed_error.message,
                     ))
                 }
-                "CustomVerificationEmailTemplateDoesNotExistException" => {
+                "CustomVerificationEmailTemplateDoesNotExist" => {
                     SendCustomVerificationEmailError::CustomVerificationEmailTemplateDoesNotExist(
                         String::from(parsed_error.message),
                     )
                 }
-                "FromEmailAddressNotVerifiedException" => {
+                "FromEmailAddressNotVerified" => {
                     SendCustomVerificationEmailError::FromEmailAddressNotVerified(String::from(
                         parsed_error.message,
                     ))
@@ -12842,7 +12832,7 @@ impl SendCustomVerificationEmailError {
                 "MessageRejected" => SendCustomVerificationEmailError::MessageRejected(
                     String::from(parsed_error.message),
                 ),
-                "ProductionAccessNotGrantedException" => {
+                "ProductionAccessNotGranted" => {
                     SendCustomVerificationEmailError::ProductionAccessNotGranted(String::from(
                         parsed_error.message,
                     ))
@@ -12940,7 +12930,7 @@ impl SendEmailError {
                 "AccountSendingPausedException" => {
                     SendEmailError::AccountSendingPaused(String::from(parsed_error.message))
                 }
-                "ConfigurationSetDoesNotExistException" => {
+                "ConfigurationSetDoesNotExist" => {
                     SendEmailError::ConfigurationSetDoesNotExist(String::from(parsed_error.message))
                 }
                 "ConfigurationSetSendingPausedException" => {
@@ -13043,11 +13033,9 @@ impl SendRawEmailError {
                 "AccountSendingPausedException" => {
                     SendRawEmailError::AccountSendingPaused(String::from(parsed_error.message))
                 }
-                "ConfigurationSetDoesNotExistException" => {
-                    SendRawEmailError::ConfigurationSetDoesNotExist(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "ConfigurationSetDoesNotExist" => SendRawEmailError::ConfigurationSetDoesNotExist(
+                    String::from(parsed_error.message),
+                ),
                 "ConfigurationSetSendingPausedException" => {
                     SendRawEmailError::ConfigurationSetSendingPaused(String::from(
                         parsed_error.message,
@@ -13150,7 +13138,7 @@ impl SendTemplatedEmailError {
                 "AccountSendingPausedException" => SendTemplatedEmailError::AccountSendingPaused(
                     String::from(parsed_error.message),
                 ),
-                "ConfigurationSetDoesNotExistException" => {
+                "ConfigurationSetDoesNotExist" => {
                     SendTemplatedEmailError::ConfigurationSetDoesNotExist(String::from(
                         parsed_error.message,
                     ))
@@ -13168,7 +13156,7 @@ impl SendTemplatedEmailError {
                 "MessageRejected" => {
                     SendTemplatedEmailError::MessageRejected(String::from(parsed_error.message))
                 }
-                "TemplateDoesNotExistException" => SendTemplatedEmailError::TemplateDoesNotExist(
+                "TemplateDoesNotExist" => SendTemplatedEmailError::TemplateDoesNotExist(
                     String::from(parsed_error.message),
                 ),
                 _ => SendTemplatedEmailError::Unknown(String::from(body)),
@@ -13252,11 +13240,9 @@ impl SetActiveReceiptRuleSetError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "RuleSetDoesNotExistException" => {
-                    SetActiveReceiptRuleSetError::RuleSetDoesNotExist(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "RuleSetDoesNotExist" => SetActiveReceiptRuleSetError::RuleSetDoesNotExist(
+                    String::from(parsed_error.message),
+                ),
                 _ => SetActiveReceiptRuleSetError::Unknown(String::from(body)),
             },
             Err(_) => SetActiveReceiptRuleSetError::Unknown(body.to_string()),
@@ -13702,14 +13688,12 @@ impl SetReceiptRulePositionError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "RuleDoesNotExistException" => SetReceiptRulePositionError::RuleDoesNotExist(
+                "RuleDoesNotExist" => SetReceiptRulePositionError::RuleDoesNotExist(String::from(
+                    parsed_error.message,
+                )),
+                "RuleSetDoesNotExist" => SetReceiptRulePositionError::RuleSetDoesNotExist(
                     String::from(parsed_error.message),
                 ),
-                "RuleSetDoesNotExistException" => {
-                    SetReceiptRulePositionError::RuleSetDoesNotExist(String::from(
-                        parsed_error.message,
-                    ))
-                }
                 _ => SetReceiptRulePositionError::Unknown(String::from(body)),
             },
             Err(_) => SetReceiptRulePositionError::Unknown(body.to_string()),
@@ -13791,17 +13775,13 @@ impl TestRenderTemplateError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "InvalidRenderingParameterException" => {
-                    TestRenderTemplateError::InvalidRenderingParameter(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "MissingRenderingAttributeException" => {
-                    TestRenderTemplateError::MissingRenderingAttribute(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "TemplateDoesNotExistException" => TestRenderTemplateError::TemplateDoesNotExist(
+                "InvalidRenderingParameter" => TestRenderTemplateError::InvalidRenderingParameter(
+                    String::from(parsed_error.message),
+                ),
+                "MissingRenderingAttribute" => TestRenderTemplateError::MissingRenderingAttribute(
+                    String::from(parsed_error.message),
+                ),
+                "TemplateDoesNotExist" => TestRenderTemplateError::TemplateDoesNotExist(
                     String::from(parsed_error.message),
                 ),
                 _ => TestRenderTemplateError::Unknown(String::from(body)),
@@ -13963,27 +13943,27 @@ impl UpdateConfigurationSetEventDestinationError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ConfigurationSetDoesNotExistException" => {
+                "ConfigurationSetDoesNotExist" => {
                     UpdateConfigurationSetEventDestinationError::ConfigurationSetDoesNotExist(
                         String::from(parsed_error.message),
                     )
                 }
-                "EventDestinationDoesNotExistException" => {
+                "EventDestinationDoesNotExist" => {
                     UpdateConfigurationSetEventDestinationError::EventDestinationDoesNotExist(
                         String::from(parsed_error.message),
                     )
                 }
-                "InvalidCloudWatchDestinationException" => {
+                "InvalidCloudWatchDestination" => {
                     UpdateConfigurationSetEventDestinationError::InvalidCloudWatchDestination(
                         String::from(parsed_error.message),
                     )
                 }
-                "InvalidFirehoseDestinationException" => {
+                "InvalidFirehoseDestination" => {
                     UpdateConfigurationSetEventDestinationError::InvalidFirehoseDestination(
                         String::from(parsed_error.message),
                     )
                 }
-                "InvalidSNSDestinationException" => {
+                "InvalidSNSDestination" => {
                     UpdateConfigurationSetEventDestinationError::InvalidSNSDestination(
                         String::from(parsed_error.message),
                     )
@@ -14077,7 +14057,7 @@ impl UpdateConfigurationSetReputationMetricsEnabledError {
         match Self::deserialize(&mut stack) {
                             Ok(parsed_error) => {
                                 match &parsed_error.code[..] {
-                                    "ConfigurationSetDoesNotExistException" => UpdateConfigurationSetReputationMetricsEnabledError::ConfigurationSetDoesNotExist(String::from(parsed_error.message)),_ => UpdateConfigurationSetReputationMetricsEnabledError::Unknown(String::from(body))
+                                    "ConfigurationSetDoesNotExist" => UpdateConfigurationSetReputationMetricsEnabledError::ConfigurationSetDoesNotExist(String::from(parsed_error.message)),_ => UpdateConfigurationSetReputationMetricsEnabledError::Unknown(String::from(body))
                                 }
                            },
                            Err(_) => UpdateConfigurationSetReputationMetricsEnabledError::Unknown(body.to_string())
@@ -14160,7 +14140,7 @@ impl UpdateConfigurationSetSendingEnabledError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ConfigurationSetDoesNotExistException" => {
+                "ConfigurationSetDoesNotExist" => {
                     UpdateConfigurationSetSendingEnabledError::ConfigurationSetDoesNotExist(
                         String::from(parsed_error.message),
                     )
@@ -14247,12 +14227,12 @@ impl UpdateConfigurationSetTrackingOptionsError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "ConfigurationSetDoesNotExistException" => {
+                "ConfigurationSetDoesNotExist" => {
                     UpdateConfigurationSetTrackingOptionsError::ConfigurationSetDoesNotExist(
                         String::from(parsed_error.message),
                     )
                 }
-                "InvalidTrackingOptionsException" => {
+                "InvalidTrackingOptions" => {
                     UpdateConfigurationSetTrackingOptionsError::InvalidTrackingOptions(
                         String::from(parsed_error.message),
                     )
@@ -14349,7 +14329,7 @@ impl UpdateCustomVerificationEmailTemplateError {
         match Self::deserialize(&mut stack) {
                             Ok(parsed_error) => {
                                 match &parsed_error.code[..] {
-                                    "CustomVerificationEmailInvalidContentException" => UpdateCustomVerificationEmailTemplateError::CustomVerificationEmailInvalidContent(String::from(parsed_error.message)),"CustomVerificationEmailTemplateDoesNotExistException" => UpdateCustomVerificationEmailTemplateError::CustomVerificationEmailTemplateDoesNotExist(String::from(parsed_error.message)),"FromEmailAddressNotVerifiedException" => UpdateCustomVerificationEmailTemplateError::FromEmailAddressNotVerified(String::from(parsed_error.message)),_ => UpdateCustomVerificationEmailTemplateError::Unknown(String::from(body))
+                                    "CustomVerificationEmailInvalidContent" => UpdateCustomVerificationEmailTemplateError::CustomVerificationEmailInvalidContent(String::from(parsed_error.message)),"CustomVerificationEmailTemplateDoesNotExist" => UpdateCustomVerificationEmailTemplateError::CustomVerificationEmailTemplateDoesNotExist(String::from(parsed_error.message)),"FromEmailAddressNotVerified" => UpdateCustomVerificationEmailTemplateError::FromEmailAddressNotVerified(String::from(parsed_error.message)),_ => UpdateCustomVerificationEmailTemplateError::Unknown(String::from(body))
                                 }
                            },
                            Err(_) => UpdateCustomVerificationEmailTemplateError::Unknown(body.to_string())
@@ -14436,24 +14416,22 @@ impl UpdateReceiptRuleError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "InvalidLambdaFunctionException" => UpdateReceiptRuleError::InvalidLambdaFunction(
+                "InvalidLambdaFunction" => UpdateReceiptRuleError::InvalidLambdaFunction(
                     String::from(parsed_error.message),
                 ),
-                "InvalidS3ConfigurationException" => {
-                    UpdateReceiptRuleError::InvalidS3Configuration(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "InvalidSnsTopicException" => {
+                "InvalidS3Configuration" => UpdateReceiptRuleError::InvalidS3Configuration(
+                    String::from(parsed_error.message),
+                ),
+                "InvalidSnsTopic" => {
                     UpdateReceiptRuleError::InvalidSnsTopic(String::from(parsed_error.message))
                 }
-                "LimitExceededException" => {
+                "LimitExceeded" => {
                     UpdateReceiptRuleError::LimitExceeded(String::from(parsed_error.message))
                 }
-                "RuleDoesNotExistException" => {
+                "RuleDoesNotExist" => {
                     UpdateReceiptRuleError::RuleDoesNotExist(String::from(parsed_error.message))
                 }
-                "RuleSetDoesNotExistException" => {
+                "RuleSetDoesNotExist" => {
                     UpdateReceiptRuleError::RuleSetDoesNotExist(String::from(parsed_error.message))
                 }
                 _ => UpdateReceiptRuleError::Unknown(String::from(body)),
@@ -14539,10 +14517,10 @@ impl UpdateTemplateError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "InvalidTemplateException" => {
+                "InvalidTemplate" => {
                     UpdateTemplateError::InvalidTemplate(String::from(parsed_error.message))
                 }
-                "TemplateDoesNotExistException" => {
+                "TemplateDoesNotExist" => {
                     UpdateTemplateError::TemplateDoesNotExist(String::from(parsed_error.message))
                 }
                 _ => UpdateTemplateError::Unknown(String::from(body)),

--- a/rusoto/services/sns/src/generated.rs
+++ b/rusoto/services/sns/src/generated.rs
@@ -2635,7 +2635,7 @@ impl AddPermissionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationErrorException" => {
                     AddPermissionError::AuthorizationError(String::from(parsed_error.message))
@@ -2653,6 +2653,14 @@ impl AddPermissionError {
             },
             Err(_) => AddPermissionError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -2722,7 +2730,7 @@ impl CheckIfPhoneNumberIsOptedOutError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationErrorException" => {
                     CheckIfPhoneNumberIsOptedOutError::AuthorizationError(String::from(
@@ -2744,6 +2752,14 @@ impl CheckIfPhoneNumberIsOptedOutError {
             },
             Err(_) => CheckIfPhoneNumberIsOptedOutError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -2817,7 +2833,7 @@ impl ConfirmSubscriptionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationErrorException" => {
                     ConfirmSubscriptionError::AuthorizationError(String::from(parsed_error.message))
@@ -2840,6 +2856,14 @@ impl ConfirmSubscriptionError {
             },
             Err(_) => ConfirmSubscriptionError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -2910,7 +2934,7 @@ impl CreatePlatformApplicationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationErrorException" => {
                     CreatePlatformApplicationError::AuthorizationError(String::from(
@@ -2927,6 +2951,14 @@ impl CreatePlatformApplicationError {
             },
             Err(_) => CreatePlatformApplicationError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -2997,7 +3029,7 @@ impl CreatePlatformEndpointError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationErrorException" => CreatePlatformEndpointError::AuthorizationError(
                     String::from(parsed_error.message),
@@ -3015,6 +3047,14 @@ impl CreatePlatformEndpointError {
             },
             Err(_) => CreatePlatformEndpointError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -3086,7 +3126,7 @@ impl CreateTopicError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationErrorException" => {
                     CreateTopicError::AuthorizationError(String::from(parsed_error.message))
@@ -3104,6 +3144,14 @@ impl CreateTopicError {
             },
             Err(_) => CreateTopicError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -3171,7 +3219,7 @@ impl DeleteEndpointError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationErrorException" => {
                     DeleteEndpointError::AuthorizationError(String::from(parsed_error.message))
@@ -3186,6 +3234,14 @@ impl DeleteEndpointError {
             },
             Err(_) => DeleteEndpointError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -3252,7 +3308,7 @@ impl DeletePlatformApplicationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationErrorException" => {
                     DeletePlatformApplicationError::AuthorizationError(String::from(
@@ -3269,6 +3325,14 @@ impl DeletePlatformApplicationError {
             },
             Err(_) => DeletePlatformApplicationError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -3339,7 +3403,7 @@ impl DeleteTopicError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationErrorException" => {
                     DeleteTopicError::AuthorizationError(String::from(parsed_error.message))
@@ -3357,6 +3421,14 @@ impl DeleteTopicError {
             },
             Err(_) => DeleteTopicError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -3426,7 +3498,7 @@ impl GetEndpointAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationErrorException" => GetEndpointAttributesError::AuthorizationError(
                     String::from(parsed_error.message),
@@ -3444,6 +3516,14 @@ impl GetEndpointAttributesError {
             },
             Err(_) => GetEndpointAttributesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -3515,7 +3595,7 @@ impl GetPlatformApplicationAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationErrorException" => {
                     GetPlatformApplicationAttributesError::AuthorizationError(String::from(
@@ -3537,6 +3617,14 @@ impl GetPlatformApplicationAttributesError {
             },
             Err(_) => GetPlatformApplicationAttributesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -3608,7 +3696,7 @@ impl GetSMSAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationErrorException" => {
                     GetSMSAttributesError::AuthorizationError(String::from(parsed_error.message))
@@ -3626,6 +3714,14 @@ impl GetSMSAttributesError {
             },
             Err(_) => GetSMSAttributesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -3695,7 +3791,7 @@ impl GetSubscriptionAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationErrorException" => {
                     GetSubscriptionAttributesError::AuthorizationError(String::from(
@@ -3715,6 +3811,14 @@ impl GetSubscriptionAttributesError {
             },
             Err(_) => GetSubscriptionAttributesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -3786,7 +3890,7 @@ impl GetTopicAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationErrorException" => {
                     GetTopicAttributesError::AuthorizationError(String::from(parsed_error.message))
@@ -3804,6 +3908,14 @@ impl GetTopicAttributesError {
             },
             Err(_) => GetTopicAttributesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -3875,7 +3987,7 @@ impl ListEndpointsByPlatformApplicationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationErrorException" => {
                     ListEndpointsByPlatformApplicationError::AuthorizationError(String::from(
@@ -3899,6 +4011,14 @@ impl ListEndpointsByPlatformApplicationError {
             },
             Err(_) => ListEndpointsByPlatformApplicationError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -3970,7 +4090,7 @@ impl ListPhoneNumbersOptedOutError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationErrorException" => {
                     ListPhoneNumbersOptedOutError::AuthorizationError(String::from(
@@ -3990,6 +4110,14 @@ impl ListPhoneNumbersOptedOutError {
             },
             Err(_) => ListPhoneNumbersOptedOutError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -4059,7 +4187,7 @@ impl ListPlatformApplicationsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationErrorException" => {
                     ListPlatformApplicationsError::AuthorizationError(String::from(
@@ -4076,6 +4204,14 @@ impl ListPlatformApplicationsError {
             },
             Err(_) => ListPlatformApplicationsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -4144,7 +4280,7 @@ impl ListSubscriptionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationErrorException" => {
                     ListSubscriptionsError::AuthorizationError(String::from(parsed_error.message))
@@ -4159,6 +4295,14 @@ impl ListSubscriptionsError {
             },
             Err(_) => ListSubscriptionsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -4229,7 +4373,7 @@ impl ListSubscriptionsByTopicError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationErrorException" => {
                     ListSubscriptionsByTopicError::AuthorizationError(String::from(
@@ -4249,6 +4393,14 @@ impl ListSubscriptionsByTopicError {
             },
             Err(_) => ListSubscriptionsByTopicError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -4318,7 +4470,7 @@ impl ListTopicsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationErrorException" => {
                     ListTopicsError::AuthorizationError(String::from(parsed_error.message))
@@ -4333,6 +4485,14 @@ impl ListTopicsError {
             },
             Err(_) => ListTopicsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -4401,7 +4561,7 @@ impl OptInPhoneNumberError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationErrorException" => {
                     OptInPhoneNumberError::AuthorizationError(String::from(parsed_error.message))
@@ -4419,6 +4579,14 @@ impl OptInPhoneNumberError {
             },
             Err(_) => OptInPhoneNumberError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -4494,7 +4662,7 @@ impl PublishError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationErrorException" => {
                     PublishError::AuthorizationError(String::from(parsed_error.message))
@@ -4519,6 +4687,14 @@ impl PublishError {
             },
             Err(_) => PublishError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -4591,7 +4767,7 @@ impl RemovePermissionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationErrorException" => {
                     RemovePermissionError::AuthorizationError(String::from(parsed_error.message))
@@ -4609,6 +4785,14 @@ impl RemovePermissionError {
             },
             Err(_) => RemovePermissionError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -4678,7 +4862,7 @@ impl SetEndpointAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationErrorException" => SetEndpointAttributesError::AuthorizationError(
                     String::from(parsed_error.message),
@@ -4696,6 +4880,14 @@ impl SetEndpointAttributesError {
             },
             Err(_) => SetEndpointAttributesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -4767,7 +4959,7 @@ impl SetPlatformApplicationAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationErrorException" => {
                     SetPlatformApplicationAttributesError::AuthorizationError(String::from(
@@ -4789,6 +4981,14 @@ impl SetPlatformApplicationAttributesError {
             },
             Err(_) => SetPlatformApplicationAttributesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -4860,7 +5060,7 @@ impl SetSMSAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationErrorException" => {
                     SetSMSAttributesError::AuthorizationError(String::from(parsed_error.message))
@@ -4878,6 +5078,14 @@ impl SetSMSAttributesError {
             },
             Err(_) => SetSMSAttributesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -4947,7 +5155,7 @@ impl SetSubscriptionAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationErrorException" => {
                     SetSubscriptionAttributesError::AuthorizationError(String::from(
@@ -4967,6 +5175,14 @@ impl SetSubscriptionAttributesError {
             },
             Err(_) => SetSubscriptionAttributesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -5038,7 +5254,7 @@ impl SetTopicAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationErrorException" => {
                     SetTopicAttributesError::AuthorizationError(String::from(parsed_error.message))
@@ -5056,6 +5272,14 @@ impl SetTopicAttributesError {
             },
             Err(_) => SetTopicAttributesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -5129,7 +5353,7 @@ impl SubscribeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationErrorException" => {
                     SubscribeError::AuthorizationError(String::from(parsed_error.message))
@@ -5148,6 +5372,14 @@ impl SubscribeError {
             },
             Err(_) => SubscribeError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -5218,7 +5450,7 @@ impl UnsubscribeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "AuthorizationErrorException" => {
                     UnsubscribeError::AuthorizationError(String::from(parsed_error.message))
@@ -5236,6 +5468,14 @@ impl UnsubscribeError {
             },
             Err(_) => UnsubscribeError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 

--- a/rusoto/services/sns/src/generated.rs
+++ b/rusoto/services/sns/src/generated.rs
@@ -2637,18 +2637,16 @@ impl AddPermissionError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AuthorizationErrorException" => {
+                "AuthorizationError" => {
                     AddPermissionError::AuthorizationError(String::from(parsed_error.message))
                 }
-                "InternalErrorException" => {
+                "InternalError" => {
                     AddPermissionError::InternalError(String::from(parsed_error.message))
                 }
-                "InvalidParameterException" => {
+                "InvalidParameter" => {
                     AddPermissionError::InvalidParameter(String::from(parsed_error.message))
                 }
-                "NotFoundException" => {
-                    AddPermissionError::NotFound(String::from(parsed_error.message))
-                }
+                "NotFound" => AddPermissionError::NotFound(String::from(parsed_error.message)),
                 _ => AddPermissionError::Unknown(String::from(body)),
             },
             Err(_) => AddPermissionError::Unknown(body.to_string()),
@@ -2732,20 +2730,16 @@ impl CheckIfPhoneNumberIsOptedOutError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AuthorizationErrorException" => {
-                    CheckIfPhoneNumberIsOptedOutError::AuthorizationError(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "InternalErrorException" => CheckIfPhoneNumberIsOptedOutError::InternalError(
+                "AuthorizationError" => CheckIfPhoneNumberIsOptedOutError::AuthorizationError(
                     String::from(parsed_error.message),
                 ),
-                "InvalidParameterException" => {
-                    CheckIfPhoneNumberIsOptedOutError::InvalidParameter(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "ThrottledException" => {
+                "InternalError" => CheckIfPhoneNumberIsOptedOutError::InternalError(String::from(
+                    parsed_error.message,
+                )),
+                "InvalidParameter" => CheckIfPhoneNumberIsOptedOutError::InvalidParameter(
+                    String::from(parsed_error.message),
+                ),
+                "Throttled" => {
                     CheckIfPhoneNumberIsOptedOutError::Throttled(String::from(parsed_error.message))
                 }
                 _ => CheckIfPhoneNumberIsOptedOutError::Unknown(String::from(body)),
@@ -2835,19 +2829,19 @@ impl ConfirmSubscriptionError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AuthorizationErrorException" => {
+                "AuthorizationError" => {
                     ConfirmSubscriptionError::AuthorizationError(String::from(parsed_error.message))
                 }
-                "InternalErrorException" => {
+                "InternalError" => {
                     ConfirmSubscriptionError::InternalError(String::from(parsed_error.message))
                 }
-                "InvalidParameterException" => {
+                "InvalidParameter" => {
                     ConfirmSubscriptionError::InvalidParameter(String::from(parsed_error.message))
                 }
-                "NotFoundException" => {
+                "NotFound" => {
                     ConfirmSubscriptionError::NotFound(String::from(parsed_error.message))
                 }
-                "SubscriptionLimitExceededException" => {
+                "SubscriptionLimitExceeded" => {
                     ConfirmSubscriptionError::SubscriptionLimitExceeded(String::from(
                         parsed_error.message,
                     ))
@@ -2936,15 +2930,13 @@ impl CreatePlatformApplicationError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AuthorizationErrorException" => {
-                    CreatePlatformApplicationError::AuthorizationError(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "InternalErrorException" => CreatePlatformApplicationError::InternalError(
+                "AuthorizationError" => CreatePlatformApplicationError::AuthorizationError(
                     String::from(parsed_error.message),
                 ),
-                "InvalidParameterException" => CreatePlatformApplicationError::InvalidParameter(
+                "InternalError" => CreatePlatformApplicationError::InternalError(String::from(
+                    parsed_error.message,
+                )),
+                "InvalidParameter" => CreatePlatformApplicationError::InvalidParameter(
                     String::from(parsed_error.message),
                 ),
                 _ => CreatePlatformApplicationError::Unknown(String::from(body)),
@@ -3031,16 +3023,16 @@ impl CreatePlatformEndpointError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AuthorizationErrorException" => CreatePlatformEndpointError::AuthorizationError(
+                "AuthorizationError" => CreatePlatformEndpointError::AuthorizationError(
                     String::from(parsed_error.message),
                 ),
-                "InternalErrorException" => {
+                "InternalError" => {
                     CreatePlatformEndpointError::InternalError(String::from(parsed_error.message))
                 }
-                "InvalidParameterException" => CreatePlatformEndpointError::InvalidParameter(
-                    String::from(parsed_error.message),
-                ),
-                "NotFoundException" => {
+                "InvalidParameter" => CreatePlatformEndpointError::InvalidParameter(String::from(
+                    parsed_error.message,
+                )),
+                "NotFound" => {
                     CreatePlatformEndpointError::NotFound(String::from(parsed_error.message))
                 }
                 _ => CreatePlatformEndpointError::Unknown(String::from(body)),
@@ -3128,16 +3120,16 @@ impl CreateTopicError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AuthorizationErrorException" => {
+                "AuthorizationError" => {
                     CreateTopicError::AuthorizationError(String::from(parsed_error.message))
                 }
-                "InternalErrorException" => {
+                "InternalError" => {
                     CreateTopicError::InternalError(String::from(parsed_error.message))
                 }
-                "InvalidParameterException" => {
+                "InvalidParameter" => {
                     CreateTopicError::InvalidParameter(String::from(parsed_error.message))
                 }
-                "TopicLimitExceededException" => {
+                "TopicLimitExceeded" => {
                     CreateTopicError::TopicLimitExceeded(String::from(parsed_error.message))
                 }
                 _ => CreateTopicError::Unknown(String::from(body)),
@@ -3221,13 +3213,13 @@ impl DeleteEndpointError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AuthorizationErrorException" => {
+                "AuthorizationError" => {
                     DeleteEndpointError::AuthorizationError(String::from(parsed_error.message))
                 }
-                "InternalErrorException" => {
+                "InternalError" => {
                     DeleteEndpointError::InternalError(String::from(parsed_error.message))
                 }
-                "InvalidParameterException" => {
+                "InvalidParameter" => {
                     DeleteEndpointError::InvalidParameter(String::from(parsed_error.message))
                 }
                 _ => DeleteEndpointError::Unknown(String::from(body)),
@@ -3310,15 +3302,13 @@ impl DeletePlatformApplicationError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AuthorizationErrorException" => {
-                    DeletePlatformApplicationError::AuthorizationError(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "InternalErrorException" => DeletePlatformApplicationError::InternalError(
+                "AuthorizationError" => DeletePlatformApplicationError::AuthorizationError(
                     String::from(parsed_error.message),
                 ),
-                "InvalidParameterException" => DeletePlatformApplicationError::InvalidParameter(
+                "InternalError" => DeletePlatformApplicationError::InternalError(String::from(
+                    parsed_error.message,
+                )),
+                "InvalidParameter" => DeletePlatformApplicationError::InvalidParameter(
                     String::from(parsed_error.message),
                 ),
                 _ => DeletePlatformApplicationError::Unknown(String::from(body)),
@@ -3405,18 +3395,16 @@ impl DeleteTopicError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AuthorizationErrorException" => {
+                "AuthorizationError" => {
                     DeleteTopicError::AuthorizationError(String::from(parsed_error.message))
                 }
-                "InternalErrorException" => {
+                "InternalError" => {
                     DeleteTopicError::InternalError(String::from(parsed_error.message))
                 }
-                "InvalidParameterException" => {
+                "InvalidParameter" => {
                     DeleteTopicError::InvalidParameter(String::from(parsed_error.message))
                 }
-                "NotFoundException" => {
-                    DeleteTopicError::NotFound(String::from(parsed_error.message))
-                }
+                "NotFound" => DeleteTopicError::NotFound(String::from(parsed_error.message)),
                 _ => DeleteTopicError::Unknown(String::from(body)),
             },
             Err(_) => DeleteTopicError::Unknown(body.to_string()),
@@ -3500,16 +3488,16 @@ impl GetEndpointAttributesError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AuthorizationErrorException" => GetEndpointAttributesError::AuthorizationError(
+                "AuthorizationError" => GetEndpointAttributesError::AuthorizationError(
                     String::from(parsed_error.message),
                 ),
-                "InternalErrorException" => {
+                "InternalError" => {
                     GetEndpointAttributesError::InternalError(String::from(parsed_error.message))
                 }
-                "InvalidParameterException" => {
+                "InvalidParameter" => {
                     GetEndpointAttributesError::InvalidParameter(String::from(parsed_error.message))
                 }
-                "NotFoundException" => {
+                "NotFound" => {
                     GetEndpointAttributesError::NotFound(String::from(parsed_error.message))
                 }
                 _ => GetEndpointAttributesError::Unknown(String::from(body)),
@@ -3597,22 +3585,18 @@ impl GetPlatformApplicationAttributesError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AuthorizationErrorException" => {
-                    GetPlatformApplicationAttributesError::AuthorizationError(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "InternalErrorException" => GetPlatformApplicationAttributesError::InternalError(
+                "AuthorizationError" => GetPlatformApplicationAttributesError::AuthorizationError(
                     String::from(parsed_error.message),
                 ),
-                "InvalidParameterException" => {
-                    GetPlatformApplicationAttributesError::InvalidParameter(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "NotFoundException" => GetPlatformApplicationAttributesError::NotFound(
+                "InternalError" => GetPlatformApplicationAttributesError::InternalError(
                     String::from(parsed_error.message),
                 ),
+                "InvalidParameter" => GetPlatformApplicationAttributesError::InvalidParameter(
+                    String::from(parsed_error.message),
+                ),
+                "NotFound" => GetPlatformApplicationAttributesError::NotFound(String::from(
+                    parsed_error.message,
+                )),
                 _ => GetPlatformApplicationAttributesError::Unknown(String::from(body)),
             },
             Err(_) => GetPlatformApplicationAttributesError::Unknown(body.to_string()),
@@ -3698,18 +3682,16 @@ impl GetSMSAttributesError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AuthorizationErrorException" => {
+                "AuthorizationError" => {
                     GetSMSAttributesError::AuthorizationError(String::from(parsed_error.message))
                 }
-                "InternalErrorException" => {
+                "InternalError" => {
                     GetSMSAttributesError::InternalError(String::from(parsed_error.message))
                 }
-                "InvalidParameterException" => {
+                "InvalidParameter" => {
                     GetSMSAttributesError::InvalidParameter(String::from(parsed_error.message))
                 }
-                "ThrottledException" => {
-                    GetSMSAttributesError::Throttled(String::from(parsed_error.message))
-                }
+                "Throttled" => GetSMSAttributesError::Throttled(String::from(parsed_error.message)),
                 _ => GetSMSAttributesError::Unknown(String::from(body)),
             },
             Err(_) => GetSMSAttributesError::Unknown(body.to_string()),
@@ -3793,18 +3775,16 @@ impl GetSubscriptionAttributesError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AuthorizationErrorException" => {
-                    GetSubscriptionAttributesError::AuthorizationError(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "InternalErrorException" => GetSubscriptionAttributesError::InternalError(
+                "AuthorizationError" => GetSubscriptionAttributesError::AuthorizationError(
                     String::from(parsed_error.message),
                 ),
-                "InvalidParameterException" => GetSubscriptionAttributesError::InvalidParameter(
+                "InternalError" => GetSubscriptionAttributesError::InternalError(String::from(
+                    parsed_error.message,
+                )),
+                "InvalidParameter" => GetSubscriptionAttributesError::InvalidParameter(
                     String::from(parsed_error.message),
                 ),
-                "NotFoundException" => {
+                "NotFound" => {
                     GetSubscriptionAttributesError::NotFound(String::from(parsed_error.message))
                 }
                 _ => GetSubscriptionAttributesError::Unknown(String::from(body)),
@@ -3892,18 +3872,16 @@ impl GetTopicAttributesError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AuthorizationErrorException" => {
+                "AuthorizationError" => {
                     GetTopicAttributesError::AuthorizationError(String::from(parsed_error.message))
                 }
-                "InternalErrorException" => {
+                "InternalError" => {
                     GetTopicAttributesError::InternalError(String::from(parsed_error.message))
                 }
-                "InvalidParameterException" => {
+                "InvalidParameter" => {
                     GetTopicAttributesError::InvalidParameter(String::from(parsed_error.message))
                 }
-                "NotFoundException" => {
-                    GetTopicAttributesError::NotFound(String::from(parsed_error.message))
-                }
+                "NotFound" => GetTopicAttributesError::NotFound(String::from(parsed_error.message)),
                 _ => GetTopicAttributesError::Unknown(String::from(body)),
             },
             Err(_) => GetTopicAttributesError::Unknown(body.to_string()),
@@ -3989,24 +3967,20 @@ impl ListEndpointsByPlatformApplicationError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AuthorizationErrorException" => {
+                "AuthorizationError" => {
                     ListEndpointsByPlatformApplicationError::AuthorizationError(String::from(
                         parsed_error.message,
                     ))
                 }
-                "InternalErrorException" => {
-                    ListEndpointsByPlatformApplicationError::InternalError(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "InvalidParameterException" => {
-                    ListEndpointsByPlatformApplicationError::InvalidParameter(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "NotFoundException" => ListEndpointsByPlatformApplicationError::NotFound(
+                "InternalError" => ListEndpointsByPlatformApplicationError::InternalError(
                     String::from(parsed_error.message),
                 ),
+                "InvalidParameter" => ListEndpointsByPlatformApplicationError::InvalidParameter(
+                    String::from(parsed_error.message),
+                ),
+                "NotFound" => ListEndpointsByPlatformApplicationError::NotFound(String::from(
+                    parsed_error.message,
+                )),
                 _ => ListEndpointsByPlatformApplicationError::Unknown(String::from(body)),
             },
             Err(_) => ListEndpointsByPlatformApplicationError::Unknown(body.to_string()),
@@ -4092,18 +4066,16 @@ impl ListPhoneNumbersOptedOutError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AuthorizationErrorException" => {
-                    ListPhoneNumbersOptedOutError::AuthorizationError(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "InternalErrorException" => {
-                    ListPhoneNumbersOptedOutError::InternalError(String::from(parsed_error.message))
-                }
-                "InvalidParameterException" => ListPhoneNumbersOptedOutError::InvalidParameter(
+                "AuthorizationError" => ListPhoneNumbersOptedOutError::AuthorizationError(
                     String::from(parsed_error.message),
                 ),
-                "ThrottledException" => {
+                "InternalError" => {
+                    ListPhoneNumbersOptedOutError::InternalError(String::from(parsed_error.message))
+                }
+                "InvalidParameter" => ListPhoneNumbersOptedOutError::InvalidParameter(
+                    String::from(parsed_error.message),
+                ),
+                "Throttled" => {
                     ListPhoneNumbersOptedOutError::Throttled(String::from(parsed_error.message))
                 }
                 _ => ListPhoneNumbersOptedOutError::Unknown(String::from(body)),
@@ -4189,15 +4161,13 @@ impl ListPlatformApplicationsError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AuthorizationErrorException" => {
-                    ListPlatformApplicationsError::AuthorizationError(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "InternalErrorException" => {
+                "AuthorizationError" => ListPlatformApplicationsError::AuthorizationError(
+                    String::from(parsed_error.message),
+                ),
+                "InternalError" => {
                     ListPlatformApplicationsError::InternalError(String::from(parsed_error.message))
                 }
-                "InvalidParameterException" => ListPlatformApplicationsError::InvalidParameter(
+                "InvalidParameter" => ListPlatformApplicationsError::InvalidParameter(
                     String::from(parsed_error.message),
                 ),
                 _ => ListPlatformApplicationsError::Unknown(String::from(body)),
@@ -4282,13 +4252,13 @@ impl ListSubscriptionsError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AuthorizationErrorException" => {
+                "AuthorizationError" => {
                     ListSubscriptionsError::AuthorizationError(String::from(parsed_error.message))
                 }
-                "InternalErrorException" => {
+                "InternalError" => {
                     ListSubscriptionsError::InternalError(String::from(parsed_error.message))
                 }
-                "InvalidParameterException" => {
+                "InvalidParameter" => {
                     ListSubscriptionsError::InvalidParameter(String::from(parsed_error.message))
                 }
                 _ => ListSubscriptionsError::Unknown(String::from(body)),
@@ -4375,18 +4345,16 @@ impl ListSubscriptionsByTopicError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AuthorizationErrorException" => {
-                    ListSubscriptionsByTopicError::AuthorizationError(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "InternalErrorException" => {
-                    ListSubscriptionsByTopicError::InternalError(String::from(parsed_error.message))
-                }
-                "InvalidParameterException" => ListSubscriptionsByTopicError::InvalidParameter(
+                "AuthorizationError" => ListSubscriptionsByTopicError::AuthorizationError(
                     String::from(parsed_error.message),
                 ),
-                "NotFoundException" => {
+                "InternalError" => {
+                    ListSubscriptionsByTopicError::InternalError(String::from(parsed_error.message))
+                }
+                "InvalidParameter" => ListSubscriptionsByTopicError::InvalidParameter(
+                    String::from(parsed_error.message),
+                ),
+                "NotFound" => {
                     ListSubscriptionsByTopicError::NotFound(String::from(parsed_error.message))
                 }
                 _ => ListSubscriptionsByTopicError::Unknown(String::from(body)),
@@ -4472,13 +4440,13 @@ impl ListTopicsError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AuthorizationErrorException" => {
+                "AuthorizationError" => {
                     ListTopicsError::AuthorizationError(String::from(parsed_error.message))
                 }
-                "InternalErrorException" => {
+                "InternalError" => {
                     ListTopicsError::InternalError(String::from(parsed_error.message))
                 }
-                "InvalidParameterException" => {
+                "InvalidParameter" => {
                     ListTopicsError::InvalidParameter(String::from(parsed_error.message))
                 }
                 _ => ListTopicsError::Unknown(String::from(body)),
@@ -4563,18 +4531,16 @@ impl OptInPhoneNumberError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AuthorizationErrorException" => {
+                "AuthorizationError" => {
                     OptInPhoneNumberError::AuthorizationError(String::from(parsed_error.message))
                 }
-                "InternalErrorException" => {
+                "InternalError" => {
                     OptInPhoneNumberError::InternalError(String::from(parsed_error.message))
                 }
-                "InvalidParameterException" => {
+                "InvalidParameter" => {
                     OptInPhoneNumberError::InvalidParameter(String::from(parsed_error.message))
                 }
-                "ThrottledException" => {
-                    OptInPhoneNumberError::Throttled(String::from(parsed_error.message))
-                }
+                "Throttled" => OptInPhoneNumberError::Throttled(String::from(parsed_error.message)),
                 _ => OptInPhoneNumberError::Unknown(String::from(body)),
             },
             Err(_) => OptInPhoneNumberError::Unknown(body.to_string()),
@@ -4664,23 +4630,21 @@ impl PublishError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AuthorizationErrorException" => {
+                "AuthorizationError" => {
                     PublishError::AuthorizationError(String::from(parsed_error.message))
                 }
-                "EndpointDisabledException" => {
+                "EndpointDisabled" => {
                     PublishError::EndpointDisabled(String::from(parsed_error.message))
                 }
-                "InternalErrorException" => {
-                    PublishError::InternalError(String::from(parsed_error.message))
-                }
-                "InvalidParameterException" => {
+                "InternalError" => PublishError::InternalError(String::from(parsed_error.message)),
+                "InvalidParameter" => {
                     PublishError::InvalidParameter(String::from(parsed_error.message))
                 }
-                "InvalidParameterValueException" => {
+                "ParameterValueInvalid" => {
                     PublishError::InvalidParameterValue(String::from(parsed_error.message))
                 }
-                "NotFoundException" => PublishError::NotFound(String::from(parsed_error.message)),
-                "PlatformApplicationDisabledException" => {
+                "NotFound" => PublishError::NotFound(String::from(parsed_error.message)),
+                "PlatformApplicationDisabled" => {
                     PublishError::PlatformApplicationDisabled(String::from(parsed_error.message))
                 }
                 _ => PublishError::Unknown(String::from(body)),
@@ -4769,18 +4733,16 @@ impl RemovePermissionError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AuthorizationErrorException" => {
+                "AuthorizationError" => {
                     RemovePermissionError::AuthorizationError(String::from(parsed_error.message))
                 }
-                "InternalErrorException" => {
+                "InternalError" => {
                     RemovePermissionError::InternalError(String::from(parsed_error.message))
                 }
-                "InvalidParameterException" => {
+                "InvalidParameter" => {
                     RemovePermissionError::InvalidParameter(String::from(parsed_error.message))
                 }
-                "NotFoundException" => {
-                    RemovePermissionError::NotFound(String::from(parsed_error.message))
-                }
+                "NotFound" => RemovePermissionError::NotFound(String::from(parsed_error.message)),
                 _ => RemovePermissionError::Unknown(String::from(body)),
             },
             Err(_) => RemovePermissionError::Unknown(body.to_string()),
@@ -4864,16 +4826,16 @@ impl SetEndpointAttributesError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AuthorizationErrorException" => SetEndpointAttributesError::AuthorizationError(
+                "AuthorizationError" => SetEndpointAttributesError::AuthorizationError(
                     String::from(parsed_error.message),
                 ),
-                "InternalErrorException" => {
+                "InternalError" => {
                     SetEndpointAttributesError::InternalError(String::from(parsed_error.message))
                 }
-                "InvalidParameterException" => {
+                "InvalidParameter" => {
                     SetEndpointAttributesError::InvalidParameter(String::from(parsed_error.message))
                 }
-                "NotFoundException" => {
+                "NotFound" => {
                     SetEndpointAttributesError::NotFound(String::from(parsed_error.message))
                 }
                 _ => SetEndpointAttributesError::Unknown(String::from(body)),
@@ -4961,22 +4923,18 @@ impl SetPlatformApplicationAttributesError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AuthorizationErrorException" => {
-                    SetPlatformApplicationAttributesError::AuthorizationError(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "InternalErrorException" => SetPlatformApplicationAttributesError::InternalError(
+                "AuthorizationError" => SetPlatformApplicationAttributesError::AuthorizationError(
                     String::from(parsed_error.message),
                 ),
-                "InvalidParameterException" => {
-                    SetPlatformApplicationAttributesError::InvalidParameter(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "NotFoundException" => SetPlatformApplicationAttributesError::NotFound(
+                "InternalError" => SetPlatformApplicationAttributesError::InternalError(
                     String::from(parsed_error.message),
                 ),
+                "InvalidParameter" => SetPlatformApplicationAttributesError::InvalidParameter(
+                    String::from(parsed_error.message),
+                ),
+                "NotFound" => SetPlatformApplicationAttributesError::NotFound(String::from(
+                    parsed_error.message,
+                )),
                 _ => SetPlatformApplicationAttributesError::Unknown(String::from(body)),
             },
             Err(_) => SetPlatformApplicationAttributesError::Unknown(body.to_string()),
@@ -5062,18 +5020,16 @@ impl SetSMSAttributesError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AuthorizationErrorException" => {
+                "AuthorizationError" => {
                     SetSMSAttributesError::AuthorizationError(String::from(parsed_error.message))
                 }
-                "InternalErrorException" => {
+                "InternalError" => {
                     SetSMSAttributesError::InternalError(String::from(parsed_error.message))
                 }
-                "InvalidParameterException" => {
+                "InvalidParameter" => {
                     SetSMSAttributesError::InvalidParameter(String::from(parsed_error.message))
                 }
-                "ThrottledException" => {
-                    SetSMSAttributesError::Throttled(String::from(parsed_error.message))
-                }
+                "Throttled" => SetSMSAttributesError::Throttled(String::from(parsed_error.message)),
                 _ => SetSMSAttributesError::Unknown(String::from(body)),
             },
             Err(_) => SetSMSAttributesError::Unknown(body.to_string()),
@@ -5157,18 +5113,16 @@ impl SetSubscriptionAttributesError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AuthorizationErrorException" => {
-                    SetSubscriptionAttributesError::AuthorizationError(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "InternalErrorException" => SetSubscriptionAttributesError::InternalError(
+                "AuthorizationError" => SetSubscriptionAttributesError::AuthorizationError(
                     String::from(parsed_error.message),
                 ),
-                "InvalidParameterException" => SetSubscriptionAttributesError::InvalidParameter(
+                "InternalError" => SetSubscriptionAttributesError::InternalError(String::from(
+                    parsed_error.message,
+                )),
+                "InvalidParameter" => SetSubscriptionAttributesError::InvalidParameter(
                     String::from(parsed_error.message),
                 ),
-                "NotFoundException" => {
+                "NotFound" => {
                     SetSubscriptionAttributesError::NotFound(String::from(parsed_error.message))
                 }
                 _ => SetSubscriptionAttributesError::Unknown(String::from(body)),
@@ -5256,18 +5210,16 @@ impl SetTopicAttributesError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AuthorizationErrorException" => {
+                "AuthorizationError" => {
                     SetTopicAttributesError::AuthorizationError(String::from(parsed_error.message))
                 }
-                "InternalErrorException" => {
+                "InternalError" => {
                     SetTopicAttributesError::InternalError(String::from(parsed_error.message))
                 }
-                "InvalidParameterException" => {
+                "InvalidParameter" => {
                     SetTopicAttributesError::InvalidParameter(String::from(parsed_error.message))
                 }
-                "NotFoundException" => {
-                    SetTopicAttributesError::NotFound(String::from(parsed_error.message))
-                }
+                "NotFound" => SetTopicAttributesError::NotFound(String::from(parsed_error.message)),
                 _ => SetTopicAttributesError::Unknown(String::from(body)),
             },
             Err(_) => SetTopicAttributesError::Unknown(body.to_string()),
@@ -5355,17 +5307,17 @@ impl SubscribeError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AuthorizationErrorException" => {
+                "AuthorizationError" => {
                     SubscribeError::AuthorizationError(String::from(parsed_error.message))
                 }
-                "InternalErrorException" => {
+                "InternalError" => {
                     SubscribeError::InternalError(String::from(parsed_error.message))
                 }
-                "InvalidParameterException" => {
+                "InvalidParameter" => {
                     SubscribeError::InvalidParameter(String::from(parsed_error.message))
                 }
-                "NotFoundException" => SubscribeError::NotFound(String::from(parsed_error.message)),
-                "SubscriptionLimitExceededException" => {
+                "NotFound" => SubscribeError::NotFound(String::from(parsed_error.message)),
+                "SubscriptionLimitExceeded" => {
                     SubscribeError::SubscriptionLimitExceeded(String::from(parsed_error.message))
                 }
                 _ => SubscribeError::Unknown(String::from(body)),
@@ -5452,18 +5404,16 @@ impl UnsubscribeError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "AuthorizationErrorException" => {
+                "AuthorizationError" => {
                     UnsubscribeError::AuthorizationError(String::from(parsed_error.message))
                 }
-                "InternalErrorException" => {
+                "InternalError" => {
                     UnsubscribeError::InternalError(String::from(parsed_error.message))
                 }
-                "InvalidParameterException" => {
+                "InvalidParameter" => {
                     UnsubscribeError::InvalidParameter(String::from(parsed_error.message))
                 }
-                "NotFoundException" => {
-                    UnsubscribeError::NotFound(String::from(parsed_error.message))
-                }
+                "NotFound" => UnsubscribeError::NotFound(String::from(parsed_error.message)),
                 _ => UnsubscribeError::Unknown(String::from(body)),
             },
             Err(_) => UnsubscribeError::Unknown(body.to_string()),

--- a/rusoto/services/sqs/src/generated.rs
+++ b/rusoto/services/sqs/src/generated.rs
@@ -2446,13 +2446,21 @@ impl AddPermissionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "OverLimit" => AddPermissionError::OverLimit(String::from(parsed_error.message)),
                 _ => AddPermissionError::Unknown(String::from(body)),
             },
             Err(_) => AddPermissionError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -2515,7 +2523,7 @@ impl ChangeMessageVisibilityError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "MessageNotInflight" => ChangeMessageVisibilityError::MessageNotInflight(
                     String::from(parsed_error.message),
@@ -2527,6 +2535,14 @@ impl ChangeMessageVisibilityError {
             },
             Err(_) => ChangeMessageVisibilityError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -2596,7 +2612,7 @@ impl ChangeMessageVisibilityBatchError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "BatchEntryIdsNotDistinct" => {
                     ChangeMessageVisibilityBatchError::BatchEntryIdsNotDistinct(String::from(
@@ -2618,6 +2634,14 @@ impl ChangeMessageVisibilityBatchError {
             },
             Err(_) => ChangeMessageVisibilityBatchError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -2685,7 +2709,7 @@ impl CreateQueueError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "QueueDeletedRecently" => {
                     CreateQueueError::QueueDeletedRecently(String::from(parsed_error.message))
@@ -2697,6 +2721,14 @@ impl CreateQueueError {
             },
             Err(_) => CreateQueueError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -2760,7 +2792,7 @@ impl DeleteMessageError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidIdFormat" => {
                     DeleteMessageError::InvalidIdFormat(String::from(parsed_error.message))
@@ -2772,6 +2804,14 @@ impl DeleteMessageError {
             },
             Err(_) => DeleteMessageError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -2839,7 +2879,7 @@ impl DeleteMessageBatchError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "BatchEntryIdsNotDistinct" => DeleteMessageBatchError::BatchEntryIdsNotDistinct(
                     String::from(parsed_error.message),
@@ -2859,6 +2899,14 @@ impl DeleteMessageBatchError {
             },
             Err(_) => DeleteMessageBatchError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -2922,12 +2970,20 @@ impl DeleteQueueError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteQueueError::Unknown(String::from(body)),
             },
             Err(_) => DeleteQueueError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -2987,7 +3043,7 @@ impl GetQueueAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidAttributeName" => GetQueueAttributesError::InvalidAttributeName(
                     String::from(parsed_error.message),
@@ -2996,6 +3052,14 @@ impl GetQueueAttributesError {
             },
             Err(_) => GetQueueAttributesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -3058,7 +3122,7 @@ impl GetQueueUrlError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "QueueDoesNotExist" => {
                     GetQueueUrlError::QueueDoesNotExist(String::from(parsed_error.message))
@@ -3067,6 +3131,14 @@ impl GetQueueUrlError {
             },
             Err(_) => GetQueueUrlError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -3127,7 +3199,7 @@ impl ListDeadLetterSourceQueuesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "QueueDoesNotExist" => ListDeadLetterSourceQueuesError::QueueDoesNotExist(
                     String::from(parsed_error.message),
@@ -3136,6 +3208,14 @@ impl ListDeadLetterSourceQueuesError {
             },
             Err(_) => ListDeadLetterSourceQueuesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -3196,12 +3276,20 @@ impl ListQueueTagsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListQueueTagsError::Unknown(String::from(body)),
             },
             Err(_) => ListQueueTagsError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -3259,12 +3347,20 @@ impl ListQueuesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListQueuesError::Unknown(String::from(body)),
             },
             Err(_) => ListQueuesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -3326,7 +3422,7 @@ impl PurgeQueueError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "PurgeQueueInProgress" => {
                     PurgeQueueError::PurgeQueueInProgress(String::from(parsed_error.message))
@@ -3338,6 +3434,14 @@ impl PurgeQueueError {
             },
             Err(_) => PurgeQueueError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -3399,13 +3503,21 @@ impl ReceiveMessageError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "OverLimit" => ReceiveMessageError::OverLimit(String::from(parsed_error.message)),
                 _ => ReceiveMessageError::Unknown(String::from(body)),
             },
             Err(_) => ReceiveMessageError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -3464,12 +3576,20 @@ impl RemovePermissionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => RemovePermissionError::Unknown(String::from(body)),
             },
             Err(_) => RemovePermissionError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -3531,7 +3651,7 @@ impl SendMessageError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidMessageContents" => {
                     SendMessageError::InvalidMessageContents(String::from(parsed_error.message))
@@ -3543,6 +3663,14 @@ impl SendMessageError {
             },
             Err(_) => SendMessageError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -3614,7 +3742,7 @@ impl SendMessageBatchError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "BatchEntryIdsNotDistinct" => SendMessageBatchError::BatchEntryIdsNotDistinct(
                     String::from(parsed_error.message),
@@ -3640,6 +3768,14 @@ impl SendMessageBatchError {
             },
             Err(_) => SendMessageBatchError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -3705,7 +3841,7 @@ impl SetQueueAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidAttributeName" => SetQueueAttributesError::InvalidAttributeName(
                     String::from(parsed_error.message),
@@ -3714,6 +3850,14 @@ impl SetQueueAttributesError {
             },
             Err(_) => SetQueueAttributesError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -3774,12 +3918,20 @@ impl TagQueueError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => TagQueueError::Unknown(String::from(body)),
             },
             Err(_) => TagQueueError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -3837,12 +3989,20 @@ impl UntagQueueError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => UntagQueueError::Unknown(String::from(body)),
             },
             Err(_) => UntagQueueError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 

--- a/rusoto/services/sqs/src/generated.rs
+++ b/rusoto/services/sqs/src/generated.rs
@@ -2525,9 +2525,11 @@ impl ChangeMessageVisibilityError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "MessageNotInflight" => ChangeMessageVisibilityError::MessageNotInflight(
-                    String::from(parsed_error.message),
-                ),
+                "AWS.SimpleQueueService.MessageNotInflight" => {
+                    ChangeMessageVisibilityError::MessageNotInflight(String::from(
+                        parsed_error.message,
+                    ))
+                }
                 "ReceiptHandleIsInvalid" => ChangeMessageVisibilityError::ReceiptHandleIsInvalid(
                     String::from(parsed_error.message),
                 ),
@@ -2614,18 +2616,22 @@ impl ChangeMessageVisibilityBatchError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "BatchEntryIdsNotDistinct" => {
+                "AWS.SimpleQueueService.BatchEntryIdsNotDistinct" => {
                     ChangeMessageVisibilityBatchError::BatchEntryIdsNotDistinct(String::from(
                         parsed_error.message,
                     ))
                 }
-                "EmptyBatchRequest" => ChangeMessageVisibilityBatchError::EmptyBatchRequest(
-                    String::from(parsed_error.message),
-                ),
-                "InvalidBatchEntryId" => ChangeMessageVisibilityBatchError::InvalidBatchEntryId(
-                    String::from(parsed_error.message),
-                ),
-                "TooManyEntriesInBatchRequest" => {
+                "AWS.SimpleQueueService.EmptyBatchRequest" => {
+                    ChangeMessageVisibilityBatchError::EmptyBatchRequest(String::from(
+                        parsed_error.message,
+                    ))
+                }
+                "AWS.SimpleQueueService.InvalidBatchEntryId" => {
+                    ChangeMessageVisibilityBatchError::InvalidBatchEntryId(String::from(
+                        parsed_error.message,
+                    ))
+                }
+                "AWS.SimpleQueueService.TooManyEntriesInBatchRequest" => {
                     ChangeMessageVisibilityBatchError::TooManyEntriesInBatchRequest(String::from(
                         parsed_error.message,
                     ))
@@ -2711,10 +2717,10 @@ impl CreateQueueError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "QueueDeletedRecently" => {
+                "AWS.SimpleQueueService.QueueDeletedRecently" => {
                     CreateQueueError::QueueDeletedRecently(String::from(parsed_error.message))
                 }
-                "QueueNameExists" => {
+                "QueueAlreadyExists" => {
                     CreateQueueError::QueueNameExists(String::from(parsed_error.message))
                 }
                 _ => CreateQueueError::Unknown(String::from(body)),
@@ -2881,16 +2887,18 @@ impl DeleteMessageBatchError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "BatchEntryIdsNotDistinct" => DeleteMessageBatchError::BatchEntryIdsNotDistinct(
-                    String::from(parsed_error.message),
-                ),
-                "EmptyBatchRequest" => {
+                "AWS.SimpleQueueService.BatchEntryIdsNotDistinct" => {
+                    DeleteMessageBatchError::BatchEntryIdsNotDistinct(String::from(
+                        parsed_error.message,
+                    ))
+                }
+                "AWS.SimpleQueueService.EmptyBatchRequest" => {
                     DeleteMessageBatchError::EmptyBatchRequest(String::from(parsed_error.message))
                 }
-                "InvalidBatchEntryId" => {
+                "AWS.SimpleQueueService.InvalidBatchEntryId" => {
                     DeleteMessageBatchError::InvalidBatchEntryId(String::from(parsed_error.message))
                 }
-                "TooManyEntriesInBatchRequest" => {
+                "AWS.SimpleQueueService.TooManyEntriesInBatchRequest" => {
                     DeleteMessageBatchError::TooManyEntriesInBatchRequest(String::from(
                         parsed_error.message,
                     ))
@@ -3124,7 +3132,7 @@ impl GetQueueUrlError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "QueueDoesNotExist" => {
+                "AWS.SimpleQueueService.NonExistentQueue" => {
                     GetQueueUrlError::QueueDoesNotExist(String::from(parsed_error.message))
                 }
                 _ => GetQueueUrlError::Unknown(String::from(body)),
@@ -3201,9 +3209,11 @@ impl ListDeadLetterSourceQueuesError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "QueueDoesNotExist" => ListDeadLetterSourceQueuesError::QueueDoesNotExist(
-                    String::from(parsed_error.message),
-                ),
+                "AWS.SimpleQueueService.NonExistentQueue" => {
+                    ListDeadLetterSourceQueuesError::QueueDoesNotExist(String::from(
+                        parsed_error.message,
+                    ))
+                }
                 _ => ListDeadLetterSourceQueuesError::Unknown(String::from(body)),
             },
             Err(_) => ListDeadLetterSourceQueuesError::Unknown(body.to_string()),
@@ -3424,10 +3434,10 @@ impl PurgeQueueError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "PurgeQueueInProgress" => {
+                "AWS.SimpleQueueService.PurgeQueueInProgress" => {
                     PurgeQueueError::PurgeQueueInProgress(String::from(parsed_error.message))
                 }
-                "QueueDoesNotExist" => {
+                "AWS.SimpleQueueService.NonExistentQueue" => {
                     PurgeQueueError::QueueDoesNotExist(String::from(parsed_error.message))
                 }
                 _ => PurgeQueueError::Unknown(String::from(body)),
@@ -3656,7 +3666,7 @@ impl SendMessageError {
                 "InvalidMessageContents" => {
                     SendMessageError::InvalidMessageContents(String::from(parsed_error.message))
                 }
-                "UnsupportedOperation" => {
+                "AWS.SimpleQueueService.UnsupportedOperation" => {
                     SendMessageError::UnsupportedOperation(String::from(parsed_error.message))
                 }
                 _ => SendMessageError::Unknown(String::from(body)),
@@ -3744,24 +3754,26 @@ impl SendMessageBatchError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "BatchEntryIdsNotDistinct" => SendMessageBatchError::BatchEntryIdsNotDistinct(
-                    String::from(parsed_error.message),
-                ),
-                "BatchRequestTooLong" => {
+                "AWS.SimpleQueueService.BatchEntryIdsNotDistinct" => {
+                    SendMessageBatchError::BatchEntryIdsNotDistinct(String::from(
+                        parsed_error.message,
+                    ))
+                }
+                "AWS.SimpleQueueService.BatchRequestTooLong" => {
                     SendMessageBatchError::BatchRequestTooLong(String::from(parsed_error.message))
                 }
-                "EmptyBatchRequest" => {
+                "AWS.SimpleQueueService.EmptyBatchRequest" => {
                     SendMessageBatchError::EmptyBatchRequest(String::from(parsed_error.message))
                 }
-                "InvalidBatchEntryId" => {
+                "AWS.SimpleQueueService.InvalidBatchEntryId" => {
                     SendMessageBatchError::InvalidBatchEntryId(String::from(parsed_error.message))
                 }
-                "TooManyEntriesInBatchRequest" => {
+                "AWS.SimpleQueueService.TooManyEntriesInBatchRequest" => {
                     SendMessageBatchError::TooManyEntriesInBatchRequest(String::from(
                         parsed_error.message,
                     ))
                 }
-                "UnsupportedOperation" => {
+                "AWS.SimpleQueueService.UnsupportedOperation" => {
                     SendMessageBatchError::UnsupportedOperation(String::from(parsed_error.message))
                 }
                 _ => SendMessageBatchError::Unknown(String::from(body)),

--- a/rusoto/services/sts/src/generated.rs
+++ b/rusoto/services/sts/src/generated.rs
@@ -1240,7 +1240,7 @@ impl AssumeRoleError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "MalformedPolicyDocumentException" => {
                     AssumeRoleError::MalformedPolicyDocument(String::from(parsed_error.message))
@@ -1255,6 +1255,14 @@ impl AssumeRoleError {
             },
             Err(_) => AssumeRoleError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -1327,7 +1335,7 @@ impl AssumeRoleWithSAMLError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ExpiredTokenException" => {
                     AssumeRoleWithSAMLError::ExpiredToken(String::from(parsed_error.message))
@@ -1353,6 +1361,14 @@ impl AssumeRoleWithSAMLError {
             },
             Err(_) => AssumeRoleWithSAMLError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -1432,7 +1448,7 @@ impl AssumeRoleWithWebIdentityError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "ExpiredTokenException" => {
                     AssumeRoleWithWebIdentityError::ExpiredToken(String::from(parsed_error.message))
@@ -1467,6 +1483,14 @@ impl AssumeRoleWithWebIdentityError {
             },
             Err(_) => AssumeRoleWithWebIdentityError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -1535,7 +1559,7 @@ impl DecodeAuthorizationMessageError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "InvalidAuthorizationMessageException" => {
                     DecodeAuthorizationMessageError::InvalidAuthorizationMessage(String::from(
@@ -1546,6 +1570,14 @@ impl DecodeAuthorizationMessageError {
             },
             Err(_) => DecodeAuthorizationMessageError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -1606,12 +1638,20 @@ impl GetCallerIdentityError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetCallerIdentityError::Unknown(String::from(body)),
             },
             Err(_) => GetCallerIdentityError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -1677,7 +1717,7 @@ impl GetFederationTokenError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "MalformedPolicyDocumentException" => {
                     GetFederationTokenError::MalformedPolicyDocument(String::from(
@@ -1694,6 +1734,14 @@ impl GetFederationTokenError {
             },
             Err(_) => GetFederationTokenError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 
@@ -1758,7 +1806,7 @@ impl GetSessionTokenError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
-        match XmlErrorDeserializer::deserialize("Error", &mut stack) {
+        match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 "RegionDisabledException" => {
                     GetSessionTokenError::RegionDisabled(String::from(parsed_error.message))
@@ -1767,6 +1815,14 @@ impl GetSessionTokenError {
             },
             Err(_) => GetSessionTokenError::Unknown(body.to_string()),
         }
+    }
+
+    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError>
+    where
+        T: Peek + Next,
+    {
+        start_element("ErrorResponse", stack)?;
+        XmlErrorDeserializer::deserialize("Error", stack)
     }
 }
 

--- a/rusoto/services/sts/src/generated.rs
+++ b/rusoto/services/sts/src/generated.rs
@@ -1242,10 +1242,10 @@ impl AssumeRoleError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "MalformedPolicyDocumentException" => {
+                "MalformedPolicyDocument" => {
                     AssumeRoleError::MalformedPolicyDocument(String::from(parsed_error.message))
                 }
-                "PackedPolicyTooLargeException" => {
+                "PackedPolicyTooLarge" => {
                     AssumeRoleError::PackedPolicyTooLarge(String::from(parsed_error.message))
                 }
                 "RegionDisabledException" => {
@@ -1340,18 +1340,16 @@ impl AssumeRoleWithSAMLError {
                 "ExpiredTokenException" => {
                     AssumeRoleWithSAMLError::ExpiredToken(String::from(parsed_error.message))
                 }
-                "IDPRejectedClaimException" => {
+                "IDPRejectedClaim" => {
                     AssumeRoleWithSAMLError::IDPRejectedClaim(String::from(parsed_error.message))
                 }
-                "InvalidIdentityTokenException" => AssumeRoleWithSAMLError::InvalidIdentityToken(
+                "InvalidIdentityToken" => AssumeRoleWithSAMLError::InvalidIdentityToken(
                     String::from(parsed_error.message),
                 ),
-                "MalformedPolicyDocumentException" => {
-                    AssumeRoleWithSAMLError::MalformedPolicyDocument(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "PackedPolicyTooLargeException" => AssumeRoleWithSAMLError::PackedPolicyTooLarge(
+                "MalformedPolicyDocument" => AssumeRoleWithSAMLError::MalformedPolicyDocument(
+                    String::from(parsed_error.message),
+                ),
+                "PackedPolicyTooLarge" => AssumeRoleWithSAMLError::PackedPolicyTooLarge(
                     String::from(parsed_error.message),
                 ),
                 "RegionDisabledException" => {
@@ -1453,29 +1451,23 @@ impl AssumeRoleWithWebIdentityError {
                 "ExpiredTokenException" => {
                     AssumeRoleWithWebIdentityError::ExpiredToken(String::from(parsed_error.message))
                 }
-                "IDPCommunicationErrorException" => {
-                    AssumeRoleWithWebIdentityError::IDPCommunicationError(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "IDPRejectedClaimException" => AssumeRoleWithWebIdentityError::IDPRejectedClaim(
+                "IDPCommunicationError" => AssumeRoleWithWebIdentityError::IDPCommunicationError(
                     String::from(parsed_error.message),
                 ),
-                "InvalidIdentityTokenException" => {
-                    AssumeRoleWithWebIdentityError::InvalidIdentityToken(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "MalformedPolicyDocumentException" => {
+                "IDPRejectedClaim" => AssumeRoleWithWebIdentityError::IDPRejectedClaim(
+                    String::from(parsed_error.message),
+                ),
+                "InvalidIdentityToken" => AssumeRoleWithWebIdentityError::InvalidIdentityToken(
+                    String::from(parsed_error.message),
+                ),
+                "MalformedPolicyDocument" => {
                     AssumeRoleWithWebIdentityError::MalformedPolicyDocument(String::from(
                         parsed_error.message,
                     ))
                 }
-                "PackedPolicyTooLargeException" => {
-                    AssumeRoleWithWebIdentityError::PackedPolicyTooLarge(String::from(
-                        parsed_error.message,
-                    ))
-                }
+                "PackedPolicyTooLarge" => AssumeRoleWithWebIdentityError::PackedPolicyTooLarge(
+                    String::from(parsed_error.message),
+                ),
                 "RegionDisabledException" => AssumeRoleWithWebIdentityError::RegionDisabled(
                     String::from(parsed_error.message),
                 ),
@@ -1719,12 +1711,10 @@ impl GetFederationTokenError {
         find_start_element(&mut stack);
         match Self::deserialize(&mut stack) {
             Ok(parsed_error) => match &parsed_error.code[..] {
-                "MalformedPolicyDocumentException" => {
-                    GetFederationTokenError::MalformedPolicyDocument(String::from(
-                        parsed_error.message,
-                    ))
-                }
-                "PackedPolicyTooLargeException" => GetFederationTokenError::PackedPolicyTooLarge(
+                "MalformedPolicyDocument" => GetFederationTokenError::MalformedPolicyDocument(
+                    String::from(parsed_error.message),
+                ),
+                "PackedPolicyTooLarge" => GetFederationTokenError::PackedPolicyTooLarge(
                     String::from(parsed_error.message),
                 ),
                 "RegionDisabledException" => {

--- a/service_crategen/src/botocore.rs
+++ b/service_crategen/src/botocore.rs
@@ -341,6 +341,8 @@ pub struct Metadata {
     pub service_abbreviation: Option<String>,
     #[serde(rename="serviceFullName")]
     pub service_full_name: String,
+    #[serde(rename="serviceId")]
+    pub service_id: Option<String>,
     #[serde(rename="signatureVersion")]
     pub signature_version: String,
     #[serde(rename="signingName")]

--- a/service_crategen/src/botocore.rs
+++ b/service_crategen/src/botocore.rs
@@ -102,10 +102,6 @@ pub struct Output {
 
 #[derive(Debug, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Error {
-    pub documentation: Option<String>,
-    pub error: Option<HttpError>,
-    pub exception: Option<bool>,
-    pub fault: Option<bool>,
     pub shape: String,
 }
 

--- a/service_crategen/src/commands/generate/codegen/error_types.rs
+++ b/service_crategen/src/commands/generate/codegen/error_types.rs
@@ -218,8 +218,10 @@ impl XmlErrorTypes {
 
         if operation.errors.is_some() {
             for error in operation.errors() {
-                type_matchers.push(format!("\"{error_shape}\" => {error_type}::{error_name}(String::from(parsed_error.message))",
-                    error_shape = error.shape,
+                let shape = service.get_shape(&error.shape).unwrap();
+                let error_code = shape.error.as_ref().and_then(|http_error| http_error.code.as_ref()).unwrap_or(&error.shape);
+                type_matchers.push(format!("\"{error_code}\" => {error_type}::{error_name}(String::from(parsed_error.message))",
+                    error_code = error_code,
                     error_type = error_type,
                     error_name = error.idiomatic_error_name()))
             }

--- a/service_crategen/src/commands/generate/codegen/error_types.rs
+++ b/service_crategen/src/commands/generate/codegen/error_types.rs
@@ -159,7 +159,7 @@ impl GenerateErrorTypes for XmlErrorTypes {
                         let reader = EventReader::new(body.as_bytes());
                         let mut stack = XmlResponse::new(reader.into_iter().peekable());
                         find_start_element(&mut stack);
-                        match XmlErrorDeserializer::deserialize(\"Error\", &mut stack) {{
+                        match Self::deserialize(&mut stack) {{
                             Ok(parsed_error) => {{
                                 match &parsed_error.code[..] {{
                                     {type_matchers}
@@ -168,8 +168,13 @@ impl GenerateErrorTypes for XmlErrorTypes {
                            Err(_) => {type_name}::Unknown(body.to_string())
                        }}
                     }}
+
+                    fn deserialize<T>(stack: &mut T) -> Result<XmlError, XmlParseError> where T: Peek + Next {{
+                        {error_deserializer}
+                    }}
                 }}",
                 type_name = error_type_name(service, operation_name),
+                error_deserializer = self.generate_error_deserializer(service),
                 type_matchers = self.generate_error_type_matchers(operation_name, operation, service))
     }
 
@@ -186,6 +191,25 @@ impl GenerateErrorTypes for XmlErrorTypes {
 }
 
 impl XmlErrorTypes {
+    fn generate_error_deserializer(&self, service: &Service) -> String {
+        if service.service_id() == Some("EC2") {
+            // https://docs.aws.amazon.com/AWSEC2/latest/APIReference/errors-overview.html
+            "
+            start_element(\"Response\", stack)?;
+            start_element(\"Errors\", stack)?;
+            XmlErrorDeserializer::deserialize(\"Error\", stack)
+            ".to_owned()
+        } else if service.service_id() == Some("S3") {
+            // https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html
+            "XmlErrorDeserializer::deserialize(\"Error\", stack)".to_owned()
+        } else {
+            "
+            start_element(\"ErrorResponse\", stack)?;
+            XmlErrorDeserializer::deserialize(\"Error\", stack)
+            ".to_owned()
+        }
+    }
+
     /// generate the arms for a match expression that maps an error name string from the response XML
     /// to a concrete error type from this operation's errors enum
     fn generate_error_type_matchers(&self, operation_name: &str, operation: &Operation, service: &Service) -> String {

--- a/service_crategen/src/service.rs
+++ b/service_crategen/src/service.rs
@@ -29,6 +29,10 @@ impl <'b> Service <'b> {
         &self.definition.metadata.service_full_name
     }
 
+    pub fn service_id(&self) -> Option<&str> {
+        self.definition.metadata.service_id.as_ref().map(|service_id| service_id.as_str())
+    }
+
     pub fn documentation(&self) -> Option<&String> {
         self.definition.documentation.as_ref()
     }


### PR DESCRIPTION
This pull-request improves deserializer of XML error responses (i.e., protocol = query, ec2, and rest-xml).

I've tested with this code https://gist.github.com/eagletmt/a2cda9a8b42b9df9f020706274a95c08

## Before
```
Err Unknown("<?xml version=\"1.0\"?><ErrorResponse xmlns=\"http://queue.amazonaws.com/doc/2012-11-05/\"><Error><Type>Sender</Type><Code>AWS.SimpleQueueService.NonExistentQueue</Code><Message>The specified queue does not exist for this wsdl version.</Message><Detail/></Error><RequestId>8f8f9957-c0d9-536a-9ca6-ca7483be06ad</RequestId></ErrorResponse>")
Err NoSuchBucket("The specified bucket does not exist")
Err Unknown("<?xml version=\"1.0\"?>\n<ErrorResponse xmlns=\"https://route53.amazonaws.com/doc/2013-04-01/\"><Error><Type>Sender</Type><Code>NoSuchHostedZone</Code><Message>No hosted zone found with ID: NO-SUCH-ZONE</Message></Error><RequestId>20c2984f-279e-11e8-9a16-83e7725d8022</RequestId></ErrorResponse>")
```

## After
```
Err QueueDoesNotExist("The specified queue does not exist for this wsdl version.")
Err NoSuchBucket("The specified bucket does not exist")
Err NoSuchHostedZone("No hosted zone found with ID: NO-SUCH-ZONE")
```