### PR TITLE
Add support for named profiles in credentials file

### DIFF
--- a/rusoto/credential/src/profile.rs
+++ b/rusoto/credential/src/profile.rs
@@ -167,7 +167,7 @@ fn parse_credentials_file(
 
     let file = try!(File::open(file_path));
 
-    let profile_regex = Regex::new(r"^\[([^\]]+)\]$").expect("Failed to compile regex");
+    let profile_regex = Regex::new(r"^\[(profile )?([^\]]+)\]$").expect("Failed to compile regex");
     let mut profiles: HashMap<String, AwsCredentials> = HashMap::new();
     let mut access_key: Option<String> = None;
     let mut secret_key: Option<String> = None;
@@ -208,7 +208,7 @@ fn parse_credentials_file(
             token = None;
 
             let caps = profile_regex.captures(&unwrapped_line).unwrap();
-            profile_name = Some(caps.get(1).unwrap().as_str().to_string());
+            profile_name = Some(caps.get(2).unwrap().as_str().to_string());
             continue;
         }
 


### PR DESCRIPTION
This change adds the option to use a `~/.aws/config` formatted file. See: https://docs.aws.amazon.com/cli/latest/userguide/cli-multiple-profiles.html