### PR TITLE
Allow replacing openssl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,20 @@ script:
           cargo check --tests --features "all" )
       fi
   - |
+      if [ "$JOB" = "unit_tests_rustls_A" ]; then
+        echo "Running Rusoto tests (rustls phase A)" \
+         && pip install --user toml \
+         && .travis/split_workspace 1 2 \
+         && cargo test --all -v --no-default-features --features=rustls
+      fi
+  - |
+      if [ "$JOB" = "unit_tests_rustls_B" ]; then
+        echo "Running Rusoto tests (rustls phase B)" \
+         && pip install --user toml \
+         && .travis/split_workspace 2 2 \
+         && cargo test --all -v --no-default-features --features=rustls
+      fi
+  - |
       if [[ "$TRAVIS_OS_NAME" == "linux" && "$TRAVIS_RUST_VERSION" == "stable" && "$JOB" == "integration_tests_and_docs" ]]; then
         echo "Running cargo docs on stable Rust on Linux" &&
         cargo doc --all --no-deps
@@ -59,6 +73,8 @@ env:
     - JOB=unit_tests_A
     - JOB=unit_tests_B
     - JOB=integration_tests_and_docs
+    - JOB=unit_tests_rustls_A
+    - JOB=unit_tests_rustls_B
 branches:
   only:
     - master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 - Add example to Rusoto Logs documentation
 - Add custom dev dependency capability to services crategen
 
+- Allow replacing OpenSSL with rustls by adding `features = ["rustls"], default_features=false` to your Cargo.toml
+
 ## [0.33.1] - 2018-08-07
 
 - Fix `rusoto_mock` versions available

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,6 +28,7 @@ build: off
 test_script:
   - cargo update
   - cargo test --all --lib -v
+  - cargo test --all --lib -v --no-default-features --features=rustls
   - cd integration_tests
   - cargo check --tests --features "all"
   - cd ..

--- a/mock/Cargo.toml
+++ b/mock/Cargo.toml
@@ -26,6 +26,7 @@ version = "0.0"
 [dependencies.rusoto_core]
 version = "> 0.25.0"
 path = "../rusoto/core"
+default_features = false
 
 [features]
 nightly-testing = ["clippy", "rusoto_core/nightly-testing"]

--- a/rusoto/core/Cargo.toml
+++ b/rusoto/core/Cargo.toml
@@ -27,7 +27,8 @@ rustc_version = "0.2.1"
 futures = "0.1.16"
 hmac = "0.5.0"
 hyper = "0.12.0"
-hyper-tls = "0.3.0"
+hyper-tls = { version = "0.3.0", optional = true }
+hyper-rustls = { version = "0.14.0", optional = true }
 lazy_static = "1.0"
 log = "0.4.1"
 md5 = "0.3.6"
@@ -56,5 +57,8 @@ serde_json = "1.0.1"
 serde_test = "1.0.1"
 
 [features]
+default = ["native-tls"]
 nightly-testing = ["clippy", "rusoto_credential/nightly-testing"]
+native-tls = ["hyper-tls"]
+rustls = ["hyper-rustls"]
 unstable = []

--- a/rusoto/core/README.md
+++ b/rusoto/core/README.md
@@ -33,7 +33,7 @@ You may be looking for:
 
 Rust 1.26.1 or later is required.
 
-On Linux, OpenSSL is required.
+On Linux, OpenSSL is required unless `features=["rustls"]` is used.
 
 ## Installation
 
@@ -91,6 +91,17 @@ fn main() {
         },
     }
 }
+```
+
+### Usage with rustls
+
+If you do not want to use OpenSSL, you can replace it with rustls by editing your Cargo.toml:
+
+``` toml
+[dependencies]
+rusoto_core = { version="0.32.0", default_features=false, features=["rustls"] }
+rusoto_sqs = { version="0.32.0", default_features=false, features=["rustls"] }
+rusoto_s3 = { version="0.32.0", default_features=false, features=["rustls"] }
 ```
 
 ### Credentials

--- a/rusoto/core/src/lib.rs
+++ b/rusoto/core/src/lib.rs
@@ -12,7 +12,10 @@
 
 extern crate futures;
 extern crate hyper;
-extern crate hyper_tls;
+#[cfg(feature = "native-tls")]
+extern crate hyper_tls as tls;
+#[cfg(feature = "rustls")]
+extern crate hyper_rustls as tls;
 #[macro_use]
 extern crate lazy_static;
 #[macro_use]

--- a/rusoto/core/src/request.rs
+++ b/rusoto/core/src/request.rs
@@ -25,7 +25,7 @@ use hyper::body::Payload;
 use hyper::StatusCode;
 use hyper::Method;
 use hyper::client::HttpConnector;
-use hyper_tls::HttpsConnector;
+use tls::HttpsConnector;
 use tokio_timer::Timeout;
 
 use log::Level::Debug;
@@ -302,6 +302,7 @@ pub struct HttpClient<C = HttpsConnector<HttpConnector>> {
 impl HttpClient {
     /// Create a tls-enabled http client.
     pub fn new() -> Result<Self, TlsError> {
+        #[cfg(feature="native-tls")]
         let connector = match HttpsConnector::new(4) {
             Ok(connector) => connector,
             Err(tls_error) => {
@@ -310,6 +311,9 @@ impl HttpClient {
                 })
             }
         };
+
+        #[cfg(feature="rustls")]
+        let connector = HttpsConnector::new(4);
 
         Ok(Self::from_connector(connector))
     }

--- a/rusoto/services/acm/Cargo.toml
+++ b/rusoto/services/acm/Cargo.toml
@@ -21,6 +21,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/alexaforbusiness/Cargo.toml
+++ b/rusoto/services/alexaforbusiness/Cargo.toml
@@ -21,6 +21,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/apigateway/Cargo.toml
+++ b/rusoto/services/apigateway/Cargo.toml
@@ -22,6 +22,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/application-autoscaling/Cargo.toml
+++ b/rusoto/services/application-autoscaling/Cargo.toml
@@ -21,6 +21,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/appstream/Cargo.toml
+++ b/rusoto/services/appstream/Cargo.toml
@@ -21,6 +21,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/athena/Cargo.toml
+++ b/rusoto/services/athena/Cargo.toml
@@ -21,6 +21,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/autoscaling/Cargo.toml
+++ b/rusoto/services/autoscaling/Cargo.toml
@@ -20,6 +20,12 @@ xml-rs = "0.7"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/batch/Cargo.toml
+++ b/rusoto/services/batch/Cargo.toml
@@ -22,6 +22,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/budgets/Cargo.toml
+++ b/rusoto/services/budgets/Cargo.toml
@@ -21,6 +21,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/clouddirectory/Cargo.toml
+++ b/rusoto/services/clouddirectory/Cargo.toml
@@ -22,6 +22,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/cloudformation/Cargo.toml
+++ b/rusoto/services/cloudformation/Cargo.toml
@@ -20,6 +20,12 @@ xml-rs = "0.7"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/cloudfront/Cargo.toml
+++ b/rusoto/services/cloudfront/Cargo.toml
@@ -19,6 +19,12 @@ xml-rs = "0.7"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/cloudhsm/Cargo.toml
+++ b/rusoto/services/cloudhsm/Cargo.toml
@@ -21,6 +21,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/cloudhsmv2/Cargo.toml
+++ b/rusoto/services/cloudhsmv2/Cargo.toml
@@ -21,6 +21,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/cloudsearch/Cargo.toml
+++ b/rusoto/services/cloudsearch/Cargo.toml
@@ -20,6 +20,12 @@ xml-rs = "0.7"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/cloudsearchdomain/Cargo.toml
+++ b/rusoto/services/cloudsearchdomain/Cargo.toml
@@ -22,6 +22,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/cloudtrail/Cargo.toml
+++ b/rusoto/services/cloudtrail/Cargo.toml
@@ -21,6 +21,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/cloudwatch/Cargo.toml
+++ b/rusoto/services/cloudwatch/Cargo.toml
@@ -20,6 +20,12 @@ xml-rs = "0.7"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/codebuild/Cargo.toml
+++ b/rusoto/services/codebuild/Cargo.toml
@@ -21,6 +21,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/codecommit/Cargo.toml
+++ b/rusoto/services/codecommit/Cargo.toml
@@ -21,6 +21,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/codedeploy/Cargo.toml
+++ b/rusoto/services/codedeploy/Cargo.toml
@@ -21,6 +21,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/codepipeline/Cargo.toml
+++ b/rusoto/services/codepipeline/Cargo.toml
@@ -21,6 +21,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/codestar/Cargo.toml
+++ b/rusoto/services/codestar/Cargo.toml
@@ -21,6 +21,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/cognito-identity/Cargo.toml
+++ b/rusoto/services/cognito-identity/Cargo.toml
@@ -21,6 +21,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/cognito-idp/Cargo.toml
+++ b/rusoto/services/cognito-idp/Cargo.toml
@@ -21,6 +21,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/cognito-sync/Cargo.toml
+++ b/rusoto/services/cognito-sync/Cargo.toml
@@ -22,6 +22,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/config/Cargo.toml
+++ b/rusoto/services/config/Cargo.toml
@@ -21,6 +21,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/cur/Cargo.toml
+++ b/rusoto/services/cur/Cargo.toml
@@ -21,6 +21,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/datapipeline/Cargo.toml
+++ b/rusoto/services/datapipeline/Cargo.toml
@@ -21,6 +21,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/dax/Cargo.toml
+++ b/rusoto/services/dax/Cargo.toml
@@ -21,6 +21,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/devicefarm/Cargo.toml
+++ b/rusoto/services/devicefarm/Cargo.toml
@@ -21,6 +21,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/directconnect/Cargo.toml
+++ b/rusoto/services/directconnect/Cargo.toml
@@ -21,6 +21,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/discovery/Cargo.toml
+++ b/rusoto/services/discovery/Cargo.toml
@@ -21,6 +21,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/dms/Cargo.toml
+++ b/rusoto/services/dms/Cargo.toml
@@ -21,6 +21,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/ds/Cargo.toml
+++ b/rusoto/services/ds/Cargo.toml
@@ -21,6 +21,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/dynamodb/Cargo.toml
+++ b/rusoto/services/dynamodb/Cargo.toml
@@ -21,6 +21,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/dynamodbstreams/Cargo.toml
+++ b/rusoto/services/dynamodbstreams/Cargo.toml
@@ -21,6 +21,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/ec2/Cargo.toml
+++ b/rusoto/services/ec2/Cargo.toml
@@ -20,6 +20,12 @@ xml-rs = "0.7"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/ecr/Cargo.toml
+++ b/rusoto/services/ecr/Cargo.toml
@@ -21,6 +21,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/ecs/Cargo.toml
+++ b/rusoto/services/ecs/Cargo.toml
@@ -21,6 +21,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/efs/Cargo.toml
+++ b/rusoto/services/efs/Cargo.toml
@@ -22,6 +22,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/elasticache/Cargo.toml
+++ b/rusoto/services/elasticache/Cargo.toml
@@ -20,6 +20,12 @@ xml-rs = "0.7"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/elasticbeanstalk/Cargo.toml
+++ b/rusoto/services/elasticbeanstalk/Cargo.toml
@@ -20,6 +20,12 @@ xml-rs = "0.7"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/elastictranscoder/Cargo.toml
+++ b/rusoto/services/elastictranscoder/Cargo.toml
@@ -22,6 +22,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/elb/Cargo.toml
+++ b/rusoto/services/elb/Cargo.toml
@@ -20,6 +20,12 @@ xml-rs = "0.7"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/elbv2/Cargo.toml
+++ b/rusoto/services/elbv2/Cargo.toml
@@ -20,6 +20,12 @@ xml-rs = "0.7"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/emr/Cargo.toml
+++ b/rusoto/services/emr/Cargo.toml
@@ -21,6 +21,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/events/Cargo.toml
+++ b/rusoto/services/events/Cargo.toml
@@ -21,6 +21,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/firehose/Cargo.toml
+++ b/rusoto/services/firehose/Cargo.toml
@@ -21,6 +21,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/gamelift/Cargo.toml
+++ b/rusoto/services/gamelift/Cargo.toml
@@ -21,6 +21,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/glacier/Cargo.toml
+++ b/rusoto/services/glacier/Cargo.toml
@@ -22,6 +22,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/glue/Cargo.toml
+++ b/rusoto/services/glue/Cargo.toml
@@ -21,6 +21,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/greengrass/Cargo.toml
+++ b/rusoto/services/greengrass/Cargo.toml
@@ -22,6 +22,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/health/Cargo.toml
+++ b/rusoto/services/health/Cargo.toml
@@ -21,6 +21,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/iam/Cargo.toml
+++ b/rusoto/services/iam/Cargo.toml
@@ -20,6 +20,12 @@ xml-rs = "0.7"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/importexport/Cargo.toml
+++ b/rusoto/services/importexport/Cargo.toml
@@ -20,6 +20,12 @@ xml-rs = "0.7"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/inspector/Cargo.toml
+++ b/rusoto/services/inspector/Cargo.toml
@@ -21,6 +21,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/iot/Cargo.toml
+++ b/rusoto/services/iot/Cargo.toml
@@ -22,6 +22,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/kinesis/Cargo.toml
+++ b/rusoto/services/kinesis/Cargo.toml
@@ -21,6 +21,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/kinesisanalytics/Cargo.toml
+++ b/rusoto/services/kinesisanalytics/Cargo.toml
@@ -21,6 +21,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/kms/Cargo.toml
+++ b/rusoto/services/kms/Cargo.toml
@@ -21,6 +21,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/lambda/Cargo.toml
+++ b/rusoto/services/lambda/Cargo.toml
@@ -22,6 +22,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/lex-models/Cargo.toml
+++ b/rusoto/services/lex-models/Cargo.toml
@@ -22,6 +22,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/lex-runtime/Cargo.toml
+++ b/rusoto/services/lex-runtime/Cargo.toml
@@ -22,6 +22,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/lightsail/Cargo.toml
+++ b/rusoto/services/lightsail/Cargo.toml
@@ -21,6 +21,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/logs/Cargo.toml
+++ b/rusoto/services/logs/Cargo.toml
@@ -21,6 +21,7 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 
 [dev-dependencies]
 chrono = "0.4"
@@ -28,3 +29,8 @@ chrono = "0.4"
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/machinelearning/Cargo.toml
+++ b/rusoto/services/machinelearning/Cargo.toml
@@ -21,6 +21,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/marketplace-entitlement/Cargo.toml
+++ b/rusoto/services/marketplace-entitlement/Cargo.toml
@@ -21,6 +21,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/marketplacecommerceanalytics/Cargo.toml
+++ b/rusoto/services/marketplacecommerceanalytics/Cargo.toml
@@ -21,6 +21,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/meteringmarketplace/Cargo.toml
+++ b/rusoto/services/meteringmarketplace/Cargo.toml
@@ -21,6 +21,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/mgh/Cargo.toml
+++ b/rusoto/services/mgh/Cargo.toml
@@ -21,6 +21,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/mturk/Cargo.toml
+++ b/rusoto/services/mturk/Cargo.toml
@@ -21,6 +21,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/opsworks/Cargo.toml
+++ b/rusoto/services/opsworks/Cargo.toml
@@ -21,6 +21,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/opsworkscm/Cargo.toml
+++ b/rusoto/services/opsworkscm/Cargo.toml
@@ -21,6 +21,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/organizations/Cargo.toml
+++ b/rusoto/services/organizations/Cargo.toml
@@ -21,6 +21,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/polly/Cargo.toml
+++ b/rusoto/services/polly/Cargo.toml
@@ -22,6 +22,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/rds/Cargo.toml
+++ b/rusoto/services/rds/Cargo.toml
@@ -20,6 +20,12 @@ xml-rs = "0.7"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/redshift/Cargo.toml
+++ b/rusoto/services/redshift/Cargo.toml
@@ -20,6 +20,12 @@ xml-rs = "0.7"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/rekognition/Cargo.toml
+++ b/rusoto/services/rekognition/Cargo.toml
@@ -21,6 +21,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/resourcegroupstaggingapi/Cargo.toml
+++ b/rusoto/services/resourcegroupstaggingapi/Cargo.toml
@@ -21,6 +21,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/route53/Cargo.toml
+++ b/rusoto/services/route53/Cargo.toml
@@ -19,6 +19,12 @@ xml-rs = "0.7"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/route53domains/Cargo.toml
+++ b/rusoto/services/route53domains/Cargo.toml
@@ -21,6 +21,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/s3/Cargo.toml
+++ b/rusoto/services/s3/Cargo.toml
@@ -19,6 +19,12 @@ xml-rs = "0.7"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/sdb/Cargo.toml
+++ b/rusoto/services/sdb/Cargo.toml
@@ -20,6 +20,12 @@ xml-rs = "0.7"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/secretsmanager/Cargo.toml
+++ b/rusoto/services/secretsmanager/Cargo.toml
@@ -21,6 +21,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/serverlessrepo/Cargo.toml
+++ b/rusoto/services/serverlessrepo/Cargo.toml
@@ -22,6 +22,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/servicecatalog/Cargo.toml
+++ b/rusoto/services/servicecatalog/Cargo.toml
@@ -21,6 +21,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/ses/Cargo.toml
+++ b/rusoto/services/ses/Cargo.toml
@@ -20,6 +20,12 @@ xml-rs = "0.7"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/shield/Cargo.toml
+++ b/rusoto/services/shield/Cargo.toml
@@ -21,6 +21,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/sms/Cargo.toml
+++ b/rusoto/services/sms/Cargo.toml
@@ -21,6 +21,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/snowball/Cargo.toml
+++ b/rusoto/services/snowball/Cargo.toml
@@ -21,6 +21,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/sns/Cargo.toml
+++ b/rusoto/services/sns/Cargo.toml
@@ -20,6 +20,12 @@ xml-rs = "0.7"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/sqs/Cargo.toml
+++ b/rusoto/services/sqs/Cargo.toml
@@ -20,6 +20,12 @@ xml-rs = "0.7"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/ssm/Cargo.toml
+++ b/rusoto/services/ssm/Cargo.toml
@@ -21,6 +21,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/stepfunctions/Cargo.toml
+++ b/rusoto/services/stepfunctions/Cargo.toml
@@ -21,6 +21,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/storagegateway/Cargo.toml
+++ b/rusoto/services/storagegateway/Cargo.toml
@@ -21,6 +21,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/sts/Cargo.toml
+++ b/rusoto/services/sts/Cargo.toml
@@ -21,6 +21,12 @@ xml-rs = "0.7"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/support/Cargo.toml
+++ b/rusoto/services/support/Cargo.toml
@@ -21,6 +21,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/swf/Cargo.toml
+++ b/rusoto/services/swf/Cargo.toml
@@ -21,6 +21,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/waf-regional/Cargo.toml
+++ b/rusoto/services/waf-regional/Cargo.toml
@@ -21,6 +21,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/waf/Cargo.toml
+++ b/rusoto/services/waf/Cargo.toml
@@ -21,6 +21,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/workdocs/Cargo.toml
+++ b/rusoto/services/workdocs/Cargo.toml
@@ -22,6 +22,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/workspaces/Cargo.toml
+++ b/rusoto/services/workspaces/Cargo.toml
@@ -21,6 +21,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/xray/Cargo.toml
+++ b/rusoto/services/xray/Cargo.toml
@@ -22,6 +22,12 @@ serde_json = "1.0.1"
 [dependencies.rusoto_core]
 version = "0.33.1"
 path = "../../core"
+default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.27.0"
 path = "../../../mock"
+
+[features]
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/service_crategen/src/commands/generate/mod.rs
+++ b/service_crategen/src/commands/generate/mod.rs
@@ -79,6 +79,11 @@ pub fn generate_services(services: &BTreeMap<String, ServiceConfig>, out_dir: &P
             fs::create_dir(&crate_dir).expect(&format!("Unable to create directory at {}", crate_dir.display()));
         }
 
+        let mut features = BTreeMap::new();
+        features.insert("default".into(), vec!["native-tls".into()]);
+        features.insert("native-tls".into(), vec!["rusoto_core/native-tls".into()]);
+        features.insert("rustls".into(), vec!["rusoto_core/rustls".into()]);
+
         let service_dependencies = service.get_dependencies();
         let service_dev_dependencies = service.get_dev_dependencies();
 
@@ -126,6 +131,7 @@ pub fn generate_services(services: &BTreeMap<String, ServiceConfig>, out_dir: &P
                 version: service_config.version.clone(),
                 homepage: Some("https://www.rusoto.org/".into())
             },
+            features: Some(features),
             dependencies: service_dependencies,
             dev_dependencies: service_dev_dependencies,
             ..cargo::Manifest::default()

--- a/service_crategen/src/service.rs
+++ b/service_crategen/src/service.rs
@@ -104,7 +104,7 @@ impl <'b> Service <'b> {
             path: Some("../../core".into()),
             version: Some(self.config.core_version.clone()),
             optional: None,
-            default_features: None,
+            default_features: Some(false),
             features: None
         });
 


### PR DESCRIPTION
Having rusoto as a dependency causes issues for me since it introduces an openssl dependency. This breaks my build due to https://github.com/sfackler/rust-openssl/issues/603, this patch introduces a way to replace openssl with rustls. openssl is still the default.

As an alternative approach, I could introduce a way to build rusoto without an https client so I can provide one myself.