### PR TITLE
CI: disable caching of target directories again

### DIFF
--- a/.semaphoreci/test_00_enable_cache_dirs.sh
+++ b/.semaphoreci/test_00_enable_cache_dirs.sh
@@ -5,9 +5,6 @@ set -Eeu
 # https://semaphoreci.com/docs/caching-between-builds.html#additional-dir-caching
 cached_dirs=(
     ~/.cargo
-    target
-    service_crategen/target
-    integration_tests/target
 )
 
 for dir in "${cached_dirs[@]}"; do

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,8 @@ dist: trusty
 language: rust
 # cache dependencies: https://docs.travis-ci.com/user/caching/#Rust-Cargo-cache
 cache:
-  cargo: true
   directories:
-    - service_crategen/target
-    - integration_tests/target
+    - ~/.cargo
 # run builds for all the trains (and more)
 rust:
   - 1.23.0 # test against minimum Rust version supported

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,8 +14,6 @@ environment:
       CHANNEL: beta
 cache:
   - 'C:\Users\appveyor\.cargo'
-  - 'target'
-  - 'integration_tests\target'
 # Install Rust and Cargo
 # (Based on from https://github.com/rust-lang/libc/blob/master/appveyor.yml)
 install:


### PR DESCRIPTION
This disables the caching of `target/` directories introduced in #1011.

Reasons for reverting this:

* Caches are too large:

  In Travis, for instance, we reach the time limit for uploading the cache:

  ```
  running `casher push` took longer than 180 seconds and has been aborted.
  You can extend the timeout with `cache.timeout`. See https://docs.travis-ci.com/user/caching/#Setting-the-timeout for details
  ```

  This limit can be adjusted but it's probably not worth it. I increased it and tried a few builds, performance did not improve. It just takes too long to upload and download the cache. Also, the cache is not reused when the compiler is updated and we'd have to manually clean the cache since there is no automated way to get rid of cache no longer used by any installed compiler.

  In case of Semaphore CI and Appveyor, the situation is similar. We simply hit the size limit.

* Caches are not reused on a fresh git clone

  Git doesn't set modification times during checkout. Thus, newly checked out files have a timestamp corresponding to the checkout time. We'd need to set the timestamp to something like the commit time. I tried this but this doesn't appear to work reliably.