### PR TITLE
Fix "bounds on generic parameters are ignored in type aliases"

### DIFF
--- a/rusoto/credential/src/lib.rs
+++ b/rusoto/credential/src/lib.rs
@@ -288,8 +288,8 @@ impl<P: ProvideAwsCredentials + 'static> Future for AutoRefreshingProviderFuture
 }
 
 /// Threadsafe `AutoRefreshingProvider` that locks cached credentials with a `Mutex`
-pub type AutoRefreshingProviderSync<P: ProvideAwsCredentials + 'static> =
-    BaseAutoRefreshingProvider<P, Mutex<Shared<P::Future>>>;
+pub type AutoRefreshingProviderSync<P> =
+    BaseAutoRefreshingProvider<P, Mutex<Shared<<P as ProvideAwsCredentials>::Future>>>;
 
 impl<P: ProvideAwsCredentials + 'static> AutoRefreshingProviderSync<P> {
     /// Grab a RefreshingProvider that locks it's credentials with a Mutex so it's thread safe.
@@ -316,8 +316,8 @@ impl<P: ProvideAwsCredentials + 'static> ProvideAwsCredentials for AutoRefreshin
 }
 
 /// `!Sync` `AutoRefreshingProvider` that caches credentials in a `RefCell`
-pub type AutoRefreshingProvider<P: ProvideAwsCredentials + 'static> =
-    BaseAutoRefreshingProvider<P, RefCell<Shared<P::Future>>>;
+pub type AutoRefreshingProvider<P> =
+    BaseAutoRefreshingProvider<P, RefCell<Shared<<P as ProvideAwsCredentials>::Future>>>;
 
 impl<P: ProvideAwsCredentials + 'static> AutoRefreshingProvider<P> {
     /// Grab a provider that locks it's credentials with a RefCell. If you're looking for


### PR DESCRIPTION
Recent nightly compilers appear to find some more ignored bounds. I adjusted the code as suggested [here](https://github.com/rust-lang/rust/issues/21903#issuecomment-372719515). About the `'static` I removed, as far as I understand, this should still be enforced by the bounds on `BaseAutoRefreshingProvider`.

Fixed errors:

```
error: bounds on generic parameters are ignored in type aliases
   --> /home/travis/build/rusoto/rusoto/rusoto/credential/src/lib.rs:291:40
    |
291 | pub type AutoRefreshingProviderSync<P: ProvideAwsCredentials + 'static> =
    |                                        ^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^
    |
note: lint level defined here
   --> /home/travis/build/rusoto/rusoto/rusoto/credential/src/lib.rs:4:45
    |
4   | #![cfg_attr(not(feature = "unstable"), deny(warnings))]
    |                                             ^^^^^^^^
    = note: #[deny(ignored_generic_bounds)] implied by #[deny(warnings)]
error: bounds on generic parameters are ignored in type aliases
   --> /home/travis/build/rusoto/rusoto/rusoto/credential/src/lib.rs:319:36
    |
319 | pub type AutoRefreshingProvider<P: ProvideAwsCredentials + 'static> =
    |                                    ^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^
error: aborting due to 2 previous errors
error: Could not compile `rusoto_credential`.
To learn more, run the command again with --verbose.
```