### PR TITLE
Travis/Appveyor: disable incremental compilation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ after_success:
 env:
   global:
     - RUST_BACKTRACE=1
-
+    - CARGO_INCREMENTAL=0
 branches:
   only:
     - master

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ environment:
   global:
     # This will be used as part of the zipfile name
     PROJECT_NAME: rusoto
+    CARGO_INCREMENTAL: 1
   matrix:
     - TARGET: x86_64-pc-windows-msvc
       CHANNEL: stable

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ environment:
   global:
     # This will be used as part of the zipfile name
     PROJECT_NAME: rusoto
-    CARGO_INCREMENTAL: 1
+    CARGO_INCREMENTAL: 0
   matrix:
     - TARGET: x86_64-pc-windows-msvc
       CHANNEL: stable


### PR DESCRIPTION
Starting with Rustc 1.24 incremental compilation has been [enabled by default for non-release builds](https://github.com/rust-lang/cargo/pull/4817). I ran some tests and disabling it on Travis appears quite a bit faster.

For comparison:
• [Build with default settings](https://travis-ci.org/pgerber/rusoto/builds/355482158) (incr. build for >=1.24)
• [Incr. build explicitly disabled](https://travis-ci.org/pgerber/rusoto/builds/355479094)

I guess this explains the speed difference between 1.23 and beta/nightly.