### PR TITLE
Adds Cloudfront integration test.

### DIFF
--- a/integration_tests/tests/cloudfront.rs
+++ b/integration_tests/tests/cloudfront.rs
@@ -10,10 +10,10 @@ use rusoto_core::Region;
 #[test]
 fn should_list_distributions() {
     let _ = env_logger::try_init();
-    let client = CloudFrontClient::simple(Region::UsEast1);
+    let client = CloudFrontClient::new(Region::UsEast1);
     let request = ListDistributionsRequest::default();
 
-    let result = client.list_distributions(&request).sync();
+    let result = client.list_distributions(request).sync();
     println!("{:#?}", result);
     assert!(result.is_ok());
 }

--- a/integration_tests/tests/cloudfront.rs
+++ b/integration_tests/tests/cloudfront.rs
@@ -1,0 +1,18 @@
+#![cfg(feature = "cloudfront")]
+
+extern crate rusoto_core;
+extern crate rusoto_cloudfront;
+
+use rusoto_cloudfront::{CloudFront, CloudFrontClient, ListDistributionsRequest};
+use rusoto_core::Region;
+
+#[test]
+fn should_list_distirbutions() {
+    let client = CloudFrontClient::simple(Region::UsEast1);
+    let request = ListDistributionsRequest::default();
+
+    let result = client.list_distributions(&request).sync();
+    println!("{:#?}", result);
+    assert!(result.is_ok());
+}
+

--- a/integration_tests/tests/cloudfront.rs
+++ b/integration_tests/tests/cloudfront.rs
@@ -2,12 +2,14 @@
 
 extern crate rusoto_core;
 extern crate rusoto_cloudfront;
+extern crate env_logger;
 
 use rusoto_cloudfront::{CloudFront, CloudFrontClient, ListDistributionsRequest};
 use rusoto_core::Region;
 
 #[test]
-fn should_list_distirbutions() {
+fn should_list_distributions() {
+    let _ = env_logger::try_init();
     let client = CloudFrontClient::simple(Region::UsEast1);
     let request = ListDistributionsRequest::default();
 


### PR DESCRIPTION
This shows we've got a bug: https://docs.aws.amazon.com/general/latest/gr/rande.html#cf_region states 
> Amazon CloudFront distributions have a single endpoint: cloudfront.amazonaws.com and only supports HTTPS requests. When you submit requests to CloudFront programmatically, specify us-east-1 for the US East (N. Virginia) Region.

Test fails:
> failed to lookup address information: nodename nor servname provided, or not known