### PR TITLE
expose futures for all credential providers

### DIFF
--- a/rusoto/credential/src/environment.rs
+++ b/rusoto/credential/src/environment.rs
@@ -21,6 +21,7 @@ const E_INVALID_EXPIRATION: &str = "Invalid AWS_CREDENTIAL_EXPIRATION in environ
 #[derive(Debug)]
 pub struct EnvironmentProvider;
 
+/// Provides AWS credentials from environment variables as a Future.
 pub struct EnvironmentProviderFuture {
     inner: FutureResult<AwsCredentials, CredentialsError>
 }

--- a/rusoto/credential/src/profile.rs
+++ b/rusoto/credential/src/profile.rs
@@ -116,6 +116,7 @@ impl ProfileProvider {
     }
 }
 
+/// Provides AWS credentials from a profile in a credentials file as a Future.
 pub struct ProfileProviderFuture {
     inner: FutureResult<AwsCredentials, CredentialsError>
 }


### PR DESCRIPTION
I built a custom credential provider, and needed access to the Futures which appeared to be private in the library. This exposes them.

let me know if you want me to revert the rustfmt changes.