### PR TITLE
Travis/Appveyor: ensure all target directories are cached

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,11 @@ sudo: required
 dist: trusty
 language: rust
 # cache dependencies: https://docs.travis-ci.com/user/caching/#Rust-Cargo-cache
-cache: cargo
+cache:
+  cargo: true
+  directories:
+    - service_crategen/target
+    - integration_tests/target
 # run builds for all the trains (and more)
 rust:
   - 1.23.0 # test against minimum Rust version supported
@@ -12,9 +16,6 @@ rust:
 os:
   - linux
   - osx
-cache:
-  directories:
-    - $HOME/.cargo
 before_install:
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then ulimit -n 1024; fi
   - rustup install nightly

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,8 @@ environment:
       CHANNEL: beta
 cache:
   - 'C:\Users\appveyor\.cargo'
+  - 'target'
+  - 'integration_tests\target'
 # Install Rust and Cargo
 # (Based on from https://github.com/rust-lang/libc/blob/master/appveyor.yml)
 install:


### PR DESCRIPTION
This should make sure all the cache-worthy directories are cached. So far, only `$HOME/.cargo/` was actually cached. This also removes the duplicate `cache` key in the YAML file (second entry overrode first).

These directories are now cached:

* `~/.cargo` (by cargo: true)
* `target` (by cargo: true)
* `service_crategen/target`
* `integration_tests/target`

For reference:
[Rust Cargo cache](https://docs.travis-ci.com/user/caching/#Rust-Cargo-cache)
[Enabling multiple caching features](https://docs.travis-ci.com/user/caching/#Enabling-multiple-caching-features)