### PR TITLE
Add documentation and examples for EnvironmentProvider

### DIFF
--- a/rusoto/credential/src/environment.rs
+++ b/rusoto/credential/src/environment.rs
@@ -1,7 +1,6 @@
 //! The Credentials Provider to read from Environment Variables.
 
-use std::str::FromStr;
-use chrono::{Utc, DateTime};
+use chrono::{FixedOffset, Utc, DateTime};
 
 use futures::{Future, Poll};
 use futures::future::{FutureResult, result};
@@ -18,6 +17,53 @@ const E_NO_SECRET_ACCESS_KEY: &str = "No (or empty) AWS_SECRET_ACCESS_KEY in env
 const E_INVALID_EXPIRATION: &str = "Invalid AWS_CREDENTIAL_EXPIRATION in environment";
 
 /// Provides AWS credentials from environment variables.
+///
+/// # Available Environment Variables
+///
+/// * `AWS_ACCESS_KEY_ID`:
+///
+///   [Access key ID](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys)
+///
+/// * `AWS_SECRET_ACCESS_KEY`:
+///
+///   [Secret access key](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys)
+///
+/// * `AWS_SESSION_TOKEN`:
+///
+///   [Session token](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html)
+///
+/// * `AWS_CREDENTIAL_EXPIRATION`:
+///
+///   Expiration time in RFC 3339 format (e.g. `1996-12-19T16:39:57-08:00`). If unset, credentials
+///   won't expire.
+///
+/// # Example
+///
+/// ```
+/// # extern crate futures;
+/// # extern crate rusoto_credential;
+/// #
+/// # fn main() {
+/// use futures::future::Future;
+/// use rusoto_credential::{EnvironmentProvider, ProvideAwsCredentials};
+/// use std::env;
+///
+/// env::set_var("AWS_ACCESS_KEY_ID", "ANTN35UAENTS5UIAEATD");
+/// env::set_var("AWS_SECRET_ACCESS_KEY", "TtnuieannGt2rGuie2t8Tt7urarg5nauedRndrur");
+/// env::set_var("AWS_SESSION_TOKEN", "DfnGs8Td4rT8r4srxAg6Td4rT8r4srxAg6GtkTir");
+///
+/// let creds = EnvironmentProvider.credentials().wait().unwrap();
+///
+/// assert_eq!(creds.aws_access_key_id(), "ANTN35UAENTS5UIAEATD");
+/// assert_eq!(creds.aws_secret_access_key(), "TtnuieannGt2rGuie2t8Tt7urarg5nauedRndrur");
+/// assert_eq!(creds.token(), &Some("DfnGs8Td4rT8r4srxAg6Td4rT8r4srxAg6GtkTir".to_string()));
+/// assert!(creds.expires_at().is_none()); // doesn't expire
+///
+/// env::set_var("AWS_CREDENTIAL_EXPIRATION", "2018-04-21T01:13:02Z");
+/// let creds = EnvironmentProvider.credentials().wait().unwrap();
+/// assert_eq!(creds.expires_at().unwrap().to_rfc3339(), "2018-04-21T01:13:02+00:00");
+/// # }
+/// ```
 #[derive(Debug)]
 pub struct EnvironmentProvider;
 
@@ -45,7 +91,7 @@ impl ProvideAwsCredentials for EnvironmentProvider {
     }
 }
 
-/// Grabs the Credentials from the environment. These credentials are good for 10 minutes.
+/// Grabs the Credentials from the environment.
 fn credentials_from_environment() -> Result<AwsCredentials, CredentialsError> {
     let env_key = match non_empty_env_var(AWS_ACCESS_KEY_ID) {
         Some(val) => val,
@@ -61,7 +107,7 @@ fn credentials_from_environment() -> Result<AwsCredentials, CredentialsError> {
     let token = non_empty_env_var(AWS_SESSION_TOKEN);
     // Mimik botocore's behavior, see https://github.com/boto/botocore/pull/1187.
     let expires_at = match non_empty_env_var(AWS_CREDENTIAL_EXPIRATION) {
-        Some(val) => match DateTime::<Utc>::from_str(&val) {
+        Some(val) => match DateTime::<FixedOffset>::parse_from_rfc3339(&val).map(|dt| dt.with_timezone(&Utc)) {
             Ok(e) => Some(e),
             Err(e) => return Err(CredentialsError::new(format!("{} '{}': {}", E_INVALID_EXPIRATION, val, e)))
         },


### PR DESCRIPTION
This change also switches `from_str()` to `parse_from_rfc3339`. They are almost identical but `from_str()` fails to parse some strings that conform to RFC 3339. For compatibility reasons, it's probably better to switch.