### PR TITLE
Remove Display implementation for Region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 (Please put an entry here in each PR)
 
+- Remove `impl Display for Region` since it was of little use and confusingly similar to `Region::name()`.
 - More efficiently and correctly remove scheme from `Region::Custom` endpoints
 - Prevent reactor from hanging indefinitely when using the new tokio release
 - Fix deserialization for empty JSON responses

--- a/rusoto/core/src/region.rs
+++ b/rusoto/core/src/region.rs
@@ -194,18 +194,6 @@ impl<'de> Deserialize<'de> for Region {
     }
 }
 
-impl Display for Region {
-    fn fmt(&self, f: &mut Formatter) -> Result<(), FmtError> {
-        match *self {
-            Region::Custom {
-                ref endpoint,
-                ref name,
-            } => write!(f, "{} with endpoint {}", &name, &endpoint),
-            ref r @ _ => write!(f, "{}", r.name()),
-        }
-    }
-}
-
 impl FromStr for Region {
     type Err = ParseRegionError;
 
@@ -296,39 +284,6 @@ mod tests {
         assert_eq!("us-gov-west-1".parse(), Ok(Region::UsGovWest1));
         assert_eq!("cn-north-1".parse(), Ok(Region::CnNorth1));
         assert_eq!("cn-northwest-1".parse(), Ok(Region::CnNorthwest1));
-    }
-
-    #[test]
-    fn region_display() {
-        assert_eq!(Region::ApNortheast1.to_string(),
-                   "ap-northeast-1".to_owned());
-        assert_eq!(Region::ApNortheast2.to_string(),
-                   "ap-northeast-2".to_owned());
-        assert_eq!(Region::ApSouth1.to_string(), "ap-south-1".to_owned());
-        assert_eq!(Region::ApSoutheast1.to_string(),
-                   "ap-southeast-1".to_owned());
-        assert_eq!(Region::ApSoutheast2.to_string(),
-                   "ap-southeast-2".to_owned());
-        assert_eq!(Region::CaCentral1.to_string(), "ca-central-1".to_owned());
-        assert_eq!(Region::EuCentral1.to_string(), "eu-central-1".to_owned());
-        assert_eq!(Region::EuWest1.to_string(), "eu-west-1".to_owned());
-        assert_eq!(Region::EuWest2.to_string(), "eu-west-2".to_owned());
-        assert_eq!(Region::EuWest3.to_string(), "eu-west-3".to_owned());
-        assert_eq!(Region::SaEast1.to_string(), "sa-east-1".to_owned());
-        assert_eq!(Region::UsEast1.to_string(), "us-east-1".to_owned());
-        assert_eq!(Region::UsEast2.to_string(), "us-east-2".to_owned());
-        assert_eq!(Region::UsWest1.to_string(), "us-west-1".to_owned());
-        assert_eq!(Region::UsWest2.to_string(), "us-west-2".to_owned());
-        assert_eq!(Region::UsGovWest1.to_string(), "us-gov-west-1".to_owned());
-        assert_eq!(Region::CnNorth1.to_string(), "cn-north-1".to_owned());
-        assert_eq!(Region::CnNorthwest1.to_string(), "cn-northwest-1".to_owned());
-        assert_eq!(
-            Region::Custom {
-                endpoint: "https://s3.provider.net".to_owned(),
-                name: "aa-south-1".to_owned(),
-            }.to_string(),
-            "aa-south-1 with endpoint https://s3.provider.net"
-        )
     }
 
     #[test]


### PR DESCRIPTION
It is very easy to accidentally use `<Region as Display>::fmt()` instead of `Region::name()` if the name is desired. In fact both methods return the same unless a `Region::Custom` endpoint is in use. So far I've seen this used incorrectly twice [[1],[2]].

Alternatively, the `Display` implementation could be kept and `Region::name()` could be removed. I prefer `Region::name()` though. It's name makes very clear that the name is what you get.

[1]: https://github.com/rusoto/rusoto/pull/1018#pullrequestreview-113346404
[2]: https://github.com/rusoto/rusoto/commit/3033dea24a6cc23c8072d5f1baae0e6e9fc31162