### PR TITLE
Derive PartialEq trait except for streaming fields

### DIFF
--- a/rusoto/services/acm/src/generated.rs
+++ b/rusoto/services/acm/src/generated.rs
@@ -30,7 +30,7 @@ use rusoto_core::signature::SignedRequest;
 use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AddTagsToCertificateRequest {
     /// <p>String that contains the ARN of the ACM certificate to which the tag is to be applied. This must be of the form:</p> <p> <code>arn:aws:acm:region:123456789012:certificate/12345678-1234-1234-1234-123456789012</code> </p> <p>For more information about ARNs, see <a href="http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html">Amazon Resource Names (ARNs) and AWS Service Namespaces</a>. </p>
     #[serde(rename = "CertificateArn")]
@@ -41,7 +41,7 @@ pub struct AddTagsToCertificateRequest {
 }
 
 /// <p>Contains metadata about an ACM certificate. This structure is returned in the response to a <a>DescribeCertificate</a> request. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CertificateDetail {
     /// <p>The Amazon Resource Name (ARN) of the certificate. For more information about ARNs, see <a href="http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html">Amazon Resource Names (ARNs) and AWS Service Namespaces</a> in the <i>AWS General Reference</i>.</p>
     #[serde(rename = "CertificateArn")]
@@ -150,7 +150,7 @@ pub struct CertificateDetail {
 }
 
 /// <p>Structure that contains options for your certificate. Currently, you can use this only to specify whether to opt in to or out of certificate transparency logging. Some browsers require that public certificates issued for your domain be recorded in a log. Certificates that are not logged typically generate a browser error. Transparency makes it possible for you to detect SSL/TLS certificates that have been mistakenly or maliciously issued for your domain. For general information, see <a href="http://docs.aws.amazon.com/http:/docs.aws.amazon.comacm/latest/userguide/acm-concepts.html#concept-transparency">Certificate Transparency Logging</a>. </p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CertificateOptions {
     /// <p>You can opt out of certificate transparency logging by specifying the <code>DISABLED</code> option. Opt in by specifying <code>ENABLED</code>. </p>
     #[serde(rename = "CertificateTransparencyLoggingPreference")]
@@ -159,7 +159,7 @@ pub struct CertificateOptions {
 }
 
 /// <p>This structure is returned in the response object of <a>ListCertificates</a> action. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CertificateSummary {
     /// <p>Amazon Resource Name (ARN) of the certificate. This is of the form:</p> <p> <code>arn:aws:acm:region:123456789012:certificate/12345678-1234-1234-1234-123456789012</code> </p> <p>For more information about ARNs, see <a href="http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html">Amazon Resource Names (ARNs) and AWS Service Namespaces</a>. </p>
     #[serde(rename = "CertificateArn")]
@@ -171,21 +171,21 @@ pub struct CertificateSummary {
     pub domain_name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteCertificateRequest {
     /// <p>String that contains the ARN of the ACM certificate to be deleted. This must be of the form:</p> <p> <code>arn:aws:acm:region:123456789012:certificate/12345678-1234-1234-1234-123456789012</code> </p> <p>For more information about ARNs, see <a href="http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html">Amazon Resource Names (ARNs) and AWS Service Namespaces</a>.</p>
     #[serde(rename = "CertificateArn")]
     pub certificate_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeCertificateRequest {
     /// <p>The Amazon Resource Name (ARN) of the ACM certificate. The ARN must have the following form:</p> <p> <code>arn:aws:acm:region:123456789012:certificate/12345678-1234-1234-1234-123456789012</code> </p> <p>For more information about ARNs, see <a href="http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html">Amazon Resource Names (ARNs) and AWS Service Namespaces</a>.</p>
     #[serde(rename = "CertificateArn")]
     pub certificate_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeCertificateResponse {
     /// <p>Metadata about an ACM certificate.</p>
     #[serde(rename = "Certificate")]
@@ -194,7 +194,7 @@ pub struct DescribeCertificateResponse {
 }
 
 /// <p>Contains information about the validation of each domain name in the certificate.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DomainValidation {
     /// <p>A fully qualified domain name (FQDN) in the certificate. For example, <code>www.example.com</code> or <code>example.com</code>. </p>
     #[serde(rename = "DomainName")]
@@ -222,7 +222,7 @@ pub struct DomainValidation {
 }
 
 /// <p>Contains information about the domain names that you want ACM to use to send you emails that enable you to validate domain ownership.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DomainValidationOption {
     /// <p>A fully qualified domain name (FQDN) in the certificate request.</p>
     #[serde(rename = "DomainName")]
@@ -232,7 +232,7 @@ pub struct DomainValidationOption {
     pub validation_domain: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ExportCertificateRequest {
     /// <p>An Amazon Resource Name (ARN) of the issued certificate. This must be of the form:</p> <p> <code>arn:aws:acm:region:account:certificate/12345678-1234-1234-1234-123456789012</code> </p>
     #[serde(rename = "CertificateArn")]
@@ -247,7 +247,7 @@ pub struct ExportCertificateRequest {
     pub passphrase: Vec<u8>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ExportCertificateResponse {
     /// <p>The base64 PEM-encoded certificate.</p>
     #[serde(rename = "Certificate")]
@@ -264,7 +264,7 @@ pub struct ExportCertificateResponse {
 }
 
 /// <p>The Extended Key Usage X.509 v3 extension defines one or more purposes for which the public key can be used. This is in addition to or in place of the basic purposes specified by the Key Usage extension. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ExtendedKeyUsage {
     /// <p>The name of an Extended Key Usage value.</p>
     #[serde(rename = "Name")]
@@ -277,7 +277,7 @@ pub struct ExtendedKeyUsage {
 }
 
 /// <p>This structure can be used in the <a>ListCertificates</a> action to filter the output of the certificate list. </p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct Filters {
     /// <p>Specify one or more <a>ExtendedKeyUsage</a> extension values.</p>
     #[serde(rename = "extendedKeyUsage")]
@@ -293,14 +293,14 @@ pub struct Filters {
     pub key_usage: Option<Vec<String>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetCertificateRequest {
     /// <p>String that contains a certificate ARN in the following format:</p> <p> <code>arn:aws:acm:region:123456789012:certificate/12345678-1234-1234-1234-123456789012</code> </p> <p>For more information about ARNs, see <a href="http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html">Amazon Resource Names (ARNs) and AWS Service Namespaces</a>.</p>
     #[serde(rename = "CertificateArn")]
     pub certificate_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetCertificateResponse {
     /// <p>String that contains the ACM certificate represented by the ARN specified at input.</p>
     #[serde(rename = "Certificate")]
@@ -312,7 +312,7 @@ pub struct GetCertificateResponse {
     pub certificate_chain: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ImportCertificateRequest {
     /// <p>The certificate to import.</p>
     #[serde(rename = "Certificate")]
@@ -344,7 +344,7 @@ pub struct ImportCertificateRequest {
     pub private_key: Vec<u8>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ImportCertificateResponse {
     /// <p>The <a href="http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html">Amazon Resource Name (ARN)</a> of the imported certificate.</p>
     #[serde(rename = "CertificateArn")]
@@ -353,7 +353,7 @@ pub struct ImportCertificateResponse {
 }
 
 /// <p>The Key Usage X.509 v3 extension defines the purpose of the public key contained in the certificate.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct KeyUsage {
     /// <p>A string value that contains a Key Usage extension name.</p>
     #[serde(rename = "Name")]
@@ -361,7 +361,7 @@ pub struct KeyUsage {
     pub name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListCertificatesRequest {
     /// <p>Filter the certificate list by status value.</p>
     #[serde(rename = "CertificateStatuses")]
@@ -381,7 +381,7 @@ pub struct ListCertificatesRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListCertificatesResponse {
     /// <p>A list of ACM certificates.</p>
     #[serde(rename = "CertificateSummaryList")]
@@ -393,14 +393,14 @@ pub struct ListCertificatesResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListTagsForCertificateRequest {
     /// <p>String that contains the ARN of the ACM certificate for which you want to list the tags. This must have the following form:</p> <p> <code>arn:aws:acm:region:123456789012:certificate/12345678-1234-1234-1234-123456789012</code> </p> <p>For more information about ARNs, see <a href="http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html">Amazon Resource Names (ARNs) and AWS Service Namespaces</a>. </p>
     #[serde(rename = "CertificateArn")]
     pub certificate_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListTagsForCertificateResponse {
     /// <p>The key-value pairs that define the applied tags.</p>
     #[serde(rename = "Tags")]
@@ -408,7 +408,7 @@ pub struct ListTagsForCertificateResponse {
     pub tags: Option<Vec<Tag>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RemoveTagsFromCertificateRequest {
     /// <p>String that contains the ARN of the ACM Certificate with one or more tags that you want to remove. This must be of the form:</p> <p> <code>arn:aws:acm:region:123456789012:certificate/12345678-1234-1234-1234-123456789012</code> </p> <p>For more information about ARNs, see <a href="http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html">Amazon Resource Names (ARNs) and AWS Service Namespaces</a>. </p>
     #[serde(rename = "CertificateArn")]
@@ -419,7 +419,7 @@ pub struct RemoveTagsFromCertificateRequest {
 }
 
 /// <p>Contains information about the status of ACM's <a href="http://docs.aws.amazon.com/http:/docs.aws.amazon.comacm/latest/userguide/acm-renewal.html">managed renewal</a> for the certificate. This structure exists only when the certificate type is <code>AMAZON_ISSUED</code>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RenewalSummary {
     /// <p>Contains information about the validation of each domain name in the certificate, as it pertains to ACM's <a href="http://docs.aws.amazon.com/http:/docs.aws.amazon.comacm/latest/userguide/acm-renewal.html">managed renewal</a>. This is different from the initial validation that occurs as a result of the <a>RequestCertificate</a> request. This field exists only when the certificate type is <code>AMAZON_ISSUED</code>.</p>
     #[serde(rename = "DomainValidationOptions")]
@@ -429,7 +429,7 @@ pub struct RenewalSummary {
     pub renewal_status: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RequestCertificateRequest {
     /// <p>The Amazon Resource Name (ARN) of the private certificate authority (CA) that will be used to issue the certificate. For more information about private CAs, see the <a href="http://docs.aws.amazon.com/http:/docs.aws.amazon.comacm-pca/latest/userguide/PcaWelcome.html">AWS Certificate Manager Private Certificate Authority (PCA)</a> user guide. The ARN must have the following form: </p> <p> <code>arn:aws:acm-pca:region:account:certificate-authority/12345678-1234-1234-1234-123456789012</code> </p>
     #[serde(rename = "CertificateAuthorityArn")]
@@ -460,7 +460,7 @@ pub struct RequestCertificateRequest {
     pub validation_method: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RequestCertificateResponse {
     /// <p>String that contains the ARN of the issued certificate. This must be of the form:</p> <p> <code>arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012</code> </p>
     #[serde(rename = "CertificateArn")]
@@ -468,7 +468,7 @@ pub struct RequestCertificateResponse {
     pub certificate_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ResendValidationEmailRequest {
     /// <p>String that contains the ARN of the requested certificate. The certificate ARN is generated and returned by the <a>RequestCertificate</a> action as soon as the request is made. By default, using this parameter causes email to be sent to all top-level domains you specified in the certificate request. The ARN must be of the form: </p> <p> <code>arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012</code> </p>
     #[serde(rename = "CertificateArn")]
@@ -482,7 +482,7 @@ pub struct ResendValidationEmailRequest {
 }
 
 /// <p>Contains a DNS record value that you can use to can use to validate ownership or control of a domain. This is used by the <a>DescribeCertificate</a> action. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ResourceRecord {
     /// <p>The name of the DNS record to create in your domain. This is supplied by ACM.</p>
     #[serde(rename = "Name")]
@@ -496,7 +496,7 @@ pub struct ResourceRecord {
 }
 
 /// <p>A key-value pair that identifies or specifies metadata about an ACM resource.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Tag {
     /// <p>The key of the tag.</p>
     #[serde(rename = "Key")]
@@ -507,7 +507,7 @@ pub struct Tag {
     pub value: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateCertificateOptionsRequest {
     /// <p>ARN of the requested certificate to update. This must be of the form:</p> <p> <code>arn:aws:acm:us-east-1:<i>account</i>:certificate/<i>12345678-1234-1234-1234-123456789012</i> </code> </p>
     #[serde(rename = "CertificateArn")]

--- a/rusoto/services/acm/src/generated.rs
+++ b/rusoto/services/acm/src/generated.rs
@@ -542,7 +542,8 @@ impl AddTagsToCertificateError {
     pub fn from_body(body: &str) -> AddTagsToCertificateError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -638,7 +639,8 @@ impl DeleteCertificateError {
     pub fn from_body(body: &str) -> DeleteCertificateError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -728,7 +730,8 @@ impl DescribeCertificateError {
     pub fn from_body(body: &str) -> DescribeCertificateError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -816,7 +819,8 @@ impl ExportCertificateError {
     pub fn from_body(body: &str) -> ExportCertificateError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -908,7 +912,8 @@ impl GetCertificateError {
     pub fn from_body(body: &str) -> GetCertificateError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -996,7 +1001,8 @@ impl ImportCertificateError {
     pub fn from_body(body: &str) -> ImportCertificateError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1078,7 +1084,8 @@ impl ListCertificatesError {
     pub fn from_body(body: &str) -> ListCertificatesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1154,7 +1161,8 @@ impl ListTagsForCertificateError {
     pub fn from_body(body: &str) -> ListTagsForCertificateError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1242,7 +1250,8 @@ impl RemoveTagsFromCertificateError {
     pub fn from_body(body: &str) -> RemoveTagsFromCertificateError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1336,7 +1345,8 @@ impl RequestCertificateError {
     pub fn from_body(body: &str) -> RequestCertificateError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1432,7 +1442,8 @@ impl ResendValidationEmailError {
     pub fn from_body(body: &str) -> ResendValidationEmailError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1532,7 +1543,8 @@ impl UpdateCertificateOptionsError {
     pub fn from_body(body: &str) -> UpdateCertificateOptionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/alexaforbusiness/src/generated.rs
+++ b/rusoto/services/alexaforbusiness/src/generated.rs
@@ -1539,7 +1539,8 @@ impl AssociateContactWithAddressBookError {
     pub fn from_body(body: &str) -> AssociateContactWithAddressBookError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1615,7 +1616,8 @@ impl AssociateDeviceWithRoomError {
     pub fn from_body(body: &str) -> AssociateDeviceWithRoomError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1693,7 +1695,8 @@ impl AssociateSkillGroupWithRoomError {
     pub fn from_body(body: &str) -> AssociateSkillGroupWithRoomError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1771,7 +1774,8 @@ impl CreateAddressBookError {
     pub fn from_body(body: &str) -> CreateAddressBookError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1857,7 +1861,8 @@ impl CreateContactError {
     pub fn from_body(body: &str) -> CreateContactError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1941,7 +1946,8 @@ impl CreateProfileError {
     pub fn from_body(body: &str) -> CreateProfileError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2025,7 +2031,8 @@ impl CreateRoomError {
     pub fn from_body(body: &str) -> CreateRoomError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2107,7 +2114,8 @@ impl CreateSkillGroupError {
     pub fn from_body(body: &str) -> CreateSkillGroupError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2191,7 +2199,8 @@ impl CreateUserError {
     pub fn from_body(body: &str) -> CreateUserError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2271,7 +2280,8 @@ impl DeleteAddressBookError {
     pub fn from_body(body: &str) -> DeleteAddressBookError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2351,7 +2361,8 @@ impl DeleteContactError {
     pub fn from_body(body: &str) -> DeleteContactError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2429,7 +2440,8 @@ impl DeleteProfileError {
     pub fn from_body(body: &str) -> DeleteProfileError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2507,7 +2519,8 @@ impl DeleteRoomError {
     pub fn from_body(body: &str) -> DeleteRoomError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2579,7 +2592,8 @@ impl DeleteRoomSkillParameterError {
     pub fn from_body(body: &str) -> DeleteRoomSkillParameterError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2655,7 +2669,8 @@ impl DeleteSkillGroupError {
     pub fn from_body(body: &str) -> DeleteSkillGroupError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2733,7 +2748,8 @@ impl DeleteUserError {
     pub fn from_body(body: &str) -> DeleteUserError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2805,7 +2821,8 @@ impl DisassociateContactFromAddressBookError {
     pub fn from_body(body: &str) -> DisassociateContactFromAddressBookError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2879,7 +2896,8 @@ impl DisassociateDeviceFromRoomError {
     pub fn from_body(body: &str) -> DisassociateDeviceFromRoomError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2953,7 +2971,8 @@ impl DisassociateSkillGroupFromRoomError {
     pub fn from_body(body: &str) -> DisassociateSkillGroupFromRoomError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3029,7 +3048,8 @@ impl GetAddressBookError {
     pub fn from_body(body: &str) -> GetAddressBookError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3107,7 +3127,8 @@ impl GetContactError {
     pub fn from_body(body: &str) -> GetContactError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3181,7 +3202,8 @@ impl GetDeviceError {
     pub fn from_body(body: &str) -> GetDeviceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3255,7 +3277,8 @@ impl GetProfileError {
     pub fn from_body(body: &str) -> GetProfileError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3329,7 +3352,8 @@ impl GetRoomError {
     pub fn from_body(body: &str) -> GetRoomError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3403,7 +3427,8 @@ impl GetRoomSkillParameterError {
     pub fn from_body(body: &str) -> GetRoomSkillParameterError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3483,7 +3508,8 @@ impl GetSkillGroupError {
     pub fn from_body(body: &str) -> GetSkillGroupError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3559,7 +3585,8 @@ impl ListSkillsError {
     pub fn from_body(body: &str) -> ListSkillsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3631,7 +3658,8 @@ impl ListTagsError {
     pub fn from_body(body: &str) -> ListTagsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3703,7 +3731,8 @@ impl PutRoomSkillParameterError {
     pub fn from_body(body: &str) -> PutRoomSkillParameterError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3779,7 +3808,8 @@ impl ResolveRoomError {
     pub fn from_body(body: &str) -> ResolveRoomError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3855,7 +3885,8 @@ impl RevokeInvitationError {
     pub fn from_body(body: &str) -> RevokeInvitationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3931,7 +3962,8 @@ impl SearchAddressBooksError {
     pub fn from_body(body: &str) -> SearchAddressBooksError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4005,7 +4037,8 @@ impl SearchContactsError {
     pub fn from_body(body: &str) -> SearchContactsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4077,7 +4110,8 @@ impl SearchDevicesError {
     pub fn from_body(body: &str) -> SearchDevicesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4149,7 +4183,8 @@ impl SearchProfilesError {
     pub fn from_body(body: &str) -> SearchProfilesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4221,7 +4256,8 @@ impl SearchRoomsError {
     pub fn from_body(body: &str) -> SearchRoomsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4293,7 +4329,8 @@ impl SearchSkillGroupsError {
     pub fn from_body(body: &str) -> SearchSkillGroupsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4367,7 +4404,8 @@ impl SearchUsersError {
     pub fn from_body(body: &str) -> SearchUsersError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4443,7 +4481,8 @@ impl SendInvitationError {
     pub fn from_body(body: &str) -> SendInvitationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4523,7 +4562,8 @@ impl StartDeviceSyncError {
     pub fn from_body(body: &str) -> StartDeviceSyncError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4597,7 +4637,8 @@ impl TagResourceError {
     pub fn from_body(body: &str) -> TagResourceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4673,7 +4714,8 @@ impl UntagResourceError {
     pub fn from_body(body: &str) -> UntagResourceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4753,7 +4795,8 @@ impl UpdateAddressBookError {
     pub fn from_body(body: &str) -> UpdateAddressBookError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4837,7 +4880,8 @@ impl UpdateContactError {
     pub fn from_body(body: &str) -> UpdateContactError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4915,7 +4959,8 @@ impl UpdateDeviceError {
     pub fn from_body(body: &str) -> UpdateDeviceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4993,7 +5038,8 @@ impl UpdateProfileError {
     pub fn from_body(body: &str) -> UpdateProfileError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5077,7 +5123,8 @@ impl UpdateRoomError {
     pub fn from_body(body: &str) -> UpdateRoomError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5155,7 +5202,8 @@ impl UpdateSkillGroupError {
     pub fn from_body(body: &str) -> UpdateSkillGroupError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/alexaforbusiness/src/generated.rs
+++ b/rusoto/services/alexaforbusiness/src/generated.rs
@@ -31,7 +31,7 @@ use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 /// <p>An address book with attributes.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AddressBook {
     /// <p>The ARN of the address book.</p>
     #[serde(rename = "AddressBookArn")]
@@ -48,7 +48,7 @@ pub struct AddressBook {
 }
 
 /// <p>Information related to an address book.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AddressBookData {
     /// <p>The ARN of the address book.</p>
     #[serde(rename = "AddressBookArn")]
@@ -64,7 +64,7 @@ pub struct AddressBookData {
     pub name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AssociateContactWithAddressBookRequest {
     /// <p>The ARN of the address book with which to associate the contact.</p>
     #[serde(rename = "AddressBookArn")]
@@ -74,10 +74,10 @@ pub struct AssociateContactWithAddressBookRequest {
     pub contact_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AssociateContactWithAddressBookResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AssociateDeviceWithRoomRequest {
     /// <p>The ARN of the device to associate to a room. Required.</p>
     #[serde(rename = "DeviceArn")]
@@ -89,10 +89,10 @@ pub struct AssociateDeviceWithRoomRequest {
     pub room_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AssociateDeviceWithRoomResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AssociateSkillGroupWithRoomRequest {
     /// <p>The ARN of the room with which to associate the skill group. Required.</p>
     #[serde(rename = "RoomArn")]
@@ -104,11 +104,11 @@ pub struct AssociateSkillGroupWithRoomRequest {
     pub skill_group_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AssociateSkillGroupWithRoomResponse {}
 
 /// <p>A contact with attributes.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Contact {
     /// <p>The ARN of the contact.</p>
     #[serde(rename = "ContactArn")]
@@ -133,7 +133,7 @@ pub struct Contact {
 }
 
 /// <p>Information related to a contact.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ContactData {
     /// <p>The ARN of the contact.</p>
     #[serde(rename = "ContactArn")]
@@ -157,7 +157,7 @@ pub struct ContactData {
     pub phone_number: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateAddressBookRequest {
     /// <p>A unique, user-specified identifier for the request that ensures idempotency.</p>
     #[serde(rename = "ClientRequestToken")]
@@ -172,7 +172,7 @@ pub struct CreateAddressBookRequest {
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateAddressBookResponse {
     /// <p>The ARN of the newly created address book.</p>
     #[serde(rename = "AddressBookArn")]
@@ -180,7 +180,7 @@ pub struct CreateAddressBookResponse {
     pub address_book_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateContactRequest {
     /// <p>A unique, user-specified identifier for this request that ensures idempotency.</p>
     #[serde(rename = "ClientRequestToken")]
@@ -202,7 +202,7 @@ pub struct CreateContactRequest {
     pub phone_number: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateContactResponse {
     /// <p>The ARN of the newly created address book.</p>
     #[serde(rename = "ContactArn")]
@@ -210,7 +210,7 @@ pub struct CreateContactResponse {
     pub contact_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateProfileRequest {
     /// <p>The valid address for the room.</p>
     #[serde(rename = "Address")]
@@ -248,7 +248,7 @@ pub struct CreateProfileRequest {
     pub wake_word: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateProfileResponse {
     /// <p>The ARN of the newly created room profile in the response.</p>
     #[serde(rename = "ProfileArn")]
@@ -256,7 +256,7 @@ pub struct CreateProfileResponse {
     pub profile_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateRoomRequest {
     /// <p>A unique, user-specified identifier for this request that ensures idempotency. </p>
     #[serde(rename = "ClientRequestToken")]
@@ -283,7 +283,7 @@ pub struct CreateRoomRequest {
     pub tags: Option<Vec<Tag>>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateRoomResponse {
     /// <p>The ARN of the newly created room in the response.</p>
     #[serde(rename = "RoomArn")]
@@ -291,7 +291,7 @@ pub struct CreateRoomResponse {
     pub room_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateSkillGroupRequest {
     /// <p>A unique, user-specified identifier for this request that ensures idempotency. </p>
     #[serde(rename = "ClientRequestToken")]
@@ -306,7 +306,7 @@ pub struct CreateSkillGroupRequest {
     pub skill_group_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateSkillGroupResponse {
     /// <p>The ARN of the newly created skill group in the response.</p>
     #[serde(rename = "SkillGroupArn")]
@@ -314,7 +314,7 @@ pub struct CreateSkillGroupResponse {
     pub skill_group_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateUserRequest {
     /// <p>A unique, user-specified identifier for this request that ensures idempotency. </p>
     #[serde(rename = "ClientRequestToken")]
@@ -341,7 +341,7 @@ pub struct CreateUserRequest {
     pub user_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateUserResponse {
     /// <p>The ARN of the newly created user in the response.</p>
     #[serde(rename = "UserArn")]
@@ -349,27 +349,27 @@ pub struct CreateUserResponse {
     pub user_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteAddressBookRequest {
     /// <p>The ARN of the address book to delete.</p>
     #[serde(rename = "AddressBookArn")]
     pub address_book_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteAddressBookResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteContactRequest {
     /// <p>The ARN of the contact to delete.</p>
     #[serde(rename = "ContactArn")]
     pub contact_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteContactResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteProfileRequest {
     /// <p>The ARN of the room profile to delete. Required.</p>
     #[serde(rename = "ProfileArn")]
@@ -377,10 +377,10 @@ pub struct DeleteProfileRequest {
     pub profile_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteProfileResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteRoomRequest {
     /// <p>The ARN of the room to delete. Required.</p>
     #[serde(rename = "RoomArn")]
@@ -388,10 +388,10 @@ pub struct DeleteRoomRequest {
     pub room_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteRoomResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteRoomSkillParameterRequest {
     /// <p>The room skill parameter key for which to remove details.</p>
     #[serde(rename = "ParameterKey")]
@@ -405,10 +405,10 @@ pub struct DeleteRoomSkillParameterRequest {
     pub skill_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteRoomSkillParameterResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteSkillGroupRequest {
     /// <p>The ARN of the skill group to delete. Required.</p>
     #[serde(rename = "SkillGroupArn")]
@@ -416,10 +416,10 @@ pub struct DeleteSkillGroupRequest {
     pub skill_group_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteSkillGroupResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteUserRequest {
     /// <p>The ARN of the user's enrollment in the organization. Required.</p>
     #[serde(rename = "EnrollmentId")]
@@ -430,11 +430,11 @@ pub struct DeleteUserRequest {
     pub user_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteUserResponse {}
 
 /// <p>A device with attributes.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Device {
     /// <p>The ARN of a device.</p>
     #[serde(rename = "DeviceArn")]
@@ -475,7 +475,7 @@ pub struct Device {
 }
 
 /// <p>Device attributes.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeviceData {
     /// <p>The ARN of a device.</p>
     #[serde(rename = "DeviceArn")]
@@ -520,7 +520,7 @@ pub struct DeviceData {
 }
 
 /// <p>Details of a device’s status.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeviceStatusDetail {
     /// <p>The device status detail code.</p>
     #[serde(rename = "Code")]
@@ -529,7 +529,7 @@ pub struct DeviceStatusDetail {
 }
 
 /// <p>Detailed information about a device's status.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeviceStatusInfo {
     /// <p>One or more device status detail descriptions.</p>
     #[serde(rename = "DeviceStatusDetails")]
@@ -537,7 +537,7 @@ pub struct DeviceStatusInfo {
     pub device_status_details: Option<Vec<DeviceStatusDetail>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DisassociateContactFromAddressBookRequest {
     /// <p>The ARN of the address from which to disassociate the contact.</p>
     #[serde(rename = "AddressBookArn")]
@@ -547,10 +547,10 @@ pub struct DisassociateContactFromAddressBookRequest {
     pub contact_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DisassociateContactFromAddressBookResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DisassociateDeviceFromRoomRequest {
     /// <p>The ARN of the device to disassociate from a room. Required.</p>
     #[serde(rename = "DeviceArn")]
@@ -558,10 +558,10 @@ pub struct DisassociateDeviceFromRoomRequest {
     pub device_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DisassociateDeviceFromRoomResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DisassociateSkillGroupFromRoomRequest {
     /// <p>The ARN of the room from which the skill group is to be disassociated. Required.</p>
     #[serde(rename = "RoomArn")]
@@ -573,11 +573,11 @@ pub struct DisassociateSkillGroupFromRoomRequest {
     pub skill_group_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DisassociateSkillGroupFromRoomResponse {}
 
 /// <p>A filter name and value pair that is used to return a more specific list of results. Filters can be used to match a set of resources by various criteria.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct Filter {
     /// <p>The key of a filter.</p>
     #[serde(rename = "Key")]
@@ -587,14 +587,14 @@ pub struct Filter {
     pub values: Vec<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetAddressBookRequest {
     /// <p>The ARN of the address book for which to request details.</p>
     #[serde(rename = "AddressBookArn")]
     pub address_book_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetAddressBookResponse {
     /// <p>The details of the requested address book.</p>
     #[serde(rename = "AddressBook")]
@@ -602,14 +602,14 @@ pub struct GetAddressBookResponse {
     pub address_book: Option<AddressBook>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetContactRequest {
     /// <p>The ARN of the contact for which to request details.</p>
     #[serde(rename = "ContactArn")]
     pub contact_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetContactResponse {
     /// <p>The details of the requested contact.</p>
     #[serde(rename = "Contact")]
@@ -617,7 +617,7 @@ pub struct GetContactResponse {
     pub contact: Option<Contact>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetDeviceRequest {
     /// <p>The ARN of the device for which to request details. Required.</p>
     #[serde(rename = "DeviceArn")]
@@ -625,7 +625,7 @@ pub struct GetDeviceRequest {
     pub device_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetDeviceResponse {
     /// <p>The details of the device requested. Required.</p>
     #[serde(rename = "Device")]
@@ -633,7 +633,7 @@ pub struct GetDeviceResponse {
     pub device: Option<Device>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetProfileRequest {
     /// <p>The ARN of the room profile for which to request details. Required.</p>
     #[serde(rename = "ProfileArn")]
@@ -641,7 +641,7 @@ pub struct GetProfileRequest {
     pub profile_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetProfileResponse {
     /// <p>The details of the room profile requested. Required.</p>
     #[serde(rename = "Profile")]
@@ -649,7 +649,7 @@ pub struct GetProfileResponse {
     pub profile: Option<Profile>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetRoomRequest {
     /// <p>The ARN of the room for which to request details. Required.</p>
     #[serde(rename = "RoomArn")]
@@ -657,7 +657,7 @@ pub struct GetRoomRequest {
     pub room_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetRoomResponse {
     /// <p>The details of the room requested.</p>
     #[serde(rename = "Room")]
@@ -665,7 +665,7 @@ pub struct GetRoomResponse {
     pub room: Option<Room>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetRoomSkillParameterRequest {
     /// <p>The room skill parameter key for which to get details. Required.</p>
     #[serde(rename = "ParameterKey")]
@@ -679,7 +679,7 @@ pub struct GetRoomSkillParameterRequest {
     pub skill_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetRoomSkillParameterResponse {
     /// <p>The details of the room skill parameter requested. Required.</p>
     #[serde(rename = "RoomSkillParameter")]
@@ -687,7 +687,7 @@ pub struct GetRoomSkillParameterResponse {
     pub room_skill_parameter: Option<RoomSkillParameter>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetSkillGroupRequest {
     /// <p>The ARN of the skill group for which to get details. Required.</p>
     #[serde(rename = "SkillGroupArn")]
@@ -695,7 +695,7 @@ pub struct GetSkillGroupRequest {
     pub skill_group_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetSkillGroupResponse {
     /// <p>The details of the skill group requested. Required.</p>
     #[serde(rename = "SkillGroup")]
@@ -703,7 +703,7 @@ pub struct GetSkillGroupResponse {
     pub skill_group: Option<SkillGroup>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListSkillsRequest {
     /// <p>The maximum number of results to include in the response. If more results exist than the specified <code>MaxResults</code> value, a token is included in the response so that the remaining results can be retrieved. Required.</p>
     #[serde(rename = "MaxResults")]
@@ -719,7 +719,7 @@ pub struct ListSkillsRequest {
     pub skill_group_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListSkillsResponse {
     /// <p>The token returned to indicate that there is more data available.</p>
     #[serde(rename = "NextToken")]
@@ -731,7 +731,7 @@ pub struct ListSkillsResponse {
     pub skill_summaries: Option<Vec<SkillSummary>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListTagsRequest {
     /// <p>The ARN of the specific resource for which to list tags. Required.</p>
     #[serde(rename = "Arn")]
@@ -746,7 +746,7 @@ pub struct ListTagsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListTagsResponse {
     /// <p>The token returned to indicate that there is more data available.</p>
     #[serde(rename = "NextToken")]
@@ -759,7 +759,7 @@ pub struct ListTagsResponse {
 }
 
 /// <p>A room profile with attributes.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Profile {
     /// <p>The address of a room profile.</p>
     #[serde(rename = "Address")]
@@ -804,7 +804,7 @@ pub struct Profile {
 }
 
 /// <p>The data of a room profile.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ProfileData {
     /// <p>The address of a room profile.</p>
     #[serde(rename = "Address")]
@@ -836,7 +836,7 @@ pub struct ProfileData {
     pub wake_word: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PutRoomSkillParameterRequest {
     /// <p>The ARN of the room associated with the room skill parameter. Required.</p>
     #[serde(rename = "RoomArn")]
@@ -850,10 +850,10 @@ pub struct PutRoomSkillParameterRequest {
     pub skill_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PutRoomSkillParameterResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ResolveRoomRequest {
     /// <p>The ARN of the skill that was requested. Required.</p>
     #[serde(rename = "SkillId")]
@@ -863,7 +863,7 @@ pub struct ResolveRoomRequest {
     pub user_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ResolveRoomResponse {
     /// <p>The ARN of the room from which the skill request was invoked.</p>
     #[serde(rename = "RoomArn")]
@@ -879,7 +879,7 @@ pub struct ResolveRoomResponse {
     pub room_skill_parameters: Option<Vec<RoomSkillParameter>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RevokeInvitationRequest {
     /// <p>The ARN of the enrollment invitation to revoke. Required.</p>
     #[serde(rename = "EnrollmentId")]
@@ -891,11 +891,11 @@ pub struct RevokeInvitationRequest {
     pub user_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RevokeInvitationResponse {}
 
 /// <p>A room with attributes.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Room {
     /// <p>The description of a room.</p>
     #[serde(rename = "Description")]
@@ -920,7 +920,7 @@ pub struct Room {
 }
 
 /// <p>The data of a room.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RoomData {
     /// <p>The description of a room.</p>
     #[serde(rename = "Description")]
@@ -949,7 +949,7 @@ pub struct RoomData {
 }
 
 /// <p>A skill parameter associated with a room.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RoomSkillParameter {
     /// <p>The parameter key of a room skill parameter. ParameterKey is an enumerated type that only takes “DEFAULT” or “SCOPE” as valid values.</p>
     #[serde(rename = "ParameterKey")]
@@ -959,7 +959,7 @@ pub struct RoomSkillParameter {
     pub parameter_value: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SearchAddressBooksRequest {
     /// <p>The filters to use to list a specified set of address books. The supported filter key is AddressBookName.</p>
     #[serde(rename = "Filters")]
@@ -979,7 +979,7 @@ pub struct SearchAddressBooksRequest {
     pub sort_criteria: Option<Vec<Sort>>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SearchAddressBooksResponse {
     /// <p>The address books that meet the specified set of filter criteria, in sort order.</p>
     #[serde(rename = "AddressBooks")]
@@ -995,7 +995,7 @@ pub struct SearchAddressBooksResponse {
     pub total_count: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SearchContactsRequest {
     /// <p>The filters to use to list a specified set of address books. The supported filter keys are DisplayName, FirstName, LastName, and AddressBookArns.</p>
     #[serde(rename = "Filters")]
@@ -1015,7 +1015,7 @@ pub struct SearchContactsRequest {
     pub sort_criteria: Option<Vec<Sort>>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SearchContactsResponse {
     /// <p>The contacts that meet the specified set of filter criteria, in sort order.</p>
     #[serde(rename = "Contacts")]
@@ -1031,7 +1031,7 @@ pub struct SearchContactsResponse {
     pub total_count: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SearchDevicesRequest {
     /// <p>The filters to use to list a specified set of devices. Supported filter keys are DeviceName, DeviceStatus, DeviceStatusDetailCode, RoomName, DeviceType, DeviceSerialNumber, and UnassociatedOnly.</p>
     #[serde(rename = "Filters")]
@@ -1051,7 +1051,7 @@ pub struct SearchDevicesRequest {
     pub sort_criteria: Option<Vec<Sort>>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SearchDevicesResponse {
     /// <p>The devices that meet the specified set of filter criteria, in sort order.</p>
     #[serde(rename = "Devices")]
@@ -1067,7 +1067,7 @@ pub struct SearchDevicesResponse {
     pub total_count: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SearchProfilesRequest {
     /// <p>The filters to use to list a specified set of room profiles. Supported filter keys are ProfileName and Address. Required. </p>
     #[serde(rename = "Filters")]
@@ -1087,7 +1087,7 @@ pub struct SearchProfilesRequest {
     pub sort_criteria: Option<Vec<Sort>>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SearchProfilesResponse {
     /// <p>The token returned to indicate that there is more data available.</p>
     #[serde(rename = "NextToken")]
@@ -1103,7 +1103,7 @@ pub struct SearchProfilesResponse {
     pub total_count: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SearchRoomsRequest {
     /// <p>The filters to use to list a specified set of rooms. The supported filter keys are RoomName and ProfileName.</p>
     #[serde(rename = "Filters")]
@@ -1123,7 +1123,7 @@ pub struct SearchRoomsRequest {
     pub sort_criteria: Option<Vec<Sort>>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SearchRoomsResponse {
     /// <p>The token returned to indicate that there is more data available.</p>
     #[serde(rename = "NextToken")]
@@ -1139,7 +1139,7 @@ pub struct SearchRoomsResponse {
     pub total_count: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SearchSkillGroupsRequest {
     /// <p>The filters to use to list a specified set of skill groups. The supported filter key is SkillGroupName. </p>
     #[serde(rename = "Filters")]
@@ -1159,7 +1159,7 @@ pub struct SearchSkillGroupsRequest {
     pub sort_criteria: Option<Vec<Sort>>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SearchSkillGroupsResponse {
     /// <p>The token returned to indicate that there is more data available.</p>
     #[serde(rename = "NextToken")]
@@ -1175,7 +1175,7 @@ pub struct SearchSkillGroupsResponse {
     pub total_count: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SearchUsersRequest {
     /// <p>The filters to use for listing a specific set of users. Required. Supported filter keys are UserId, FirstName, LastName, Email, and EnrollmentStatus.</p>
     #[serde(rename = "Filters")]
@@ -1195,7 +1195,7 @@ pub struct SearchUsersRequest {
     pub sort_criteria: Option<Vec<Sort>>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SearchUsersResponse {
     /// <p>The token returned to indicate that there is more data available.</p>
     #[serde(rename = "NextToken")]
@@ -1211,7 +1211,7 @@ pub struct SearchUsersResponse {
     pub users: Option<Vec<UserData>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SendInvitationRequest {
     /// <p>The ARN of the user to whom to send an invitation. Required.</p>
     #[serde(rename = "UserArn")]
@@ -1219,11 +1219,11 @@ pub struct SendInvitationRequest {
     pub user_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SendInvitationResponse {}
 
 /// <p>A skill group with attributes.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SkillGroup {
     /// <p>The description of a skill group.</p>
     #[serde(rename = "Description")]
@@ -1240,7 +1240,7 @@ pub struct SkillGroup {
 }
 
 /// <p>The attributes of a skill group.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SkillGroupData {
     /// <p>The description of a skill group.</p>
     #[serde(rename = "Description")]
@@ -1257,7 +1257,7 @@ pub struct SkillGroupData {
 }
 
 /// <p>The summary of skills.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SkillSummary {
     /// <p>The ARN of the skill summary.</p>
     #[serde(rename = "SkillId")]
@@ -1274,7 +1274,7 @@ pub struct SkillSummary {
 }
 
 /// <p>An object representing a sort criteria. </p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct Sort {
     /// <p>The sort key of a sort object.</p>
     #[serde(rename = "Key")]
@@ -1284,7 +1284,7 @@ pub struct Sort {
     pub value: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StartDeviceSyncRequest {
     /// <p>The ARN of the device to sync. Required.</p>
     #[serde(rename = "DeviceArn")]
@@ -1299,11 +1299,11 @@ pub struct StartDeviceSyncRequest {
     pub room_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StartDeviceSyncResponse {}
 
 /// <p>A key-value pair that can be associated with a resource. </p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Tag {
     /// <p>The key of a tag. Tag keys are case-sensitive. </p>
     #[serde(rename = "Key")]
@@ -1315,7 +1315,7 @@ pub struct Tag {
     pub value: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct TagResourceRequest {
     /// <p>The ARN of the resource to which to add metadata tags. Required. </p>
     #[serde(rename = "Arn")]
@@ -1325,10 +1325,10 @@ pub struct TagResourceRequest {
     pub tags: Vec<Tag>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct TagResourceResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UntagResourceRequest {
     /// <p>The ARN of the resource from which to remove metadata tags. Required. </p>
     #[serde(rename = "Arn")]
@@ -1338,10 +1338,10 @@ pub struct UntagResourceRequest {
     pub tag_keys: Vec<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UntagResourceResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateAddressBookRequest {
     /// <p>The ARN of the room to update.</p>
     #[serde(rename = "AddressBookArn")]
@@ -1356,10 +1356,10 @@ pub struct UpdateAddressBookRequest {
     pub name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateAddressBookResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateContactRequest {
     /// <p>The ARN of the contact to update.</p>
     #[serde(rename = "ContactArn")]
@@ -1382,10 +1382,10 @@ pub struct UpdateContactRequest {
     pub phone_number: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateContactResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateDeviceRequest {
     /// <p>The ARN of the device to update. Required.</p>
     #[serde(rename = "DeviceArn")]
@@ -1397,10 +1397,10 @@ pub struct UpdateDeviceRequest {
     pub device_name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateDeviceResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateProfileRequest {
     /// <p>The updated address for the room profile.</p>
     #[serde(rename = "Address")]
@@ -1444,10 +1444,10 @@ pub struct UpdateProfileRequest {
     pub wake_word: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateProfileResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateRoomRequest {
     /// <p>The updated description for the room.</p>
     #[serde(rename = "Description")]
@@ -1471,10 +1471,10 @@ pub struct UpdateRoomRequest {
     pub room_name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateRoomResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateSkillGroupRequest {
     /// <p>The updated description for the skill group.</p>
     #[serde(rename = "Description")]
@@ -1490,11 +1490,11 @@ pub struct UpdateSkillGroupRequest {
     pub skill_group_name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateSkillGroupResponse {}
 
 /// <p>Information related to a user.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UserData {
     /// <p>The email of a user.</p>
     #[serde(rename = "Email")]

--- a/rusoto/services/apigateway/src/generated.rs
+++ b/rusoto/services/apigateway/src/generated.rs
@@ -31,7 +31,7 @@ use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 /// <p>Access log settings, including the access log format and access log destination ARN.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AccessLogSettings {
     /// <p>The ARN of the CloudWatch Logs log group to receive access logs.</p>
     #[serde(rename = "destinationArn")]
@@ -44,7 +44,7 @@ pub struct AccessLogSettings {
 }
 
 /// <p><p>Represents an AWS account that is associated with API Gateway.</p> <div class="remarks"> <p>To view the account info, call <code>GET</code> on this resource.</p> <h4>Error Codes</h4> <p>The following exception may be thrown when the request fails.</p> <ul> <li>UnauthorizedException</li> <li>NotFoundException</li> <li>TooManyRequestsException</li> </ul> <p>For detailed error code information, including the corresponding HTTP Status Codes, see <a href="http://docs.aws.amazon.com/apigateway/api-reference/handling-errors/#api-error-codes">API Gateway Error Codes</a></p> <h4>Example: Get the information about an account.</h4> <h5>Request</h5> <pre><code>GET /account HTTP/1.1 Content-Type: application/json Host: apigateway.us-east-1.amazonaws.com X-Amz-Date: 20160531T184618Z Authorization: AWS4-HMAC-SHA256 Credential={access<em>key</em>ID}/us-east-1/apigateway/aws4<em>request, SignedHeaders=content-type;host;x-amz-date, Signature={sig4</em>hash} </code></pre> <h5>Response</h5> <p>The successful response returns a <code>200 OK</code> status code and a payload similar to the following:</p> <pre><code>{ &quot;_links&quot;: { &quot;curies&quot;: { &quot;href&quot;: &quot;http://docs.aws.amazon.com/apigateway/latest/developerguide/account-apigateway-{rel}.html&quot;, &quot;name&quot;: &quot;account&quot;, &quot;templated&quot;: true }, &quot;self&quot;: { &quot;href&quot;: &quot;/account&quot; }, &quot;account:update&quot;: { &quot;href&quot;: &quot;/account&quot; } }, &quot;cloudwatchRoleArn&quot;: &quot;arn:aws:iam::123456789012:role/apigAwsProxyRole&quot;, &quot;throttleSettings&quot;: { &quot;rateLimit&quot;: 500, &quot;burstLimit&quot;: 1000 } } </code></pre> <p>In addition to making the REST API call directly, you can use the AWS CLI and an AWS SDK to access this resource.</p> </div> <div class="seeAlso"> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-limits.html">API Gateway Limits</a> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/welcome.html">Developer Guide</a>, <a href="http://docs.aws.amazon.com/cli/latest/reference/apigateway/get-account.html">AWS CLI</a> </div></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Account {
     /// <p>The version of the API keys used for the account.</p>
     #[serde(rename = "apiKeyVersion")]
@@ -65,7 +65,7 @@ pub struct Account {
 }
 
 /// <p><p>A resource that can be distributed to callers for executing <a>Method</a> resources that require an API key. API keys can be mapped to any <a>Stage</a> on any <a>RestApi</a>, which indicates that the callers with the API key can make requests to that stage.</p> <div class="seeAlso"> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-api-keys.html">Use API Keys</a> </div></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ApiKey {
     /// <p>The timestamp when the API Key was created.</p>
     #[serde(rename = "createdDate")]
@@ -106,7 +106,7 @@ pub struct ApiKey {
 }
 
 /// <p>The identifier of an <a>ApiKey</a> used in a <a>UsagePlan</a>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ApiKeyIds {
     /// <p>A list of all the <a>ApiKey</a> identifiers.</p>
     #[serde(rename = "ids")]
@@ -119,7 +119,7 @@ pub struct ApiKeyIds {
 }
 
 /// <p><p>Represents a collection of API keys as represented by an <a>ApiKeys</a> resource.</p> <div class="seeAlso"> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-api-keys.html">Use API Keys</a> </div></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ApiKeys {
     /// <p>The current page of elements from this collection.</p>
     #[serde(rename = "items")]
@@ -135,7 +135,7 @@ pub struct ApiKeys {
 }
 
 /// <p>API stage name of the associated API stage in a usage plan.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ApiStage {
     /// <p>API Id of the associated API stage in a usage plan.</p>
     #[serde(rename = "apiId")]
@@ -148,7 +148,7 @@ pub struct ApiStage {
 }
 
 /// <p><p>Represents an authorization layer for methods. If enabled on a method, API Gateway will activate the authorizer when a client calls the method.</p> <div class="seeAlso"> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/use-custom-authorizer.html">Enable custom authorization</a> </div></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Authorizer {
     /// <p>Optional customer-defined field, used in Swagger imports and exports without functional impact.</p>
     #[serde(rename = "authType")]
@@ -193,7 +193,7 @@ pub struct Authorizer {
 }
 
 /// <p><p>Represents a collection of <a>Authorizer</a> resources.</p> <div class="seeAlso"> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/use-custom-authorizer.html">Enable custom authorization</a> </div></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Authorizers {
     /// <p>The current page of elements from this collection.</p>
     #[serde(rename = "items")]
@@ -205,7 +205,7 @@ pub struct Authorizers {
 }
 
 /// <p><p>Represents the base path that callers of the API must provide as part of the URL after the domain name.</p> <div class="remarks">A custom domain name plus a <code>BasePathMapping</code> specification identifies a deployed <a>RestApi</a> in a given stage of the owner <a>Account</a>.</div> <div class="seeAlso"> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-custom-domains.html">Use Custom Domain Names</a> </div></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BasePathMapping {
     /// <p>The base path name that callers of the API must provide as part of the URL after the domain name.</p>
     #[serde(rename = "basePath")]
@@ -222,7 +222,7 @@ pub struct BasePathMapping {
 }
 
 /// <p><p>Represents a collection of <a>BasePathMapping</a> resources.</p> <div class="seeAlso"> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-custom-domains.html">Use Custom Domain Names</a> </div></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BasePathMappings {
     /// <p>The current page of elements from this collection.</p>
     #[serde(rename = "items")]
@@ -234,7 +234,7 @@ pub struct BasePathMappings {
 }
 
 /// <p>Configuration settings of a canary deployment.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CanarySettings {
     /// <p>The ID of the canary deployment.</p>
     #[serde(rename = "deploymentId")]
@@ -255,7 +255,7 @@ pub struct CanarySettings {
 }
 
 /// <p><p>Represents a client certificate used to configure client-side SSL authentication while sending requests to the integration endpoint.</p> <div class="remarks">Client certificates are used to authenticate an API by the backend server. To authenticate an API client (or user), use IAM roles and policies, a custom <a>Authorizer</a> or an Amazon Cognito user pool.</div> <div class="seeAlso"> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/getting-started-client-side-ssl-authentication.html">Use Client-Side Certificate</a> </div></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ClientCertificate {
     /// <p>The identifier of the client certificate.</p>
     #[serde(rename = "clientCertificateId")]
@@ -280,7 +280,7 @@ pub struct ClientCertificate {
 }
 
 /// <p><p>Represents a collection of <a>ClientCertificate</a> resources.</p> <div class="seeAlso"> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/getting-started-client-side-ssl-authentication.html">Use Client-Side Certificate</a> </div></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ClientCertificates {
     /// <p>The current page of elements from this collection.</p>
     #[serde(rename = "items")]
@@ -292,7 +292,7 @@ pub struct ClientCertificates {
 }
 
 /// <p>Request to create an <a>ApiKey</a> resource.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateApiKeyRequest {
     /// <p>An AWS Marketplace customer identifier , when integrating with the AWS SaaS Marketplace.</p>
     #[serde(rename = "customerId")]
@@ -325,7 +325,7 @@ pub struct CreateApiKeyRequest {
 }
 
 /// <p>Request to add a new <a>Authorizer</a> to an existing <a>RestApi</a> resource.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateAuthorizerRequest {
     /// <p>Optional customer-defined field, used in Swagger imports and exports without functional impact.</p>
     #[serde(rename = "authType")]
@@ -367,7 +367,7 @@ pub struct CreateAuthorizerRequest {
 }
 
 /// <p>Requests API Gateway to create a new <a>BasePathMapping</a> resource.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateBasePathMappingRequest {
     /// <p>The base path name that callers of the API must provide as part of the URL after the domain name. This value must be unique for all of the mappings across a single API. Leave this blank if you do not want callers to specify a base path name after the domain name.</p>
     #[serde(rename = "basePath")]
@@ -386,7 +386,7 @@ pub struct CreateBasePathMappingRequest {
 }
 
 /// <p>Requests API Gateway to create a <a>Deployment</a> resource.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateDeploymentRequest {
     /// <p>Enables a cache cluster for the <a>Stage</a> resource specified in the input.</p>
     #[serde(rename = "cacheClusterEnabled")]
@@ -422,7 +422,7 @@ pub struct CreateDeploymentRequest {
 }
 
 /// <p>Creates a new documentation part of a given API.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateDocumentationPartRequest {
     /// <p>[Required] The location of the targeted API entity of the to-be-created documentation part.</p>
     #[serde(rename = "location")]
@@ -436,7 +436,7 @@ pub struct CreateDocumentationPartRequest {
 }
 
 /// <p>Creates a new documentation version of a given API.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateDocumentationVersionRequest {
     /// <p>A description about the new documentation snapshot.</p>
     #[serde(rename = "description")]
@@ -455,7 +455,7 @@ pub struct CreateDocumentationVersionRequest {
 }
 
 /// <p>A request to create a new domain name.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateDomainNameRequest {
     /// <p>The reference to an AWS-managed certificate that will be used by edge-optimized endpoint for this domain name. AWS Certificate Manager is the only supported source.</p>
     #[serde(rename = "certificateArn")]
@@ -495,7 +495,7 @@ pub struct CreateDomainNameRequest {
 }
 
 /// <p>Request to add a new <a>Model</a> to an existing <a>RestApi</a> resource.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateModelRequest {
     /// <p>[Required] The content-type for the model.</p>
     #[serde(rename = "contentType")]
@@ -517,7 +517,7 @@ pub struct CreateModelRequest {
 }
 
 /// <p>Creates a <a>RequestValidator</a> of a given <a>RestApi</a>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateRequestValidatorRequest {
     /// <p>The name of the to-be-created <a>RequestValidator</a>.</p>
     #[serde(rename = "name")]
@@ -537,7 +537,7 @@ pub struct CreateRequestValidatorRequest {
 }
 
 /// <p>Requests API Gateway to create a <a>Resource</a> resource.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateResourceRequest {
     /// <p>[Required] The parent resource's identifier.</p>
     #[serde(rename = "parentId")]
@@ -551,7 +551,7 @@ pub struct CreateResourceRequest {
 }
 
 /// <p>The POST Request to add a new <a>RestApi</a> resource to your collection.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateRestApiRequest {
     /// <p>The source of the API key for metering requests according to a usage plan. Valid values are: <ul><li><code>HEADER</code> to read the API key from the <code>X-API-Key</code> header of a request. </li><li><code>AUTHORIZER</code> to read the API key from the <code>UsageIdentifierKey</code> from a custom authorizer.</li></ul> </p>
     #[serde(rename = "apiKeySource")]
@@ -591,7 +591,7 @@ pub struct CreateRestApiRequest {
 }
 
 /// <p>Requests API Gateway to create a <a>Stage</a> resource.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateStageRequest {
     /// <p>Whether cache clustering is enabled for the stage.</p>
     #[serde(rename = "cacheClusterEnabled")]
@@ -633,7 +633,7 @@ pub struct CreateStageRequest {
 }
 
 /// <p>The POST request to create a usage plan key for adding an existing API key to a usage plan.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateUsagePlanKeyRequest {
     /// <p>[Required] The identifier of a <a>UsagePlanKey</a> resource for a plan customer.</p>
     #[serde(rename = "keyId")]
@@ -647,7 +647,7 @@ pub struct CreateUsagePlanKeyRequest {
 }
 
 /// <p>The POST request to create a usage plan with the name, description, throttle limits and quota limits, as well as the associated API stages, specified in the payload.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateUsagePlanRequest {
     /// <p>The associated API stages of the usage plan.</p>
     #[serde(rename = "apiStages")]
@@ -671,7 +671,7 @@ pub struct CreateUsagePlanRequest {
 }
 
 /// <p>Creates a VPC link, under the caller's account in a selected region, in an asynchronous operation that typically takes 2-4 minutes to complete and become operational. The caller must have permissions to create and update VPC Endpoint services.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateVpcLinkRequest {
     /// <p>The description of the VPC link.</p>
     #[serde(rename = "description")]
@@ -686,7 +686,7 @@ pub struct CreateVpcLinkRequest {
 }
 
 /// <p>A request to delete the <a>ApiKey</a> resource.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteApiKeyRequest {
     /// <p>[Required] The identifier of the <a>ApiKey</a> resource to be deleted.</p>
     #[serde(rename = "apiKey")]
@@ -694,7 +694,7 @@ pub struct DeleteApiKeyRequest {
 }
 
 /// <p>Request to delete an existing <a>Authorizer</a> resource.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteAuthorizerRequest {
     /// <p>[Required] The identifier of the <a>Authorizer</a> resource.</p>
     #[serde(rename = "authorizerId")]
@@ -705,7 +705,7 @@ pub struct DeleteAuthorizerRequest {
 }
 
 /// <p>A request to delete the <a>BasePathMapping</a> resource.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteBasePathMappingRequest {
     /// <p>[Required] The base path name of the <a>BasePathMapping</a> resource to delete.</p>
     #[serde(rename = "basePath")]
@@ -716,7 +716,7 @@ pub struct DeleteBasePathMappingRequest {
 }
 
 /// <p>A request to delete the <a>ClientCertificate</a> resource.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteClientCertificateRequest {
     /// <p>[Required] The identifier of the <a>ClientCertificate</a> resource to be deleted.</p>
     #[serde(rename = "clientCertificateId")]
@@ -724,7 +724,7 @@ pub struct DeleteClientCertificateRequest {
 }
 
 /// <p>Requests API Gateway to delete a <a>Deployment</a> resource.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteDeploymentRequest {
     /// <p>[Required] The identifier of the <a>Deployment</a> resource to delete.</p>
     #[serde(rename = "deploymentId")]
@@ -735,7 +735,7 @@ pub struct DeleteDeploymentRequest {
 }
 
 /// <p>Deletes an existing documentation part of an API.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteDocumentationPartRequest {
     /// <p>[Required] The identifier of the to-be-deleted documentation part.</p>
     #[serde(rename = "documentationPartId")]
@@ -746,7 +746,7 @@ pub struct DeleteDocumentationPartRequest {
 }
 
 /// <p>Deletes an existing documentation version of an API.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteDocumentationVersionRequest {
     /// <p>[Required] The version identifier of a to-be-deleted documentation snapshot.</p>
     #[serde(rename = "documentationVersion")]
@@ -757,7 +757,7 @@ pub struct DeleteDocumentationVersionRequest {
 }
 
 /// <p>A request to delete the <a>DomainName</a> resource.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteDomainNameRequest {
     /// <p>[Required] The name of the <a>DomainName</a> resource to be deleted.</p>
     #[serde(rename = "domainName")]
@@ -765,7 +765,7 @@ pub struct DeleteDomainNameRequest {
 }
 
 /// <p>Clears any customization of a <a>GatewayResponse</a> of a specified response type on the given <a>RestApi</a> and resets it with the default settings.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteGatewayResponseRequest {
     /// <p>[Required] <p>The response type of the associated <a>GatewayResponse</a>. Valid values are <ul><li>ACCESS_DENIED</li><li>API_CONFIGURATION_ERROR</li><li>AUTHORIZER_FAILURE</li><li> AUTHORIZER_CONFIGURATION_ERROR</li><li>BAD_REQUEST_PARAMETERS</li><li>BAD_REQUEST_BODY</li><li>DEFAULT_4XX</li><li>DEFAULT_5XX</li><li>EXPIRED_TOKEN</li><li>INVALID_SIGNATURE</li><li>INTEGRATION_FAILURE</li><li>INTEGRATION_TIMEOUT</li><li>INVALID_API_KEY</li><li>MISSING_AUTHENTICATION_TOKEN</li><li> QUOTA_EXCEEDED</li><li>REQUEST_TOO_LARGE</li><li>RESOURCE_NOT_FOUND</li><li>THROTTLED</li><li>UNAUTHORIZED</li><li>UNSUPPORTED_MEDIA_TYPE</li></ul> </p></p>
     #[serde(rename = "responseType")]
@@ -776,7 +776,7 @@ pub struct DeleteGatewayResponseRequest {
 }
 
 /// <p>Represents a delete integration request.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteIntegrationRequest {
     /// <p>[Required] Specifies a delete integration request's HTTP method.</p>
     #[serde(rename = "httpMethod")]
@@ -790,7 +790,7 @@ pub struct DeleteIntegrationRequest {
 }
 
 /// <p>Represents a delete integration response request.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteIntegrationResponseRequest {
     /// <p>[Required] Specifies a delete integration response request's HTTP method.</p>
     #[serde(rename = "httpMethod")]
@@ -807,7 +807,7 @@ pub struct DeleteIntegrationResponseRequest {
 }
 
 /// <p>Request to delete an existing <a>Method</a> resource.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteMethodRequest {
     /// <p>[Required] The HTTP verb of the <a>Method</a> resource.</p>
     #[serde(rename = "httpMethod")]
@@ -821,7 +821,7 @@ pub struct DeleteMethodRequest {
 }
 
 /// <p>A request to delete an existing <a>MethodResponse</a> resource.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteMethodResponseRequest {
     /// <p>[Required] The HTTP verb of the <a>Method</a> resource.</p>
     #[serde(rename = "httpMethod")]
@@ -838,7 +838,7 @@ pub struct DeleteMethodResponseRequest {
 }
 
 /// <p>Request to delete an existing model in an existing <a>RestApi</a> resource.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteModelRequest {
     /// <p>[Required] The name of the model to delete.</p>
     #[serde(rename = "modelName")]
@@ -849,7 +849,7 @@ pub struct DeleteModelRequest {
 }
 
 /// <p>Deletes a specified <a>RequestValidator</a> of a given <a>RestApi</a>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteRequestValidatorRequest {
     /// <p>[Required] The identifier of the <a>RequestValidator</a> to be deleted.</p>
     #[serde(rename = "requestValidatorId")]
@@ -860,7 +860,7 @@ pub struct DeleteRequestValidatorRequest {
 }
 
 /// <p>Request to delete a <a>Resource</a>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteResourceRequest {
     /// <p>[Required] The identifier of the <a>Resource</a> resource.</p>
     #[serde(rename = "resourceId")]
@@ -871,7 +871,7 @@ pub struct DeleteResourceRequest {
 }
 
 /// <p>Request to delete the specified API from your collection.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteRestApiRequest {
     /// <p>[Required] The string identifier of the associated <a>RestApi</a>.</p>
     #[serde(rename = "restApiId")]
@@ -879,7 +879,7 @@ pub struct DeleteRestApiRequest {
 }
 
 /// <p>Requests API Gateway to delete a <a>Stage</a> resource.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteStageRequest {
     /// <p>[Required] The string identifier of the associated <a>RestApi</a>.</p>
     #[serde(rename = "restApiId")]
@@ -890,7 +890,7 @@ pub struct DeleteStageRequest {
 }
 
 /// <p>The DELETE request to delete a usage plan key and remove the underlying API key from the associated usage plan.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteUsagePlanKeyRequest {
     /// <p>[Required] The Id of the <a>UsagePlanKey</a> resource to be deleted.</p>
     #[serde(rename = "keyId")]
@@ -901,7 +901,7 @@ pub struct DeleteUsagePlanKeyRequest {
 }
 
 /// <p>The DELETE request to delete a usage plan of a given plan Id.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteUsagePlanRequest {
     /// <p>[Required] The Id of the to-be-deleted usage plan.</p>
     #[serde(rename = "usagePlanId")]
@@ -909,7 +909,7 @@ pub struct DeleteUsagePlanRequest {
 }
 
 /// <p>Deletes an existing <a>VpcLink</a> of a specified identifier.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteVpcLinkRequest {
     /// <p>[Required] The identifier of the <a>VpcLink</a>. It is used in an <a>Integration</a> to reference this <a>VpcLink</a>.</p>
     #[serde(rename = "vpcLinkId")]
@@ -917,7 +917,7 @@ pub struct DeleteVpcLinkRequest {
 }
 
 /// <p><p>An immutable representation of a <a>RestApi</a> resource that can be called by users using <a>Stages</a>. A deployment must be associated with a <a>Stage</a> for it to be callable over the Internet.</p> <div class="remarks">To create a deployment, call <code>POST</code> on the <a>Deployments</a> resource of a <a>RestApi</a>. To view, update, or delete a deployment, call <code>GET</code>, <code>PATCH</code>, or <code>DELETE</code> on the specified deployment resource (<code>/restapis/{restapi<em>id}/deployments/{deployment</em>id}</code>).</div> <div class="seeAlso"><a>RestApi</a>, <a>Deployments</a>, <a>Stage</a>, <a href="http://docs.aws.amazon.com/cli/latest/reference/apigateway/get-deployment.html">AWS CLI</a>, <a href="https://aws.amazon.com/tools/">AWS SDKs</a> </div></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Deployment {
     /// <p>A summary of the <a>RestApi</a> at the date and time that the deployment resource was created.</p>
     #[serde(rename = "apiSummary")]
@@ -940,7 +940,7 @@ pub struct Deployment {
 }
 
 /// <p>The input configuration for a canary deployment.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeploymentCanarySettings {
     /// <p>The percentage (0.0-100.0) of traffic routed to the canary deployment.</p>
     #[serde(rename = "percentTraffic")]
@@ -957,7 +957,7 @@ pub struct DeploymentCanarySettings {
 }
 
 /// <p><p>Represents a collection resource that contains zero or more references to your existing deployments, and links that guide you on how to interact with your collection. The collection offers a paginated view of the contained deployments.</p> <div class="remarks">To create a new deployment of a <a>RestApi</a>, make a <code>POST</code> request against this resource. To view, update, or delete an existing deployment, make a <code>GET</code>, <code>PATCH</code>, or <code>DELETE</code> request, respectively, on a specified <a>Deployment</a> resource.</div> <div class="seeAlso"> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-deploy-api.html">Deploying an API</a>, <a href="http://docs.aws.amazon.com/cli/latest/reference/apigateway/get-deployment.html">AWS CLI</a>, <a href="https://aws.amazon.com/tools/">AWS SDKs</a> </div></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Deployments {
     /// <p>The current page of elements from this collection.</p>
     #[serde(rename = "items")]
@@ -969,7 +969,7 @@ pub struct Deployments {
 }
 
 /// <p><p>A documentation part for a targeted API entity.</p> <div class="remarks"> <p>A documentation part consists of a content map (<code>properties</code>) and a target (<code>location</code>). The target specifies an API entity to which the documentation content applies. The supported API entity types are <code>API</code>, <code>AUTHORIZER</code>, <code>MODEL</code>, <code>RESOURCE</code>, <code>METHOD</code>, <code>PATH<em>PARAMETER</code>, <code>QUERY</em>PARAMETER</code>, <code>REQUEST<em>HEADER</code>, <code>REQUEST</em>BODY</code>, <code>RESPONSE</code>, <code>RESPONSE<em>HEADER</code>, and <code>RESPONSE</em>BODY</code>. Valid <code>location</code> fields depend on the API entity type. All valid fields are not required.</p> <p>The content map is a JSON string of API-specific key-value pairs. Although an API can use any shape for the content map, only the Swagger-compliant documentation fields will be injected into the associated API entity definition in the exported Swagger definition file.</p></div> <div class="seeAlso"> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-documenting-api.html">Documenting an API</a>, <a>DocumentationParts</a> </div></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DocumentationPart {
     /// <p>The <a>DocumentationPart</a> identifier, generated by API Gateway when the <code>DocumentationPart</code> is created.</p>
     #[serde(rename = "id")]
@@ -986,7 +986,7 @@ pub struct DocumentationPart {
 }
 
 /// <p><p>A collection of the imported <a>DocumentationPart</a> identifiers.</p> <div class="remarks">This is used to return the result when documentation parts in an external (e.g., Swagger) file are imported into API Gateway</div> <div class="seeAlso"> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-documenting-api.html">Documenting an API</a>, <a href="http://docs.aws.amazon.com/apigateway/api-reference/link-relation/documentationpart-import/">documentationpart:import</a>, <a>DocumentationPart</a> </div></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DocumentationPartIds {
     /// <p>A list of the returned documentation part identifiers.</p>
     #[serde(rename = "ids")]
@@ -999,7 +999,7 @@ pub struct DocumentationPartIds {
 }
 
 /// <p>Specifies the target API entity to which the documentation applies.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct DocumentationPartLocation {
     /// <p>The HTTP verb of a method. It is a valid field for the API entity types of <code>METHOD</code>, <code>PATH_PARAMETER</code>, <code>QUERY_PARAMETER</code>, <code>REQUEST_HEADER</code>, <code>REQUEST_BODY</code>, <code>RESPONSE</code>, <code>RESPONSE_HEADER</code>, and <code>RESPONSE_BODY</code>. The default value is <code>*</code> for any method. When an applicable child entity inherits the content of an entity of the same type with more general specifications of the other <code>location</code> attributes, the child entity's <code>method</code> attribute must match that of the parent entity exactly.</p>
     #[serde(rename = "method")]
@@ -1023,7 +1023,7 @@ pub struct DocumentationPartLocation {
 }
 
 /// <p><p>The collection of documentation parts of an API.</p> <div class="remarks"/> <div class="seeAlso"> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-documenting-api.html">Documenting an API</a>, <a>DocumentationPart</a> </div></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DocumentationParts {
     /// <p>The current page of elements from this collection.</p>
     #[serde(rename = "items")]
@@ -1035,7 +1035,7 @@ pub struct DocumentationParts {
 }
 
 /// <p><p>A snapshot of the documentation of an API.</p> <div class="remarks"><p>Publishing API documentation involves creating a documentation version associated with an API stage and exporting the versioned documentation to an external (e.g., Swagger) file.</p></div> <div class="seeAlso"> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-documenting-api.html">Documenting an API</a>, <a>DocumentationPart</a>, <a>DocumentationVersions</a> </div></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DocumentationVersion {
     /// <p>The date when the API documentation snapshot is created.</p>
     #[serde(rename = "createdDate")]
@@ -1052,7 +1052,7 @@ pub struct DocumentationVersion {
 }
 
 /// <p><p>The collection of documentation snapshots of an API. </p> <div class="remarks"><p>Use the <a>DocumentationVersions</a> to manage documentation snapshots associated with various API stages.</p></div> <div class="seeAlso"> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-documenting-api.html">Documenting an API</a>, <a>DocumentationPart</a>, <a>DocumentationVersion</a> </div></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DocumentationVersions {
     /// <p>The current page of elements from this collection.</p>
     #[serde(rename = "items")]
@@ -1064,7 +1064,7 @@ pub struct DocumentationVersions {
 }
 
 /// <p><p>Represents a custom domain name as a user-friendly host name of an API (<a>RestApi</a>).</p> <div class="Remarks"> <p>When you deploy an API, API Gateway creates a default host name for the API. This default API host name is of the <code>{restapi-id}.execute-api.{region}.amazonaws.com</code> format. With the default host name, you can access the API&#39;s root resource with the URL of <code>https://{restapi-id}.execute-api.{region}.amazonaws.com/{stage}/</code>. When you set up a custom domain name of <code>apis.example.com</code> for this API, you can then access the same resource using the URL of the <code>https://apis.examples.com/myApi</code>, where <code>myApi</code> is the base path mapping (<a>BasePathMapping</a>) of your API under the custom domain name. </p> </div> <div class="seeAlso"> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-custom-domains.html">Set a Custom Host Name for an API</a> </div></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DomainName {
     /// <p>The reference to an AWS-managed certificate that will be used by edge-optimized endpoint for this domain name. AWS Certificate Manager is the only supported source.</p>
     #[serde(rename = "certificateArn")]
@@ -1113,7 +1113,7 @@ pub struct DomainName {
 }
 
 /// <p><p>Represents a collection of <a>DomainName</a> resources.</p> <div class="seeAlso"> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-custom-domains.html">Use Client-Side Certificate</a> </div></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DomainNames {
     /// <p>The current page of elements from this collection.</p>
     #[serde(rename = "items")]
@@ -1125,7 +1125,7 @@ pub struct DomainNames {
 }
 
 /// <p>The endpoint configuration to indicate the types of endpoints an API (<a>RestApi</a>) or its custom domain name (<a>DomainName</a>) has. </p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct EndpointConfiguration {
     /// <p>A list of endpoint types of an API (<a>RestApi</a>) or its custom domain name (<a>DomainName</a>). For an edge-optimized API and its custom domain name, the endpoint type is <code>"EDGE"</code>. For a regional API and its custom domain name, the endpoint type is <code>REGIONAL</code>.</p>
     #[serde(rename = "types")]
@@ -1134,7 +1134,7 @@ pub struct EndpointConfiguration {
 }
 
 /// <p>The binary blob response to <a>GetExport</a>, which contains the generated SDK.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ExportResponse {
     /// <p>The binary blob response to <a>GetExport</a>, which contains the export.</p>
     pub body: Option<Vec<u8>>,
@@ -1145,7 +1145,7 @@ pub struct ExportResponse {
 }
 
 /// <p>Request to flush authorizer cache entries on a specified stage.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct FlushStageAuthorizersCacheRequest {
     /// <p>The string identifier of the associated <a>RestApi</a>.</p>
     #[serde(rename = "restApiId")]
@@ -1156,7 +1156,7 @@ pub struct FlushStageAuthorizersCacheRequest {
 }
 
 /// <p>Requests API Gateway to flush a stage's cache.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct FlushStageCacheRequest {
     /// <p>[Required] The string identifier of the associated <a>RestApi</a>.</p>
     #[serde(rename = "restApiId")]
@@ -1167,7 +1167,7 @@ pub struct FlushStageCacheRequest {
 }
 
 /// <p><p>A gateway response of a given response type and status code, with optional response parameters and mapping templates.</p> <div class="remarks"> For more information about valid gateway response types, see <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/supported-gateway-response-types.html">Gateway Response Types Supported by API Gateway</a> <div class="example"> <h4>Example: Get a Gateway Response of a given response type</h4> <h5>Request</h5> <p>This example shows how to get a gateway response of the <code>MISSING<em>AUTHENTICATION</em>TOKEN</code> type.</p> <pre><code>GET /restapis/o81lxisefl/gatewayresponses/MISSING<em>AUTHENTICATION</em>TOKEN HTTP/1.1 Host: beta-apigateway.us-east-1.amazonaws.com Content-Type: application/json X-Amz-Date: 20170503T202516Z Authorization: AWS4-HMAC-SHA256 Credential={access-key-id}/20170503/us-east-1/apigateway/aws4<em>request, SignedHeaders=content-type;host;x-amz-date, Signature=1b52460e3159c1a26cff29093855d50ea141c1c5b937528fecaf60f51129697a Cache-Control: no-cache Postman-Token: 3b2a1ce9-c848-2e26-2e2f-9c2caefbed45 </code></pre> <p>The response type is specified as a URL path.</p> <h5>Response</h5> <p>The successful operation returns the <code>200 OK</code> status code and a payload similar to the following:</p> <pre><code>{ &quot;</em>links&quot;: { &quot;curies&quot;: { &quot;href&quot;: &quot;http://docs.aws.amazon.com/apigateway/latest/developerguide/restapi-gatewayresponse-{rel}.html&quot;, &quot;name&quot;: &quot;gatewayresponse&quot;, &quot;templated&quot;: true }, &quot;self&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/MISSING<em>AUTHENTICATION</em>TOKEN&quot; }, &quot;gatewayresponse:delete&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/MISSING<em>AUTHENTICATION</em>TOKEN&quot; }, &quot;gatewayresponse:put&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/{response<em>type}&quot;, &quot;templated&quot;: true }, &quot;gatewayresponse:update&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/MISSING</em>AUTHENTICATION<em>TOKEN&quot; } }, &quot;defaultResponse&quot;: false, &quot;responseParameters&quot;: { &quot;gatewayresponse.header.x-request-path&quot;: &quot;method.request.path.petId&quot;, &quot;gatewayresponse.header.Access-Control-Allow-Origin&quot;: &quot;&apos;a.b.c&apos;&quot;, &quot;gatewayresponse.header.x-request-query&quot;: &quot;method.request.querystring.q&quot;, &quot;gatewayresponse.header.x-request-header&quot;: &quot;method.request.header.Accept&quot; }, &quot;responseTemplates&quot;: { &quot;application/json&quot;: &quot;{\n &quot;message&quot;: $context.error.messageString,\n &quot;type&quot;: &quot;$context.error.responseType&quot;,\n &quot;stage&quot;: &quot;$context.stage&quot;,\n &quot;resourcePath&quot;: &quot;$context.resourcePath&quot;,\n &quot;stageVariables.a&quot;: &quot;$stageVariables.a&quot;,\n &quot;statusCode&quot;: &quot;&apos;404&apos;&quot;\n}&quot; }, &quot;responseType&quot;: &quot;MISSING</em>AUTHENTICATION_TOKEN&quot;, &quot;statusCode&quot;: &quot;404&quot; }</code></pre> <p></p> </div> </div> <div class="seeAlso"> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/customize-gateway-responses.html">Customize Gateway Responses</a> </div></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GatewayResponse {
     /// <p>A Boolean flag to indicate whether this <a>GatewayResponse</a> is the default gateway response (<code>true</code>) or not (<code>false</code>). A default gateway response is one generated by API Gateway without any customization by an API developer. </p>
     #[serde(rename = "defaultResponse")]
@@ -1192,7 +1192,7 @@ pub struct GatewayResponse {
 }
 
 /// <p><p>The collection of the <a>GatewayResponse</a> instances of a <a>RestApi</a> as a <code>responseType</code>-to-<a>GatewayResponse</a> object map of key-value pairs. As such, pagination is not supported for querying this collection.</p> <div class="remarks"> For more information about valid gateway response types, see <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/supported-gateway-response-types.html">Gateway Response Types Supported by API Gateway</a> <div class="example"> <h4>Example: Get the collection of gateway responses of an API</h4> <h5>Request</h5> <p>This example request shows how to retrieve the <a>GatewayResponses</a> collection from an API.</p> <pre><code>GET /restapis/o81lxisefl/gatewayresponses HTTP/1.1 Host: beta-apigateway.us-east-1.amazonaws.com Content-Type: application/json X-Amz-Date: 20170503T220604Z Authorization: AWS4-HMAC-SHA256 Credential={access-key-id}/20170503/us-east-1/apigateway/aws4<em>request, SignedHeaders=content-type;host;x-amz-date, Signature=59b42fe54a76a5de8adf2c67baa6d39206f8e9ad49a1d77ccc6a5da3103a398a Cache-Control: no-cache Postman-Token: 5637af27-dc29-fc5c-9dfe-0645d52cb515 </code></pre> <p></p> <h5>Response</h5> <p>The successful operation returns the <code>200 OK</code> status code and a payload similar to the following:</p> <pre><code>{ &quot;</em>links&quot;: { &quot;curies&quot;: { &quot;href&quot;: &quot;http://docs.aws.amazon.com/apigateway/latest/developerguide/restapi-gatewayresponse-{rel}.html&quot;, &quot;name&quot;: &quot;gatewayresponse&quot;, &quot;templated&quot;: true }, &quot;self&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses&quot; }, &quot;first&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses&quot; }, &quot;gatewayresponse:by-type&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/{response<em>type}&quot;, &quot;templated&quot;: true }, &quot;item&quot;: [ { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/INTEGRATION</em>FAILURE&quot; }, { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/RESOURCE<em>NOT</em>FOUND&quot; }, { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/REQUEST<em>TOO</em>LARGE&quot; }, { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/THROTTLED&quot; }, { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/UNSUPPORTED<em>MEDIA</em>TYPE&quot; }, { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/AUTHORIZER<em>CONFIGURATION</em>ERROR&quot; }, { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/DEFAULT<em>5XX&quot; }, { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/DEFAULT</em>4XX&quot; }, { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/BAD<em>REQUEST</em>PARAMETERS&quot; }, { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/BAD<em>REQUEST</em>BODY&quot; }, { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/EXPIRED<em>TOKEN&quot; }, { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/ACCESS</em>DENIED&quot; }, { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/INVALID<em>API</em>KEY&quot; }, { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/UNAUTHORIZED&quot; }, { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/API<em>CONFIGURATION</em>ERROR&quot; }, { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/QUOTA<em>EXCEEDED&quot; }, { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/INTEGRATION</em>TIMEOUT&quot; }, { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/MISSING<em>AUTHENTICATION</em>TOKEN&quot; }, { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/INVALID<em>SIGNATURE&quot; }, { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/AUTHORIZER</em>FAILURE&quot; } ] }, &quot;<em>embedded&quot;: { &quot;item&quot;: [ { &quot;</em>links&quot;: { &quot;self&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/INTEGRATION<em>FAILURE&quot; }, &quot;gatewayresponse:put&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/{response</em>type}&quot;, &quot;templated&quot;: true }, &quot;gatewayresponse:update&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/INTEGRATION<em>FAILURE&quot; } }, &quot;defaultResponse&quot;: true, &quot;responseParameters&quot;: {}, &quot;responseTemplates&quot;: { &quot;application/json&quot;: &quot;{&quot;message&quot;:$context.error.messageString}&quot; }, &quot;responseType&quot;: &quot;INTEGRATION</em>FAILURE&quot;, &quot;statusCode&quot;: &quot;504&quot; }, { &quot;<em>links&quot;: { &quot;self&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/RESOURCE</em>NOT<em>FOUND&quot; }, &quot;gatewayresponse:put&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/{response</em>type}&quot;, &quot;templated&quot;: true }, &quot;gatewayresponse:update&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/RESOURCE<em>NOT</em>FOUND&quot; } }, &quot;defaultResponse&quot;: true, &quot;responseParameters&quot;: {}, &quot;responseTemplates&quot;: { &quot;application/json&quot;: &quot;{&quot;message&quot;:$context.error.messageString}&quot; }, &quot;responseType&quot;: &quot;RESOURCE<em>NOT</em>FOUND&quot;, &quot;statusCode&quot;: &quot;404&quot; }, { &quot;<em>links&quot;: { &quot;self&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/REQUEST</em>TOO<em>LARGE&quot; }, &quot;gatewayresponse:put&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/{response</em>type}&quot;, &quot;templated&quot;: true }, &quot;gatewayresponse:update&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/REQUEST<em>TOO</em>LARGE&quot; } }, &quot;defaultResponse&quot;: true, &quot;responseParameters&quot;: {}, &quot;responseTemplates&quot;: { &quot;application/json&quot;: &quot;{&quot;message&quot;:$context.error.messageString}&quot; }, &quot;responseType&quot;: &quot;REQUEST<em>TOO</em>LARGE&quot;, &quot;statusCode&quot;: &quot;413&quot; }, { &quot;<em>links&quot;: { &quot;self&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/THROTTLED&quot; }, &quot;gatewayresponse:put&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/{response</em>type}&quot;, &quot;templated&quot;: true }, &quot;gatewayresponse:update&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/THROTTLED&quot; } }, &quot;defaultResponse&quot;: true, &quot;responseParameters&quot;: {}, &quot;responseTemplates&quot;: { &quot;application/json&quot;: &quot;{&quot;message&quot;:$context.error.messageString}&quot; }, &quot;responseType&quot;: &quot;THROTTLED&quot;, &quot;statusCode&quot;: &quot;429&quot; }, { &quot;<em>links&quot;: { &quot;self&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/UNSUPPORTED</em>MEDIA<em>TYPE&quot; }, &quot;gatewayresponse:put&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/{response</em>type}&quot;, &quot;templated&quot;: true }, &quot;gatewayresponse:update&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/UNSUPPORTED<em>MEDIA</em>TYPE&quot; } }, &quot;defaultResponse&quot;: true, &quot;responseParameters&quot;: {}, &quot;responseTemplates&quot;: { &quot;application/json&quot;: &quot;{&quot;message&quot;:$context.error.messageString}&quot; }, &quot;responseType&quot;: &quot;UNSUPPORTED<em>MEDIA</em>TYPE&quot;, &quot;statusCode&quot;: &quot;415&quot; }, { &quot;<em>links&quot;: { &quot;self&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/AUTHORIZER</em>CONFIGURATION<em>ERROR&quot; }, &quot;gatewayresponse:put&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/{response</em>type}&quot;, &quot;templated&quot;: true }, &quot;gatewayresponse:update&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/AUTHORIZER<em>CONFIGURATION</em>ERROR&quot; } }, &quot;defaultResponse&quot;: true, &quot;responseParameters&quot;: {}, &quot;responseTemplates&quot;: { &quot;application/json&quot;: &quot;{&quot;message&quot;:$context.error.messageString}&quot; }, &quot;responseType&quot;: &quot;AUTHORIZER<em>CONFIGURATION</em>ERROR&quot;, &quot;statusCode&quot;: &quot;500&quot; }, { &quot;<em>links&quot;: { &quot;self&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/DEFAULT</em>5XX&quot; }, &quot;gatewayresponse:put&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/{response<em>type}&quot;, &quot;templated&quot;: true }, &quot;gatewayresponse:update&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/DEFAULT</em>5XX&quot; } }, &quot;defaultResponse&quot;: true, &quot;responseParameters&quot;: {}, &quot;responseTemplates&quot;: { &quot;application/json&quot;: &quot;{&quot;message&quot;:$context.error.messageString}&quot; }, &quot;responseType&quot;: &quot;DEFAULT<em>5XX&quot; }, { &quot;</em>links&quot;: { &quot;self&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/DEFAULT<em>4XX&quot; }, &quot;gatewayresponse:put&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/{response</em>type}&quot;, &quot;templated&quot;: true }, &quot;gatewayresponse:update&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/DEFAULT<em>4XX&quot; } }, &quot;defaultResponse&quot;: true, &quot;responseParameters&quot;: {}, &quot;responseTemplates&quot;: { &quot;application/json&quot;: &quot;{&quot;message&quot;:$context.error.messageString}&quot; }, &quot;responseType&quot;: &quot;DEFAULT</em>4XX&quot; }, { &quot;<em>links&quot;: { &quot;self&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/BAD</em>REQUEST<em>PARAMETERS&quot; }, &quot;gatewayresponse:put&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/{response</em>type}&quot;, &quot;templated&quot;: true }, &quot;gatewayresponse:update&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/BAD<em>REQUEST</em>PARAMETERS&quot; } }, &quot;defaultResponse&quot;: true, &quot;responseParameters&quot;: {}, &quot;responseTemplates&quot;: { &quot;application/json&quot;: &quot;{&quot;message&quot;:$context.error.messageString}&quot; }, &quot;responseType&quot;: &quot;BAD<em>REQUEST</em>PARAMETERS&quot;, &quot;statusCode&quot;: &quot;400&quot; }, { &quot;<em>links&quot;: { &quot;self&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/BAD</em>REQUEST<em>BODY&quot; }, &quot;gatewayresponse:put&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/{response</em>type}&quot;, &quot;templated&quot;: true }, &quot;gatewayresponse:update&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/BAD<em>REQUEST</em>BODY&quot; } }, &quot;defaultResponse&quot;: true, &quot;responseParameters&quot;: {}, &quot;responseTemplates&quot;: { &quot;application/json&quot;: &quot;{&quot;message&quot;:$context.error.messageString}&quot; }, &quot;responseType&quot;: &quot;BAD<em>REQUEST</em>BODY&quot;, &quot;statusCode&quot;: &quot;400&quot; }, { &quot;<em>links&quot;: { &quot;self&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/EXPIRED</em>TOKEN&quot; }, &quot;gatewayresponse:put&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/{response<em>type}&quot;, &quot;templated&quot;: true }, &quot;gatewayresponse:update&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/EXPIRED</em>TOKEN&quot; } }, &quot;defaultResponse&quot;: true, &quot;responseParameters&quot;: {}, &quot;responseTemplates&quot;: { &quot;application/json&quot;: &quot;{&quot;message&quot;:$context.error.messageString}&quot; }, &quot;responseType&quot;: &quot;EXPIRED<em>TOKEN&quot;, &quot;statusCode&quot;: &quot;403&quot; }, { &quot;</em>links&quot;: { &quot;self&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/ACCESS<em>DENIED&quot; }, &quot;gatewayresponse:put&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/{response</em>type}&quot;, &quot;templated&quot;: true }, &quot;gatewayresponse:update&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/ACCESS<em>DENIED&quot; } }, &quot;defaultResponse&quot;: true, &quot;responseParameters&quot;: {}, &quot;responseTemplates&quot;: { &quot;application/json&quot;: &quot;{&quot;message&quot;:$context.error.messageString}&quot; }, &quot;responseType&quot;: &quot;ACCESS</em>DENIED&quot;, &quot;statusCode&quot;: &quot;403&quot; }, { &quot;<em>links&quot;: { &quot;self&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/INVALID</em>API<em>KEY&quot; }, &quot;gatewayresponse:put&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/{response</em>type}&quot;, &quot;templated&quot;: true }, &quot;gatewayresponse:update&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/INVALID<em>API</em>KEY&quot; } }, &quot;defaultResponse&quot;: true, &quot;responseParameters&quot;: {}, &quot;responseTemplates&quot;: { &quot;application/json&quot;: &quot;{&quot;message&quot;:$context.error.messageString}&quot; }, &quot;responseType&quot;: &quot;INVALID<em>API</em>KEY&quot;, &quot;statusCode&quot;: &quot;403&quot; }, { &quot;<em>links&quot;: { &quot;self&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/UNAUTHORIZED&quot; }, &quot;gatewayresponse:put&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/{response</em>type}&quot;, &quot;templated&quot;: true }, &quot;gatewayresponse:update&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/UNAUTHORIZED&quot; } }, &quot;defaultResponse&quot;: true, &quot;responseParameters&quot;: {}, &quot;responseTemplates&quot;: { &quot;application/json&quot;: &quot;{&quot;message&quot;:$context.error.messageString}&quot; }, &quot;responseType&quot;: &quot;UNAUTHORIZED&quot;, &quot;statusCode&quot;: &quot;401&quot; }, { &quot;<em>links&quot;: { &quot;self&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/API</em>CONFIGURATION<em>ERROR&quot; }, &quot;gatewayresponse:put&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/{response</em>type}&quot;, &quot;templated&quot;: true }, &quot;gatewayresponse:update&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/API<em>CONFIGURATION</em>ERROR&quot; } }, &quot;defaultResponse&quot;: true, &quot;responseParameters&quot;: {}, &quot;responseTemplates&quot;: { &quot;application/json&quot;: &quot;{&quot;message&quot;:$context.error.messageString}&quot; }, &quot;responseType&quot;: &quot;API<em>CONFIGURATION</em>ERROR&quot;, &quot;statusCode&quot;: &quot;500&quot; }, { &quot;<em>links&quot;: { &quot;self&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/QUOTA</em>EXCEEDED&quot; }, &quot;gatewayresponse:put&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/{response<em>type}&quot;, &quot;templated&quot;: true }, &quot;gatewayresponse:update&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/QUOTA</em>EXCEEDED&quot; } }, &quot;defaultResponse&quot;: true, &quot;responseParameters&quot;: {}, &quot;responseTemplates&quot;: { &quot;application/json&quot;: &quot;{&quot;message&quot;:$context.error.messageString}&quot; }, &quot;responseType&quot;: &quot;QUOTA<em>EXCEEDED&quot;, &quot;statusCode&quot;: &quot;429&quot; }, { &quot;</em>links&quot;: { &quot;self&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/INTEGRATION<em>TIMEOUT&quot; }, &quot;gatewayresponse:put&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/{response</em>type}&quot;, &quot;templated&quot;: true }, &quot;gatewayresponse:update&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/INTEGRATION<em>TIMEOUT&quot; } }, &quot;defaultResponse&quot;: true, &quot;responseParameters&quot;: {}, &quot;responseTemplates&quot;: { &quot;application/json&quot;: &quot;{&quot;message&quot;:$context.error.messageString}&quot; }, &quot;responseType&quot;: &quot;INTEGRATION</em>TIMEOUT&quot;, &quot;statusCode&quot;: &quot;504&quot; }, { &quot;<em>links&quot;: { &quot;self&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/MISSING</em>AUTHENTICATION<em>TOKEN&quot; }, &quot;gatewayresponse:put&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/{response</em>type}&quot;, &quot;templated&quot;: true }, &quot;gatewayresponse:update&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/MISSING<em>AUTHENTICATION</em>TOKEN&quot; } }, &quot;defaultResponse&quot;: true, &quot;responseParameters&quot;: {}, &quot;responseTemplates&quot;: { &quot;application/json&quot;: &quot;{&quot;message&quot;:$context.error.messageString}&quot; }, &quot;responseType&quot;: &quot;MISSING<em>AUTHENTICATION</em>TOKEN&quot;, &quot;statusCode&quot;: &quot;403&quot; }, { &quot;<em>links&quot;: { &quot;self&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/INVALID</em>SIGNATURE&quot; }, &quot;gatewayresponse:put&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/{response<em>type}&quot;, &quot;templated&quot;: true }, &quot;gatewayresponse:update&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/INVALID</em>SIGNATURE&quot; } }, &quot;defaultResponse&quot;: true, &quot;responseParameters&quot;: {}, &quot;responseTemplates&quot;: { &quot;application/json&quot;: &quot;{&quot;message&quot;:$context.error.messageString}&quot; }, &quot;responseType&quot;: &quot;INVALID<em>SIGNATURE&quot;, &quot;statusCode&quot;: &quot;403&quot; }, { &quot;</em>links&quot;: { &quot;self&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/AUTHORIZER<em>FAILURE&quot; }, &quot;gatewayresponse:put&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/{response</em>type}&quot;, &quot;templated&quot;: true }, &quot;gatewayresponse:update&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/AUTHORIZER<em>FAILURE&quot; } }, &quot;defaultResponse&quot;: true, &quot;responseParameters&quot;: {}, &quot;responseTemplates&quot;: { &quot;application/json&quot;: &quot;{&quot;message&quot;:$context.error.messageString}&quot; }, &quot;responseType&quot;: &quot;AUTHORIZER</em>FAILURE&quot;, &quot;statusCode&quot;: &quot;500&quot; } ] } }</code></pre> <p></p> </div> </div> <div class="seeAlso"> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/customize-gateway-responses.html">Customize Gateway Responses</a> </div></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GatewayResponses {
     /// <p>Returns the entire collection, because of no pagination support.</p>
     #[serde(rename = "items")]
@@ -1204,7 +1204,7 @@ pub struct GatewayResponses {
 }
 
 /// <p>A request to generate a <a>ClientCertificate</a> resource.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GenerateClientCertificateRequest {
     /// <p>The description of the <a>ClientCertificate</a>.</p>
     #[serde(rename = "description")]
@@ -1213,11 +1213,11 @@ pub struct GenerateClientCertificateRequest {
 }
 
 /// <p>Requests API Gateway to get information about the current <a>Account</a> resource.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetAccountRequest {}
 
 /// <p>A request to get information about the current <a>ApiKey</a> resource.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetApiKeyRequest {
     /// <p>[Required] The identifier of the <a>ApiKey</a> resource.</p>
     #[serde(rename = "apiKey")]
@@ -1229,7 +1229,7 @@ pub struct GetApiKeyRequest {
 }
 
 /// <p>A request to get information about the current <a>ApiKeys</a> resource.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetApiKeysRequest {
     /// <p>The identifier of a customer in AWS Marketplace or an external system, such as a developer portal.</p>
     #[serde(rename = "customerId")]
@@ -1254,7 +1254,7 @@ pub struct GetApiKeysRequest {
 }
 
 /// <p>Request to describe an existing <a>Authorizer</a> resource.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetAuthorizerRequest {
     /// <p>[Required] The identifier of the <a>Authorizer</a> resource.</p>
     #[serde(rename = "authorizerId")]
@@ -1265,7 +1265,7 @@ pub struct GetAuthorizerRequest {
 }
 
 /// <p>Request to describe an existing <a>Authorizers</a> resource.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetAuthorizersRequest {
     /// <p>The maximum number of returned results per page. The default value is 25 and the maximum value is 500.</p>
     #[serde(rename = "limit")]
@@ -1281,7 +1281,7 @@ pub struct GetAuthorizersRequest {
 }
 
 /// <p>Request to describe a <a>BasePathMapping</a> resource.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetBasePathMappingRequest {
     /// <p>[Required] The base path name that callers of the API must provide as part of the URL after the domain name. This value must be unique for all of the mappings across a single API. Leave this blank if you do not want callers to specify any base path name after the domain name.</p>
     #[serde(rename = "basePath")]
@@ -1292,7 +1292,7 @@ pub struct GetBasePathMappingRequest {
 }
 
 /// <p>A request to get information about a collection of <a>BasePathMapping</a> resources.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetBasePathMappingsRequest {
     /// <p>[Required] The domain name of a <a>BasePathMapping</a> resource.</p>
     #[serde(rename = "domainName")]
@@ -1308,7 +1308,7 @@ pub struct GetBasePathMappingsRequest {
 }
 
 /// <p>A request to get information about the current <a>ClientCertificate</a> resource.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetClientCertificateRequest {
     /// <p>[Required] The identifier of the <a>ClientCertificate</a> resource to be described.</p>
     #[serde(rename = "clientCertificateId")]
@@ -1316,7 +1316,7 @@ pub struct GetClientCertificateRequest {
 }
 
 /// <p>A request to get information about a collection of <a>ClientCertificate</a> resources.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetClientCertificatesRequest {
     /// <p>The maximum number of returned results per page. The default value is 25 and the maximum value is 500.</p>
     #[serde(rename = "limit")]
@@ -1329,7 +1329,7 @@ pub struct GetClientCertificatesRequest {
 }
 
 /// <p>Requests API Gateway to get information about a <a>Deployment</a> resource.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetDeploymentRequest {
     /// <p>[Required] The identifier of the <a>Deployment</a> resource to get information about.</p>
     #[serde(rename = "deploymentId")]
@@ -1344,7 +1344,7 @@ pub struct GetDeploymentRequest {
 }
 
 /// <p>Requests API Gateway to get information about a <a>Deployments</a> collection.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetDeploymentsRequest {
     /// <p>The maximum number of returned results per page. The default value is 25 and the maximum value is 500.</p>
     #[serde(rename = "limit")]
@@ -1360,7 +1360,7 @@ pub struct GetDeploymentsRequest {
 }
 
 /// <p>Gets a specified documentation part of a given API.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetDocumentationPartRequest {
     /// <p>[Required] The string identifier of the associated <a>RestApi</a>.</p>
     #[serde(rename = "documentationPartId")]
@@ -1371,7 +1371,7 @@ pub struct GetDocumentationPartRequest {
 }
 
 /// <p>Gets the documentation parts of an API. The result may be filtered by the type, name, or path of API entities (targets).</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetDocumentationPartsRequest {
     /// <p>The maximum number of returned results per page. The default value is 25 and the maximum value is 500.</p>
     #[serde(rename = "limit")]
@@ -1403,7 +1403,7 @@ pub struct GetDocumentationPartsRequest {
 }
 
 /// <p>Gets a documentation snapshot of an API.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetDocumentationVersionRequest {
     /// <p>[Required] The version identifier of the to-be-retrieved documentation snapshot.</p>
     #[serde(rename = "documentationVersion")]
@@ -1414,7 +1414,7 @@ pub struct GetDocumentationVersionRequest {
 }
 
 /// <p>Gets the documentation versions of an API.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetDocumentationVersionsRequest {
     /// <p>The maximum number of returned results per page. The default value is 25 and the maximum value is 500.</p>
     #[serde(rename = "limit")]
@@ -1430,7 +1430,7 @@ pub struct GetDocumentationVersionsRequest {
 }
 
 /// <p>Request to get the name of a <a>DomainName</a> resource.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetDomainNameRequest {
     /// <p>[Required] The name of the <a>DomainName</a> resource.</p>
     #[serde(rename = "domainName")]
@@ -1438,7 +1438,7 @@ pub struct GetDomainNameRequest {
 }
 
 /// <p>Request to describe a collection of <a>DomainName</a> resources.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetDomainNamesRequest {
     /// <p>The maximum number of returned results per page. The default value is 25 and the maximum value is 500.</p>
     #[serde(rename = "limit")]
@@ -1451,7 +1451,7 @@ pub struct GetDomainNamesRequest {
 }
 
 /// <p>Request a new export of a <a>RestApi</a> for a particular <a>Stage</a>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetExportRequest {
     /// <p>The content-type of the export, for example <code>application/json</code>. Currently <code>application/json</code> and <code>application/yaml</code> are supported for <code>exportType</code> of <code>swagger</code>. This should be specified in the <code>Accept</code> header for direct API requests.</p>
     #[serde(rename = "accepts")]
@@ -1473,7 +1473,7 @@ pub struct GetExportRequest {
 }
 
 /// <p>Gets a <a>GatewayResponse</a> of a specified response type on the given <a>RestApi</a>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetGatewayResponseRequest {
     /// <p>[Required] <p>The response type of the associated <a>GatewayResponse</a>. Valid values are <ul><li>ACCESS_DENIED</li><li>API_CONFIGURATION_ERROR</li><li>AUTHORIZER_FAILURE</li><li> AUTHORIZER_CONFIGURATION_ERROR</li><li>BAD_REQUEST_PARAMETERS</li><li>BAD_REQUEST_BODY</li><li>DEFAULT_4XX</li><li>DEFAULT_5XX</li><li>EXPIRED_TOKEN</li><li>INVALID_SIGNATURE</li><li>INTEGRATION_FAILURE</li><li>INTEGRATION_TIMEOUT</li><li>INVALID_API_KEY</li><li>MISSING_AUTHENTICATION_TOKEN</li><li> QUOTA_EXCEEDED</li><li>REQUEST_TOO_LARGE</li><li>RESOURCE_NOT_FOUND</li><li>THROTTLED</li><li>UNAUTHORIZED</li><li>UNSUPPORTED_MEDIA_TYPE</li></ul> </p></p>
     #[serde(rename = "responseType")]
@@ -1484,7 +1484,7 @@ pub struct GetGatewayResponseRequest {
 }
 
 /// <p>Gets the <a>GatewayResponses</a> collection on the given <a>RestApi</a>. If an API developer has not added any definitions for gateway responses, the result will be the API Gateway-generated default <a>GatewayResponses</a> collection for the supported response types.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetGatewayResponsesRequest {
     /// <p>The maximum number of returned results per page. The default value is 25 and the maximum value is 500. The <a>GatewayResponses</a> collection does not support pagination and the limit does not apply here.</p>
     #[serde(rename = "limit")]
@@ -1500,7 +1500,7 @@ pub struct GetGatewayResponsesRequest {
 }
 
 /// <p>Represents a request to get the integration configuration.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetIntegrationRequest {
     /// <p>[Required] Specifies a get integration request's HTTP method.</p>
     #[serde(rename = "httpMethod")]
@@ -1514,7 +1514,7 @@ pub struct GetIntegrationRequest {
 }
 
 /// <p>Represents a get integration response request.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetIntegrationResponseRequest {
     /// <p>[Required] Specifies a get integration response request's HTTP method.</p>
     #[serde(rename = "httpMethod")]
@@ -1531,7 +1531,7 @@ pub struct GetIntegrationResponseRequest {
 }
 
 /// <p>Request to describe an existing <a>Method</a> resource.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetMethodRequest {
     /// <p>[Required] Specifies the method request's HTTP method type.</p>
     #[serde(rename = "httpMethod")]
@@ -1545,7 +1545,7 @@ pub struct GetMethodRequest {
 }
 
 /// <p>Request to describe a <a>MethodResponse</a> resource.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetMethodResponseRequest {
     /// <p>[Required] The HTTP verb of the <a>Method</a> resource.</p>
     #[serde(rename = "httpMethod")]
@@ -1562,7 +1562,7 @@ pub struct GetMethodResponseRequest {
 }
 
 /// <p>Request to list information about a model in an existing <a>RestApi</a> resource.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetModelRequest {
     /// <p>A query parameter of a Boolean value to resolve (<code>true</code>) all external model references and returns a flattened model schema or not (<code>false</code>) The default is <code>false</code>.</p>
     #[serde(rename = "flatten")]
@@ -1577,7 +1577,7 @@ pub struct GetModelRequest {
 }
 
 /// <p>Request to generate a sample mapping template used to transform the payload.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetModelTemplateRequest {
     /// <p>[Required] The name of the model for which to generate a template.</p>
     #[serde(rename = "modelName")]
@@ -1588,7 +1588,7 @@ pub struct GetModelTemplateRequest {
 }
 
 /// <p>Request to list existing <a>Models</a> defined for a <a>RestApi</a> resource.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetModelsRequest {
     /// <p>The maximum number of returned results per page. The default value is 25 and the maximum value is 500.</p>
     #[serde(rename = "limit")]
@@ -1604,7 +1604,7 @@ pub struct GetModelsRequest {
 }
 
 /// <p>Gets a <a>RequestValidator</a> of a given <a>RestApi</a>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetRequestValidatorRequest {
     /// <p>[Required] The identifier of the <a>RequestValidator</a> to be retrieved.</p>
     #[serde(rename = "requestValidatorId")]
@@ -1615,7 +1615,7 @@ pub struct GetRequestValidatorRequest {
 }
 
 /// <p>Gets the <a>RequestValidators</a> collection of a given <a>RestApi</a>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetRequestValidatorsRequest {
     /// <p>The maximum number of returned results per page. The default value is 25 and the maximum value is 500.</p>
     #[serde(rename = "limit")]
@@ -1631,7 +1631,7 @@ pub struct GetRequestValidatorsRequest {
 }
 
 /// <p>Request to list information about a resource.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetResourceRequest {
     /// <p>A query parameter to retrieve the specified resources embedded in the returned <a>Resource</a> representation in the response. This <code>embed</code> parameter value is a list of comma-separated strings. Currently, the request supports only retrieval of the embedded <a>Method</a> resources this way. The query parameter value must be a single-valued list and contain the <code>"methods"</code> string. For example, <code>GET /restapis/{restapi_id}/resources/{resource_id}?embed=methods</code>.</p>
     #[serde(rename = "embed")]
@@ -1646,7 +1646,7 @@ pub struct GetResourceRequest {
 }
 
 /// <p>Request to list information about a collection of resources.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetResourcesRequest {
     /// <p>A query parameter used to retrieve the specified resources embedded in the returned <a>Resources</a> resource in the response. This <code>embed</code> parameter value is a list of comma-separated strings. Currently, the request supports only retrieval of the embedded <a>Method</a> resources this way. The query parameter value must be a single-valued list and contain the <code>"methods"</code> string. For example, <code>GET /restapis/{restapi_id}/resources?embed=methods</code>.</p>
     #[serde(rename = "embed")]
@@ -1666,7 +1666,7 @@ pub struct GetResourcesRequest {
 }
 
 /// <p>The GET request to list an existing <a>RestApi</a> defined for your collection. </p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetRestApiRequest {
     /// <p>[Required] The string identifier of the associated <a>RestApi</a>.</p>
     #[serde(rename = "restApiId")]
@@ -1674,7 +1674,7 @@ pub struct GetRestApiRequest {
 }
 
 /// <p>The GET request to list existing <a>RestApis</a> defined for your collection.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetRestApisRequest {
     /// <p>The maximum number of returned results per page. The default value is 25 and the maximum value is 500.</p>
     #[serde(rename = "limit")]
@@ -1687,7 +1687,7 @@ pub struct GetRestApisRequest {
 }
 
 /// <p>Request a new generated client SDK for a <a>RestApi</a> and <a>Stage</a>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetSdkRequest {
     /// <p>A string-to-string key-value map of query parameters <code>sdkType</code>-dependent properties of the SDK. For <code>sdkType</code> of <code>objectivec</code> or <code>swift</code>, a parameter named <code>classPrefix</code> is required. For <code>sdkType</code> of <code>android</code>, parameters named <code>groupId</code>, <code>artifactId</code>, <code>artifactVersion</code>, and <code>invokerPackage</code> are required. For <code>sdkType</code> of <code>java</code>, parameters named <code>serviceName</code> and <code>javaPackageName</code> are required. </p>
     #[serde(rename = "parameters")]
@@ -1705,7 +1705,7 @@ pub struct GetSdkRequest {
 }
 
 /// <p>Get an <a>SdkType</a> instance.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetSdkTypeRequest {
     /// <p>[Required] The identifier of the queried <a>SdkType</a> instance.</p>
     #[serde(rename = "id")]
@@ -1713,7 +1713,7 @@ pub struct GetSdkTypeRequest {
 }
 
 /// <p>Get the <a>SdkTypes</a> collection.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetSdkTypesRequest {
     /// <p>The maximum number of returned results per page. The default value is 25 and the maximum value is 500.</p>
     #[serde(rename = "limit")]
@@ -1726,7 +1726,7 @@ pub struct GetSdkTypesRequest {
 }
 
 /// <p>Requests API Gateway to get information about a <a>Stage</a> resource.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetStageRequest {
     /// <p>[Required] The string identifier of the associated <a>RestApi</a>.</p>
     #[serde(rename = "restApiId")]
@@ -1737,7 +1737,7 @@ pub struct GetStageRequest {
 }
 
 /// <p>Requests API Gateway to get information about one or more <a>Stage</a> resources.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetStagesRequest {
     /// <p>The stages' deployment identifiers.</p>
     #[serde(rename = "deploymentId")]
@@ -1749,7 +1749,7 @@ pub struct GetStagesRequest {
 }
 
 /// <p>Gets the <a>Tags</a> collection for a given resource.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetTagsRequest {
     /// <p>(Not currently supported) The maximum number of returned results per page. The default value is 25 and the maximum value is 500.</p>
     #[serde(rename = "limit")]
@@ -1765,7 +1765,7 @@ pub struct GetTagsRequest {
 }
 
 /// <p>The GET request to get a usage plan key of a given key identifier.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetUsagePlanKeyRequest {
     /// <p>[Required] The key Id of the to-be-retrieved <a>UsagePlanKey</a> resource representing a plan customer.</p>
     #[serde(rename = "keyId")]
@@ -1776,7 +1776,7 @@ pub struct GetUsagePlanKeyRequest {
 }
 
 /// <p>The GET request to get all the usage plan keys representing the API keys added to a specified usage plan.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetUsagePlanKeysRequest {
     /// <p>The maximum number of returned results per page. The default value is 25 and the maximum value is 500.</p>
     #[serde(rename = "limit")]
@@ -1796,7 +1796,7 @@ pub struct GetUsagePlanKeysRequest {
 }
 
 /// <p>The GET request to get a usage plan of a given plan identifier.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetUsagePlanRequest {
     /// <p>[Required] The identifier of the <a>UsagePlan</a> resource to be retrieved.</p>
     #[serde(rename = "usagePlanId")]
@@ -1804,7 +1804,7 @@ pub struct GetUsagePlanRequest {
 }
 
 /// <p>The GET request to get all the usage plans of the caller's account.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetUsagePlansRequest {
     /// <p>The identifier of the API key associated with the usage plans.</p>
     #[serde(rename = "keyId")]
@@ -1821,7 +1821,7 @@ pub struct GetUsagePlansRequest {
 }
 
 /// <p>The GET request to get the usage data of a usage plan in a specified time interval.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetUsageRequest {
     /// <p>[Required] The ending date (e.g., 2016-12-31) of the usage data.</p>
     #[serde(rename = "endDate")]
@@ -1847,7 +1847,7 @@ pub struct GetUsageRequest {
 }
 
 /// <p>Gets a specified VPC link under the caller's account in a region.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetVpcLinkRequest {
     /// <p>[Required] The identifier of the <a>VpcLink</a>. It is used in an <a>Integration</a> to reference this <a>VpcLink</a>.</p>
     #[serde(rename = "vpcLinkId")]
@@ -1855,7 +1855,7 @@ pub struct GetVpcLinkRequest {
 }
 
 /// <p>Gets the <a>VpcLinks</a> collection under the caller's account in a selected region.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetVpcLinksRequest {
     /// <p>The maximum number of returned results per page. The default value is 25 and the maximum value is 500.</p>
     #[serde(rename = "limit")]
@@ -1868,7 +1868,7 @@ pub struct GetVpcLinksRequest {
 }
 
 /// <p>The POST request to import API keys from an external source, such as a CSV-formatted file.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ImportApiKeysRequest {
     /// <p>The payload of the POST request to import API keys. For the payload format, see <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/api-key-file-format.html">API Key File Format</a>.</p>
     #[serde(rename = "body")]
@@ -1888,7 +1888,7 @@ pub struct ImportApiKeysRequest {
 }
 
 /// <p>Import documentation parts from an external (e.g., Swagger) definition file. </p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ImportDocumentationPartsRequest {
     /// <p>[Required] Raw byte array representing the to-be-imported documentation parts. To import from a Swagger file, this is a JSON object.</p>
     #[serde(rename = "body")]
@@ -1912,7 +1912,7 @@ pub struct ImportDocumentationPartsRequest {
 }
 
 /// <p>A POST request to import an API to API Gateway using an input of an API definition file.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ImportRestApiRequest {
     /// <p>[Required] The POST request body containing external API definitions. Currently, only Swagger definition JSON files are supported. The maximum size of the API definition file is 2MB.</p>
     #[serde(rename = "body")]
@@ -1933,7 +1933,7 @@ pub struct ImportRestApiRequest {
 }
 
 /// <p><p>Represents an HTTP, HTTP<em>PROXY, AWS, AWS</em>PROXY, or Mock integration.</p> <div class="remarks">In the API Gateway console, the built-in Lambda integration is an AWS integration.</div> <div class="seeAlso"> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-create-api.html">Creating an API</a> </div></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Integration {
     /// <p>Specifies the integration's cache key parameters.</p>
     #[serde(rename = "cacheKeyParameters")]
@@ -1994,7 +1994,7 @@ pub struct Integration {
 }
 
 /// <p><p>Represents an integration response. The status code must map to an existing <a>MethodResponse</a>, and parameters and templates can be used to transform the back-end response.</p> <div class="seeAlso"> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-create-api.html">Creating an API</a> </div></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct IntegrationResponse {
     /// <p>Specifies how to handle response payload content type conversions. Supported values are <code>CONVERT_TO_BINARY</code> and <code>CONVERT_TO_TEXT</code>, with the following behaviors:</p> <ul> <li><p><code>CONVERT_TO_BINARY</code>: Converts a response payload from a Base64-encoded string to the corresponding binary blob.</p></li> <li><p><code>CONVERT_TO_TEXT</code>: Converts a response payload from a binary blob to a Base64-encoded string.</p></li> </ul> <p>If this property is not defined, the response payload will be passed through from the integration response to the method response without modification.</p>
     #[serde(rename = "contentHandling")]
@@ -2019,7 +2019,7 @@ pub struct IntegrationResponse {
 }
 
 /// <p><p> Represents a client-facing interface by which the client calls the API to access back-end resources. A <b>Method</b> resource is integrated with an <a>Integration</a> resource. Both consist of a request and one or more responses. The method request takes the client input that is passed to the back end through the integration request. A method response returns the output from the back end to the client through an integration response. A method request is embodied in a <b>Method</b> resource, whereas an integration request is embodied in an <a>Integration</a> resource. On the other hand, a method response is represented by a <a>MethodResponse</a> resource, whereas an integration response is represented by an <a>IntegrationResponse</a> resource. </p> <div class="remarks"> <p/> <h4>Example: Retrive the GET method on a specified resource</h4> <h5>Request</h5> <p>The following example request retrieves the information about the GET method on an API resource (<code>3kzxbg5sa2</code>) of an API (<code>fugvjdxtri</code>). </p> <pre><code>GET /restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET HTTP/1.1 Content-Type: application/json Host: apigateway.us-east-1.amazonaws.com X-Amz-Date: 20160603T210259Z Authorization: AWS4-HMAC-SHA256 Credential={access<em>key</em>ID}/20160603/us-east-1/apigateway/aws4<em>request, SignedHeaders=content-type;host;x-amz-date, Signature={sig4</em>hash}</code></pre> <h5>Response</h5> <p>The successful response returns a <code>200 OK</code> status code and a payload similar to the following:</p> <pre><code>{ &quot;<em>links&quot;: { &quot;curies&quot;: [ { &quot;href&quot;: &quot;http://docs.aws.amazon.com/apigateway/latest/developerguide/restapi-integration-{rel}.html&quot;, &quot;name&quot;: &quot;integration&quot;, &quot;templated&quot;: true }, { &quot;href&quot;: &quot;http://docs.aws.amazon.com/apigateway/latest/developerguide/restapi-integration-response-{rel}.html&quot;, &quot;name&quot;: &quot;integrationresponse&quot;, &quot;templated&quot;: true }, { &quot;href&quot;: &quot;http://docs.aws.amazon.com/apigateway/latest/developerguide/restapi-method-{rel}.html&quot;, &quot;name&quot;: &quot;method&quot;, &quot;templated&quot;: true }, { &quot;href&quot;: &quot;http://docs.aws.amazon.com/apigateway/latest/developerguide/restapi-method-response-{rel}.html&quot;, &quot;name&quot;: &quot;methodresponse&quot;, &quot;templated&quot;: true } ], &quot;self&quot;: { &quot;href&quot;: &quot;/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET&quot;, &quot;name&quot;: &quot;GET&quot;, &quot;title&quot;: &quot;GET&quot; }, &quot;integration:put&quot;: { &quot;href&quot;: &quot;/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/integration&quot; }, &quot;method:delete&quot;: { &quot;href&quot;: &quot;/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET&quot; }, &quot;method:integration&quot;: { &quot;href&quot;: &quot;/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/integration&quot; }, &quot;method:responses&quot;: { &quot;href&quot;: &quot;/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/responses/200&quot;, &quot;name&quot;: &quot;200&quot;, &quot;title&quot;: &quot;200&quot; }, &quot;method:update&quot;: { &quot;href&quot;: &quot;/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET&quot; }, &quot;methodresponse:put&quot;: { &quot;href&quot;: &quot;/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/responses/{status</em>code}&quot;, &quot;templated&quot;: true } }, &quot;apiKeyRequired&quot;: true, &quot;authorizationType&quot;: &quot;NONE&quot;, &quot;httpMethod&quot;: &quot;GET&quot;, &quot;<em>embedded&quot;: { &quot;method:integration&quot;: { &quot;</em>links&quot;: { &quot;self&quot;: { &quot;href&quot;: &quot;/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/integration&quot; }, &quot;integration:delete&quot;: { &quot;href&quot;: &quot;/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/integration&quot; }, &quot;integration:responses&quot;: { &quot;href&quot;: &quot;/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/integration/responses/200&quot;, &quot;name&quot;: &quot;200&quot;, &quot;title&quot;: &quot;200&quot; }, &quot;integration:update&quot;: { &quot;href&quot;: &quot;/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/integration&quot; }, &quot;integrationresponse:put&quot;: { &quot;href&quot;: &quot;/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/integration/responses/{status<em>code}&quot;, &quot;templated&quot;: true } }, &quot;cacheKeyParameters&quot;: [], &quot;cacheNamespace&quot;: &quot;3kzxbg5sa2&quot;, &quot;credentials&quot;: &quot;arn:aws:iam::123456789012:role/apigAwsProxyRole&quot;, &quot;httpMethod&quot;: &quot;POST&quot;, &quot;passthroughBehavior&quot;: &quot;WHEN</em>NO<em>MATCH&quot;, &quot;requestParameters&quot;: { &quot;integration.request.header.Content-Type&quot;: &quot;&#39;application/x-amz-json-1.1&#39;&quot; }, &quot;requestTemplates&quot;: { &quot;application/json&quot;: &quot;{\n}&quot; }, &quot;type&quot;: &quot;AWS&quot;, &quot;uri&quot;: &quot;arn:aws:apigateway:us-east-1:kinesis:action/ListStreams&quot;, &quot;</em>embedded&quot;: { &quot;integration:responses&quot;: { &quot;<em>links&quot;: { &quot;self&quot;: { &quot;href&quot;: &quot;/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/integration/responses/200&quot;, &quot;name&quot;: &quot;200&quot;, &quot;title&quot;: &quot;200&quot; }, &quot;integrationresponse:delete&quot;: { &quot;href&quot;: &quot;/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/integration/responses/200&quot; }, &quot;integrationresponse:update&quot;: { &quot;href&quot;: &quot;/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/integration/responses/200&quot; } }, &quot;responseParameters&quot;: { &quot;method.response.header.Content-Type&quot;: &quot;&#39;application/xml&#39;&quot; }, &quot;responseTemplates&quot;: { &quot;application/json&quot;: &quot;$util.urlDecode(&quot;%3CkinesisStreams%3E%23foreach(%24stream%20in%20%24input.path(%27%24.StreamNames%27))%3Cstream%3E%3Cname%3E%24stream%3C%2Fname%3E%3C%2Fstream%3E%23end%3C%2FkinesisStreams%3E&quot;)&quot; }, &quot;statusCode&quot;: &quot;200&quot; } } }, &quot;method:responses&quot;: { &quot;</em>links&quot;: { &quot;self&quot;: { &quot;href&quot;: &quot;/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/responses/200&quot;, &quot;name&quot;: &quot;200&quot;, &quot;title&quot;: &quot;200&quot; }, &quot;methodresponse:delete&quot;: { &quot;href&quot;: &quot;/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/responses/200&quot; }, &quot;methodresponse:update&quot;: { &quot;href&quot;: &quot;/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/responses/200&quot; } }, &quot;responseModels&quot;: { &quot;application/json&quot;: &quot;Empty&quot; }, &quot;responseParameters&quot;: { &quot;method.response.header.Content-Type&quot;: false }, &quot;statusCode&quot;: &quot;200&quot; } } }</code></pre> <p>In the example above, the response template for the <code>200 OK</code> response maps the JSON output from the <code>ListStreams</code> action in the back end to an XML output. The mapping template is URL-encoded as <code>%3CkinesisStreams%3E%23foreach(%24stream%20in%20%24input.path(%27%24.StreamNames%27))%3Cstream%3E%3Cname%3E%24stream%3C%2Fname%3E%3C%2Fstream%3E%23end%3C%2FkinesisStreams%3E</code> and the output is decoded using the <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html#util-templat-reference">$util.urlDecode()</a> helper function.</p> </div> <div class="seeAlso"> <a>MethodResponse</a>, <a>Integration</a>, <a>IntegrationResponse</a>, <a>Resource</a>, <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-method-settings.html">Set up an API&#39;s method</a> </div></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Method {
     /// <p>A boolean flag specifying whether a valid <a>ApiKey</a> is required to invoke this method.</p>
     #[serde(rename = "apiKeyRequired")]
@@ -2068,7 +2068,7 @@ pub struct Method {
 }
 
 /// <p><p>Represents a method response of a given HTTP status code returned to the client. The method response is passed from the back end through the associated integration response that can be transformed using a mapping template. </p> <div class="remarks"> <p/> <h4>Example: A <b>MethodResponse</b> instance of an API</h4> <h5>Request</h5> <p>The example request retrieves a <b>MethodResponse</b> of the 200 status code.</p> <pre><code>GET /restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/responses/200 HTTP/1.1 Content-Type: application/json Host: apigateway.us-east-1.amazonaws.com X-Amz-Date: 20160603T222952Z Authorization: AWS4-HMAC-SHA256 Credential={access<em>key</em>ID}/20160603/us-east-1/apigateway/aws4<em>request, SignedHeaders=content-type;host;x-amz-date, Signature={sig4</em>hash}</code></pre> <h5>Response</h5> <p>The successful response returns <code>200 OK</code> status and a payload as follows:</p> <pre><code>{ &quot;_links&quot;: { &quot;curies&quot;: { &quot;href&quot;: &quot;http://docs.aws.amazon.com/apigateway/latest/developerguide/restapi-method-response-{rel}.html&quot;, &quot;name&quot;: &quot;methodresponse&quot;, &quot;templated&quot;: true }, &quot;self&quot;: { &quot;href&quot;: &quot;/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/responses/200&quot;, &quot;title&quot;: &quot;200&quot; }, &quot;methodresponse:delete&quot;: { &quot;href&quot;: &quot;/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/responses/200&quot; }, &quot;methodresponse:update&quot;: { &quot;href&quot;: &quot;/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/responses/200&quot; } }, &quot;responseModels&quot;: { &quot;application/json&quot;: &quot;Empty&quot; }, &quot;responseParameters&quot;: { &quot;method.response.header.Content-Type&quot;: false }, &quot;statusCode&quot;: &quot;200&quot; }</code></pre> <p/> </div> <div class="seeAlso"> <a>Method</a>, <a>IntegrationResponse</a>, <a>Integration</a> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-create-api.html">Creating an API</a> </div></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct MethodResponse {
     /// <p>Specifies the <a>Model</a> resources used for the response's content-type. Response models are represented as a key/value map, with a content-type as the key and a <a>Model</a> name as the value.</p>
     #[serde(rename = "responseModels")]
@@ -2085,7 +2085,7 @@ pub struct MethodResponse {
 }
 
 /// <p>Specifies the method setting properties.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct MethodSetting {
     /// <p>Specifies whether the cached responses are encrypted. The PATCH path for this setting is <code>/{method_setting_key}/caching/dataEncrypted</code>, and the value is a Boolean.</p>
     #[serde(rename = "cacheDataEncrypted")]
@@ -2130,7 +2130,7 @@ pub struct MethodSetting {
 }
 
 /// <p>Represents a summary of a <a>Method</a> resource, given a particular date and time.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct MethodSnapshot {
     /// <p>Specifies whether the method requires a valid <a>ApiKey</a>.</p>
     #[serde(rename = "apiKeyRequired")]
@@ -2143,7 +2143,7 @@ pub struct MethodSnapshot {
 }
 
 /// <p><p>Represents the data structure of a method&#39;s request or response payload.</p> <div class="remarks"> <p>A request model defines the data structure of the client-supplied request payload. A response model defines the data structure of the response payload returned by the back end. Although not required, models are useful for mapping payloads between the front end and back end.</p> <p>A model is used for generating an API&#39;s SDK, validating the input request body, and creating a skeletal mapping template.</p> </div> <div class="seeAlso"> <a>Method</a>, <a>MethodResponse</a>, <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/models-mappings.html">Models and Mappings</a> </div></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Model {
     /// <p>The content-type for the model.</p>
     #[serde(rename = "contentType")]
@@ -2168,7 +2168,7 @@ pub struct Model {
 }
 
 /// <p><p>Represents a collection of <a>Model</a> resources.</p> <div class="seeAlso"> <a>Method</a>, <a>MethodResponse</a>, <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/models-mappings.html">Models and Mappings</a> </div></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Models {
     /// <p>The current page of elements from this collection.</p>
     #[serde(rename = "items")]
@@ -2180,7 +2180,7 @@ pub struct Models {
 }
 
 /// <p>A single patch operation to apply to the specified resource. Please refer to http://tools.ietf.org/html/rfc6902#section-4 for an explanation of how each operation is used.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PatchOperation {
     /// <p>The <code>copy</code> update operation's source as identified by a <code>JSON-Pointer</code> value referencing the location within the targeted resource to copy the value from. For example, to promote a canary deployment, you copy the canary deployment ID to the affiliated deployment ID by calling a PATCH request on a <a>Stage</a> resource with <code>"op":"copy"</code>, <code>"from":"/canarySettings/deploymentId"</code> and <code>"path":"/deploymentId"</code>.</p>
     #[serde(rename = "from")]
@@ -2201,7 +2201,7 @@ pub struct PatchOperation {
 }
 
 /// <p>Creates a customization of a <a>GatewayResponse</a> of a specified response type and status code on the given <a>RestApi</a>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PutGatewayResponseRequest {
     /// <p><p>Response parameters (paths, query strings and headers) of the <a>GatewayResponse</a> as a string-to-string map of key-value pairs.</p></p>
     #[serde(rename = "responseParameters")]
@@ -2224,7 +2224,7 @@ pub struct PutGatewayResponseRequest {
 }
 
 /// <p>Sets up a method's integration.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PutIntegrationRequest {
     /// <p>Specifies a put integration input's cache key parameters.</p>
     #[serde(rename = "cacheKeyParameters")]
@@ -2289,7 +2289,7 @@ pub struct PutIntegrationRequest {
 }
 
 /// <p>Represents a put integration response request.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PutIntegrationResponseRequest {
     /// <p>Specifies how to handle response payload content type conversions. Supported values are <code>CONVERT_TO_BINARY</code> and <code>CONVERT_TO_TEXT</code>, with the following behaviors:</p> <ul> <li><p><code>CONVERT_TO_BINARY</code>: Converts a response payload from a Base64-encoded string to the corresponding binary blob.</p></li> <li><p><code>CONVERT_TO_TEXT</code>: Converts a response payload from a binary blob to a Base64-encoded string.</p></li> </ul> <p>If this property is not defined, the response payload will be passed through from the integration response to the method response without modification.</p>
     #[serde(rename = "contentHandling")]
@@ -2322,7 +2322,7 @@ pub struct PutIntegrationResponseRequest {
 }
 
 /// <p>Request to add a method to an existing <a>Resource</a> resource.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PutMethodRequest {
     /// <p>Specifies whether the method required a valid <a>ApiKey</a>.</p>
     #[serde(rename = "apiKeyRequired")]
@@ -2367,7 +2367,7 @@ pub struct PutMethodRequest {
 }
 
 /// <p>Request to add a <a>MethodResponse</a> to an existing <a>Method</a> resource.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PutMethodResponseRequest {
     /// <p>[Required] The HTTP verb of the <a>Method</a> resource.</p>
     #[serde(rename = "httpMethod")]
@@ -2392,7 +2392,7 @@ pub struct PutMethodResponseRequest {
 }
 
 /// <p>A PUT request to update an existing API, with external API definitions specified as the request body.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PutRestApiRequest {
     /// <p>[Required] The PUT request body containing external API definitions. Currently, only Swagger definition JSON files are supported. The maximum size of the API definition file is 2MB.</p>
     #[serde(rename = "body")]
@@ -2420,7 +2420,7 @@ pub struct PutRestApiRequest {
 }
 
 /// <p>Quotas configured for a usage plan.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct QuotaSettings {
     /// <p>The maximum number of requests that can be made in a given time period.</p>
     #[serde(rename = "limit")]
@@ -2437,7 +2437,7 @@ pub struct QuotaSettings {
 }
 
 /// <p><p>A set of validation rules for incoming <a>Method</a> requests.</p> <div class="remarks"> <p>In Swagger, a <a>RequestValidator</a> of an API is defined by the <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions.html#api-gateway-swagger-extensions-request-validators.requestValidator.html">x-amazon-apigateway-request-validators.requestValidator</a> object. It the referenced using the <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions.html#api-gateway-swagger-extensions-request-validator">x-amazon-apigateway-request-validator</a> property.</p> </div> <div class="seeAlso"><a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-method-request-validation.html">Enable Basic Request Validation in API Gateway</a></div></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RequestValidator {
     /// <p>The identifier of this <a>RequestValidator</a>.</p>
     #[serde(rename = "id")]
@@ -2458,7 +2458,7 @@ pub struct RequestValidator {
 }
 
 /// <p><p>A collection of <a>RequestValidator</a> resources of a given <a>RestApi</a>.</p> <div class="remarks"> <p>In Swagger, the <a>RequestValidators</a> of an API is defined by the <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions.html#api-gateway-swagger-extensions-request-validators.html">x-amazon-apigateway-request-validators</a> extension.</p> </div> <div class="seeAlso"><a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-method-request-validation.html">Enable Basic Request Validation in API Gateway</a></div></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RequestValidators {
     /// <p>The current page of elements from this collection.</p>
     #[serde(rename = "items")]
@@ -2470,7 +2470,7 @@ pub struct RequestValidators {
 }
 
 /// <p><p>Represents an API resource.</p> <div class="seeAlso"> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-create-api.html">Create an API</a> </div></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Resource {
     /// <p>The resource's identifier.</p>
     #[serde(rename = "id")]
@@ -2495,7 +2495,7 @@ pub struct Resource {
 }
 
 /// <p><p>Represents a collection of <a>Resource</a> resources.</p> <div class="seeAlso"> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-create-api.html">Create an API</a> </div></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Resources {
     /// <p>The current page of elements from this collection.</p>
     #[serde(rename = "items")]
@@ -2507,7 +2507,7 @@ pub struct Resources {
 }
 
 /// <p><p>Represents a REST API.</p> <div class="seeAlso"> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-create-api.html">Create an API</a> </div></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RestApi {
     /// <p>The source of the API key for metering requests according to a usage plan. Valid values are: <ul><li><code>HEADER</code> to read the API key from the <code>X-API-Key</code> header of a request. </li><li><code>AUTHORIZER</code> to read the API key from the <code>UsageIdentifierKey</code> from a custom authorizer.</li></ul> </p>
     #[serde(rename = "apiKeySource")]
@@ -2556,7 +2556,7 @@ pub struct RestApi {
 }
 
 /// <p><p>Contains references to your APIs and links that guide you in how to interact with your collection. A collection offers a paginated view of your APIs.</p> <div class="seeAlso"> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-create-api.html">Create an API</a> </div></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RestApis {
     /// <p>The current page of elements from this collection.</p>
     #[serde(rename = "items")]
@@ -2568,7 +2568,7 @@ pub struct RestApis {
 }
 
 /// <p>A configuration property of an SDK type.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SdkConfigurationProperty {
     /// <p>The default value of an <a>SdkType</a> configuration property.</p>
     #[serde(rename = "defaultValue")]
@@ -2593,7 +2593,7 @@ pub struct SdkConfigurationProperty {
 }
 
 /// <p>The binary blob response to <a>GetSdk</a>, which contains the generated SDK.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SdkResponse {
     /// <p>The binary blob response to <a>GetSdk</a>, which contains the generated SDK.</p>
     pub body: Option<Vec<u8>>,
@@ -2604,7 +2604,7 @@ pub struct SdkResponse {
 }
 
 /// <p>A type of SDK that API Gateway can generate.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SdkType {
     /// <p>A list of configuration properties of an <a>SdkType</a>.</p>
     #[serde(rename = "configurationProperties")]
@@ -2625,7 +2625,7 @@ pub struct SdkType {
 }
 
 /// <p>The collection of <a>SdkType</a> instances.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SdkTypes {
     /// <p>The current page of elements from this collection.</p>
     #[serde(rename = "items")]
@@ -2637,7 +2637,7 @@ pub struct SdkTypes {
 }
 
 /// <p><p>Represents a unique identifier for a version of a deployed <a>RestApi</a> that is callable by users.</p> <div class="seeAlso"> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-deploy-api.html">Deploy an API</a> </div></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Stage {
     /// <p>Settings for logging access in this stage.</p>
     #[serde(rename = "accessLogSettings")]
@@ -2702,7 +2702,7 @@ pub struct Stage {
 }
 
 /// <p>A reference to a unique stage identified in the format <code>{restApiId}/{stage}</code>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StageKey {
     /// <p>The string identifier of the associated <a>RestApi</a>.</p>
     #[serde(rename = "restApiId")]
@@ -2715,7 +2715,7 @@ pub struct StageKey {
 }
 
 /// <p><p>A list of <a>Stage</a> resources that are associated with the <a>ApiKey</a> resource.</p> <div class="seeAlso"><a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/stages.html">Deploying API in Stages</a></div></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Stages {
     /// <p>The current page of elements from this collection.</p>
     #[serde(rename = "item")]
@@ -2724,7 +2724,7 @@ pub struct Stages {
 }
 
 /// <p>Adds or updates a tag on a given resource.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct TagResourceRequest {
     /// <p>[Required] The ARN of a resource that can be tagged. The resource ARN must be URL-encoded. At present, <a>Stage</a> is the only taggable resource.</p>
     #[serde(rename = "resourceArn")]
@@ -2735,7 +2735,7 @@ pub struct TagResourceRequest {
 }
 
 /// <p>The collection of tags. Each tag element is associated with a given resource.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Tags {
     /// <p>The collection of tags. Each tag element is associated with a given resource.</p>
     #[serde(rename = "tags")]
@@ -2744,7 +2744,7 @@ pub struct Tags {
 }
 
 /// <p><p>Represents a mapping template used to transform a payload.</p> <div class="seeAlso"> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/models-mappings.html#models-mappings-mappings">Mapping Templates</a> </div></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Template {
     /// <p>The Apache <a href="http://velocity.apache.org/engine/devel/vtl-reference-guide.html" target="_blank">Velocity Template Language (VTL)</a> template content used for the template resource.</p>
     #[serde(rename = "value")]
@@ -2753,7 +2753,7 @@ pub struct Template {
 }
 
 /// <p>Make a request to simulate the execution of an <a>Authorizer</a>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct TestInvokeAuthorizerRequest {
     /// <p>[Optional] A key-value map of additional context variables.</p>
     #[serde(rename = "additionalContext")]
@@ -2784,7 +2784,7 @@ pub struct TestInvokeAuthorizerRequest {
 }
 
 /// <p>Represents the response of the test invoke request for a custom <a>Authorizer</a></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct TestInvokeAuthorizerResponse {
     #[serde(rename = "authorization")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2816,7 +2816,7 @@ pub struct TestInvokeAuthorizerResponse {
 }
 
 /// <p>Make a request to simulate the execution of a <a>Method</a>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct TestInvokeMethodRequest {
     /// <p>The simulated request body of an incoming invocation request.</p>
     #[serde(rename = "body")]
@@ -2850,7 +2850,7 @@ pub struct TestInvokeMethodRequest {
 }
 
 /// <p><p>Represents the response of the test invoke request in the HTTP method.</p> <div class="seeAlso"> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-test-method.html#how-to-test-method-console">Test API using the API Gateway console</a> </div></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct TestInvokeMethodResponse {
     /// <p>The body of the HTTP response.</p>
     #[serde(rename = "body")]
@@ -2875,7 +2875,7 @@ pub struct TestInvokeMethodResponse {
 }
 
 /// <p> The API request rate limits.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ThrottleSettings {
     /// <p>The API request burst limit, the maximum rate limit over a time ranging from one to a few seconds, depending upon whether the underlying token bucket is at its full capacity.</p>
     #[serde(rename = "burstLimit")]
@@ -2888,7 +2888,7 @@ pub struct ThrottleSettings {
 }
 
 /// <p>Removes a tag from a given resource.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UntagResourceRequest {
     /// <p>[Required] The ARN of a resource that can be tagged. The resource ARN must be URL-encoded. At present, <a>Stage</a> is the only taggable resource.</p>
     #[serde(rename = "resourceArn")]
@@ -2899,7 +2899,7 @@ pub struct UntagResourceRequest {
 }
 
 /// <p>Requests API Gateway to change information about the current <a>Account</a> resource.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateAccountRequest {
     /// <p>A list of update operations to be applied to the specified resource and in the order specified in this list.</p>
     #[serde(rename = "patchOperations")]
@@ -2908,7 +2908,7 @@ pub struct UpdateAccountRequest {
 }
 
 /// <p>A request to change information about an <a>ApiKey</a> resource.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateApiKeyRequest {
     /// <p>[Required] The identifier of the <a>ApiKey</a> resource to be updated.</p>
     #[serde(rename = "apiKey")]
@@ -2920,7 +2920,7 @@ pub struct UpdateApiKeyRequest {
 }
 
 /// <p>Request to update an existing <a>Authorizer</a> resource.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateAuthorizerRequest {
     /// <p>[Required] The identifier of the <a>Authorizer</a> resource.</p>
     #[serde(rename = "authorizerId")]
@@ -2935,7 +2935,7 @@ pub struct UpdateAuthorizerRequest {
 }
 
 /// <p>A request to change information about the <a>BasePathMapping</a> resource.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateBasePathMappingRequest {
     /// <p>[Required] The base path of the <a>BasePathMapping</a> resource to change.</p>
     #[serde(rename = "basePath")]
@@ -2950,7 +2950,7 @@ pub struct UpdateBasePathMappingRequest {
 }
 
 /// <p>A request to change information about an <a>ClientCertificate</a> resource.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateClientCertificateRequest {
     /// <p>[Required] The identifier of the <a>ClientCertificate</a> resource to be updated.</p>
     #[serde(rename = "clientCertificateId")]
@@ -2962,7 +2962,7 @@ pub struct UpdateClientCertificateRequest {
 }
 
 /// <p>Requests API Gateway to change information about a <a>Deployment</a> resource.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateDeploymentRequest {
     /// <p>The replacement identifier for the <a>Deployment</a> resource to change information about.</p>
     #[serde(rename = "deploymentId")]
@@ -2977,7 +2977,7 @@ pub struct UpdateDeploymentRequest {
 }
 
 /// <p>Updates an existing documentation part of a given API.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateDocumentationPartRequest {
     /// <p>[Required] The identifier of the to-be-updated documentation part.</p>
     #[serde(rename = "documentationPartId")]
@@ -2992,7 +2992,7 @@ pub struct UpdateDocumentationPartRequest {
 }
 
 /// <p>Updates an existing documentation version of an API.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateDocumentationVersionRequest {
     /// <p>[Required] The version identifier of the to-be-updated documentation version.</p>
     #[serde(rename = "documentationVersion")]
@@ -3007,7 +3007,7 @@ pub struct UpdateDocumentationVersionRequest {
 }
 
 /// <p>A request to change information about the <a>DomainName</a> resource.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateDomainNameRequest {
     /// <p>[Required] The name of the <a>DomainName</a> resource to be changed.</p>
     #[serde(rename = "domainName")]
@@ -3019,7 +3019,7 @@ pub struct UpdateDomainNameRequest {
 }
 
 /// <p>Updates a <a>GatewayResponse</a> of a specified response type on the given <a>RestApi</a>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateGatewayResponseRequest {
     /// <p>A list of update operations to be applied to the specified resource and in the order specified in this list.</p>
     #[serde(rename = "patchOperations")]
@@ -3034,7 +3034,7 @@ pub struct UpdateGatewayResponseRequest {
 }
 
 /// <p>Represents an update integration request.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateIntegrationRequest {
     /// <p>[Required] Represents an update integration request's HTTP method.</p>
     #[serde(rename = "httpMethod")]
@@ -3052,7 +3052,7 @@ pub struct UpdateIntegrationRequest {
 }
 
 /// <p>Represents an update integration response request.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateIntegrationResponseRequest {
     /// <p>[Required] Specifies an update integration response request's HTTP method.</p>
     #[serde(rename = "httpMethod")]
@@ -3073,7 +3073,7 @@ pub struct UpdateIntegrationResponseRequest {
 }
 
 /// <p>Request to update an existing <a>Method</a> resource.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateMethodRequest {
     /// <p>[Required] The HTTP verb of the <a>Method</a> resource.</p>
     #[serde(rename = "httpMethod")]
@@ -3091,7 +3091,7 @@ pub struct UpdateMethodRequest {
 }
 
 /// <p>A request to update an existing <a>MethodResponse</a> resource.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateMethodResponseRequest {
     /// <p>[Required] The HTTP verb of the <a>Method</a> resource.</p>
     #[serde(rename = "httpMethod")]
@@ -3112,7 +3112,7 @@ pub struct UpdateMethodResponseRequest {
 }
 
 /// <p>Request to update an existing model in an existing <a>RestApi</a> resource.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateModelRequest {
     /// <p>[Required] The name of the model to update.</p>
     #[serde(rename = "modelName")]
@@ -3127,7 +3127,7 @@ pub struct UpdateModelRequest {
 }
 
 /// <p>Updates a <a>RequestValidator</a> of a given <a>RestApi</a>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateRequestValidatorRequest {
     /// <p>A list of update operations to be applied to the specified resource and in the order specified in this list.</p>
     #[serde(rename = "patchOperations")]
@@ -3142,7 +3142,7 @@ pub struct UpdateRequestValidatorRequest {
 }
 
 /// <p>Request to change information about a <a>Resource</a> resource.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateResourceRequest {
     /// <p>A list of update operations to be applied to the specified resource and in the order specified in this list.</p>
     #[serde(rename = "patchOperations")]
@@ -3157,7 +3157,7 @@ pub struct UpdateResourceRequest {
 }
 
 /// <p>Request to update an existing <a>RestApi</a> resource in your collection.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateRestApiRequest {
     /// <p>A list of update operations to be applied to the specified resource and in the order specified in this list.</p>
     #[serde(rename = "patchOperations")]
@@ -3169,7 +3169,7 @@ pub struct UpdateRestApiRequest {
 }
 
 /// <p>Requests API Gateway to change information about a <a>Stage</a> resource.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateStageRequest {
     /// <p>A list of update operations to be applied to the specified resource and in the order specified in this list.</p>
     #[serde(rename = "patchOperations")]
@@ -3184,7 +3184,7 @@ pub struct UpdateStageRequest {
 }
 
 /// <p>The PATCH request to update a usage plan of a given plan Id.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateUsagePlanRequest {
     /// <p>A list of update operations to be applied to the specified resource and in the order specified in this list.</p>
     #[serde(rename = "patchOperations")]
@@ -3196,7 +3196,7 @@ pub struct UpdateUsagePlanRequest {
 }
 
 /// <p>The PATCH request to grant a temporary extension to the remaining quota of a usage plan associated with a specified API key.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateUsageRequest {
     /// <p>[Required] The identifier of the API key associated with the usage plan in which a temporary extension is granted to the remaining quota.</p>
     #[serde(rename = "keyId")]
@@ -3211,7 +3211,7 @@ pub struct UpdateUsageRequest {
 }
 
 /// <p>Updates an existing <a>VpcLink</a> of a specified identifier.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateVpcLinkRequest {
     /// <p>A list of update operations to be applied to the specified resource and in the order specified in this list.</p>
     #[serde(rename = "patchOperations")]
@@ -3223,7 +3223,7 @@ pub struct UpdateVpcLinkRequest {
 }
 
 /// <p><p>Represents the usage data of a usage plan.</p> <div class="remarks"/> <div class="seeAlso"> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-api-usage-plans.html">Create and Use Usage Plans</a>, <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-create-usage-plans-with-console.html#api-gateway-usage-plan-manage-usage">Manage Usage in a Usage Plan</a> </div></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Usage {
     /// <p>The ending date of the usage data.</p>
     #[serde(rename = "endDate")]
@@ -3247,7 +3247,7 @@ pub struct Usage {
 }
 
 /// <p><p>Represents a usage plan than can specify who can assess associated API stages with specified request limits and quotas.</p> <div class="remarks"> <p>In a usage plan, you associate an API by specifying the API&#39;s Id and a stage name of the specified API. You add plan customers by adding API keys to the plan. </p> </div> <div class="seeAlso"> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-api-usage-plans.html">Create and Use Usage Plans</a> </div></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UsagePlan {
     /// <p>The associated API stages of a usage plan.</p>
     #[serde(rename = "apiStages")]
@@ -3280,7 +3280,7 @@ pub struct UsagePlan {
 }
 
 /// <p><p>Represents a usage plan key to identify a plan customer.</p> <div class="remarks"> <p>To associate an API stage with a selected API key in a usage plan, you must create a UsagePlanKey resource to represent the selected <a>ApiKey</a>.</p> </div>&quot; <div class="seeAlso"> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-api-usage-plans.html">Create and Use Usage Plans</a> </div></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UsagePlanKey {
     /// <p>The Id of a usage plan key.</p>
     #[serde(rename = "id")]
@@ -3301,7 +3301,7 @@ pub struct UsagePlanKey {
 }
 
 /// <p><p>Represents the collection of usage plan keys added to usage plans for the associated API keys and, possibly, other types of keys.</p> <div class="seeAlso"> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-api-usage-plans.html">Create and Use Usage Plans</a> </div></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UsagePlanKeys {
     /// <p>The current page of elements from this collection.</p>
     #[serde(rename = "items")]
@@ -3313,7 +3313,7 @@ pub struct UsagePlanKeys {
 }
 
 /// <p><p>Represents a collection of usage plans for an AWS account.</p> <div class="seeAlso"> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-api-usage-plans.html">Create and Use Usage Plans</a> </div></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UsagePlans {
     /// <p>The current page of elements from this collection.</p>
     #[serde(rename = "items")]
@@ -3325,7 +3325,7 @@ pub struct UsagePlans {
 }
 
 /// <p><p>A API Gateway VPC link for a <a>RestApi</a> to access resources in an Amazon Virtual Private Cloud (VPC).</p> <div class="remarks"> <p><p>To enable access to a resource in an Amazon Virtual Private Cloud through Amazon API Gateway, you, as an API developer, create a <a>VpcLink</a> resource targeted for one or more network load balancers of the VPC and then integrate an API method with a private integration that uses the <a>VpcLink</a>. The private integration has an integration type of <code>HTTP</code> or <code>HTTP<em>PROXY</code> and has a connection type of <code>VPC</em>LINK</code>. The integration uses the <code>connectionId</code> property to identify the <a>VpcLink</a> used.</p> </p> </div></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct VpcLink {
     /// <p>The description of the VPC link.</p>
     #[serde(rename = "description")]
@@ -3354,7 +3354,7 @@ pub struct VpcLink {
 }
 
 /// <p><p>The collection of VPC links under the caller&#39;s account in a region.</p> <div class="seeAlso"> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/getting-started-with-private-integration.html">Getting Started with Private Integrations</a>, <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-private-integration.html">Set up Private Integrations</a> </div></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct VpcLinks {
     /// <p>The current page of elements from this collection.</p>
     #[serde(rename = "items")]

--- a/rusoto/services/apigateway/src/generated.rs
+++ b/rusoto/services/apigateway/src/generated.rs
@@ -3394,7 +3394,8 @@ impl CreateApiKeyError {
     pub fn from_body(body: &str) -> CreateApiKeyError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3496,7 +3497,8 @@ impl CreateAuthorizerError {
     pub fn from_body(body: &str) -> CreateAuthorizerError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3598,7 +3600,8 @@ impl CreateBasePathMappingError {
     pub fn from_body(body: &str) -> CreateBasePathMappingError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3706,7 +3709,8 @@ impl CreateDeploymentError {
     pub fn from_body(body: &str) -> CreateDeploymentError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3818,7 +3822,8 @@ impl CreateDocumentationPartError {
     pub fn from_body(body: &str) -> CreateDocumentationPartError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3928,7 +3933,8 @@ impl CreateDocumentationVersionError {
     pub fn from_body(body: &str) -> CreateDocumentationVersionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4034,7 +4040,8 @@ impl CreateDomainNameError {
     pub fn from_body(body: &str) -> CreateDomainNameError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4134,7 +4141,8 @@ impl CreateModelError {
     pub fn from_body(body: &str) -> CreateModelError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4236,7 +4244,8 @@ impl CreateRequestValidatorError {
     pub fn from_body(body: &str) -> CreateRequestValidatorError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4342,7 +4351,8 @@ impl CreateResourceError {
     pub fn from_body(body: &str) -> CreateResourceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4446,7 +4456,8 @@ impl CreateRestApiError {
     pub fn from_body(body: &str) -> CreateRestApiError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4546,7 +4557,8 @@ impl CreateStageError {
     pub fn from_body(body: &str) -> CreateStageError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4650,7 +4662,8 @@ impl CreateUsagePlanError {
     pub fn from_body(body: &str) -> CreateUsagePlanError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4756,7 +4769,8 @@ impl CreateUsagePlanKeyError {
     pub fn from_body(body: &str) -> CreateUsagePlanKeyError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4856,7 +4870,8 @@ impl CreateVpcLinkError {
     pub fn from_body(body: &str) -> CreateVpcLinkError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4946,7 +4961,8 @@ impl DeleteApiKeyError {
     pub fn from_body(body: &str) -> DeleteApiKeyError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5038,7 +5054,8 @@ impl DeleteAuthorizerError {
     pub fn from_body(body: &str) -> DeleteAuthorizerError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5140,7 +5157,8 @@ impl DeleteBasePathMappingError {
     pub fn from_body(body: &str) -> DeleteBasePathMappingError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5242,7 +5260,8 @@ impl DeleteClientCertificateError {
     pub fn from_body(body: &str) -> DeleteClientCertificateError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5340,7 +5359,8 @@ impl DeleteDeploymentError {
     pub fn from_body(body: &str) -> DeleteDeploymentError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5438,7 +5458,8 @@ impl DeleteDocumentationPartError {
     pub fn from_body(body: &str) -> DeleteDocumentationPartError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5542,7 +5563,8 @@ impl DeleteDocumentationVersionError {
     pub fn from_body(body: &str) -> DeleteDocumentationVersionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5642,7 +5664,8 @@ impl DeleteDomainNameError {
     pub fn from_body(body: &str) -> DeleteDomainNameError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5736,7 +5759,8 @@ impl DeleteGatewayResponseError {
     pub fn from_body(body: &str) -> DeleteGatewayResponseError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5838,7 +5862,8 @@ impl DeleteIntegrationError {
     pub fn from_body(body: &str) -> DeleteIntegrationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5938,7 +5963,8 @@ impl DeleteIntegrationResponseError {
     pub fn from_body(body: &str) -> DeleteIntegrationResponseError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6040,7 +6066,8 @@ impl DeleteMethodError {
     pub fn from_body(body: &str) -> DeleteMethodError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6134,7 +6161,8 @@ impl DeleteMethodResponseError {
     pub fn from_body(body: &str) -> DeleteMethodResponseError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6238,7 +6266,8 @@ impl DeleteModelError {
     pub fn from_body(body: &str) -> DeleteModelError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6336,7 +6365,8 @@ impl DeleteRequestValidatorError {
     pub fn from_body(body: &str) -> DeleteRequestValidatorError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6440,7 +6470,8 @@ impl DeleteResourceError {
     pub fn from_body(body: &str) -> DeleteResourceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6540,7 +6571,8 @@ impl DeleteRestApiError {
     pub fn from_body(body: &str) -> DeleteRestApiError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6636,7 +6668,8 @@ impl DeleteStageError {
     pub fn from_body(body: &str) -> DeleteStageError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6730,7 +6763,8 @@ impl DeleteUsagePlanError {
     pub fn from_body(body: &str) -> DeleteUsagePlanError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6828,7 +6862,8 @@ impl DeleteUsagePlanKeyError {
     pub fn from_body(body: &str) -> DeleteUsagePlanKeyError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6930,7 +6965,8 @@ impl DeleteVpcLinkError {
     pub fn from_body(body: &str) -> DeleteVpcLinkError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7026,7 +7062,8 @@ impl FlushStageAuthorizersCacheError {
     pub fn from_body(body: &str) -> FlushStageAuthorizersCacheError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7124,7 +7161,8 @@ impl FlushStageCacheError {
     pub fn from_body(body: &str) -> FlushStageCacheError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7218,7 +7256,8 @@ impl GenerateClientCertificateError {
     pub fn from_body(body: &str) -> GenerateClientCertificateError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7310,7 +7349,8 @@ impl GetAccountError {
     pub fn from_body(body: &str) -> GetAccountError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7396,7 +7436,8 @@ impl GetApiKeyError {
     pub fn from_body(body: &str) -> GetApiKeyError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7482,7 +7523,8 @@ impl GetApiKeysError {
     pub fn from_body(body: &str) -> GetApiKeysError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7570,7 +7612,8 @@ impl GetAuthorizerError {
     pub fn from_body(body: &str) -> GetAuthorizerError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7662,7 +7705,8 @@ impl GetAuthorizersError {
     pub fn from_body(body: &str) -> GetAuthorizersError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7756,7 +7800,8 @@ impl GetBasePathMappingError {
     pub fn from_body(body: &str) -> GetBasePathMappingError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7848,7 +7893,8 @@ impl GetBasePathMappingsError {
     pub fn from_body(body: &str) -> GetBasePathMappingsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7940,7 +7986,8 @@ impl GetClientCertificateError {
     pub fn from_body(body: &str) -> GetClientCertificateError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8032,7 +8079,8 @@ impl GetClientCertificatesError {
     pub fn from_body(body: &str) -> GetClientCertificatesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8126,7 +8174,8 @@ impl GetDeploymentError {
     pub fn from_body(body: &str) -> GetDeploymentError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8222,7 +8271,8 @@ impl GetDeploymentsError {
     pub fn from_body(body: &str) -> GetDeploymentsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8316,7 +8366,8 @@ impl GetDocumentationPartError {
     pub fn from_body(body: &str) -> GetDocumentationPartError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8410,7 +8461,8 @@ impl GetDocumentationPartsError {
     pub fn from_body(body: &str) -> GetDocumentationPartsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8506,7 +8558,8 @@ impl GetDocumentationVersionError {
     pub fn from_body(body: &str) -> GetDocumentationVersionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8600,7 +8653,8 @@ impl GetDocumentationVersionsError {
     pub fn from_body(body: &str) -> GetDocumentationVersionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8698,7 +8752,8 @@ impl GetDomainNameError {
     pub fn from_body(body: &str) -> GetDomainNameError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8792,7 +8847,8 @@ impl GetDomainNamesError {
     pub fn from_body(body: &str) -> GetDomainNamesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8886,7 +8942,8 @@ impl GetExportError {
     pub fn from_body(body: &str) -> GetExportError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8978,7 +9035,8 @@ impl GetGatewayResponseError {
     pub fn from_body(body: &str) -> GetGatewayResponseError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9072,7 +9130,8 @@ impl GetGatewayResponsesError {
     pub fn from_body(body: &str) -> GetGatewayResponsesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9168,7 +9227,8 @@ impl GetIntegrationError {
     pub fn from_body(body: &str) -> GetIntegrationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9258,7 +9318,8 @@ impl GetIntegrationResponseError {
     pub fn from_body(body: &str) -> GetIntegrationResponseError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9350,7 +9411,8 @@ impl GetMethodError {
     pub fn from_body(body: &str) -> GetMethodError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9436,7 +9498,8 @@ impl GetMethodResponseError {
     pub fn from_body(body: &str) -> GetMethodResponseError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9528,7 +9591,8 @@ impl GetModelError {
     pub fn from_body(body: &str) -> GetModelError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9616,7 +9680,8 @@ impl GetModelTemplateError {
     pub fn from_body(body: &str) -> GetModelTemplateError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9712,7 +9777,8 @@ impl GetModelsError {
     pub fn from_body(body: &str) -> GetModelsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9802,7 +9868,8 @@ impl GetRequestValidatorError {
     pub fn from_body(body: &str) -> GetRequestValidatorError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9896,7 +9963,8 @@ impl GetRequestValidatorsError {
     pub fn from_body(body: &str) -> GetRequestValidatorsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9992,7 +10060,8 @@ impl GetResourceError {
     pub fn from_body(body: &str) -> GetResourceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -10082,7 +10151,8 @@ impl GetResourcesError {
     pub fn from_body(body: &str) -> GetResourcesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -10174,7 +10244,8 @@ impl GetRestApiError {
     pub fn from_body(body: &str) -> GetRestApiError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -10260,7 +10331,8 @@ impl GetRestApisError {
     pub fn from_body(body: &str) -> GetRestApisError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -10354,7 +10426,8 @@ impl GetSdkError {
     pub fn from_body(body: &str) -> GetSdkError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -10444,7 +10517,8 @@ impl GetSdkTypeError {
     pub fn from_body(body: &str) -> GetSdkTypeError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -10528,7 +10602,8 @@ impl GetSdkTypesError {
     pub fn from_body(body: &str) -> GetSdkTypesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -10614,7 +10689,8 @@ impl GetStageError {
     pub fn from_body(body: &str) -> GetStageError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -10700,7 +10776,8 @@ impl GetStagesError {
     pub fn from_body(body: &str) -> GetStagesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -10790,7 +10867,8 @@ impl GetTagsError {
     pub fn from_body(body: &str) -> GetTagsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -10884,7 +10962,8 @@ impl GetUsageError {
     pub fn from_body(body: &str) -> GetUsageError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -10974,7 +11053,8 @@ impl GetUsagePlanError {
     pub fn from_body(body: &str) -> GetUsagePlanError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -11068,7 +11148,8 @@ impl GetUsagePlanKeyError {
     pub fn from_body(body: &str) -> GetUsagePlanKeyError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -11164,7 +11245,8 @@ impl GetUsagePlanKeysError {
     pub fn from_body(body: &str) -> GetUsagePlanKeysError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -11262,7 +11344,8 @@ impl GetUsagePlansError {
     pub fn from_body(body: &str) -> GetUsagePlansError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -11360,7 +11443,8 @@ impl GetVpcLinkError {
     pub fn from_body(body: &str) -> GetVpcLinkError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -11446,7 +11530,8 @@ impl GetVpcLinksError {
     pub fn from_body(body: &str) -> GetVpcLinksError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -11542,7 +11627,8 @@ impl ImportApiKeysError {
     pub fn from_body(body: &str) -> ImportApiKeysError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -11648,7 +11734,8 @@ impl ImportDocumentationPartsError {
     pub fn from_body(body: &str) -> ImportDocumentationPartsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -11752,7 +11839,8 @@ impl ImportRestApiError {
     pub fn from_body(body: &str) -> ImportRestApiError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -11854,7 +11942,8 @@ impl PutGatewayResponseError {
     pub fn from_body(body: &str) -> PutGatewayResponseError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -11958,7 +12047,8 @@ impl PutIntegrationError {
     pub fn from_body(body: &str) -> PutIntegrationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -12062,7 +12152,8 @@ impl PutIntegrationResponseError {
     pub fn from_body(body: &str) -> PutIntegrationResponseError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -12172,7 +12263,8 @@ impl PutMethodError {
     pub fn from_body(body: &str) -> PutMethodError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -12274,7 +12366,8 @@ impl PutMethodResponseError {
     pub fn from_body(body: &str) -> PutMethodResponseError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -12384,7 +12477,8 @@ impl PutRestApiError {
     pub fn from_body(body: &str) -> PutRestApiError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -12486,7 +12580,8 @@ impl TagResourceError {
     pub fn from_body(body: &str) -> TagResourceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -12586,7 +12681,8 @@ impl TestInvokeAuthorizerError {
     pub fn from_body(body: &str) -> TestInvokeAuthorizerError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -12684,7 +12780,8 @@ impl TestInvokeMethodError {
     pub fn from_body(body: &str) -> TestInvokeMethodError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -12782,7 +12879,8 @@ impl UntagResourceError {
     pub fn from_body(body: &str) -> UntagResourceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -12882,7 +12980,8 @@ impl UpdateAccountError {
     pub fn from_body(body: &str) -> UpdateAccountError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -12980,7 +13079,8 @@ impl UpdateApiKeyError {
     pub fn from_body(body: &str) -> UpdateApiKeyError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -13076,7 +13176,8 @@ impl UpdateAuthorizerError {
     pub fn from_body(body: &str) -> UpdateAuthorizerError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -13174,7 +13275,8 @@ impl UpdateBasePathMappingError {
     pub fn from_body(body: &str) -> UpdateBasePathMappingError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -13276,7 +13378,8 @@ impl UpdateClientCertificateError {
     pub fn from_body(body: &str) -> UpdateClientCertificateError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -13376,7 +13479,8 @@ impl UpdateDeploymentError {
     pub fn from_body(body: &str) -> UpdateDeploymentError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -13480,7 +13584,8 @@ impl UpdateDocumentationPartError {
     pub fn from_body(body: &str) -> UpdateDocumentationPartError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -13588,7 +13693,8 @@ impl UpdateDocumentationVersionError {
     pub fn from_body(body: &str) -> UpdateDocumentationVersionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -13692,7 +13798,8 @@ impl UpdateDomainNameError {
     pub fn from_body(body: &str) -> UpdateDomainNameError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -13792,7 +13899,8 @@ impl UpdateGatewayResponseError {
     pub fn from_body(body: &str) -> UpdateGatewayResponseError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -13892,7 +14000,8 @@ impl UpdateIntegrationError {
     pub fn from_body(body: &str) -> UpdateIntegrationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -13996,7 +14105,8 @@ impl UpdateIntegrationResponseError {
     pub fn from_body(body: &str) -> UpdateIntegrationResponseError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -14100,7 +14210,8 @@ impl UpdateMethodError {
     pub fn from_body(body: &str) -> UpdateMethodError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -14200,7 +14311,8 @@ impl UpdateMethodResponseError {
     pub fn from_body(body: &str) -> UpdateMethodResponseError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -14308,7 +14420,8 @@ impl UpdateModelError {
     pub fn from_body(body: &str) -> UpdateModelError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -14404,7 +14517,8 @@ impl UpdateRequestValidatorError {
     pub fn from_body(body: &str) -> UpdateRequestValidatorError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -14504,7 +14618,8 @@ impl UpdateResourceError {
     pub fn from_body(body: &str) -> UpdateResourceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -14606,7 +14721,8 @@ impl UpdateRestApiError {
     pub fn from_body(body: &str) -> UpdateRestApiError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -14708,7 +14824,8 @@ impl UpdateStageError {
     pub fn from_body(body: &str) -> UpdateStageError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -14804,7 +14921,8 @@ impl UpdateUsageError {
     pub fn from_body(body: &str) -> UpdateUsageError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -14900,7 +15018,8 @@ impl UpdateUsagePlanError {
     pub fn from_body(body: &str) -> UpdateUsagePlanError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -15002,7 +15121,8 @@ impl UpdateVpcLinkError {
     pub fn from_body(body: &str) -> UpdateVpcLinkError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/application-autoscaling/src/generated.rs
+++ b/rusoto/services/application-autoscaling/src/generated.rs
@@ -643,7 +643,8 @@ impl DeleteScalingPolicyError {
     pub fn from_body(body: &str) -> DeleteScalingPolicyError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -735,7 +736,8 @@ impl DeleteScheduledActionError {
     pub fn from_body(body: &str) -> DeleteScheduledActionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -827,7 +829,8 @@ impl DeregisterScalableTargetError {
     pub fn from_body(body: &str) -> DeregisterScalableTargetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -919,7 +922,8 @@ impl DescribeScalableTargetsError {
     pub fn from_body(body: &str) -> DescribeScalableTargetsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1011,7 +1015,8 @@ impl DescribeScalingActivitiesError {
     pub fn from_body(body: &str) -> DescribeScalingActivitiesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1109,7 +1114,8 @@ impl DescribeScalingPoliciesError {
     pub fn from_body(body: &str) -> DescribeScalingPoliciesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1207,7 +1213,8 @@ impl DescribeScheduledActionsError {
     pub fn from_body(body: &str) -> DescribeScheduledActionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1303,7 +1310,8 @@ impl PutScalingPolicyError {
     pub fn from_body(body: &str) -> PutScalingPolicyError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1403,7 +1411,8 @@ impl PutScheduledActionError {
     pub fn from_body(body: &str) -> PutScheduledActionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1499,7 +1508,8 @@ impl RegisterScalableTargetError {
     pub fn from_body(body: &str) -> RegisterScalableTargetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/application-autoscaling/src/generated.rs
+++ b/rusoto/services/application-autoscaling/src/generated.rs
@@ -31,7 +31,7 @@ use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 /// <p>Represents a CloudWatch alarm associated with a scaling policy.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Alarm {
     /// <p>The Amazon Resource Name (ARN) of the alarm.</p>
     #[serde(rename = "AlarmARN")]
@@ -42,7 +42,7 @@ pub struct Alarm {
 }
 
 /// <p>Configures a customized metric for a target tracking policy.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CustomizedMetricSpecification {
     /// <p>The dimensions of the metric.</p>
     #[serde(rename = "Dimensions")]
@@ -63,7 +63,7 @@ pub struct CustomizedMetricSpecification {
     pub unit: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteScalingPolicyRequest {
     /// <p>The name of the scaling policy.</p>
     #[serde(rename = "PolicyName")]
@@ -79,10 +79,10 @@ pub struct DeleteScalingPolicyRequest {
     pub service_namespace: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteScalingPolicyResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteScheduledActionRequest {
     /// <p><p>The identifier of the resource associated with the scheduled action. This string consists of the resource type and unique identifier.</p> <ul> <li> <p>ECS service - The resource type is <code>service</code> and the unique identifier is the cluster name and service name. Example: <code>service/default/sample-webapp</code>.</p> </li> <li> <p>Spot fleet request - The resource type is <code>spot-fleet-request</code> and the unique identifier is the Spot fleet request ID. Example: <code>spot-fleet-request/sfr-73fbd2ce-aa30-494c-8788-1cee4EXAMPLE</code>.</p> </li> <li> <p>EMR cluster - The resource type is <code>instancegroup</code> and the unique identifier is the cluster ID and instance group ID. Example: <code>instancegroup/j-2EEZNYKUA1NTV/ig-1791Y4E1L8YI0</code>.</p> </li> <li> <p>AppStream 2.0 fleet - The resource type is <code>fleet</code> and the unique identifier is the fleet name. Example: <code>fleet/sample-fleet</code>.</p> </li> <li> <p>DynamoDB table - The resource type is <code>table</code> and the unique identifier is the resource ID. Example: <code>table/my-table</code>.</p> </li> <li> <p>DynamoDB global secondary index - The resource type is <code>index</code> and the unique identifier is the resource ID. Example: <code>table/my-table/index/my-table-index</code>.</p> </li> <li> <p>Aurora DB cluster - The resource type is <code>cluster</code> and the unique identifier is the cluster name. Example: <code>cluster:my-db-cluster</code>.</p> </li> <li> <p>Amazon SageMaker endpoint variants - The resource type is <code>variant</code> and the unique identifier is the resource ID. Example: <code>endpoint/my-end-point/variant/KMeansClustering</code>.</p> </li> </ul></p>
     #[serde(rename = "ResourceId")]
@@ -99,10 +99,10 @@ pub struct DeleteScheduledActionRequest {
     pub service_namespace: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteScheduledActionResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeregisterScalableTargetRequest {
     /// <p><p>The identifier of the resource associated with the scalable target. This string consists of the resource type and unique identifier.</p> <ul> <li> <p>ECS service - The resource type is <code>service</code> and the unique identifier is the cluster name and service name. Example: <code>service/default/sample-webapp</code>.</p> </li> <li> <p>Spot fleet request - The resource type is <code>spot-fleet-request</code> and the unique identifier is the Spot fleet request ID. Example: <code>spot-fleet-request/sfr-73fbd2ce-aa30-494c-8788-1cee4EXAMPLE</code>.</p> </li> <li> <p>EMR cluster - The resource type is <code>instancegroup</code> and the unique identifier is the cluster ID and instance group ID. Example: <code>instancegroup/j-2EEZNYKUA1NTV/ig-1791Y4E1L8YI0</code>.</p> </li> <li> <p>AppStream 2.0 fleet - The resource type is <code>fleet</code> and the unique identifier is the fleet name. Example: <code>fleet/sample-fleet</code>.</p> </li> <li> <p>DynamoDB table - The resource type is <code>table</code> and the unique identifier is the resource ID. Example: <code>table/my-table</code>.</p> </li> <li> <p>DynamoDB global secondary index - The resource type is <code>index</code> and the unique identifier is the resource ID. Example: <code>table/my-table/index/my-table-index</code>.</p> </li> <li> <p>Aurora DB cluster - The resource type is <code>cluster</code> and the unique identifier is the cluster name. Example: <code>cluster:my-db-cluster</code>.</p> </li> <li> <p>Amazon SageMaker endpoint variants - The resource type is <code>variant</code> and the unique identifier is the resource ID. Example: <code>endpoint/my-end-point/variant/KMeansClustering</code>.</p> </li> </ul></p>
     #[serde(rename = "ResourceId")]
@@ -115,10 +115,10 @@ pub struct DeregisterScalableTargetRequest {
     pub service_namespace: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeregisterScalableTargetResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeScalableTargetsRequest {
     /// <p>The maximum number of scalable targets. This value can be between 1 and 50. The default value is 50.</p> <p>If this parameter is used, the operation returns up to <code>MaxResults</code> results at a time, along with a <code>NextToken</code> value. To get the next set of results, include the <code>NextToken</code> value in a subsequent call. If this parameter is not used, the operation returns up to 50 results and a <code>NextToken</code> value, if applicable.</p>
     #[serde(rename = "MaxResults")]
@@ -141,7 +141,7 @@ pub struct DescribeScalableTargetsRequest {
     pub service_namespace: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeScalableTargetsResponse {
     /// <p>The token required to get the next set of results. This value is <code>null</code> if there are no more results to return.</p>
     #[serde(rename = "NextToken")]
@@ -153,7 +153,7 @@ pub struct DescribeScalableTargetsResponse {
     pub scalable_targets: Option<Vec<ScalableTarget>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeScalingActivitiesRequest {
     /// <p>The maximum number of scalable targets. This value can be between 1 and 50. The default value is 50.</p> <p>If this parameter is used, the operation returns up to <code>MaxResults</code> results at a time, along with a <code>NextToken</code> value. To get the next set of results, include the <code>NextToken</code> value in a subsequent call. If this parameter is not used, the operation returns up to 50 results and a <code>NextToken</code> value, if applicable.</p>
     #[serde(rename = "MaxResults")]
@@ -176,7 +176,7 @@ pub struct DescribeScalingActivitiesRequest {
     pub service_namespace: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeScalingActivitiesResponse {
     /// <p>The token required to get the next set of results. This value is <code>null</code> if there are no more results to return.</p>
     #[serde(rename = "NextToken")]
@@ -188,7 +188,7 @@ pub struct DescribeScalingActivitiesResponse {
     pub scaling_activities: Option<Vec<ScalingActivity>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeScalingPoliciesRequest {
     /// <p>The maximum number of scalable targets. This value can be between 1 and 50. The default value is 50.</p> <p>If this parameter is used, the operation returns up to <code>MaxResults</code> results at a time, along with a <code>NextToken</code> value. To get the next set of results, include the <code>NextToken</code> value in a subsequent call. If this parameter is not used, the operation returns up to 50 results and a <code>NextToken</code> value, if applicable.</p>
     #[serde(rename = "MaxResults")]
@@ -215,7 +215,7 @@ pub struct DescribeScalingPoliciesRequest {
     pub service_namespace: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeScalingPoliciesResponse {
     /// <p>The token required to get the next set of results. This value is <code>null</code> if there are no more results to return.</p>
     #[serde(rename = "NextToken")]
@@ -227,7 +227,7 @@ pub struct DescribeScalingPoliciesResponse {
     pub scaling_policies: Option<Vec<ScalingPolicy>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeScheduledActionsRequest {
     /// <p>The maximum number of scheduled action results. This value can be between 1 and 50. The default value is 50.</p> <p>If this parameter is used, the operation returns up to <code>MaxResults</code> results at a time, along with a <code>NextToken</code> value. To get the next set of results, include the <code>NextToken</code> value in a subsequent call. If this parameter is not used, the operation returns up to 50 results and a <code>NextToken</code> value, if applicable.</p>
     #[serde(rename = "MaxResults")]
@@ -254,7 +254,7 @@ pub struct DescribeScheduledActionsRequest {
     pub service_namespace: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeScheduledActionsResponse {
     /// <p>The token required to get the next set of results. This value is <code>null</code> if there are no more results to return.</p>
     #[serde(rename = "NextToken")]
@@ -267,7 +267,7 @@ pub struct DescribeScheduledActionsResponse {
 }
 
 /// <p>Describes the dimension of a metric.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct MetricDimension {
     /// <p>The name of the dimension.</p>
     #[serde(rename = "Name")]
@@ -278,7 +278,7 @@ pub struct MetricDimension {
 }
 
 /// <p>Configures a predefined metric for a target tracking policy.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct PredefinedMetricSpecification {
     /// <p>The metric type. The <code>ALBRequestCountPerTarget</code> metric type applies only to Spot fleet requests and ECS services.</p>
     #[serde(rename = "PredefinedMetricType")]
@@ -289,7 +289,7 @@ pub struct PredefinedMetricSpecification {
     pub resource_label: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PutScalingPolicyRequest {
     /// <p>The name of the scaling policy.</p>
     #[serde(rename = "PolicyName")]
@@ -318,7 +318,7 @@ pub struct PutScalingPolicyRequest {
         Option<TargetTrackingScalingPolicyConfiguration>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PutScalingPolicyResponse {
     /// <p>The CloudWatch alarms created for the target tracking policy.</p>
     #[serde(rename = "Alarms")]
@@ -329,7 +329,7 @@ pub struct PutScalingPolicyResponse {
     pub policy_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PutScheduledActionRequest {
     /// <p>The date and time for the scheduled action to end.</p>
     #[serde(rename = "EndTime")]
@@ -362,10 +362,10 @@ pub struct PutScheduledActionRequest {
     pub start_time: Option<f64>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PutScheduledActionResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RegisterScalableTargetRequest {
     /// <p>The maximum value to scale to in response to a scale out event. This parameter is required if you are registering a scalable target.</p>
     #[serde(rename = "MaxCapacity")]
@@ -390,11 +390,11 @@ pub struct RegisterScalableTargetRequest {
     pub service_namespace: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RegisterScalableTargetResponse {}
 
 /// <p>Represents a scalable target.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ScalableTarget {
     /// <p>The Unix timestamp for when the scalable target was created.</p>
     #[serde(rename = "CreationTime")]
@@ -420,7 +420,7 @@ pub struct ScalableTarget {
 }
 
 /// <p>Represents the minimum and maximum capacity for a scheduled action.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ScalableTargetAction {
     /// <p>The maximum capacity.</p>
     #[serde(rename = "MaxCapacity")]
@@ -433,7 +433,7 @@ pub struct ScalableTargetAction {
 }
 
 /// <p>Represents a scaling activity.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ScalingActivity {
     /// <p>The unique identifier of the scaling activity.</p>
     #[serde(rename = "ActivityId")]
@@ -474,7 +474,7 @@ pub struct ScalingActivity {
 }
 
 /// <p>Represents a scaling policy.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ScalingPolicy {
     /// <p>The CloudWatch alarms associated with the scaling policy.</p>
     #[serde(rename = "Alarms")]
@@ -513,7 +513,7 @@ pub struct ScalingPolicy {
 }
 
 /// <p>Represents a scheduled action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ScheduledAction {
     /// <p>The date and time that the scheduled action was created.</p>
     #[serde(rename = "CreationTime")]
@@ -552,7 +552,7 @@ pub struct ScheduledAction {
 }
 
 /// <p><p>Represents a step adjustment for a <a>StepScalingPolicyConfiguration</a>. Describes an adjustment based on the difference between the value of the aggregated CloudWatch metric and the breach threshold that you&#39;ve defined for the alarm. </p> <p>For the following examples, suppose that you have an alarm with a breach threshold of 50:</p> <ul> <li> <p>To trigger the adjustment when the metric is greater than or equal to 50 and less than 60, specify a lower bound of 0 and an upper bound of 10.</p> </li> <li> <p>To trigger the adjustment when the metric is greater than 40 and less than or equal to 50, specify a lower bound of -10 and an upper bound of 0.</p> </li> </ul> <p>There are a few rules for the step adjustments for your step policy:</p> <ul> <li> <p>The ranges of your step adjustments can&#39;t overlap or have a gap.</p> </li> <li> <p>At most one step adjustment can have a null lower bound. If one step adjustment has a negative lower bound, then there must be a step adjustment with a null lower bound.</p> </li> <li> <p>At most one step adjustment can have a null upper bound. If one step adjustment has a positive upper bound, then there must be a step adjustment with a null upper bound.</p> </li> <li> <p>The upper and lower bound can&#39;t be null in the same step adjustment.</p> </li> </ul></p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct StepAdjustment {
     /// <p>The lower bound for the difference between the alarm threshold and the CloudWatch metric. If the metric value is above the breach threshold, the lower bound is inclusive (the metric must be greater than or equal to the threshold plus the lower bound). Otherwise, it is exclusive (the metric must be greater than the threshold plus the lower bound). A null value indicates negative infinity.</p>
     #[serde(rename = "MetricIntervalLowerBound")]
@@ -568,7 +568,7 @@ pub struct StepAdjustment {
 }
 
 /// <p>Represents a step scaling policy configuration.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct StepScalingPolicyConfiguration {
     /// <p>The adjustment type, which specifies how the <code>ScalingAdjustment</code> parameter in a <a>StepAdjustment</a> is interpreted.</p>
     #[serde(rename = "AdjustmentType")]
@@ -593,7 +593,7 @@ pub struct StepScalingPolicyConfiguration {
 }
 
 /// <p>Represents a target tracking scaling policy configuration.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TargetTrackingScalingPolicyConfiguration {
     /// <p>A customized metric.</p>
     #[serde(rename = "CustomizedMetricSpecification")]

--- a/rusoto/services/appstream/src/generated.rs
+++ b/rusoto/services/appstream/src/generated.rs
@@ -31,7 +31,7 @@ use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 /// <p>Describes an application in the application catalog.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Application {
     /// <p>The application name for display.</p>
     #[serde(rename = "DisplayName")]
@@ -63,7 +63,7 @@ pub struct Application {
     pub name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AssociateFleetRequest {
     /// <p>The name of the fleet. </p>
     #[serde(rename = "FleetName")]
@@ -73,11 +73,11 @@ pub struct AssociateFleetRequest {
     pub stack_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AssociateFleetResult {}
 
 /// <p>Describes the capacity for a fleet.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ComputeCapacity {
     /// <p>The desired number of streaming instances.</p>
     #[serde(rename = "DesiredInstances")]
@@ -85,7 +85,7 @@ pub struct ComputeCapacity {
 }
 
 /// <p>Describes the capacity status for a fleet.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ComputeCapacityStatus {
     /// <p>The number of currently available instances that can be used to stream sessions.</p>
     #[serde(rename = "Available")]
@@ -104,7 +104,7 @@ pub struct ComputeCapacityStatus {
     pub running: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CopyImageRequest {
     /// <p>The description that the image will have when it is copied to the destination.</p>
     #[serde(rename = "DestinationImageDescription")]
@@ -121,7 +121,7 @@ pub struct CopyImageRequest {
     pub source_image_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CopyImageResponse {
     /// <p>The name of the destination image.</p>
     #[serde(rename = "DestinationImageName")]
@@ -129,7 +129,7 @@ pub struct CopyImageResponse {
     pub destination_image_name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateDirectoryConfigRequest {
     /// <p>The fully qualified name of the directory (for example, corp.example.com).</p>
     #[serde(rename = "DirectoryName")]
@@ -142,7 +142,7 @@ pub struct CreateDirectoryConfigRequest {
     pub service_account_credentials: ServiceAccountCredentials,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateDirectoryConfigResult {
     /// <p>Information about the directory configuration.</p>
     #[serde(rename = "DirectoryConfig")]
@@ -150,7 +150,7 @@ pub struct CreateDirectoryConfigResult {
     pub directory_config: Option<DirectoryConfig>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateFleetRequest {
     /// <p>The desired capacity for the fleet.</p>
     #[serde(rename = "ComputeCapacity")]
@@ -198,7 +198,7 @@ pub struct CreateFleetRequest {
     pub vpc_config: Option<VpcConfig>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateFleetResult {
     /// <p>Information about the fleet.</p>
     #[serde(rename = "Fleet")]
@@ -206,7 +206,7 @@ pub struct CreateFleetResult {
     pub fleet: Option<Fleet>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateImageBuilderRequest {
     /// <p>The version of the AppStream 2.0 agent to use for this image builder. To use the latest version of the AppStream 2.0 agent, specify [LATEST]. </p>
     #[serde(rename = "AppstreamAgentVersion")]
@@ -243,7 +243,7 @@ pub struct CreateImageBuilderRequest {
     pub vpc_config: Option<VpcConfig>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateImageBuilderResult {
     /// <p>Information about the image builder.</p>
     #[serde(rename = "ImageBuilder")]
@@ -251,7 +251,7 @@ pub struct CreateImageBuilderResult {
     pub image_builder: Option<ImageBuilder>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateImageBuilderStreamingURLRequest {
     /// <p>The name of the image builder.</p>
     #[serde(rename = "Name")]
@@ -262,7 +262,7 @@ pub struct CreateImageBuilderStreamingURLRequest {
     pub validity: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateImageBuilderStreamingURLResult {
     /// <p>The elapsed time, in seconds after the Unix epoch, when this URL expires.</p>
     #[serde(rename = "Expires")]
@@ -274,7 +274,7 @@ pub struct CreateImageBuilderStreamingURLResult {
     pub streaming_url: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateStackRequest {
     /// <p>The description for display.</p>
     #[serde(rename = "Description")]
@@ -301,7 +301,7 @@ pub struct CreateStackRequest {
     pub storage_connectors: Option<Vec<StorageConnector>>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateStackResult {
     /// <p>Information about the stack.</p>
     #[serde(rename = "Stack")]
@@ -309,7 +309,7 @@ pub struct CreateStackResult {
     pub stack: Option<Stack>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateStreamingURLRequest {
     /// <p>The name of the application to launch after the session starts. This is the name that you specified as <b>Name</b> in the Image Assistant.</p>
     #[serde(rename = "ApplicationId")]
@@ -334,7 +334,7 @@ pub struct CreateStreamingURLRequest {
     pub validity: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateStreamingURLResult {
     /// <p>The elapsed time, in seconds after the Unix epoch, when this URL expires.</p>
     #[serde(rename = "Expires")]
@@ -346,34 +346,34 @@ pub struct CreateStreamingURLResult {
     pub streaming_url: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteDirectoryConfigRequest {
     /// <p>The name of the directory configuration.</p>
     #[serde(rename = "DirectoryName")]
     pub directory_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteDirectoryConfigResult {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteFleetRequest {
     /// <p>The name of the fleet.</p>
     #[serde(rename = "Name")]
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteFleetResult {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteImageBuilderRequest {
     /// <p>The name of the image builder.</p>
     #[serde(rename = "Name")]
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteImageBuilderResult {
     /// <p>Information about the image builder.</p>
     #[serde(rename = "ImageBuilder")]
@@ -381,14 +381,14 @@ pub struct DeleteImageBuilderResult {
     pub image_builder: Option<ImageBuilder>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteImageRequest {
     /// <p>The name of the image.</p>
     #[serde(rename = "Name")]
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteImageResult {
     /// <p>Information about the image.</p>
     #[serde(rename = "Image")]
@@ -396,17 +396,17 @@ pub struct DeleteImageResult {
     pub image: Option<Image>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteStackRequest {
     /// <p>The name of the stack.</p>
     #[serde(rename = "Name")]
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteStackResult {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeDirectoryConfigsRequest {
     /// <p>The directory names.</p>
     #[serde(rename = "DirectoryNames")]
@@ -422,7 +422,7 @@ pub struct DescribeDirectoryConfigsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeDirectoryConfigsResult {
     /// <p>Information about the directory configurations. Note that although the response syntax in this topic includes the account password, this password is not returned in the actual response. </p>
     #[serde(rename = "DirectoryConfigs")]
@@ -434,7 +434,7 @@ pub struct DescribeDirectoryConfigsResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeFleetsRequest {
     /// <p>The names of the fleets to describe.</p>
     #[serde(rename = "Names")]
@@ -446,7 +446,7 @@ pub struct DescribeFleetsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeFleetsResult {
     /// <p>Information about the fleets.</p>
     #[serde(rename = "Fleets")]
@@ -458,7 +458,7 @@ pub struct DescribeFleetsResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeImageBuildersRequest {
     /// <p>The maximum size of each page of results.</p>
     #[serde(rename = "MaxResults")]
@@ -474,7 +474,7 @@ pub struct DescribeImageBuildersRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeImageBuildersResult {
     /// <p>Information about the image builders.</p>
     #[serde(rename = "ImageBuilders")]
@@ -486,7 +486,7 @@ pub struct DescribeImageBuildersResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeImagesRequest {
     /// <p>The names of the images to describe.</p>
     #[serde(rename = "Names")]
@@ -494,7 +494,7 @@ pub struct DescribeImagesRequest {
     pub names: Option<Vec<String>>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeImagesResult {
     /// <p>Information about the images.</p>
     #[serde(rename = "Images")]
@@ -502,7 +502,7 @@ pub struct DescribeImagesResult {
     pub images: Option<Vec<Image>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeSessionsRequest {
     /// <p>The authentication method. Specify <code>API</code> for a user authenticated using a streaming URL or <code>SAML</code> for a SAML federated user. The default is to authenticate users using a streaming URL.</p>
     #[serde(rename = "AuthenticationType")]
@@ -528,7 +528,7 @@ pub struct DescribeSessionsRequest {
     pub user_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeSessionsResult {
     /// <p>The pagination token to use to retrieve the next page of results for this operation. If there are no more pages, this value is null.</p>
     #[serde(rename = "NextToken")]
@@ -540,7 +540,7 @@ pub struct DescribeSessionsResult {
     pub sessions: Option<Vec<Session>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeStacksRequest {
     /// <p>The names of the stacks to describe.</p>
     #[serde(rename = "Names")]
@@ -552,7 +552,7 @@ pub struct DescribeStacksRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeStacksResult {
     /// <p>The pagination token to use to retrieve the next page of results for this operation. If there are no more pages, this value is null.</p>
     #[serde(rename = "NextToken")]
@@ -565,7 +565,7 @@ pub struct DescribeStacksResult {
 }
 
 /// <p>Configuration information for the directory used to join domains.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DirectoryConfig {
     /// <p>The time the directory configuration was created.</p>
     #[serde(rename = "CreatedTime")]
@@ -584,7 +584,7 @@ pub struct DirectoryConfig {
     pub service_account_credentials: Option<ServiceAccountCredentials>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DisassociateFleetRequest {
     /// <p>The name of the fleet.</p>
     #[serde(rename = "FleetName")]
@@ -594,11 +594,11 @@ pub struct DisassociateFleetRequest {
     pub stack_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DisassociateFleetResult {}
 
 /// <p>Contains the information needed to join a Microsoft Active Directory domain.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct DomainJoinInfo {
     /// <p>The fully qualified name of the directory (for example, corp.example.com).</p>
     #[serde(rename = "DirectoryName")]
@@ -610,18 +610,18 @@ pub struct DomainJoinInfo {
     pub organizational_unit_distinguished_name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ExpireSessionRequest {
     /// <p>The ID of the streaming session.</p>
     #[serde(rename = "SessionId")]
     pub session_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ExpireSessionResult {}
 
 /// <p>Contains the parameters for a fleet.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Fleet {
     /// <p>The ARN for the fleet.</p>
     #[serde(rename = "Arn")]
@@ -684,7 +684,7 @@ pub struct Fleet {
 }
 
 /// <p>Describes a fleet error.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct FleetError {
     /// <p>The error code.</p>
     #[serde(rename = "ErrorCode")]
@@ -697,7 +697,7 @@ pub struct FleetError {
 }
 
 /// <p>Describes an image.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Image {
     /// <p>The applications associated with the image.</p>
     #[serde(rename = "Applications")]
@@ -757,7 +757,7 @@ pub struct Image {
 }
 
 /// <p>Describes a streaming instance used for editing an image. New images are created from a snapshot through an image builder.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ImageBuilder {
     /// <p>The version of the AppStream 2.0 agent that is currently being used by this image builder. </p>
     #[serde(rename = "AppstreamAgentVersion")]
@@ -821,7 +821,7 @@ pub struct ImageBuilder {
 }
 
 /// <p>Describes the reason why the last image builder state change occurred.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ImageBuilderStateChangeReason {
     /// <p>The state change reason code.</p>
     #[serde(rename = "Code")]
@@ -834,7 +834,7 @@ pub struct ImageBuilderStateChangeReason {
 }
 
 /// <p>Describes the reason why the last image state change occurred.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ImageStateChangeReason {
     /// <p>The state change reason code.</p>
     #[serde(rename = "Code")]
@@ -846,7 +846,7 @@ pub struct ImageStateChangeReason {
     pub message: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListAssociatedFleetsRequest {
     /// <p>The pagination token to use to retrieve the next page of results for this operation. If this value is null, it retrieves the first page.</p>
     #[serde(rename = "NextToken")]
@@ -857,7 +857,7 @@ pub struct ListAssociatedFleetsRequest {
     pub stack_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListAssociatedFleetsResult {
     /// <p>The names of the fleets.</p>
     #[serde(rename = "Names")]
@@ -869,7 +869,7 @@ pub struct ListAssociatedFleetsResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListAssociatedStacksRequest {
     /// <p>The name of the fleet.</p>
     #[serde(rename = "FleetName")]
@@ -880,7 +880,7 @@ pub struct ListAssociatedStacksRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListAssociatedStacksResult {
     /// <p>The names of the stacks.</p>
     #[serde(rename = "Names")]
@@ -892,14 +892,14 @@ pub struct ListAssociatedStacksResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListTagsForResourceRequest {
     /// <p>The Amazon Resource Name (ARN) of the resource.</p>
     #[serde(rename = "ResourceArn")]
     pub resource_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListTagsForResourceResponse {
     /// <p>The information about the tags.</p>
     #[serde(rename = "Tags")]
@@ -908,7 +908,7 @@ pub struct ListTagsForResourceResponse {
 }
 
 /// <p>Describes a resource error.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ResourceError {
     /// <p>The error code.</p>
     #[serde(rename = "ErrorCode")]
@@ -925,7 +925,7 @@ pub struct ResourceError {
 }
 
 /// <p>Describes the credentials for the service account used by the streaming instance to connect to the directory.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ServiceAccountCredentials {
     /// <p>The user name of the account. This account must have the following privileges: create computer objects, join computers to the domain, and change/reset the password on descendant computer objects for the organizational units specified.</p>
     #[serde(rename = "AccountName")]
@@ -936,7 +936,7 @@ pub struct ServiceAccountCredentials {
 }
 
 /// <p>Describes a streaming session.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Session {
     /// <p>The authentication method. The user is authenticated using a streaming URL (<code>API</code>) or SAML federation (<code>SAML</code>).</p>
     #[serde(rename = "AuthenticationType")]
@@ -960,7 +960,7 @@ pub struct Session {
 }
 
 /// <p>Describes a stack.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Stack {
     /// <p>The ARN of the stack.</p>
     #[serde(rename = "Arn")]
@@ -1000,7 +1000,7 @@ pub struct Stack {
 }
 
 /// <p>Describes a stack error.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StackError {
     /// <p>The error code.</p>
     #[serde(rename = "ErrorCode")]
@@ -1012,17 +1012,17 @@ pub struct StackError {
     pub error_message: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StartFleetRequest {
     /// <p>The name of the fleet.</p>
     #[serde(rename = "Name")]
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StartFleetResult {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StartImageBuilderRequest {
     /// <p>The version of the AppStream 2.0 agent to use for this image builder. To use the latest version of the AppStream 2.0 agent, specify [LATEST]. </p>
     #[serde(rename = "AppstreamAgentVersion")]
@@ -1033,7 +1033,7 @@ pub struct StartImageBuilderRequest {
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StartImageBuilderResult {
     /// <p>Information about the image builder.</p>
     #[serde(rename = "ImageBuilder")]
@@ -1041,24 +1041,24 @@ pub struct StartImageBuilderResult {
     pub image_builder: Option<ImageBuilder>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StopFleetRequest {
     /// <p>The name of the fleet.</p>
     #[serde(rename = "Name")]
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StopFleetResult {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StopImageBuilderRequest {
     /// <p>The name of the image builder.</p>
     #[serde(rename = "Name")]
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StopImageBuilderResult {
     /// <p>Information about the image builder.</p>
     #[serde(rename = "ImageBuilder")]
@@ -1067,7 +1067,7 @@ pub struct StopImageBuilderResult {
 }
 
 /// <p>Describes a storage connector.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct StorageConnector {
     /// <p>The type of storage connector.</p>
     #[serde(rename = "ConnectorType")]
@@ -1078,7 +1078,7 @@ pub struct StorageConnector {
     pub resource_identifier: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct TagResourceRequest {
     /// <p>The Amazon Resource Name (ARN) of the resource.</p>
     #[serde(rename = "ResourceArn")]
@@ -1088,10 +1088,10 @@ pub struct TagResourceRequest {
     pub tags: ::std::collections::HashMap<String, String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct TagResourceResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UntagResourceRequest {
     /// <p>The Amazon Resource Name (ARN) of the resource.</p>
     #[serde(rename = "ResourceArn")]
@@ -1101,10 +1101,10 @@ pub struct UntagResourceRequest {
     pub tag_keys: Vec<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UntagResourceResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateDirectoryConfigRequest {
     /// <p>The name of the directory configuration.</p>
     #[serde(rename = "DirectoryName")]
@@ -1119,7 +1119,7 @@ pub struct UpdateDirectoryConfigRequest {
     pub service_account_credentials: Option<ServiceAccountCredentials>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateDirectoryConfigResult {
     /// <p>Information about the directory configuration.</p>
     #[serde(rename = "DirectoryConfig")]
@@ -1127,7 +1127,7 @@ pub struct UpdateDirectoryConfigResult {
     pub directory_config: Option<DirectoryConfig>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateFleetRequest {
     /// <p>The fleet attributes to delete.</p>
     #[serde(rename = "AttributesToDelete")]
@@ -1178,7 +1178,7 @@ pub struct UpdateFleetRequest {
     pub vpc_config: Option<VpcConfig>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateFleetResult {
     /// <p>Information about the fleet.</p>
     #[serde(rename = "Fleet")]
@@ -1186,7 +1186,7 @@ pub struct UpdateFleetResult {
     pub fleet: Option<Fleet>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateStackRequest {
     /// <p>The stack attributes to delete.</p>
     #[serde(rename = "AttributesToDelete")]
@@ -1217,7 +1217,7 @@ pub struct UpdateStackRequest {
     pub storage_connectors: Option<Vec<StorageConnector>>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateStackResult {
     /// <p>Information about the stack.</p>
     #[serde(rename = "Stack")]
@@ -1226,7 +1226,7 @@ pub struct UpdateStackResult {
 }
 
 /// <p>Describes VPC configuration information.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct VpcConfig {
     /// <p>The security groups for the fleet.</p>
     #[serde(rename = "SecurityGroupIds")]

--- a/rusoto/services/appstream/src/generated.rs
+++ b/rusoto/services/appstream/src/generated.rs
@@ -1267,7 +1267,8 @@ impl AssociateFleetError {
     pub fn from_body(body: &str) -> AssociateFleetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1375,7 +1376,8 @@ impl CopyImageError {
     pub fn from_body(body: &str) -> CopyImageError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1475,7 +1477,8 @@ impl CreateDirectoryConfigError {
     pub fn from_body(body: &str) -> CreateDirectoryConfigError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1583,7 +1586,8 @@ impl CreateFleetError {
     pub fn from_body(body: &str) -> CreateFleetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1709,7 +1713,8 @@ impl CreateImageBuilderError {
     pub fn from_body(body: &str) -> CreateImageBuilderError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1825,7 +1830,8 @@ impl CreateImageBuilderStreamingURLError {
     pub fn from_body(body: &str) -> CreateImageBuilderStreamingURLError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1925,7 +1931,8 @@ impl CreateStackError {
     pub fn from_body(body: &str) -> CreateStackError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2033,7 +2040,8 @@ impl CreateStreamingURLError {
     pub fn from_body(body: &str) -> CreateStreamingURLError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2129,7 +2137,8 @@ impl DeleteDirectoryConfigError {
     pub fn from_body(body: &str) -> DeleteDirectoryConfigError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2217,7 +2226,8 @@ impl DeleteFleetError {
     pub fn from_body(body: &str) -> DeleteFleetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2309,7 +2319,8 @@ impl DeleteImageError {
     pub fn from_body(body: &str) -> DeleteImageError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2403,7 +2414,8 @@ impl DeleteImageBuilderError {
     pub fn from_body(body: &str) -> DeleteImageBuilderError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2495,7 +2507,8 @@ impl DeleteStackError {
     pub fn from_body(body: &str) -> DeleteStackError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2581,7 +2594,8 @@ impl DescribeDirectoryConfigsError {
     pub fn from_body(body: &str) -> DescribeDirectoryConfigsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2661,7 +2675,8 @@ impl DescribeFleetsError {
     pub fn from_body(body: &str) -> DescribeFleetsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2739,7 +2754,8 @@ impl DescribeImageBuildersError {
     pub fn from_body(body: &str) -> DescribeImageBuildersError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2819,7 +2835,8 @@ impl DescribeImagesError {
     pub fn from_body(body: &str) -> DescribeImagesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2897,7 +2914,8 @@ impl DescribeSessionsError {
     pub fn from_body(body: &str) -> DescribeSessionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2977,7 +2995,8 @@ impl DescribeStacksError {
     pub fn from_body(body: &str) -> DescribeStacksError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3059,7 +3078,8 @@ impl DisassociateFleetError {
     pub fn from_body(body: &str) -> DisassociateFleetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3145,7 +3165,8 @@ impl ExpireSessionError {
     pub fn from_body(body: &str) -> ExpireSessionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3217,7 +3238,8 @@ impl ListAssociatedFleetsError {
     pub fn from_body(body: &str) -> ListAssociatedFleetsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3291,7 +3313,8 @@ impl ListAssociatedStacksError {
     pub fn from_body(body: &str) -> ListAssociatedStacksError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3367,7 +3390,8 @@ impl ListTagsForResourceError {
     pub fn from_body(body: &str) -> ListTagsForResourceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3455,7 +3479,8 @@ impl StartFleetError {
     pub fn from_body(body: &str) -> StartFleetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3555,7 +3580,8 @@ impl StartImageBuilderError {
     pub fn from_body(body: &str) -> StartImageBuilderError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3653,7 +3679,8 @@ impl StopFleetError {
     pub fn from_body(body: &str) -> StopFleetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3737,7 +3764,8 @@ impl StopImageBuilderError {
     pub fn from_body(body: &str) -> StopImageBuilderError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3827,7 +3855,8 @@ impl TagResourceError {
     pub fn from_body(body: &str) -> TagResourceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3913,7 +3942,8 @@ impl UntagResourceError {
     pub fn from_body(body: &str) -> UntagResourceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3995,7 +4025,8 @@ impl UpdateDirectoryConfigError {
     pub fn from_body(body: &str) -> UpdateDirectoryConfigError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4103,7 +4134,8 @@ impl UpdateFleetError {
     pub fn from_body(body: &str) -> UpdateFleetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4229,7 +4261,8 @@ impl UpdateStackError {
     pub fn from_body(body: &str) -> UpdateStackError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/athena/src/generated.rs
+++ b/rusoto/services/athena/src/generated.rs
@@ -504,7 +504,8 @@ impl BatchGetNamedQueryError {
     pub fn from_body(body: &str) -> BatchGetNamedQueryError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -590,7 +591,8 @@ impl BatchGetQueryExecutionError {
     pub fn from_body(body: &str) -> BatchGetQueryExecutionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -676,7 +678,8 @@ impl CreateNamedQueryError {
     pub fn from_body(body: &str) -> CreateNamedQueryError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -760,7 +763,8 @@ impl DeleteNamedQueryError {
     pub fn from_body(body: &str) -> DeleteNamedQueryError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -844,7 +848,8 @@ impl GetNamedQueryError {
     pub fn from_body(body: &str) -> GetNamedQueryError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -928,7 +933,8 @@ impl GetQueryExecutionError {
     pub fn from_body(body: &str) -> GetQueryExecutionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1014,7 +1020,8 @@ impl GetQueryResultsError {
     pub fn from_body(body: &str) -> GetQueryResultsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1098,7 +1105,8 @@ impl ListNamedQueriesError {
     pub fn from_body(body: &str) -> ListNamedQueriesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1182,7 +1190,8 @@ impl ListQueryExecutionsError {
     pub fn from_body(body: &str) -> ListQueryExecutionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1270,7 +1279,8 @@ impl StartQueryExecutionError {
     pub fn from_body(body: &str) -> StartQueryExecutionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1360,7 +1370,8 @@ impl StopQueryExecutionError {
     pub fn from_body(body: &str) -> StopQueryExecutionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/athena/src/generated.rs
+++ b/rusoto/services/athena/src/generated.rs
@@ -30,14 +30,14 @@ use rusoto_core::signature::SignedRequest;
 use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct BatchGetNamedQueryInput {
     /// <p>An array of query IDs.</p>
     #[serde(rename = "NamedQueryIds")]
     pub named_query_ids: Vec<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BatchGetNamedQueryOutput {
     /// <p>Information about the named query IDs submitted.</p>
     #[serde(rename = "NamedQueries")]
@@ -49,14 +49,14 @@ pub struct BatchGetNamedQueryOutput {
     pub unprocessed_named_query_ids: Option<Vec<UnprocessedNamedQueryId>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct BatchGetQueryExecutionInput {
     /// <p>An array of query execution IDs.</p>
     #[serde(rename = "QueryExecutionIds")]
     pub query_execution_ids: Vec<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BatchGetQueryExecutionOutput {
     /// <p>Information about a query execution.</p>
     #[serde(rename = "QueryExecutions")]
@@ -69,7 +69,7 @@ pub struct BatchGetQueryExecutionOutput {
 }
 
 /// <p>Information about the columns in a query execution result.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ColumnInfo {
     /// <p>Indicates whether values in the column are case-sensitive.</p>
     #[serde(rename = "CaseSensitive")]
@@ -111,7 +111,7 @@ pub struct ColumnInfo {
     pub type_: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateNamedQueryInput {
     /// <p><p>A unique case-sensitive string used to ensure the request to create the query is idempotent (executes only once). If another <code>CreateNamedQuery</code> request is received, the same response is returned and another query is not created. If a parameter has changed, for example, the <code>QueryString</code>, an error is returned.</p> <important> <p>This token is listed as not required because AWS SDKs (for example the AWS SDK for Java) auto-generate the token for users. If you are not using the AWS SDK or the AWS CLI, you must provide this token or the action will fail.</p> </important></p>
     #[serde(rename = "ClientRequestToken")]
@@ -132,7 +132,7 @@ pub struct CreateNamedQueryInput {
     pub query_string: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateNamedQueryOutput {
     /// <p>The unique ID of the query.</p>
     #[serde(rename = "NamedQueryId")]
@@ -141,7 +141,7 @@ pub struct CreateNamedQueryOutput {
 }
 
 /// <p>A piece of data (a field in the table).</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Datum {
     /// <p>The value of the datum.</p>
     #[serde(rename = "VarCharValue")]
@@ -149,18 +149,18 @@ pub struct Datum {
     pub var_char_value: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteNamedQueryInput {
     /// <p>The unique ID of the query to delete.</p>
     #[serde(rename = "NamedQueryId")]
     pub named_query_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteNamedQueryOutput {}
 
 /// <p>If query results are encrypted in Amazon S3, indicates the Amazon S3 encryption option used.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct EncryptionConfiguration {
     /// <p>Indicates whether Amazon S3 server-side encryption with Amazon S3-managed keys (<code>SSE-S3</code>), server-side encryption with KMS-managed keys (<code>SSE-KMS</code>), or client-side encryption with KMS-managed keys (CSE-KMS) is used.</p>
     #[serde(rename = "EncryptionOption")]
@@ -171,14 +171,14 @@ pub struct EncryptionConfiguration {
     pub kms_key: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetNamedQueryInput {
     /// <p>The unique ID of the query. Use <a>ListNamedQueries</a> to get query IDs.</p>
     #[serde(rename = "NamedQueryId")]
     pub named_query_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetNamedQueryOutput {
     /// <p>Information about the query.</p>
     #[serde(rename = "NamedQuery")]
@@ -186,14 +186,14 @@ pub struct GetNamedQueryOutput {
     pub named_query: Option<NamedQuery>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetQueryExecutionInput {
     /// <p>The unique ID of the query execution.</p>
     #[serde(rename = "QueryExecutionId")]
     pub query_execution_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetQueryExecutionOutput {
     /// <p>Information about the query execution.</p>
     #[serde(rename = "QueryExecution")]
@@ -201,7 +201,7 @@ pub struct GetQueryExecutionOutput {
     pub query_execution: Option<QueryExecution>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetQueryResultsInput {
     /// <p>The maximum number of results (rows) to return in this request.</p>
     #[serde(rename = "MaxResults")]
@@ -216,7 +216,7 @@ pub struct GetQueryResultsInput {
     pub query_execution_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetQueryResultsOutput {
     /// <p>A token to be used by the next request if this request is truncated.</p>
     #[serde(rename = "NextToken")]
@@ -228,7 +228,7 @@ pub struct GetQueryResultsOutput {
     pub result_set: Option<ResultSet>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListNamedQueriesInput {
     /// <p>The maximum number of queries to return in this request.</p>
     #[serde(rename = "MaxResults")]
@@ -240,7 +240,7 @@ pub struct ListNamedQueriesInput {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListNamedQueriesOutput {
     /// <p>The list of unique query IDs.</p>
     #[serde(rename = "NamedQueryIds")]
@@ -252,7 +252,7 @@ pub struct ListNamedQueriesOutput {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListQueryExecutionsInput {
     /// <p>The maximum number of query executions to return in this request.</p>
     #[serde(rename = "MaxResults")]
@@ -264,7 +264,7 @@ pub struct ListQueryExecutionsInput {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListQueryExecutionsOutput {
     /// <p>A token to be used by the next request if this request is truncated.</p>
     #[serde(rename = "NextToken")]
@@ -277,7 +277,7 @@ pub struct ListQueryExecutionsOutput {
 }
 
 /// <p>A query, where <code>QueryString</code> is the SQL query statements that comprise the query.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct NamedQuery {
     /// <p>The database to which the query belongs.</p>
     #[serde(rename = "Database")]
@@ -299,7 +299,7 @@ pub struct NamedQuery {
 }
 
 /// <p>Information about a single instance of a query execution.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct QueryExecution {
     /// <p>The SQL query statements which the query execution ran.</p>
     #[serde(rename = "Query")]
@@ -328,7 +328,7 @@ pub struct QueryExecution {
 }
 
 /// <p>The database in which the query execution occurs.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct QueryExecutionContext {
     /// <p>The name of the database.</p>
     #[serde(rename = "Database")]
@@ -337,7 +337,7 @@ pub struct QueryExecutionContext {
 }
 
 /// <p>The amount of data scanned during the query execution and the amount of time that it took to execute.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct QueryExecutionStatistics {
     /// <p>The number of bytes in the data that was queried.</p>
     #[serde(rename = "DataScannedInBytes")]
@@ -350,7 +350,7 @@ pub struct QueryExecutionStatistics {
 }
 
 /// <p>The completion date, current state, submission time, and state change reason (if applicable) for the query execution.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct QueryExecutionStatus {
     /// <p>The date and time that the query completed.</p>
     #[serde(rename = "CompletionDateTime")]
@@ -371,7 +371,7 @@ pub struct QueryExecutionStatus {
 }
 
 /// <p>The location in Amazon S3 where query results are stored and the encryption option, if any, used for query results.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ResultConfiguration {
     /// <p>If query results are encrypted in S3, indicates the S3 encryption option used (for example, <code>SSE-KMS</code> or <code>CSE-KMS</code> and key information.</p>
     #[serde(rename = "EncryptionConfiguration")]
@@ -383,7 +383,7 @@ pub struct ResultConfiguration {
 }
 
 /// <p>The metadata and rows that comprise a query result set. The metadata describes the column structure and data types.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ResultSet {
     /// <p>The metadata that describes the column structure and data types of a table of query results.</p>
     #[serde(rename = "ResultSetMetadata")]
@@ -396,7 +396,7 @@ pub struct ResultSet {
 }
 
 /// <p>The metadata that describes the column structure and data types of a table of query results.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ResultSetMetadata {
     /// <p>Information about the columns in a query execution result.</p>
     #[serde(rename = "ColumnInfo")]
@@ -405,7 +405,7 @@ pub struct ResultSetMetadata {
 }
 
 /// <p>The rows that comprise a query result table.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Row {
     /// <p>The data that populates a row in a query result table.</p>
     #[serde(rename = "Data")]
@@ -413,7 +413,7 @@ pub struct Row {
     pub data: Option<Vec<Datum>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StartQueryExecutionInput {
     /// <p><p>A unique case-sensitive string used to ensure the request to create the query is idempotent (executes only once). If another <code>StartQueryExecution</code> request is received, the same response is returned and another query is not created. If a parameter has changed, for example, the <code>QueryString</code>, an error is returned.</p> <important> <p>This token is listed as not required because AWS SDKs (for example the AWS SDK for Java) auto-generate the token for users. If you are not using the AWS SDK or the AWS CLI, you must provide this token or the action will fail.</p> </important></p>
     #[serde(rename = "ClientRequestToken")]
@@ -431,7 +431,7 @@ pub struct StartQueryExecutionInput {
     pub result_configuration: ResultConfiguration,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StartQueryExecutionOutput {
     /// <p>The unique ID of the query that ran as a result of this request.</p>
     #[serde(rename = "QueryExecutionId")]
@@ -439,18 +439,18 @@ pub struct StartQueryExecutionOutput {
     pub query_execution_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StopQueryExecutionInput {
     /// <p>The unique ID of the query execution to stop.</p>
     #[serde(rename = "QueryExecutionId")]
     pub query_execution_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StopQueryExecutionOutput {}
 
 /// <p>Information about a named query ID that could not be processed.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UnprocessedNamedQueryId {
     /// <p>The error code returned when the processing request for the named query failed, if applicable.</p>
     #[serde(rename = "ErrorCode")]
@@ -467,7 +467,7 @@ pub struct UnprocessedNamedQueryId {
 }
 
 /// <p>Describes a query execution that failed to process.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UnprocessedQueryExecutionId {
     /// <p>The error code returned when the query execution failed to process, if applicable.</p>
     #[serde(rename = "ErrorCode")]

--- a/rusoto/services/autoscaling/src/generated.rs
+++ b/rusoto/services/autoscaling/src/generated.rs
@@ -83,7 +83,7 @@ impl ActivitiesDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ActivitiesType {
     /// <p>The scaling activities. Activities are sorted by start time. Activities still in progress are described first.</p>
     pub activities: Vec<Activity>,
@@ -136,7 +136,7 @@ impl ActivitiesTypeDeserializer {
     }
 }
 /// <p>Describes scaling activity, which is a long-running process that represents a change to your Auto Scaling group, such as changing its size or replacing an instance.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Activity {
     /// <p>The ID of the activity.</p>
     pub activity_id: String,
@@ -257,7 +257,7 @@ impl ActivityIdsSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ActivityType {
     /// <p>A scaling activity.</p>
     pub activity: Option<Activity>,
@@ -304,7 +304,7 @@ impl ActivityTypeDeserializer {
     }
 }
 /// <p>Describes a policy adjustment type.</p> <p>For more information, see <a href="http://docs.aws.amazon.com/AutoScaling/latest/DeveloperGuide/as-scale-based-on-demand.html">Dynamic Scaling</a> in the <i>Auto Scaling User Guide</i>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AdjustmentType {
     /// <p>The policy adjustment type. The valid values are <code>ChangeInCapacity</code>, <code>ExactCapacity</code>, and <code>PercentChangeInCapacity</code>.</p>
     pub adjustment_type: Option<String>,
@@ -394,7 +394,7 @@ impl AdjustmentTypesDeserializer {
     }
 }
 /// <p>Describes an alarm.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Alarm {
     /// <p>The Amazon Resource Name (ARN) of the alarm.</p>
     pub alarm_arn: Option<String>,
@@ -517,7 +517,7 @@ impl AssociatePublicIpAddressDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AttachInstancesQuery {
     /// <p>The name of the Auto Scaling group.</p>
     pub auto_scaling_group_name: String,
@@ -548,7 +548,7 @@ impl AttachInstancesQuerySerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AttachLoadBalancerTargetGroupsResultType {}
 
 struct AttachLoadBalancerTargetGroupsResultTypeDeserializer;
@@ -567,7 +567,7 @@ impl AttachLoadBalancerTargetGroupsResultTypeDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AttachLoadBalancerTargetGroupsType {
     /// <p>The name of the Auto Scaling group.</p>
     pub auto_scaling_group_name: String,
@@ -596,7 +596,7 @@ impl AttachLoadBalancerTargetGroupsTypeSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AttachLoadBalancersResultType {}
 
 struct AttachLoadBalancersResultTypeDeserializer;
@@ -615,7 +615,7 @@ impl AttachLoadBalancersResultTypeDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AttachLoadBalancersType {
     /// <p>The name of the Auto Scaling group.</p>
     pub auto_scaling_group_name: String,
@@ -645,7 +645,7 @@ impl AttachLoadBalancersTypeSerializer {
 }
 
 /// <p>Describes an Auto Scaling group.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AutoScalingGroup {
     /// <p>The Amazon Resource Name (ARN) of the Auto Scaling group.</p>
     pub auto_scaling_group_arn: Option<String>,
@@ -925,7 +925,7 @@ impl AutoScalingGroupNamesSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AutoScalingGroupNamesType {
     /// <p>The names of the Auto Scaling groups. If you omit this parameter, all Auto Scaling groups are described.</p>
     pub auto_scaling_group_names: Option<Vec<String>>,
@@ -1008,7 +1008,7 @@ impl AutoScalingGroupsDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AutoScalingGroupsType {
     /// <p>The groups.</p>
     pub auto_scaling_groups: Vec<AutoScalingGroup>,
@@ -1063,7 +1063,7 @@ impl AutoScalingGroupsTypeDeserializer {
     }
 }
 /// <p>Describes an EC2 instance associated with an Auto Scaling group.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AutoScalingInstanceDetails {
     /// <p>The name of the Auto Scaling group for the instance.</p>
     pub auto_scaling_group_name: String,
@@ -1213,7 +1213,7 @@ impl AutoScalingInstancesDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AutoScalingInstancesType {
     /// <p>The instances.</p>
     pub auto_scaling_instances: Option<Vec<AutoScalingInstanceDetails>>,
@@ -1447,7 +1447,7 @@ impl BlockDeviceEbsVolumeTypeDeserializer {
     }
 }
 /// <p>Describes a block device mapping.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct BlockDeviceMapping {
     /// <p>The device name exposed to the EC2 instance (for example, <code>/dev/sdh</code> or <code>xvdh</code>).</p>
     pub device_name: String,
@@ -1654,7 +1654,7 @@ impl ClassicLinkVPCSecurityGroupsSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CompleteLifecycleActionAnswer {}
 
 struct CompleteLifecycleActionAnswerDeserializer;
@@ -1673,7 +1673,7 @@ impl CompleteLifecycleActionAnswerDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CompleteLifecycleActionType {
     /// <p>The name of the Auto Scaling group.</p>
     pub auto_scaling_group_name: String,
@@ -1737,7 +1737,7 @@ impl CooldownDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateAutoScalingGroupType {
     /// <p>The name of the Auto Scaling group. This name must be unique within the scope of your AWS account.</p>
     pub auto_scaling_group_name: String,
@@ -1910,7 +1910,7 @@ impl CreateAutoScalingGroupTypeSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateLaunchConfigurationType {
     /// <p>Used for groups that launch instances into a virtual private cloud (VPC). Specifies whether to assign a public IP address to each instance. For more information, see <a href="http://docs.aws.amazon.com/autoscaling/latest/userguide/asg-in-vpc.html">Launching Auto Scaling Instances in a VPC</a> in the <i>Auto Scaling User Guide</i>.</p> <p>If you specify this parameter, be sure to specify at least one subnet when you create your group.</p> <p>Default: If the instance is launched into a default subnet, the default is to assign a public IP address. If the instance is launched into a nondefault subnet, the default is not to assign a public IP address.</p>
     pub associate_public_ip_address: Option<bool>,
@@ -2072,7 +2072,7 @@ impl CreateLaunchConfigurationTypeSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateOrUpdateTagsType {
     /// <p>One or more tags.</p>
     pub tags: Vec<Tag>,
@@ -2092,7 +2092,7 @@ impl CreateOrUpdateTagsTypeSerializer {
 }
 
 /// <p>Configures a customized metric for a target tracking policy.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CustomizedMetricSpecification {
     /// <p>The dimensions of the metric.</p>
     pub dimensions: Option<Vec<MetricDimension>>,
@@ -2201,7 +2201,7 @@ impl CustomizedMetricSpecificationSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteAutoScalingGroupType {
     /// <p>The name of the Auto Scaling group.</p>
     pub auto_scaling_group_name: String,
@@ -2231,7 +2231,7 @@ impl DeleteAutoScalingGroupTypeSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteLifecycleHookAnswer {}
 
 struct DeleteLifecycleHookAnswerDeserializer;
@@ -2250,7 +2250,7 @@ impl DeleteLifecycleHookAnswerDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteLifecycleHookType {
     /// <p>The name of the Auto Scaling group.</p>
     pub auto_scaling_group_name: String,
@@ -2278,7 +2278,7 @@ impl DeleteLifecycleHookTypeSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteNotificationConfigurationType {
     /// <p>The name of the Auto Scaling group.</p>
     pub auto_scaling_group_name: String,
@@ -2306,7 +2306,7 @@ impl DeleteNotificationConfigurationTypeSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeletePolicyType {
     /// <p>The name of the Auto Scaling group.</p>
     pub auto_scaling_group_name: Option<String>,
@@ -2336,7 +2336,7 @@ impl DeletePolicyTypeSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteScheduledActionType {
     /// <p>The name of the Auto Scaling group.</p>
     pub auto_scaling_group_name: String,
@@ -2364,7 +2364,7 @@ impl DeleteScheduledActionTypeSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteTagsType {
     /// <p>One or more tags.</p>
     pub tags: Vec<Tag>,
@@ -2383,7 +2383,7 @@ impl DeleteTagsTypeSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeAccountLimitsAnswer {
     /// <p>The maximum number of groups allowed for your AWS account. The default limit is 20 per region.</p>
     pub max_number_of_auto_scaling_groups: Option<i64>,
@@ -2460,7 +2460,7 @@ impl DescribeAccountLimitsAnswerDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeAdjustmentTypesAnswer {
     /// <p>The policy adjustment types.</p>
     pub adjustment_types: Option<Vec<AdjustmentType>>,
@@ -2507,7 +2507,7 @@ impl DescribeAdjustmentTypesAnswerDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeAutoScalingInstancesType {
     /// <p>The instances to describe; up to 50 instance IDs. If you omit this parameter, all Auto Scaling instances are described. If you specify an ID that does not exist, it is ignored with no error.</p>
     pub instance_ids: Option<Vec<String>>,
@@ -2548,7 +2548,7 @@ impl DescribeAutoScalingInstancesTypeSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeAutoScalingNotificationTypesAnswer {
     /// <p>The notification types.</p>
     pub auto_scaling_notification_types: Option<Vec<String>>,
@@ -2597,7 +2597,7 @@ impl DescribeAutoScalingNotificationTypesAnswerDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeLifecycleHookTypesAnswer {
     /// <p>The lifecycle hook types.</p>
     pub lifecycle_hook_types: Option<Vec<String>>,
@@ -2646,7 +2646,7 @@ impl DescribeLifecycleHookTypesAnswerDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeLifecycleHooksAnswer {
     /// <p>The lifecycle hooks for the specified group.</p>
     pub lifecycle_hooks: Option<Vec<LifecycleHook>>,
@@ -2694,7 +2694,7 @@ impl DescribeLifecycleHooksAnswerDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeLifecycleHooksType {
     /// <p>The name of the Auto Scaling group.</p>
     pub auto_scaling_group_name: String,
@@ -2725,7 +2725,7 @@ impl DescribeLifecycleHooksTypeSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeLoadBalancerTargetGroupsRequest {
     /// <p>The name of the Auto Scaling group.</p>
     pub auto_scaling_group_name: String,
@@ -2763,7 +2763,7 @@ impl DescribeLoadBalancerTargetGroupsRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeLoadBalancerTargetGroupsResponse {
     /// <p>Information about the target groups.</p>
     pub load_balancer_target_groups: Option<Vec<LoadBalancerTargetGroupState>>,
@@ -2819,7 +2819,7 @@ impl DescribeLoadBalancerTargetGroupsResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeLoadBalancersRequest {
     /// <p>The name of the Auto Scaling group.</p>
     pub auto_scaling_group_name: String,
@@ -2857,7 +2857,7 @@ impl DescribeLoadBalancersRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeLoadBalancersResponse {
     /// <p>The load balancers.</p>
     pub load_balancers: Option<Vec<LoadBalancerState>>,
@@ -2910,7 +2910,7 @@ impl DescribeLoadBalancersResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeMetricCollectionTypesAnswer {
     /// <p>The granularities for the metrics.</p>
     pub granularities: Option<Vec<MetricGranularityType>>,
@@ -2964,7 +2964,7 @@ impl DescribeMetricCollectionTypesAnswerDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeNotificationConfigurationsAnswer {
     /// <p>The token to use when requesting the next set of items. If there are no additional items to return, the string is empty.</p>
     pub next_token: Option<String>,
@@ -3019,7 +3019,7 @@ impl DescribeNotificationConfigurationsAnswerDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeNotificationConfigurationsType {
     /// <p>The name of the Auto Scaling group.</p>
     pub auto_scaling_group_names: Option<Vec<String>>,
@@ -3060,7 +3060,7 @@ impl DescribeNotificationConfigurationsTypeSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribePoliciesType {
     /// <p>The name of the Auto Scaling group.</p>
     pub auto_scaling_group_name: Option<String>,
@@ -3118,7 +3118,7 @@ impl DescribePoliciesTypeSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeScalingActivitiesType {
     /// <p>The activity IDs of the desired scaling activities. If you omit this parameter, all activities for the past six weeks are described. If you specify an Auto Scaling group, the results are limited to that group. The list of requested activities cannot contain more than 50 items. If unknown activities are requested, they are ignored with no error.</p>
     pub activity_ids: Option<Vec<String>>,
@@ -3167,7 +3167,7 @@ impl DescribeScalingActivitiesTypeSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeScheduledActionsType {
     /// <p>The name of the Auto Scaling group.</p>
     pub auto_scaling_group_name: Option<String>,
@@ -3232,7 +3232,7 @@ impl DescribeScheduledActionsTypeSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeTagsType {
     /// <p>A filter used to scope the tags to return.</p>
     pub filters: Option<Vec<Filter>>,
@@ -3269,7 +3269,7 @@ impl DescribeTagsTypeSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeTerminationPolicyTypesAnswer {
     /// <p>The termination policies supported by Auto Scaling (<code>OldestInstance</code>, <code>OldestLaunchConfiguration</code>, <code>NewestInstance</code>, <code>ClosestToNextInstanceHour</code>, and <code>Default</code>).</p>
     pub termination_policy_types: Option<Vec<String>>,
@@ -3318,7 +3318,7 @@ impl DescribeTerminationPolicyTypesAnswerDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DetachInstancesAnswer {
     /// <p>The activities related to detaching the instances from the Auto Scaling group.</p>
     pub activities: Option<Vec<Activity>>,
@@ -3366,7 +3366,7 @@ impl DetachInstancesAnswerDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DetachInstancesQuery {
     /// <p>The name of the Auto Scaling group.</p>
     pub auto_scaling_group_name: String,
@@ -3405,7 +3405,7 @@ impl DetachInstancesQuerySerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DetachLoadBalancerTargetGroupsResultType {}
 
 struct DetachLoadBalancerTargetGroupsResultTypeDeserializer;
@@ -3424,7 +3424,7 @@ impl DetachLoadBalancerTargetGroupsResultTypeDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DetachLoadBalancerTargetGroupsType {
     /// <p>The name of the Auto Scaling group.</p>
     pub auto_scaling_group_name: String,
@@ -3453,7 +3453,7 @@ impl DetachLoadBalancerTargetGroupsTypeSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DetachLoadBalancersResultType {}
 
 struct DetachLoadBalancersResultTypeDeserializer;
@@ -3472,7 +3472,7 @@ impl DetachLoadBalancersResultTypeDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DetachLoadBalancersType {
     /// <p>The name of the Auto Scaling group.</p>
     pub auto_scaling_group_name: String,
@@ -3501,7 +3501,7 @@ impl DetachLoadBalancersTypeSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DisableMetricsCollectionQuery {
     /// <p>The name of the Auto Scaling group.</p>
     pub auto_scaling_group_name: String,
@@ -3543,7 +3543,7 @@ impl DisableScaleInDeserializer {
     }
 }
 /// <p>Describes an Amazon EBS volume.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Ebs {
     /// <p>Indicates whether the volume is deleted on instance termination. The default is <code>true</code>.</p>
     pub delete_on_termination: Option<bool>,
@@ -3692,7 +3692,7 @@ impl EbsOptimizedDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct EnableMetricsCollectionQuery {
     /// <p>The name of the Auto Scaling group.</p>
     pub auto_scaling_group_name: String,
@@ -3726,7 +3726,7 @@ impl EnableMetricsCollectionQuerySerializer {
 }
 
 /// <p>Describes an enabled metric.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct EnabledMetric {
     /// <p>The granularity of the metric. The only valid value is <code>1Minute</code>.</p>
     pub granularity: Option<String>,
@@ -3823,7 +3823,7 @@ impl EnabledMetricsDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct EnterStandbyAnswer {
     /// <p>The activities related to moving instances into <code>Standby</code> mode.</p>
     pub activities: Option<Vec<Activity>>,
@@ -3871,7 +3871,7 @@ impl EnterStandbyAnswerDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct EnterStandbyQuery {
     /// <p>The name of the Auto Scaling group.</p>
     pub auto_scaling_group_name: String,
@@ -3924,7 +3924,7 @@ impl EstimatedInstanceWarmupDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ExecutePolicyType {
     /// <p>The name of the Auto Scaling group.</p>
     pub auto_scaling_group_name: Option<String>,
@@ -3978,7 +3978,7 @@ impl ExecutePolicyTypeSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ExitStandbyAnswer {
     /// <p>The activities related to moving instances out of <code>Standby</code> mode.</p>
     pub activities: Option<Vec<Activity>>,
@@ -4026,7 +4026,7 @@ impl ExitStandbyAnswerDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ExitStandbyQuery {
     /// <p>The name of the Auto Scaling group.</p>
     pub auto_scaling_group_name: String,
@@ -4058,7 +4058,7 @@ impl ExitStandbyQuerySerializer {
 }
 
 /// <p>Describes a filter.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Filter {
     /// <p>The name of the filter. The valid values are: <code>"auto-scaling-group"</code>, <code>"key"</code>, <code>"value"</code>, and <code>"propagate-at-launch"</code>.</p>
     pub name: Option<String>,
@@ -4141,7 +4141,7 @@ impl HeartbeatTimeoutDeserializer {
     }
 }
 /// <p>Describes an EC2 instance.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Instance {
     /// <p>The Availability Zone in which the instance is running.</p>
     pub availability_zone: String,
@@ -4253,7 +4253,7 @@ impl InstanceIdsSerializer {
 }
 
 /// <p>Describes whether detailed monitoring is enabled for the Auto Scaling instances.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct InstanceMonitoring {
     /// <p>If <code>true</code>, detailed monitoring is enabled. Otherwise, basic monitoring is enabled.</p>
     pub enabled: Option<bool>,
@@ -4374,7 +4374,7 @@ impl InstancesDeserializer {
     }
 }
 /// <p>Describes a launch configuration.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct LaunchConfiguration {
     /// <p>[EC2-VPC] Indicates whether to assign a public IP address to each instance.</p>
     pub associate_public_ip_address: Option<bool>,
@@ -4561,7 +4561,7 @@ impl LaunchConfigurationDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct LaunchConfigurationNameType {
     /// <p>The name of the launch configuration.</p>
     pub launch_configuration_name: String,
@@ -4594,7 +4594,7 @@ impl LaunchConfigurationNamesSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct LaunchConfigurationNamesType {
     /// <p>The launch configuration names. If you omit this parameter, all launch configurations are described.</p>
     pub launch_configuration_names: Option<Vec<String>>,
@@ -4677,7 +4677,7 @@ impl LaunchConfigurationsDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct LaunchConfigurationsType {
     /// <p>The launch configurations.</p>
     pub launch_configurations: Vec<LaunchConfiguration>,
@@ -4747,7 +4747,7 @@ impl LaunchTemplateNameDeserializer {
     }
 }
 /// <p>Describes a launch template.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct LaunchTemplateSpecification {
     /// <p>The ID of the launch template. You must specify either a template ID or a template name.</p>
     pub launch_template_id: Option<String>,
@@ -4856,7 +4856,7 @@ impl LifecycleActionResultDeserializer {
     }
 }
 /// <p>Describes a lifecycle hook, which tells Auto Scaling that you want to perform an action whenever it launches instances or whenever it terminates instances.</p> <p>For more information, see <a href="http://docs.aws.amazon.com/autoscaling/latest/userguide/lifecycle-hooks.html">Auto Scaling Lifecycle Hooks</a> in the <i>Auto Scaling User Guide</i>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct LifecycleHook {
     /// <p>The name of the Auto Scaling group for the lifecycle hook.</p>
     pub auto_scaling_group_name: Option<String>,
@@ -4979,7 +4979,7 @@ impl LifecycleHookNamesSerializer {
 }
 
 /// <p>Describes a lifecycle hook, which tells Auto Scaling that you want to perform an action whenever it launches instances or whenever it terminates instances.</p> <p>For more information, see <a href="http://docs.aws.amazon.com/autoscaling/latest/userguide/lifecycle-hooks.html">Auto Scaling Lifecycle Hooks</a> in the <i>Auto Scaling User Guide</i>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct LifecycleHookSpecification {
     /// <p>Defines the action the Auto Scaling group should take when the lifecycle hook timeout elapses or if an unexpected failure occurs. The valid values are <code>CONTINUE</code> and <code>ABANDON</code>.</p>
     pub default_result: Option<String>,
@@ -5183,7 +5183,7 @@ impl LoadBalancerNamesSerializer {
 }
 
 /// <p>Describes the state of a Classic Load Balancer.</p> <p>If you specify a load balancer when creating the Auto Scaling group, the state of the load balancer is <code>InService</code>.</p> <p>If you attach a load balancer to an existing Auto Scaling group, the initial state is <code>Adding</code>. The state transitions to <code>Added</code> after all instances in the group are registered with the load balancer. If ELB health checks are enabled for the load balancer, the state transitions to <code>InService</code> after at least one instance in the group passes the health check. If EC2 health checks are enabled instead, the load balancer remains in the <code>Added</code> state.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct LoadBalancerState {
     /// <p>The name of the load balancer.</p>
     pub load_balancer_name: Option<String>,
@@ -5280,7 +5280,7 @@ impl LoadBalancerStatesDeserializer {
     }
 }
 /// <p>Describes the state of a target group.</p> <p>If you attach a target group to an existing Auto Scaling group, the initial state is <code>Adding</code>. The state transitions to <code>Added</code> after all Auto Scaling instances are registered with the target group. If ELB health checks are enabled, the state transitions to <code>InService</code> after at least one Auto Scaling instance passes the health check. If EC2 health checks are enabled instead, the target group remains in the <code>Added</code> state.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct LoadBalancerTargetGroupState {
     /// <p>The Amazon Resource Name (ARN) of the target group.</p>
     pub load_balancer_target_group_arn: Option<String>,
@@ -5407,7 +5407,7 @@ impl MaxNumberOfLaunchConfigurationsDeserializer {
     }
 }
 /// <p>Describes a metric.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct MetricCollectionType {
     /// <p><p>One of the following metrics:</p> <ul> <li> <p> <code>GroupMinSize</code> </p> </li> <li> <p> <code>GroupMaxSize</code> </p> </li> <li> <p> <code>GroupDesiredCapacity</code> </p> </li> <li> <p> <code>GroupInServiceInstances</code> </p> </li> <li> <p> <code>GroupPendingInstances</code> </p> </li> <li> <p> <code>GroupStandbyInstances</code> </p> </li> <li> <p> <code>GroupTerminatingInstances</code> </p> </li> <li> <p> <code>GroupTotalInstances</code> </p> </li> </ul></p>
     pub metric: Option<String>,
@@ -5497,7 +5497,7 @@ impl MetricCollectionTypesDeserializer {
     }
 }
 /// <p>Describes the dimension of a metric.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct MetricDimension {
     /// <p>The name of the dimension.</p>
     pub name: String,
@@ -5654,7 +5654,7 @@ impl MetricDimensionsSerializer {
 }
 
 /// <p>Describes a granularity of a metric.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct MetricGranularityType {
     /// <p>The granularity. The only valid value is <code>1Minute</code>.</p>
     pub granularity: Option<String>,
@@ -5897,7 +5897,7 @@ impl NoDeviceDeserializer {
     }
 }
 /// <p>Describes a notification.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct NotificationConfiguration {
     /// <p>The name of the Auto Scaling group.</p>
     pub auto_scaling_group_name: Option<String>,
@@ -6028,7 +6028,7 @@ impl NumberOfLaunchConfigurationsDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PoliciesType {
     /// <p>The token to use when requesting the next set of items. If there are no additional items to return, the string is empty.</p>
     pub next_token: Option<String>,
@@ -6082,7 +6082,7 @@ impl PoliciesTypeDeserializer {
     }
 }
 /// <p>Contains the output of PutScalingPolicy.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PolicyARNType {
     /// <p>The CloudWatch alarms created for the target tracking policy.</p>
     pub alarms: Option<Vec<Alarm>>,
@@ -6173,7 +6173,7 @@ impl PolicyTypesSerializer {
 }
 
 /// <p>Configures a predefined metric for a target tracking policy.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PredefinedMetricSpecification {
     /// <p>The metric type.</p>
     pub predefined_metric_type: String,
@@ -6263,7 +6263,7 @@ impl ProcessNamesSerializer {
 }
 
 /// <p>Describes a process type.</p> <p>For more information, see <a href="http://docs.aws.amazon.com/autoscaling/latest/userguide/as-suspend-resume-processes.html#process-types">Auto Scaling Processes</a> in the <i>Auto Scaling User Guide</i>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ProcessType {
     /// <p><p>One of the following processes:</p> <ul> <li> <p> <code>Launch</code> </p> </li> <li> <p> <code>Terminate</code> </p> </li> <li> <p> <code>AddToLoadBalancer</code> </p> </li> <li> <p> <code>AlarmNotification</code> </p> </li> <li> <p> <code>AZRebalance</code> </p> </li> <li> <p> <code>HealthCheck</code> </p> </li> <li> <p> <code>ReplaceUnhealthy</code> </p> </li> <li> <p> <code>ScheduledActions</code> </p> </li> </ul></p>
     pub process_name: String,
@@ -6351,7 +6351,7 @@ impl ProcessesDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ProcessesType {
     /// <p>The names of the process types.</p>
     pub processes: Option<Vec<ProcessType>>,
@@ -6425,7 +6425,7 @@ impl PropagateAtLaunchDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PutLifecycleHookAnswer {}
 
 struct PutLifecycleHookAnswerDeserializer;
@@ -6444,7 +6444,7 @@ impl PutLifecycleHookAnswerDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PutLifecycleHookType {
     /// <p>The name of the Auto Scaling group.</p>
     pub auto_scaling_group_name: String,
@@ -6520,7 +6520,7 @@ impl PutLifecycleHookTypeSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PutNotificationConfigurationType {
     /// <p>The name of the Auto Scaling group.</p>
     pub auto_scaling_group_name: String,
@@ -6555,7 +6555,7 @@ impl PutNotificationConfigurationTypeSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PutScalingPolicyType {
     /// <p>The adjustment type. The valid values are <code>ChangeInCapacity</code>, <code>ExactCapacity</code>, and <code>PercentChangeInCapacity</code>.</p> <p>This parameter is supported if the policy type is <code>SimpleScaling</code> or <code>StepScaling</code>.</p> <p>For more information, see <a href="http://docs.aws.amazon.com/autoscaling/latest/userguide/as-scale-based-on-demand.html">Dynamic Scaling</a> in the <i>Auto Scaling User Guide</i>.</p>
     pub adjustment_type: Option<String>,
@@ -6665,7 +6665,7 @@ impl PutScalingPolicyTypeSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PutScheduledUpdateGroupActionType {
     /// <p>The name of the Auto Scaling group.</p>
     pub auto_scaling_group_name: String,
@@ -6749,7 +6749,7 @@ impl PutScheduledUpdateGroupActionTypeSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RecordLifecycleActionHeartbeatAnswer {}
 
 struct RecordLifecycleActionHeartbeatAnswerDeserializer;
@@ -6768,7 +6768,7 @@ impl RecordLifecycleActionHeartbeatAnswerDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RecordLifecycleActionHeartbeatType {
     /// <p>The name of the Auto Scaling group.</p>
     pub auto_scaling_group_name: String,
@@ -6883,7 +6883,7 @@ impl ScalingPoliciesDeserializer {
     }
 }
 /// <p>Describes a scaling policy.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ScalingPolicy {
     /// <p>The adjustment type, which specifies how <code>ScalingAdjustment</code> is interpreted. Valid values are <code>ChangeInCapacity</code>, <code>ExactCapacity</code>, and <code>PercentChangeInCapacity</code>.</p>
     pub adjustment_type: Option<String>,
@@ -7031,7 +7031,7 @@ impl ScalingPolicyDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ScalingProcessQuery {
     /// <p>The name of the Auto Scaling group.</p>
     pub auto_scaling_group_name: String,
@@ -7073,7 +7073,7 @@ impl ScheduledActionNamesSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ScheduledActionsType {
     /// <p>The token to use when requesting the next set of items. If there are no additional items to return, the string is empty.</p>
     pub next_token: Option<String>,
@@ -7129,7 +7129,7 @@ impl ScheduledActionsTypeDeserializer {
     }
 }
 /// <p>Describes a scheduled update to an Auto Scaling group.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ScheduledUpdateGroupAction {
     /// <p>The name of the Auto Scaling group.</p>
     pub auto_scaling_group_name: Option<String>,
@@ -7341,7 +7341,7 @@ impl SecurityGroupsSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SetDesiredCapacityType {
     /// <p>The name of the Auto Scaling group.</p>
     pub auto_scaling_group_name: String,
@@ -7377,7 +7377,7 @@ impl SetDesiredCapacityTypeSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SetInstanceHealthQuery {
     /// <p>The health status of the instance. Set to <code>Healthy</code> if you want the instance to remain in service. Set to <code>Unhealthy</code> if you want the instance to be out of service. Auto Scaling will terminate and replace the unhealthy instance.</p>
     pub health_status: String,
@@ -7413,7 +7413,7 @@ impl SetInstanceHealthQuerySerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SetInstanceProtectionAnswer {}
 
 struct SetInstanceProtectionAnswerDeserializer;
@@ -7432,7 +7432,7 @@ impl SetInstanceProtectionAnswerDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SetInstanceProtectionQuery {
     /// <p>The name of the Auto Scaling group.</p>
     pub auto_scaling_group_name: String,
@@ -7482,7 +7482,7 @@ impl SpotPriceDeserializer {
     }
 }
 /// <p><p>Describes an adjustment based on the difference between the value of the aggregated CloudWatch metric and the breach threshold that you&#39;ve defined for the alarm.</p> <p>For the following examples, suppose that you have an alarm with a breach threshold of 50:</p> <ul> <li> <p>If you want the adjustment to be triggered when the metric is greater than or equal to 50 and less than 60, specify a lower bound of 0 and an upper bound of 10.</p> </li> <li> <p>If you want the adjustment to be triggered when the metric is greater than 40 and less than or equal to 50, specify a lower bound of -10 and an upper bound of 0.</p> </li> </ul> <p>There are a few rules for the step adjustments for your step policy:</p> <ul> <li> <p>The ranges of your step adjustments can&#39;t overlap or have a gap.</p> </li> <li> <p>At most one step adjustment can have a null lower bound. If one step adjustment has a negative lower bound, then there must be a step adjustment with a null lower bound.</p> </li> <li> <p>At most one step adjustment can have a null upper bound. If one step adjustment has a positive upper bound, then there must be a step adjustment with a null upper bound.</p> </li> <li> <p>The upper and lower bound can&#39;t be null in the same step adjustment.</p> </li> </ul></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct StepAdjustment {
     /// <p>The lower bound for the difference between the alarm threshold and the CloudWatch metric. If the metric value is above the breach threshold, the lower bound is inclusive (the metric must be greater than or equal to the threshold plus the lower bound). Otherwise, it is exclusive (the metric must be greater than the threshold plus the lower bound). A null value indicates negative infinity.</p>
     pub metric_interval_lower_bound: Option<f64>,
@@ -7628,7 +7628,7 @@ impl StepAdjustmentsSerializer {
 }
 
 /// <p>Describes an Auto Scaling process that has been suspended. For more information, see <a>ProcessType</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SuspendedProcess {
     /// <p>The name of the suspended process.</p>
     pub process_name: Option<String>,
@@ -7726,7 +7726,7 @@ impl SuspendedProcessesDeserializer {
     }
 }
 /// <p>Describes a tag for an Auto Scaling group.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Tag {
     /// <p>The tag key.</p>
     pub key: String,
@@ -7781,7 +7781,7 @@ impl TagSerializer {
 }
 
 /// <p>Describes a tag for an Auto Scaling group.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct TagDescription {
     /// <p>The tag key.</p>
     pub key: Option<String>,
@@ -7936,7 +7936,7 @@ impl TagsSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct TagsType {
     /// <p>The token to use when requesting the next set of items. If there are no additional items to return, the string is empty.</p>
     pub next_token: Option<String>,
@@ -8044,7 +8044,7 @@ impl TargetGroupARNsSerializer {
 }
 
 /// <p>Represents a target tracking policy configuration.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct TargetTrackingConfiguration {
     /// <p>A customized metric.</p>
     pub customized_metric_specification: Option<CustomizedMetricSpecification>,
@@ -8155,7 +8155,7 @@ impl TargetTrackingConfigurationSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct TerminateInstanceInAutoScalingGroupType {
     /// <p>The ID of the instance.</p>
     pub instance_id: String,
@@ -8253,7 +8253,7 @@ impl TimestampTypeDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateAutoScalingGroupType {
     /// <p>The name of the Auto Scaling group.</p>
     pub auto_scaling_group_name: String,

--- a/rusoto/services/autoscaling/src/generated.rs
+++ b/rusoto/services/autoscaling/src/generated.rs
@@ -29,8 +29,9 @@ use hyper::StatusCode;
 use rusoto_core::param::{Params, ServiceParams};
 use rusoto_core::signature::SignedRequest;
 use rusoto_core::xmlerror::*;
-use rusoto_core::xmlutil::{characters, end_element, find_start_element, peek_at_name, skip_tree,
-                           start_element};
+use rusoto_core::xmlutil::{
+    characters, end_element, find_start_element, peek_at_name, skip_tree, start_element,
+};
 use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
 use std::str::FromStr;
 use xml::reader::ParserConfig;

--- a/rusoto/services/batch/src/generated.rs
+++ b/rusoto/services/batch/src/generated.rs
@@ -30,7 +30,7 @@ use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 /// <p>An object representing an AWS Batch array job.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ArrayProperties {
     /// <p>The size of the array job.</p>
     #[serde(rename = "size")]
@@ -39,7 +39,7 @@ pub struct ArrayProperties {
 }
 
 /// <p>An object representing the array properties of a job.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ArrayPropertiesDetail {
     /// <p>The job index within the array that is associated with this job. This parameter is returned for array job children.</p>
     #[serde(rename = "index")]
@@ -56,7 +56,7 @@ pub struct ArrayPropertiesDetail {
 }
 
 /// <p>An object representing the array properties of a job.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ArrayPropertiesSummary {
     /// <p>The job index within the array that is associated with this job. This parameter is returned for children of array jobs.</p>
     #[serde(rename = "index")]
@@ -69,7 +69,7 @@ pub struct ArrayPropertiesSummary {
 }
 
 /// <p>An object representing the details of a container that is part of a job attempt.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AttemptContainerDetail {
     /// <p>The Amazon Resource Name (ARN) of the Amazon ECS container instance that hosts the job attempt.</p>
     #[serde(rename = "containerInstanceArn")]
@@ -94,7 +94,7 @@ pub struct AttemptContainerDetail {
 }
 
 /// <p>An object representing a job attempt.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AttemptDetail {
     /// <p>Details about the container in this job attempt.</p>
     #[serde(rename = "container")]
@@ -114,7 +114,7 @@ pub struct AttemptDetail {
     pub stopped_at: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CancelJobRequest {
     /// <p>The AWS Batch job ID of the job to cancel.</p>
     #[serde(rename = "jobId")]
@@ -124,11 +124,11 @@ pub struct CancelJobRequest {
     pub reason: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CancelJobResponse {}
 
 /// <p>An object representing an AWS Batch compute environment.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ComputeEnvironmentDetail {
     /// <p>The Amazon Resource Name (ARN) of the compute environment. </p>
     #[serde(rename = "computeEnvironmentArn")]
@@ -166,7 +166,7 @@ pub struct ComputeEnvironmentDetail {
 }
 
 /// <p>The order in which compute environments are tried for job placement within a queue. Compute environments are tried in ascending order. For example, if two compute environments are associated with a job queue, the compute environment with a lower order integer value is tried for job placement first.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ComputeEnvironmentOrder {
     /// <p>The Amazon Resource Name (ARN) of the compute environment.</p>
     #[serde(rename = "computeEnvironment")]
@@ -177,7 +177,7 @@ pub struct ComputeEnvironmentOrder {
 }
 
 /// <p>An object representing an AWS Batch compute resource.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ComputeResource {
     /// <p>The minimum percentage that a Spot Instance price must be when compared with the On-Demand price for that instance type before instances are launched. For example, if your bid percentage is 20%, then the Spot price must be below 20% of the current On-Demand price for that EC2 instance.</p>
     #[serde(rename = "bidPercentage")]
@@ -227,7 +227,7 @@ pub struct ComputeResource {
 }
 
 /// <p>An object representing the attributes of a compute environment that can be updated.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ComputeResourceUpdate {
     /// <p>The desired number of EC2 vCPUS in the compute environment.</p>
     #[serde(rename = "desiredvCpus")]
@@ -244,7 +244,7 @@ pub struct ComputeResourceUpdate {
 }
 
 /// <p>An object representing the details of a container that is part of a job.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ContainerDetail {
     /// <p>The command that is passed to the container. </p>
     #[serde(rename = "command")]
@@ -317,7 +317,7 @@ pub struct ContainerDetail {
 }
 
 /// <p>The overrides that should be sent to a container.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ContainerOverrides {
     /// <p>The command to send to the container that overrides the default command from the Docker image or the job definition.</p>
     #[serde(rename = "command")]
@@ -338,7 +338,7 @@ pub struct ContainerOverrides {
 }
 
 /// <p>Container properties are used in job definitions to describe the container that is launched as part of a job.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ContainerProperties {
     /// <p>The command that is passed to the container. This parameter maps to <code>Cmd</code> in the <a href="https://docs.docker.com/engine/reference/api/docker_remote_api_v1.23/#create-a-container">Create a container</a> section of the <a href="https://docs.docker.com/engine/reference/api/docker_remote_api_v1.23/">Docker Remote API</a> and the <code>COMMAND</code> parameter to <a href="https://docs.docker.com/engine/reference/run/">docker run</a>. For more information, see <a href="https://docs.docker.com/engine/reference/builder/#cmd">https://docs.docker.com/engine/reference/builder/#cmd</a>.</p>
     #[serde(rename = "command")]
@@ -388,7 +388,7 @@ pub struct ContainerProperties {
 }
 
 /// <p>An object representing summary details of a container within a job.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ContainerSummary {
     /// <p>The exit code to return upon completion.</p>
     #[serde(rename = "exitCode")]
@@ -400,7 +400,7 @@ pub struct ContainerSummary {
     pub reason: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateComputeEnvironmentRequest {
     /// <p>The name for your compute environment. Up to 128 letters (uppercase and lowercase), numbers, hyphens, and underscores are allowed.</p>
     #[serde(rename = "computeEnvironmentName")]
@@ -421,7 +421,7 @@ pub struct CreateComputeEnvironmentRequest {
     pub type_: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateComputeEnvironmentResponse {
     /// <p>The Amazon Resource Name (ARN) of the compute environment. </p>
     #[serde(rename = "computeEnvironmentArn")]
@@ -433,7 +433,7 @@ pub struct CreateComputeEnvironmentResponse {
     pub compute_environment_name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateJobQueueRequest {
     /// <p>The set of compute environments mapped to a job queue and their order relative to each other. The job scheduler uses this parameter to determine which compute environment should execute a given job. Compute environments must be in the <code>VALID</code> state before you can associate them with a job queue. You can associate up to three compute environments with a job queue.</p>
     #[serde(rename = "computeEnvironmentOrder")]
@@ -450,7 +450,7 @@ pub struct CreateJobQueueRequest {
     pub state: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateJobQueueResponse {
     /// <p>The Amazon Resource Name (ARN) of the job queue.</p>
     #[serde(rename = "jobQueueArn")]
@@ -460,37 +460,37 @@ pub struct CreateJobQueueResponse {
     pub job_queue_name: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteComputeEnvironmentRequest {
     /// <p>The name or Amazon Resource Name (ARN) of the compute environment to delete. </p>
     #[serde(rename = "computeEnvironment")]
     pub compute_environment: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteComputeEnvironmentResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteJobQueueRequest {
     /// <p>The short name or full Amazon Resource Name (ARN) of the queue to delete. </p>
     #[serde(rename = "jobQueue")]
     pub job_queue: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteJobQueueResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeregisterJobDefinitionRequest {
     /// <p>The name and revision (<code>name:revision</code>) or full Amazon Resource Name (ARN) of the job definition to deregister. </p>
     #[serde(rename = "jobDefinition")]
     pub job_definition: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeregisterJobDefinitionResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeComputeEnvironmentsRequest {
     /// <p>A list of up to 100 compute environment names or full Amazon Resource Name (ARN) entries. </p>
     #[serde(rename = "computeEnvironments")]
@@ -506,7 +506,7 @@ pub struct DescribeComputeEnvironmentsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeComputeEnvironmentsResponse {
     /// <p>The list of compute environments.</p>
     #[serde(rename = "computeEnvironments")]
@@ -518,7 +518,7 @@ pub struct DescribeComputeEnvironmentsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeJobDefinitionsRequest {
     /// <p>The name of the job definition to describe.</p>
     #[serde(rename = "jobDefinitionName")]
@@ -542,7 +542,7 @@ pub struct DescribeJobDefinitionsRequest {
     pub status: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeJobDefinitionsResponse {
     /// <p>The list of job definitions. </p>
     #[serde(rename = "jobDefinitions")]
@@ -554,7 +554,7 @@ pub struct DescribeJobDefinitionsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeJobQueuesRequest {
     /// <p>A list of up to 100 queue names or full queue Amazon Resource Name (ARN) entries.</p>
     #[serde(rename = "jobQueues")]
@@ -570,7 +570,7 @@ pub struct DescribeJobQueuesRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeJobQueuesResponse {
     /// <p>The list of job queues. </p>
     #[serde(rename = "jobQueues")]
@@ -582,14 +582,14 @@ pub struct DescribeJobQueuesResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeJobsRequest {
     /// <p>A space-separated list of up to 100 job IDs.</p>
     #[serde(rename = "jobs")]
     pub jobs: Vec<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeJobsResponse {
     /// <p>The list of jobs. </p>
     #[serde(rename = "jobs")]
@@ -598,7 +598,7 @@ pub struct DescribeJobsResponse {
 }
 
 /// <p>The contents of the <code>host</code> parameter determine whether your data volume persists on the host container instance and where it is stored. If the host parameter is empty, then the Docker daemon assigns a host path for your data volume, but the data is not guaranteed to persist after the containers associated with it stop running.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Host {
     /// <p>The path on the host container instance that is presented to the container. If this parameter is empty, then the Docker daemon has assigned a host path for you. If the <code>host</code> parameter contains a <code>sourcePath</code> file location, then the data volume persists at the specified location on the host container instance until you delete it manually. If the <code>sourcePath</code> value does not exist on the host container instance, the Docker daemon creates it. If the location does exist, the contents of the source path folder are exported.</p>
     #[serde(rename = "sourcePath")]
@@ -607,7 +607,7 @@ pub struct Host {
 }
 
 /// <p>An object representing an AWS Batch job definition.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct JobDefinition {
     /// <p>An object with various properties specific to container-based jobs. </p>
     #[serde(rename = "containerProperties")]
@@ -644,7 +644,7 @@ pub struct JobDefinition {
 }
 
 /// <p>An object representing an AWS Batch job dependency.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct JobDependency {
     /// <p>The job ID of the AWS Batch job associated with this dependency.</p>
     #[serde(rename = "jobId")]
@@ -657,7 +657,7 @@ pub struct JobDependency {
 }
 
 /// <p>An object representing an AWS Batch job.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct JobDetail {
     /// <p>The array properties of the job, if it is an array job.</p>
     #[serde(rename = "arrayProperties")]
@@ -720,7 +720,7 @@ pub struct JobDetail {
 }
 
 /// <p>An object representing the details of an AWS Batch job queue.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct JobQueueDetail {
     /// <p>The compute environments that are attached to the job queue and the order in which job placement is preferred. Compute environments are selected for job placement in ascending order.</p>
     #[serde(rename = "computeEnvironmentOrder")]
@@ -748,7 +748,7 @@ pub struct JobQueueDetail {
 }
 
 /// <p>An object representing summary details of a job.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct JobSummary {
     /// <p>The array properties of the job, if it is an array job.</p>
     #[serde(rename = "arrayProperties")]
@@ -787,7 +787,7 @@ pub struct JobSummary {
 }
 
 /// <p>An object representing a job timeout configuration.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct JobTimeout {
     /// <p>The time duration in seconds (measured from the job attempt's <code>startedAt</code> timestamp) after which AWS Batch terminates your jobs if they have not finished.</p>
     #[serde(rename = "attemptDurationSeconds")]
@@ -796,7 +796,7 @@ pub struct JobTimeout {
 }
 
 /// <p>A key-value pair object.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct KeyValuePair {
     /// <p>The name of the key-value pair. For environment variables, this is the name of the environment variable.</p>
     #[serde(rename = "name")]
@@ -808,7 +808,7 @@ pub struct KeyValuePair {
     pub value: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListJobsRequest {
     /// <p>The job ID for an array job. Specifying an array job ID with this parameter lists all child jobs from within the specified array.</p>
     #[serde(rename = "arrayJobId")]
@@ -832,7 +832,7 @@ pub struct ListJobsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListJobsResponse {
     /// <p>A list of job summaries that match the request.</p>
     #[serde(rename = "jobSummaryList")]
@@ -844,7 +844,7 @@ pub struct ListJobsResponse {
 }
 
 /// <p>Details on a Docker volume mount point that is used in a job's container properties.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct MountPoint {
     /// <p>The path on the container at which to mount the host volume.</p>
     #[serde(rename = "containerPath")]
@@ -860,7 +860,7 @@ pub struct MountPoint {
     pub source_volume: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RegisterJobDefinitionRequest {
     /// <p>An object with various properties specific for container-based jobs. This parameter is required if the <code>type</code> parameter is <code>container</code>.</p>
     #[serde(rename = "containerProperties")]
@@ -886,7 +886,7 @@ pub struct RegisterJobDefinitionRequest {
     pub type_: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RegisterJobDefinitionResponse {
     /// <p>The Amazon Resource Name (ARN) of the job definition. </p>
     #[serde(rename = "jobDefinitionArn")]
@@ -900,7 +900,7 @@ pub struct RegisterJobDefinitionResponse {
 }
 
 /// <p>The retry strategy associated with a job.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RetryStrategy {
     /// <p>The number of times to move a job to the <code>RUNNABLE</code> status. You may specify between 1 and 10 attempts. If the value of <code>attempts</code> is greater than one, the job is retried if it fails until it has moved to <code>RUNNABLE</code> that many times.</p>
     #[serde(rename = "attempts")]
@@ -908,7 +908,7 @@ pub struct RetryStrategy {
     pub attempts: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SubmitJobRequest {
     /// <p>The array properties for the submitted job, such as the size of the array. The array size can be between 2 and 10,000. If you specify array properties for a job, it becomes an array job. For more information, see <a href="http://docs.aws.amazon.com/batch/latest/userguide/array_jobs.html">Array Jobs</a> in the <i>AWS Batch User Guide</i>.</p>
     #[serde(rename = "arrayProperties")]
@@ -945,7 +945,7 @@ pub struct SubmitJobRequest {
     pub timeout: Option<JobTimeout>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SubmitJobResponse {
     /// <p>The unique identifier for the job.</p>
     #[serde(rename = "jobId")]
@@ -955,7 +955,7 @@ pub struct SubmitJobResponse {
     pub job_name: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct TerminateJobRequest {
     /// <p>The AWS Batch job ID of the job to terminate.</p>
     #[serde(rename = "jobId")]
@@ -965,11 +965,11 @@ pub struct TerminateJobRequest {
     pub reason: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct TerminateJobResponse {}
 
 /// <p>The <code>ulimit</code> settings to pass to the container.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Ulimit {
     /// <p>The hard limit for the <code>ulimit</code> type.</p>
     #[serde(rename = "hardLimit")]
@@ -982,7 +982,7 @@ pub struct Ulimit {
     pub soft_limit: i64,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateComputeEnvironmentRequest {
     /// <p>The name or full Amazon Resource Name (ARN) of the compute environment to update.</p>
     #[serde(rename = "computeEnvironment")]
@@ -1001,7 +1001,7 @@ pub struct UpdateComputeEnvironmentRequest {
     pub state: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateComputeEnvironmentResponse {
     /// <p>The Amazon Resource Name (ARN) of the compute environment. </p>
     #[serde(rename = "computeEnvironmentArn")]
@@ -1013,7 +1013,7 @@ pub struct UpdateComputeEnvironmentResponse {
     pub compute_environment_name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateJobQueueRequest {
     /// <p>Details the set of compute environments mapped to a job queue and their order relative to each other. This is one of the parameters used by the job scheduler to determine which compute environment should execute a given job. </p>
     #[serde(rename = "computeEnvironmentOrder")]
@@ -1032,7 +1032,7 @@ pub struct UpdateJobQueueRequest {
     pub state: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateJobQueueResponse {
     /// <p>The Amazon Resource Name (ARN) of the job queue.</p>
     #[serde(rename = "jobQueueArn")]
@@ -1045,7 +1045,7 @@ pub struct UpdateJobQueueResponse {
 }
 
 /// <p>A data volume used in a job's container properties.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Volume {
     /// <p>The contents of the <code>host</code> parameter determine whether your data volume persists on the host container instance and where it is stored. If the host parameter is empty, then the Docker daemon assigns a host path for your data volume. However, the data is not guaranteed to persist after the containers associated with it stop running.</p>
     #[serde(rename = "host")]

--- a/rusoto/services/batch/src/generated.rs
+++ b/rusoto/services/batch/src/generated.rs
@@ -1078,7 +1078,8 @@ impl CancelJobError {
     pub fn from_body(body: &str) -> CancelJobError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1156,7 +1157,8 @@ impl CreateComputeEnvironmentError {
     pub fn from_body(body: &str) -> CreateComputeEnvironmentError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1242,7 +1244,8 @@ impl CreateJobQueueError {
     pub fn from_body(body: &str) -> CreateJobQueueError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1322,7 +1325,8 @@ impl DeleteComputeEnvironmentError {
     pub fn from_body(body: &str) -> DeleteComputeEnvironmentError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1408,7 +1412,8 @@ impl DeleteJobQueueError {
     pub fn from_body(body: &str) -> DeleteJobQueueError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1488,7 +1493,8 @@ impl DeregisterJobDefinitionError {
     pub fn from_body(body: &str) -> DeregisterJobDefinitionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1574,7 +1580,8 @@ impl DescribeComputeEnvironmentsError {
     pub fn from_body(body: &str) -> DescribeComputeEnvironmentsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1660,7 +1667,8 @@ impl DescribeJobDefinitionsError {
     pub fn from_body(body: &str) -> DescribeJobDefinitionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1746,7 +1754,8 @@ impl DescribeJobQueuesError {
     pub fn from_body(body: &str) -> DescribeJobQueuesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1832,7 +1841,8 @@ impl DescribeJobsError {
     pub fn from_body(body: &str) -> DescribeJobsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1912,7 +1922,8 @@ impl ListJobsError {
     pub fn from_body(body: &str) -> ListJobsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1990,7 +2001,8 @@ impl RegisterJobDefinitionError {
     pub fn from_body(body: &str) -> RegisterJobDefinitionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2076,7 +2088,8 @@ impl SubmitJobError {
     pub fn from_body(body: &str) -> SubmitJobError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2154,7 +2167,8 @@ impl TerminateJobError {
     pub fn from_body(body: &str) -> TerminateJobError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2234,7 +2248,8 @@ impl UpdateComputeEnvironmentError {
     pub fn from_body(body: &str) -> UpdateComputeEnvironmentError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2320,7 +2335,8 @@ impl UpdateJobQueueError {
     pub fn from_body(body: &str) -> UpdateJobQueueError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/budgets/src/generated.rs
+++ b/rusoto/services/budgets/src/generated.rs
@@ -505,7 +505,8 @@ impl CreateBudgetError {
     pub fn from_body(body: &str) -> CreateBudgetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -603,7 +604,8 @@ impl CreateNotificationError {
     pub fn from_body(body: &str) -> CreateNotificationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -707,7 +709,8 @@ impl CreateSubscriberError {
     pub fn from_body(body: &str) -> CreateSubscriberError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -805,7 +808,8 @@ impl DeleteBudgetError {
     pub fn from_body(body: &str) -> DeleteBudgetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -893,7 +897,8 @@ impl DeleteNotificationError {
     pub fn from_body(body: &str) -> DeleteNotificationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -985,7 +990,8 @@ impl DeleteSubscriberError {
     pub fn from_body(body: &str) -> DeleteSubscriberError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1075,7 +1081,8 @@ impl DescribeBudgetError {
     pub fn from_body(body: &str) -> DescribeBudgetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1169,7 +1176,8 @@ impl DescribeBudgetsError {
     pub fn from_body(body: &str) -> DescribeBudgetsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1271,7 +1279,8 @@ impl DescribeNotificationsForBudgetError {
     pub fn from_body(body: &str) -> DescribeNotificationsForBudgetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1381,7 +1390,8 @@ impl DescribeSubscribersForNotificationError {
     pub fn from_body(body: &str) -> DescribeSubscribersForNotificationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1489,7 +1499,8 @@ impl UpdateBudgetError {
     pub fn from_body(body: &str) -> UpdateBudgetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1579,7 +1590,8 @@ impl UpdateNotificationError {
     pub fn from_body(body: &str) -> UpdateNotificationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1677,7 +1689,8 @@ impl UpdateSubscriberError {
     pub fn from_body(body: &str) -> UpdateSubscriberError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/budgets/src/generated.rs
+++ b/rusoto/services/budgets/src/generated.rs
@@ -31,7 +31,7 @@ use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 /// <p>Represents the output of the <code>CreateBudget</code> operation. The content consists of the detailed metadata and data file information, and the current status of the <code>budget</code>.</p> <p>The ARN pattern for a budget is: <code>arn:aws:budgetservice::AccountId:budget/budgetName</code> </p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Budget {
     /// <p>The total amount of cost, usage, or RI utilization that you want to track with your budget.</p> <p> <code>BudgetLimit</code> is required for cost or usage budgets, but optional for RI utilization budgets. RI utilization budgets default to the only valid value for RI utilization budgets, which is <code>100</code>.</p>
     #[serde(rename = "BudgetLimit")]
@@ -65,7 +65,7 @@ pub struct Budget {
 }
 
 /// <p>The spend objects associated with this budget. The <code>actualSpend</code> tracks how much you've used, cost, usage, or RI units, and the <code>forecastedSpend</code> tracks how much you are predicted to spend if your current usage remains steady.</p> <p>For example, if it is the 20th of the month and you have spent <code>50</code> dollars on Amazon EC2, your <code>actualSpend</code> is <code>50 USD</code>, and your <code>forecastedSpend</code> is <code>75 USD</code>.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CalculatedSpend {
     /// <p>The amount of cost, usage, or RI units that you have used.</p>
     #[serde(rename = "ActualSpend")]
@@ -77,7 +77,7 @@ pub struct CalculatedSpend {
 }
 
 /// <p>The types of cost included in a budget, such as tax and subscriptions.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CostTypes {
     /// <p>Specifies whether a budget includes credits.</p> <p>The default value is <code>true</code>.</p>
     #[serde(rename = "IncludeCredit")]
@@ -126,7 +126,7 @@ pub struct CostTypes {
 }
 
 /// <p> Request of CreateBudget </p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateBudgetRequest {
     /// <p>The <code>accountId</code> that is associated with the budget.</p>
     #[serde(rename = "AccountId")]
@@ -141,11 +141,11 @@ pub struct CreateBudgetRequest {
 }
 
 /// <p> Response of CreateBudget </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateBudgetResponse {}
 
 /// <p> Request of CreateNotification </p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateNotificationRequest {
     /// <p>The <code>accountId</code> that is associated with the budget that you want to create a notification for.</p>
     #[serde(rename = "AccountId")]
@@ -162,11 +162,11 @@ pub struct CreateNotificationRequest {
 }
 
 /// <p> Response of CreateNotification </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateNotificationResponse {}
 
 /// <p> Request of CreateSubscriber </p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateSubscriberRequest {
     /// <p>The <code>accountId</code> associated with the budget that you want to create a subscriber for.</p>
     #[serde(rename = "AccountId")]
@@ -183,11 +183,11 @@ pub struct CreateSubscriberRequest {
 }
 
 /// <p> Response of CreateSubscriber </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateSubscriberResponse {}
 
 /// <p> Request of DeleteBudget </p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteBudgetRequest {
     /// <p>The <code>accountId</code> that is associated with the budget that you want to delete.</p>
     #[serde(rename = "AccountId")]
@@ -198,11 +198,11 @@ pub struct DeleteBudgetRequest {
 }
 
 /// <p> Response of DeleteBudget </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteBudgetResponse {}
 
 /// <p> Request of DeleteNotification </p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteNotificationRequest {
     /// <p>The <code>accountId</code> that is associated with the budget whose notification you want to delete.</p>
     #[serde(rename = "AccountId")]
@@ -216,11 +216,11 @@ pub struct DeleteNotificationRequest {
 }
 
 /// <p> Response of DeleteNotification </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteNotificationResponse {}
 
 /// <p> Request of DeleteSubscriber </p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteSubscriberRequest {
     /// <p>The <code>accountId</code> that is associated with the budget whose subscriber you want to delete.</p>
     #[serde(rename = "AccountId")]
@@ -237,11 +237,11 @@ pub struct DeleteSubscriberRequest {
 }
 
 /// <p> Response of DeleteSubscriber </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteSubscriberResponse {}
 
 /// <p> Request of DescribeBudget </p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeBudgetRequest {
     /// <p>The <code>accountId</code> that is associated with the budget that you want a description of.</p>
     #[serde(rename = "AccountId")]
@@ -252,7 +252,7 @@ pub struct DescribeBudgetRequest {
 }
 
 /// <p> Response of DescribeBudget </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeBudgetResponse {
     /// <p>The description of the budget.</p>
     #[serde(rename = "Budget")]
@@ -261,7 +261,7 @@ pub struct DescribeBudgetResponse {
 }
 
 /// <p> Request of DescribeBudgets </p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeBudgetsRequest {
     /// <p>The <code>accountId</code> that is associated with the budgets that you want descriptions of.</p>
     #[serde(rename = "AccountId")]
@@ -277,7 +277,7 @@ pub struct DescribeBudgetsRequest {
 }
 
 /// <p> Response of DescribeBudgets </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeBudgetsResponse {
     /// <p>A list of budgets.</p>
     #[serde(rename = "Budgets")]
@@ -290,7 +290,7 @@ pub struct DescribeBudgetsResponse {
 }
 
 /// <p> Request of DescribeNotificationsForBudget </p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeNotificationsForBudgetRequest {
     /// <p>The <code>accountId</code> that is associated with the budget whose notifications you want descriptions of.</p>
     #[serde(rename = "AccountId")]
@@ -309,7 +309,7 @@ pub struct DescribeNotificationsForBudgetRequest {
 }
 
 /// <p> Response of GetNotificationsForBudget </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeNotificationsForBudgetResponse {
     /// <p>The pagination token that indicates the next set of results that you can retrieve.</p>
     #[serde(rename = "NextToken")]
@@ -322,7 +322,7 @@ pub struct DescribeNotificationsForBudgetResponse {
 }
 
 /// <p> Request of DescribeSubscribersForNotification </p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeSubscribersForNotificationRequest {
     /// <p>The <code>accountId</code> that is associated with the budget whose subscribers you want descriptions of.</p>
     #[serde(rename = "AccountId")]
@@ -344,7 +344,7 @@ pub struct DescribeSubscribersForNotificationRequest {
 }
 
 /// <p> Response of DescribeSubscribersForNotification </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeSubscribersForNotificationResponse {
     /// <p>The pagination token that indicates the next set of results that you can retrieve.</p>
     #[serde(rename = "NextToken")]
@@ -357,7 +357,7 @@ pub struct DescribeSubscribersForNotificationResponse {
 }
 
 /// <p><p>A notification associated with a budget. A budget can have up to five notifications. </p> <p>Each notification must have at least one subscriber. A notification can have one SNS subscriber and up to ten email subscribers, for a total of 11 subscribers.</p> <p>For example, if you have a budget for 200 dollars and you want to be notified when you go over 160 dollars, create a notification with the following parameters:</p> <ul> <li> <p>A notificationType of <code>ACTUAL</code> </p> </li> <li> <p>A comparisonOperator of <code>GREATER_THAN</code> </p> </li> <li> <p>A notification threshold of <code>80</code> </p> </li> </ul></p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Notification {
     /// <p>The comparison used for this notification.</p>
     #[serde(rename = "ComparisonOperator")]
@@ -375,7 +375,7 @@ pub struct Notification {
 }
 
 /// <p>A notification with subscribers. A notification can have one SNS subscriber and up to ten email subscribers, for a total of 11 subscribers.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct NotificationWithSubscribers {
     /// <p>The notification associated with a budget.</p>
     #[serde(rename = "Notification")]
@@ -386,7 +386,7 @@ pub struct NotificationWithSubscribers {
 }
 
 /// <p><p>The amount of cost or usage being measured for a budget.</p> <p>For example, a <code>Spend</code> for <code>3 GB</code> of S3 usage would have the following parameters:</p> <ul> <li> <p>An <code>Amount</code> of <code>3</code> </p> </li> <li> <p>A <code>unit</code> of <code>GB</code> </p> </li> </ul></p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Spend {
     /// <p>The cost or usage amount associated with a budget forecast, actual spend, or budget threshold.</p>
     #[serde(rename = "Amount")]
@@ -397,7 +397,7 @@ pub struct Spend {
 }
 
 /// <p><p>The subscriber to a budget notification. The subscriber consists of a subscription type and either an Amazon Simple Notification Service topic or an email address.</p> <p>For example, an email subscriber would have the following parameters:</p> <ul> <li> <p>A <code>subscriptionType</code> of <code>EMAIL</code> </p> </li> <li> <p>An <code>address</code> of <code>example@example.com</code> </p> </li> </ul></p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Subscriber {
     /// <p>The address that AWS sends budget notifications to, either an SNS topic or an email.</p>
     #[serde(rename = "Address")]
@@ -408,7 +408,7 @@ pub struct Subscriber {
 }
 
 /// <p>The period of time covered by a budget. Has a start date and an end date. The start date must come before the end date. There are no restrictions on the end date. </p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TimePeriod {
     /// <p>The end date for a budget. If you didn't specify an end date, AWS set your end date to <code>06/15/87 00:00 UTC</code>. The defaults are the same for the AWS Billing and Cost Management console and the API.</p> <p>After the end date, AWS deletes the budget and all associated notifications and subscribers. You can change your end date with the <code>UpdateBudget</code> operation.</p>
     #[serde(rename = "End")]
@@ -421,7 +421,7 @@ pub struct TimePeriod {
 }
 
 /// <p> Request of UpdateBudget </p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateBudgetRequest {
     /// <p>The <code>accountId</code> that is associated with the budget that you want to update.</p>
     #[serde(rename = "AccountId")]
@@ -432,11 +432,11 @@ pub struct UpdateBudgetRequest {
 }
 
 /// <p> Response of UpdateBudget </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateBudgetResponse {}
 
 /// <p> Request of UpdateNotification </p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateNotificationRequest {
     /// <p>The <code>accountId</code> that is associated with the budget whose notification you want to update.</p>
     #[serde(rename = "AccountId")]
@@ -453,11 +453,11 @@ pub struct UpdateNotificationRequest {
 }
 
 /// <p> Response of UpdateNotification </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateNotificationResponse {}
 
 /// <p> Request of UpdateSubscriber </p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateSubscriberRequest {
     /// <p>The <code>accountId</code> that is associated with the budget whose subscriber you want to update.</p>
     #[serde(rename = "AccountId")]
@@ -477,7 +477,7 @@ pub struct UpdateSubscriberRequest {
 }
 
 /// <p> Response of UpdateSubscriber </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateSubscriberResponse {}
 
 /// Errors returned by CreateBudget

--- a/rusoto/services/clouddirectory/src/generated.rs
+++ b/rusoto/services/clouddirectory/src/generated.rs
@@ -29,7 +29,7 @@ use rusoto_core::signature::SignedRequest;
 use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AddFacetToObjectRequest {
     /// <p>The Amazon Resource Name (ARN) that is associated with the <a>Directory</a> where the object resides. For more information, see <a>arns</a>.</p>
     #[serde(rename = "DirectoryArn")]
@@ -46,10 +46,10 @@ pub struct AddFacetToObjectRequest {
     pub schema_facet: SchemaFacet,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AddFacetToObjectResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ApplySchemaRequest {
     /// <p>The Amazon Resource Name (ARN) that is associated with the <a>Directory</a> into which the schema is copied. For more information, see <a>arns</a>.</p>
     #[serde(rename = "DirectoryArn")]
@@ -59,7 +59,7 @@ pub struct ApplySchemaRequest {
     pub published_schema_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ApplySchemaResponse {
     /// <p>The applied schema ARN that is associated with the copied schema in the <a>Directory</a>. You can use this ARN to describe the schema information applied on this directory. For more information, see <a>arns</a>.</p>
     #[serde(rename = "AppliedSchemaArn")]
@@ -71,7 +71,7 @@ pub struct ApplySchemaResponse {
     pub directory_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AttachObjectRequest {
     /// <p>The child object reference to be attached to the object.</p>
     #[serde(rename = "ChildReference")]
@@ -87,7 +87,7 @@ pub struct AttachObjectRequest {
     pub parent_reference: ObjectReference,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AttachObjectResponse {
     /// <p>The attached <code>ObjectIdentifier</code>, which is the child <code>ObjectIdentifier</code>.</p>
     #[serde(rename = "AttachedObjectIdentifier")]
@@ -95,7 +95,7 @@ pub struct AttachObjectResponse {
     pub attached_object_identifier: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AttachPolicyRequest {
     /// <p>The Amazon Resource Name (ARN) that is associated with the <a>Directory</a> where both objects reside. For more information, see <a>arns</a>.</p>
     #[serde(rename = "DirectoryArn")]
@@ -109,10 +109,10 @@ pub struct AttachPolicyRequest {
     pub policy_reference: ObjectReference,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AttachPolicyResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AttachToIndexRequest {
     /// <p>The Amazon Resource Name (ARN) of the directory where the object and index exist.</p>
     #[serde(rename = "DirectoryArn")]
@@ -125,7 +125,7 @@ pub struct AttachToIndexRequest {
     pub target_reference: ObjectReference,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AttachToIndexResponse {
     /// <p>The <code>ObjectIdentifier</code> of the object that was attached to the index.</p>
     #[serde(rename = "AttachedObjectIdentifier")]
@@ -133,7 +133,7 @@ pub struct AttachToIndexResponse {
     pub attached_object_identifier: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AttachTypedLinkRequest {
     /// <p>A set of attributes that are associated with the typed link.</p>
     #[serde(rename = "Attributes")]
@@ -152,7 +152,7 @@ pub struct AttachTypedLinkRequest {
     pub typed_link_facet: TypedLinkSchemaAndFacetName,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AttachTypedLinkResponse {
     /// <p>Returns a typed link specifier as output.</p>
     #[serde(rename = "TypedLinkSpecifier")]
@@ -161,7 +161,7 @@ pub struct AttachTypedLinkResponse {
 }
 
 /// <p>A unique identifier for an attribute.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct AttributeKey {
     /// <p>The name of the facet that the attribute exists within.</p>
     #[serde(rename = "FacetName")]
@@ -175,7 +175,7 @@ pub struct AttributeKey {
 }
 
 /// <p>The combination of an attribute key and an attribute value.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct AttributeKeyAndValue {
     /// <p>The key of the attribute.</p>
     #[serde(rename = "Key")]
@@ -186,7 +186,7 @@ pub struct AttributeKeyAndValue {
 }
 
 /// <p>Identifies the attribute name and value for a typed link.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct AttributeNameAndValue {
     /// <p>The attribute name of the typed link.</p>
     #[serde(rename = "AttributeName")]
@@ -197,7 +197,7 @@ pub struct AttributeNameAndValue {
 }
 
 /// <p>Represents the output of a batch add facet to object operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct BatchAddFacetToObject {
     /// <p>The attributes to set on the object.</p>
     #[serde(rename = "ObjectAttributeList")]
@@ -211,11 +211,11 @@ pub struct BatchAddFacetToObject {
 }
 
 /// <p>The result of a batch add facet to object operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BatchAddFacetToObjectResponse {}
 
 /// <p>Represents the output of an <a>AttachObject</a> operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct BatchAttachObject {
     /// <p>The child object reference that is to be attached to the object.</p>
     #[serde(rename = "ChildReference")]
@@ -229,7 +229,7 @@ pub struct BatchAttachObject {
 }
 
 /// <p>Represents the output batch <a>AttachObject</a> response operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BatchAttachObjectResponse {
     /// <p>The <code>ObjectIdentifier</code> of the object that has been attached.</p>
     #[serde(rename = "attachedObjectIdentifier")]
@@ -238,7 +238,7 @@ pub struct BatchAttachObjectResponse {
 }
 
 /// <p>Attaches a policy object to a regular object inside a <a>BatchRead</a> operation. For more information, see <a>AttachPolicy</a> and <a>BatchReadRequest$Operations</a>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct BatchAttachPolicy {
     /// <p>The reference that identifies the object to which the policy will be attached.</p>
     #[serde(rename = "ObjectReference")]
@@ -249,11 +249,11 @@ pub struct BatchAttachPolicy {
 }
 
 /// <p>Represents the output of an <a>AttachPolicy</a> response operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BatchAttachPolicyResponse {}
 
 /// <p>Attaches the specified object to the specified index inside a <a>BatchRead</a> operation. For more information, see <a>AttachToIndex</a> and <a>BatchReadRequest$Operations</a>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct BatchAttachToIndex {
     /// <p>A reference to the index that you are attaching the object to.</p>
     #[serde(rename = "IndexReference")]
@@ -264,7 +264,7 @@ pub struct BatchAttachToIndex {
 }
 
 /// <p>Represents the output of a <a>AttachToIndex</a> response operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BatchAttachToIndexResponse {
     /// <p>The <code>ObjectIdentifier</code> of the object that was attached to the index.</p>
     #[serde(rename = "AttachedObjectIdentifier")]
@@ -273,7 +273,7 @@ pub struct BatchAttachToIndexResponse {
 }
 
 /// <p>Attaches a typed link to a specified source and target object inside a <a>BatchRead</a> operation. For more information, see <a>AttachTypedLink</a> and <a>BatchReadRequest$Operations</a>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct BatchAttachTypedLink {
     /// <p>A set of attributes that are associated with the typed link.</p>
     #[serde(rename = "Attributes")]
@@ -290,7 +290,7 @@ pub struct BatchAttachTypedLink {
 }
 
 /// <p>Represents the output of a <a>AttachTypedLink</a> response operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BatchAttachTypedLinkResponse {
     /// <p>Returns a typed link specifier as output.</p>
     #[serde(rename = "TypedLinkSpecifier")]
@@ -299,7 +299,7 @@ pub struct BatchAttachTypedLinkResponse {
 }
 
 /// <p>Creates an index object inside of a <a>BatchRead</a> operation. For more information, see <a>CreateIndex</a> and <a>BatchReadRequest$Operations</a>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct BatchCreateIndex {
     /// <p>The batch reference name. See <a href="http://docs.aws.amazon.com/directoryservice/latest/admin-guide/cd_advanced.html#batches">Batches</a> for more information.</p>
     #[serde(rename = "BatchReferenceName")]
@@ -322,7 +322,7 @@ pub struct BatchCreateIndex {
 }
 
 /// <p>Represents the output of a <a>CreateIndex</a> response operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BatchCreateIndexResponse {
     /// <p>The <code>ObjectIdentifier</code> of the index created by this operation.</p>
     #[serde(rename = "ObjectIdentifier")]
@@ -331,7 +331,7 @@ pub struct BatchCreateIndexResponse {
 }
 
 /// <p>Represents the output of a <a>CreateObject</a> operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct BatchCreateObject {
     /// <p>The batch reference name. See <a href="http://docs.aws.amazon.com/directoryservice/latest/admin-guide/cd_advanced.html#batches">Batches</a> for more information.</p>
     #[serde(rename = "BatchReferenceName")]
@@ -351,7 +351,7 @@ pub struct BatchCreateObject {
 }
 
 /// <p>Represents the output of a <a>CreateObject</a> response operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BatchCreateObjectResponse {
     /// <p>The ID that is associated with the object.</p>
     #[serde(rename = "ObjectIdentifier")]
@@ -360,7 +360,7 @@ pub struct BatchCreateObjectResponse {
 }
 
 /// <p>Represents the output of a <a>DeleteObject</a> operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct BatchDeleteObject {
     /// <p>The reference that identifies the object.</p>
     #[serde(rename = "ObjectReference")]
@@ -368,11 +368,11 @@ pub struct BatchDeleteObject {
 }
 
 /// <p>Represents the output of a <a>DeleteObject</a> response operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BatchDeleteObjectResponse {}
 
 /// <p>Detaches the specified object from the specified index inside a <a>BatchRead</a> operation. For more information, see <a>DetachFromIndex</a> and <a>BatchReadRequest$Operations</a>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct BatchDetachFromIndex {
     /// <p>A reference to the index object.</p>
     #[serde(rename = "IndexReference")]
@@ -383,7 +383,7 @@ pub struct BatchDetachFromIndex {
 }
 
 /// <p>Represents the output of a <a>DetachFromIndex</a> response operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BatchDetachFromIndexResponse {
     /// <p>The <code>ObjectIdentifier</code> of the object that was detached from the index.</p>
     #[serde(rename = "DetachedObjectIdentifier")]
@@ -392,7 +392,7 @@ pub struct BatchDetachFromIndexResponse {
 }
 
 /// <p>Represents the output of a <a>DetachObject</a> operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct BatchDetachObject {
     /// <p>The batch reference name. See <a href="http://docs.aws.amazon.com/directoryservice/latest/admin-guide/cd_advanced.html#batches">Batches</a> for more information.</p>
     #[serde(rename = "BatchReferenceName")]
@@ -406,7 +406,7 @@ pub struct BatchDetachObject {
 }
 
 /// <p>Represents the output of a <a>DetachObject</a> response operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BatchDetachObjectResponse {
     /// <p>The <code>ObjectIdentifier</code> of the detached object.</p>
     #[serde(rename = "detachedObjectIdentifier")]
@@ -415,7 +415,7 @@ pub struct BatchDetachObjectResponse {
 }
 
 /// <p>Detaches the specified policy from the specified directory inside a <a>BatchWrite</a> operation. For more information, see <a>DetachPolicy</a> and <a>BatchWriteRequest$Operations</a>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct BatchDetachPolicy {
     /// <p>Reference that identifies the object whose policy object will be detached.</p>
     #[serde(rename = "ObjectReference")]
@@ -426,11 +426,11 @@ pub struct BatchDetachPolicy {
 }
 
 /// <p>Represents the output of a <a>DetachPolicy</a> response operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BatchDetachPolicyResponse {}
 
 /// <p>Detaches a typed link from a specified source and target object inside a <a>BatchRead</a> operation. For more information, see <a>DetachTypedLink</a> and <a>BatchReadRequest$Operations</a>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct BatchDetachTypedLink {
     /// <p>Used to accept a typed link specifier as input.</p>
     #[serde(rename = "TypedLinkSpecifier")]
@@ -438,11 +438,11 @@ pub struct BatchDetachTypedLink {
 }
 
 /// <p>Represents the output of a <a>DetachTypedLink</a> response operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BatchDetachTypedLinkResponse {}
 
 /// <p>Retrieves metadata about an object inside a <a>BatchRead</a> operation. For more information, see <a>GetObjectInformation</a> and <a>BatchReadRequest$Operations</a>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct BatchGetObjectInformation {
     /// <p>A reference to the object.</p>
     #[serde(rename = "ObjectReference")]
@@ -450,7 +450,7 @@ pub struct BatchGetObjectInformation {
 }
 
 /// <p>Represents the output of a <a>GetObjectInformation</a> response operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BatchGetObjectInformationResponse {
     /// <p>The <code>ObjectIdentifier</code> of the specified object.</p>
     #[serde(rename = "ObjectIdentifier")]
@@ -463,7 +463,7 @@ pub struct BatchGetObjectInformationResponse {
 }
 
 /// <p>Lists indices attached to an object inside a <a>BatchRead</a> operation. For more information, see <a>ListAttachedIndices</a> and <a>BatchReadRequest$Operations</a>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct BatchListAttachedIndices {
     /// <p>The maximum number of results to retrieve.</p>
     #[serde(rename = "MaxResults")]
@@ -479,7 +479,7 @@ pub struct BatchListAttachedIndices {
 }
 
 /// <p>Represents the output of a <a>ListAttachedIndices</a> response operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BatchListAttachedIndicesResponse {
     /// <p>The indices attached to the specified object.</p>
     #[serde(rename = "IndexAttachments")]
@@ -492,7 +492,7 @@ pub struct BatchListAttachedIndicesResponse {
 }
 
 /// <p>Returns a paginated list of all the incoming <a>TypedLinkSpecifier</a> information for an object inside a <a>BatchRead</a> operation. For more information, see <a>ListIncomingTypedLinks</a> and <a>BatchReadRequest$Operations</a>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct BatchListIncomingTypedLinks {
     /// <p>Provides range filters for multiple attributes. When providing ranges to typed link selection, any inexact ranges must be specified at the end. Any attributes that do not have a range specified are presumed to match the entire range.</p>
     #[serde(rename = "FilterAttributeRanges")]
@@ -516,7 +516,7 @@ pub struct BatchListIncomingTypedLinks {
 }
 
 /// <p>Represents the output of a <a>ListIncomingTypedLinks</a> response operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BatchListIncomingTypedLinksResponse {
     /// <p>Returns one or more typed link specifiers as output.</p>
     #[serde(rename = "LinkSpecifiers")]
@@ -529,7 +529,7 @@ pub struct BatchListIncomingTypedLinksResponse {
 }
 
 /// <p>Lists objects attached to the specified index inside a <a>BatchRead</a> operation. For more information, see <a>ListIndex</a> and <a>BatchReadRequest$Operations</a>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct BatchListIndex {
     /// <p>The reference to the index to list.</p>
     #[serde(rename = "IndexReference")]
@@ -549,7 +549,7 @@ pub struct BatchListIndex {
 }
 
 /// <p>Represents the output of a <a>ListIndex</a> response operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BatchListIndexResponse {
     /// <p>The objects and indexed values attached to the index.</p>
     #[serde(rename = "IndexAttachments")]
@@ -562,7 +562,7 @@ pub struct BatchListIndexResponse {
 }
 
 /// <p>Represents the output of a <a>ListObjectAttributes</a> operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct BatchListObjectAttributes {
     /// <p>Used to filter the list of object attributes that are associated with a certain facet.</p>
     #[serde(rename = "FacetFilter")]
@@ -582,7 +582,7 @@ pub struct BatchListObjectAttributes {
 }
 
 /// <p>Represents the output of a <a>ListObjectAttributes</a> response operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BatchListObjectAttributesResponse {
     /// <p>The attributes map that is associated with the object. <code>AttributeArn</code> is the key; attribute value is the value.</p>
     #[serde(rename = "Attributes")]
@@ -595,7 +595,7 @@ pub struct BatchListObjectAttributesResponse {
 }
 
 /// <p>Represents the output of a <a>ListObjectChildren</a> operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct BatchListObjectChildren {
     /// <p>Maximum number of items to be retrieved in a single call. This is an approximate number.</p>
     #[serde(rename = "MaxResults")]
@@ -611,7 +611,7 @@ pub struct BatchListObjectChildren {
 }
 
 /// <p>Represents the output of a <a>ListObjectChildren</a> response operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BatchListObjectChildrenResponse {
     /// <p>The children structure, which is a map with the key as the <code>LinkName</code> and <code>ObjectIdentifier</code> as the value.</p>
     #[serde(rename = "Children")]
@@ -624,7 +624,7 @@ pub struct BatchListObjectChildrenResponse {
 }
 
 /// <p>Retrieves all available parent paths for any object type such as node, leaf node, policy node, and index node objects inside a <a>BatchRead</a> operation. For more information, see <a>ListObjectParentPaths</a> and <a>BatchReadRequest$Operations</a>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct BatchListObjectParentPaths {
     /// <p>The maximum number of results to retrieve.</p>
     #[serde(rename = "MaxResults")]
@@ -640,7 +640,7 @@ pub struct BatchListObjectParentPaths {
 }
 
 /// <p>Represents the output of a <a>ListObjectParentPaths</a> response operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BatchListObjectParentPathsResponse {
     /// <p>The pagination token.</p>
     #[serde(rename = "NextToken")]
@@ -653,7 +653,7 @@ pub struct BatchListObjectParentPathsResponse {
 }
 
 /// <p>Returns policies attached to an object in pagination fashion inside a <a>BatchRead</a> operation. For more information, see <a>ListObjectPolicies</a> and <a>BatchReadRequest$Operations</a>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct BatchListObjectPolicies {
     /// <p>The maximum number of results to retrieve.</p>
     #[serde(rename = "MaxResults")]
@@ -669,7 +669,7 @@ pub struct BatchListObjectPolicies {
 }
 
 /// <p>Represents the output of a <a>ListObjectPolicies</a> response operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BatchListObjectPoliciesResponse {
     /// <p>A list of policy <code>ObjectIdentifiers</code>, that are attached to the object.</p>
     #[serde(rename = "AttachedPolicyIds")]
@@ -682,7 +682,7 @@ pub struct BatchListObjectPoliciesResponse {
 }
 
 /// <p>Returns a paginated list of all the outgoing <a>TypedLinkSpecifier</a> information for an object inside a <a>BatchRead</a> operation. For more information, see <a>ListOutgoingTypedLinks</a> and <a>BatchReadRequest$Operations</a>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct BatchListOutgoingTypedLinks {
     /// <p>Provides range filters for multiple attributes. When providing ranges to typed link selection, any inexact ranges must be specified at the end. Any attributes that do not have a range specified are presumed to match the entire range.</p>
     #[serde(rename = "FilterAttributeRanges")]
@@ -706,7 +706,7 @@ pub struct BatchListOutgoingTypedLinks {
 }
 
 /// <p>Represents the output of a <a>ListOutgoingTypedLinks</a> response operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BatchListOutgoingTypedLinksResponse {
     /// <p>The pagination token.</p>
     #[serde(rename = "NextToken")]
@@ -719,7 +719,7 @@ pub struct BatchListOutgoingTypedLinksResponse {
 }
 
 /// <p>Returns all of the <code>ObjectIdentifiers</code> to which a given policy is attached inside a <a>BatchRead</a> operation. For more information, see <a>ListPolicyAttachments</a> and <a>BatchReadRequest$Operations</a>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct BatchListPolicyAttachments {
     /// <p>The maximum number of results to retrieve.</p>
     #[serde(rename = "MaxResults")]
@@ -735,7 +735,7 @@ pub struct BatchListPolicyAttachments {
 }
 
 /// <p>Represents the output of a <a>ListPolicyAttachments</a> response operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BatchListPolicyAttachmentsResponse {
     /// <p>The pagination token.</p>
     #[serde(rename = "NextToken")]
@@ -748,7 +748,7 @@ pub struct BatchListPolicyAttachmentsResponse {
 }
 
 /// <p>Lists all policies from the root of the Directory to the object specified inside a <a>BatchRead</a> operation. For more information, see <a>LookupPolicy</a> and <a>BatchReadRequest$Operations</a>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct BatchLookupPolicy {
     /// <p>The maximum number of results to retrieve.</p>
     #[serde(rename = "MaxResults")]
@@ -764,7 +764,7 @@ pub struct BatchLookupPolicy {
 }
 
 /// <p>Represents the output of a <a>LookupPolicy</a> response operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BatchLookupPolicyResponse {
     /// <p>The pagination token.</p>
     #[serde(rename = "NextToken")]
@@ -777,7 +777,7 @@ pub struct BatchLookupPolicyResponse {
 }
 
 /// <p>The batch read exception structure, which contains the exception type and message.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BatchReadException {
     /// <p>An exception message that is associated with the failure.</p>
     #[serde(rename = "Message")]
@@ -790,7 +790,7 @@ pub struct BatchReadException {
 }
 
 /// <p>Represents the output of a <code>BatchRead</code> operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct BatchReadOperation {
     /// <p>Retrieves metadata about an object.</p>
     #[serde(rename = "GetObjectInformation")]
@@ -839,7 +839,7 @@ pub struct BatchReadOperation {
 }
 
 /// <p>Represents the output of a <code>BatchRead</code> response operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BatchReadOperationResponse {
     /// <p>Identifies which operation in a batch has failed.</p>
     #[serde(rename = "ExceptionResponse")]
@@ -851,7 +851,7 @@ pub struct BatchReadOperationResponse {
     pub successful_response: Option<BatchReadSuccessfulResponse>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct BatchReadRequest {
     /// <p>Represents the manner and timing in which the successful write or update of an object is reflected in a subsequent read operation of that same object.</p>
     #[serde(rename = "ConsistencyLevel")]
@@ -865,7 +865,7 @@ pub struct BatchReadRequest {
     pub operations: Vec<BatchReadOperation>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BatchReadResponse {
     /// <p>A list of all the responses for each batch read.</p>
     #[serde(rename = "Responses")]
@@ -874,7 +874,7 @@ pub struct BatchReadResponse {
 }
 
 /// <p>Represents the output of a <code>BatchRead</code> success response operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BatchReadSuccessfulResponse {
     /// <p>Retrieves metadata about an object.</p>
     #[serde(rename = "GetObjectInformation")]
@@ -923,7 +923,7 @@ pub struct BatchReadSuccessfulResponse {
 }
 
 /// <p>A batch operation to remove a facet from an object.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct BatchRemoveFacetFromObject {
     /// <p>A reference to the object whose facet will be removed.</p>
     #[serde(rename = "ObjectReference")]
@@ -934,11 +934,11 @@ pub struct BatchRemoveFacetFromObject {
 }
 
 /// <p>An empty result that represents success.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BatchRemoveFacetFromObjectResponse {}
 
 /// <p>Represents the output of a <code>BatchUpdate</code> operation. </p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct BatchUpdateObjectAttributes {
     /// <p>Attributes update structure.</p>
     #[serde(rename = "AttributeUpdates")]
@@ -949,7 +949,7 @@ pub struct BatchUpdateObjectAttributes {
 }
 
 /// <p>Represents the output of a <code>BatchUpdate</code> response operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BatchUpdateObjectAttributesResponse {
     /// <p>ID that is associated with the object.</p>
     #[serde(rename = "ObjectIdentifier")]
@@ -958,7 +958,7 @@ pub struct BatchUpdateObjectAttributesResponse {
 }
 
 /// <p>Represents the output of a <code>BatchWrite</code> operation. </p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct BatchWriteOperation {
     /// <p>A batch operation that adds a facet to an object.</p>
     #[serde(rename = "AddFacetToObject")]
@@ -1019,7 +1019,7 @@ pub struct BatchWriteOperation {
 }
 
 /// <p>Represents the output of a <code>BatchWrite</code> response operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BatchWriteOperationResponse {
     /// <p>The result of an add facet to object batch operation.</p>
     #[serde(rename = "AddFacetToObject")]
@@ -1079,7 +1079,7 @@ pub struct BatchWriteOperationResponse {
     pub update_object_attributes: Option<BatchUpdateObjectAttributesResponse>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct BatchWriteRequest {
     /// <p>The Amazon Resource Name (ARN) that is associated with the <a>Directory</a>. For more information, see <a>arns</a>.</p>
     #[serde(rename = "DirectoryArn")]
@@ -1089,7 +1089,7 @@ pub struct BatchWriteRequest {
     pub operations: Vec<BatchWriteOperation>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BatchWriteResponse {
     /// <p>A list of all the responses for each batch write.</p>
     #[serde(rename = "Responses")]
@@ -1097,7 +1097,7 @@ pub struct BatchWriteResponse {
     pub responses: Option<Vec<BatchWriteOperationResponse>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateDirectoryRequest {
     /// <p>The name of the <a>Directory</a>. Should be unique per account, per region.</p>
     #[serde(rename = "Name")]
@@ -1107,7 +1107,7 @@ pub struct CreateDirectoryRequest {
     pub schema_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateDirectoryResponse {
     /// <p>The ARN of the published schema in the <a>Directory</a>. Once a published schema is copied into the directory, it has its own ARN, which is referred to applied schema ARN. For more information, see <a>arns</a>.</p>
     #[serde(rename = "AppliedSchemaArn")]
@@ -1123,7 +1123,7 @@ pub struct CreateDirectoryResponse {
     pub object_identifier: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateFacetRequest {
     /// <p>The attributes that are associated with the <a>Facet</a>.</p>
     #[serde(rename = "Attributes")]
@@ -1140,10 +1140,10 @@ pub struct CreateFacetRequest {
     pub schema_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateFacetResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateIndexRequest {
     /// <p>The ARN of the directory where the index should be created.</p>
     #[serde(rename = "DirectoryArn")]
@@ -1164,7 +1164,7 @@ pub struct CreateIndexRequest {
     pub parent_reference: Option<ObjectReference>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateIndexResponse {
     /// <p>The <code>ObjectIdentifier</code> of the index created by this operation.</p>
     #[serde(rename = "ObjectIdentifier")]
@@ -1172,7 +1172,7 @@ pub struct CreateIndexResponse {
     pub object_identifier: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateObjectRequest {
     /// <p>The Amazon Resource Name (ARN) that is associated with the <a>Directory</a> in which the object will be created. For more information, see <a>arns</a>.</p>
     #[serde(rename = "DirectoryArn")]
@@ -1194,7 +1194,7 @@ pub struct CreateObjectRequest {
     pub schema_facets: Vec<SchemaFacet>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateObjectResponse {
     /// <p>The identifier that is associated with the object.</p>
     #[serde(rename = "ObjectIdentifier")]
@@ -1202,14 +1202,14 @@ pub struct CreateObjectResponse {
     pub object_identifier: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateSchemaRequest {
     /// <p>The name that is associated with the schema. This is unique to each account and in each region.</p>
     #[serde(rename = "Name")]
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateSchemaResponse {
     /// <p>The Amazon Resource Name (ARN) that is associated with the schema. For more information, see <a>arns</a>.</p>
     #[serde(rename = "SchemaArn")]
@@ -1217,7 +1217,7 @@ pub struct CreateSchemaResponse {
     pub schema_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateTypedLinkFacetRequest {
     /// <p> <a>Facet</a> structure that is associated with the typed link facet.</p>
     #[serde(rename = "Facet")]
@@ -1227,24 +1227,24 @@ pub struct CreateTypedLinkFacetRequest {
     pub schema_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateTypedLinkFacetResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteDirectoryRequest {
     /// <p>The ARN of the directory to delete.</p>
     #[serde(rename = "DirectoryArn")]
     pub directory_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteDirectoryResponse {
     /// <p>The ARN of the deleted directory.</p>
     #[serde(rename = "DirectoryArn")]
     pub directory_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteFacetRequest {
     /// <p>The name of the facet to delete.</p>
     #[serde(rename = "Name")]
@@ -1254,10 +1254,10 @@ pub struct DeleteFacetRequest {
     pub schema_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteFacetResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteObjectRequest {
     /// <p>The Amazon Resource Name (ARN) that is associated with the <a>Directory</a> where the object resides. For more information, see <a>arns</a>.</p>
     #[serde(rename = "DirectoryArn")]
@@ -1267,17 +1267,17 @@ pub struct DeleteObjectRequest {
     pub object_reference: ObjectReference,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteObjectResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteSchemaRequest {
     /// <p>The Amazon Resource Name (ARN) of the development schema. For more information, see <a>arns</a>.</p>
     #[serde(rename = "SchemaArn")]
     pub schema_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteSchemaResponse {
     /// <p>The input ARN that is returned as part of the response. For more information, see <a>arns</a>.</p>
     #[serde(rename = "SchemaArn")]
@@ -1285,7 +1285,7 @@ pub struct DeleteSchemaResponse {
     pub schema_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteTypedLinkFacetRequest {
     /// <p>The unique name of the typed link facet.</p>
     #[serde(rename = "Name")]
@@ -1295,10 +1295,10 @@ pub struct DeleteTypedLinkFacetRequest {
     pub schema_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteTypedLinkFacetResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DetachFromIndexRequest {
     /// <p>The Amazon Resource Name (ARN) of the directory the index and object exist in.</p>
     #[serde(rename = "DirectoryArn")]
@@ -1311,7 +1311,7 @@ pub struct DetachFromIndexRequest {
     pub target_reference: ObjectReference,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DetachFromIndexResponse {
     /// <p>The <code>ObjectIdentifier</code> of the object that was detached from the index.</p>
     #[serde(rename = "DetachedObjectIdentifier")]
@@ -1319,7 +1319,7 @@ pub struct DetachFromIndexResponse {
     pub detached_object_identifier: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DetachObjectRequest {
     /// <p>The Amazon Resource Name (ARN) that is associated with the <a>Directory</a> where objects reside. For more information, see <a>arns</a>.</p>
     #[serde(rename = "DirectoryArn")]
@@ -1332,7 +1332,7 @@ pub struct DetachObjectRequest {
     pub parent_reference: ObjectReference,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DetachObjectResponse {
     /// <p>The <code>ObjectIdentifier</code> that was detached from the object.</p>
     #[serde(rename = "DetachedObjectIdentifier")]
@@ -1340,7 +1340,7 @@ pub struct DetachObjectResponse {
     pub detached_object_identifier: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DetachPolicyRequest {
     /// <p>The Amazon Resource Name (ARN) that is associated with the <a>Directory</a> where both objects reside. For more information, see <a>arns</a>.</p>
     #[serde(rename = "DirectoryArn")]
@@ -1353,10 +1353,10 @@ pub struct DetachPolicyRequest {
     pub policy_reference: ObjectReference,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DetachPolicyResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DetachTypedLinkRequest {
     /// <p>The Amazon Resource Name (ARN) of the directory where you want to detach the typed link.</p>
     #[serde(rename = "DirectoryArn")]
@@ -1367,7 +1367,7 @@ pub struct DetachTypedLinkRequest {
 }
 
 /// <p>Directory structure that includes the directory name and directory ARN.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Directory {
     /// <p>The date and time when the directory was created.</p>
     #[serde(rename = "CreationDateTime")]
@@ -1387,28 +1387,28 @@ pub struct Directory {
     pub state: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DisableDirectoryRequest {
     /// <p>The ARN of the directory to disable.</p>
     #[serde(rename = "DirectoryArn")]
     pub directory_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DisableDirectoryResponse {
     /// <p>The ARN of the directory that has been disabled.</p>
     #[serde(rename = "DirectoryArn")]
     pub directory_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct EnableDirectoryRequest {
     /// <p>The ARN of the directory to enable.</p>
     #[serde(rename = "DirectoryArn")]
     pub directory_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct EnableDirectoryResponse {
     /// <p>The ARN of the enabled directory.</p>
     #[serde(rename = "DirectoryArn")]
@@ -1416,7 +1416,7 @@ pub struct EnableDirectoryResponse {
 }
 
 /// <p>A structure that contains <code>Name</code>, <code>ARN</code>, <code>Attributes</code>, <a>Rule</a>s, and <code>ObjectTypes</code>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Facet {
     /// <p>The name of the <a>Facet</a>.</p>
     #[serde(rename = "Name")]
@@ -1429,7 +1429,7 @@ pub struct Facet {
 }
 
 /// <p>An attribute that is associated with the <a>Facet</a>.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct FacetAttribute {
     /// <p>A facet attribute consists of either a definition or a reference. This structure contains the attribute definition. See <a href="http://docs.aws.amazon.com/directoryservice/latest/admin-guide/cd_advanced.html#attributereferences">Attribute References</a> for more information.</p>
     #[serde(rename = "AttributeDefinition")]
@@ -1449,7 +1449,7 @@ pub struct FacetAttribute {
 }
 
 /// <p>A facet attribute definition. See <a href="http://docs.aws.amazon.com/directoryservice/latest/admin-guide/cd_advanced.html#attributereferences">Attribute References</a> for more information.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct FacetAttributeDefinition {
     /// <p>The default value of the attribute (if configured).</p>
     #[serde(rename = "DefaultValue")]
@@ -1469,7 +1469,7 @@ pub struct FacetAttributeDefinition {
 }
 
 /// <p>The facet attribute reference that specifies the attribute definition that contains the attribute facet name and attribute name.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct FacetAttributeReference {
     /// <p>The target attribute name that is associated with the facet reference. See <a href="http://docs.aws.amazon.com/directoryservice/latest/admin-guide/cd_advanced.html#attributereferences">Attribute References</a> for more information.</p>
     #[serde(rename = "TargetAttributeName")]
@@ -1480,7 +1480,7 @@ pub struct FacetAttributeReference {
 }
 
 /// <p>A structure that contains information used to update an attribute.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct FacetAttributeUpdate {
     /// <p>The action to perform when updating the attribute.</p>
     #[serde(rename = "Action")]
@@ -1492,14 +1492,14 @@ pub struct FacetAttributeUpdate {
     pub attribute: Option<FacetAttribute>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetAppliedSchemaVersionRequest {
     /// <p>The ARN of the applied schema.</p>
     #[serde(rename = "SchemaArn")]
     pub schema_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetAppliedSchemaVersionResponse {
     /// <p>Current applied schema ARN, including the minor version in use if one was provided.</p>
     #[serde(rename = "AppliedSchemaArn")]
@@ -1507,21 +1507,21 @@ pub struct GetAppliedSchemaVersionResponse {
     pub applied_schema_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetDirectoryRequest {
     /// <p>The ARN of the directory.</p>
     #[serde(rename = "DirectoryArn")]
     pub directory_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetDirectoryResponse {
     /// <p>Metadata about the directory.</p>
     #[serde(rename = "Directory")]
     pub directory: Directory,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetFacetRequest {
     /// <p>The name of the facet to retrieve.</p>
     #[serde(rename = "Name")]
@@ -1531,7 +1531,7 @@ pub struct GetFacetRequest {
     pub schema_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetFacetResponse {
     /// <p>The <a>Facet</a> structure that is associated with the facet.</p>
     #[serde(rename = "Facet")]
@@ -1539,7 +1539,7 @@ pub struct GetFacetResponse {
     pub facet: Option<Facet>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetObjectInformationRequest {
     /// <p>The consistency level at which to retrieve the object information.</p>
     #[serde(rename = "ConsistencyLevel")]
@@ -1553,7 +1553,7 @@ pub struct GetObjectInformationRequest {
     pub object_reference: ObjectReference,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetObjectInformationResponse {
     /// <p>The <code>ObjectIdentifier</code> of the specified object.</p>
     #[serde(rename = "ObjectIdentifier")]
@@ -1565,14 +1565,14 @@ pub struct GetObjectInformationResponse {
     pub schema_facets: Option<Vec<SchemaFacet>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetSchemaAsJsonRequest {
     /// <p>The ARN of the schema to retrieve.</p>
     #[serde(rename = "SchemaArn")]
     pub schema_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetSchemaAsJsonResponse {
     /// <p>The JSON representation of the schema document.</p>
     #[serde(rename = "Document")]
@@ -1584,7 +1584,7 @@ pub struct GetSchemaAsJsonResponse {
     pub name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetTypedLinkFacetInformationRequest {
     /// <p>The unique name of the typed link facet.</p>
     #[serde(rename = "Name")]
@@ -1594,7 +1594,7 @@ pub struct GetTypedLinkFacetInformationRequest {
     pub schema_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetTypedLinkFacetInformationResponse {
     /// <p>The order of identity attributes for the facet, from most significant to least significant. The ability to filter typed links considers the order that the attributes are defined on the typed link facet. When providing ranges to typed link selection, any inexact ranges must be specified at the end. Any attributes that do not have a range specified are presumed to match the entire range. Filters are interpreted in the order of the attributes on the typed link facet, not the order in which they are supplied to any API calls. For more information about identity attributes, see <a href="http://docs.aws.amazon.com/directoryservice/latest/admin-guide/objectsandlinks.html#typedlink">Typed link</a>.</p>
     #[serde(rename = "IdentityAttributeOrder")]
@@ -1603,7 +1603,7 @@ pub struct GetTypedLinkFacetInformationResponse {
 }
 
 /// <p>Represents an index and an attached object.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct IndexAttachment {
     /// <p>The indexed attribute values.</p>
     #[serde(rename = "IndexedAttributes")]
@@ -1615,7 +1615,7 @@ pub struct IndexAttachment {
     pub object_identifier: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListAppliedSchemaArnsRequest {
     /// <p>The ARN of the directory you are listing.</p>
     #[serde(rename = "DirectoryArn")]
@@ -1634,7 +1634,7 @@ pub struct ListAppliedSchemaArnsRequest {
     pub schema_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListAppliedSchemaArnsResponse {
     /// <p>The pagination token.</p>
     #[serde(rename = "NextToken")]
@@ -1646,7 +1646,7 @@ pub struct ListAppliedSchemaArnsResponse {
     pub schema_arns: Option<Vec<String>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListAttachedIndicesRequest {
     /// <p>The consistency level to use for this operation.</p>
     #[serde(rename = "ConsistencyLevel")]
@@ -1668,7 +1668,7 @@ pub struct ListAttachedIndicesRequest {
     pub target_reference: ObjectReference,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListAttachedIndicesResponse {
     /// <p>The indices attached to the specified object.</p>
     #[serde(rename = "IndexAttachments")]
@@ -1680,7 +1680,7 @@ pub struct ListAttachedIndicesResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListDevelopmentSchemaArnsRequest {
     /// <p>The maximum number of results to retrieve.</p>
     #[serde(rename = "MaxResults")]
@@ -1692,7 +1692,7 @@ pub struct ListDevelopmentSchemaArnsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListDevelopmentSchemaArnsResponse {
     /// <p>The pagination token.</p>
     #[serde(rename = "NextToken")]
@@ -1704,7 +1704,7 @@ pub struct ListDevelopmentSchemaArnsResponse {
     pub schema_arns: Option<Vec<String>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListDirectoriesRequest {
     /// <p>The maximum number of results to retrieve.</p>
     #[serde(rename = "MaxResults")]
@@ -1720,7 +1720,7 @@ pub struct ListDirectoriesRequest {
     pub state: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListDirectoriesResponse {
     /// <p>Lists all directories that are associated with your account in pagination fashion.</p>
     #[serde(rename = "Directories")]
@@ -1731,7 +1731,7 @@ pub struct ListDirectoriesResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListFacetAttributesRequest {
     /// <p>The maximum number of results to retrieve.</p>
     #[serde(rename = "MaxResults")]
@@ -1749,7 +1749,7 @@ pub struct ListFacetAttributesRequest {
     pub schema_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListFacetAttributesResponse {
     /// <p>The attributes attached to the facet.</p>
     #[serde(rename = "Attributes")]
@@ -1761,7 +1761,7 @@ pub struct ListFacetAttributesResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListFacetNamesRequest {
     /// <p>The maximum number of results to retrieve.</p>
     #[serde(rename = "MaxResults")]
@@ -1776,7 +1776,7 @@ pub struct ListFacetNamesRequest {
     pub schema_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListFacetNamesResponse {
     /// <p>The names of facets that exist within the schema.</p>
     #[serde(rename = "FacetNames")]
@@ -1788,7 +1788,7 @@ pub struct ListFacetNamesResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListIncomingTypedLinksRequest {
     /// <p>The consistency level to execute the request at.</p>
     #[serde(rename = "ConsistencyLevel")]
@@ -1818,7 +1818,7 @@ pub struct ListIncomingTypedLinksRequest {
     pub object_reference: ObjectReference,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListIncomingTypedLinksResponse {
     /// <p>Returns one or more typed link specifiers as output.</p>
     #[serde(rename = "LinkSpecifiers")]
@@ -1830,7 +1830,7 @@ pub struct ListIncomingTypedLinksResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListIndexRequest {
     /// <p>The consistency level to execute the request at.</p>
     #[serde(rename = "ConsistencyLevel")]
@@ -1856,7 +1856,7 @@ pub struct ListIndexRequest {
     pub ranges_on_indexed_values: Option<Vec<ObjectAttributeRange>>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListIndexResponse {
     /// <p>The objects and indexed values attached to the index.</p>
     #[serde(rename = "IndexAttachments")]
@@ -1868,7 +1868,7 @@ pub struct ListIndexResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListObjectAttributesRequest {
     /// <p>Represents the manner and timing in which the successful write or update of an object is reflected in a subsequent read operation of that same object.</p>
     #[serde(rename = "ConsistencyLevel")]
@@ -1894,7 +1894,7 @@ pub struct ListObjectAttributesRequest {
     pub object_reference: ObjectReference,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListObjectAttributesResponse {
     /// <p>Attributes map that is associated with the object. <code>AttributeArn</code> is the key, and attribute value is the value.</p>
     #[serde(rename = "Attributes")]
@@ -1906,7 +1906,7 @@ pub struct ListObjectAttributesResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListObjectChildrenRequest {
     /// <p>Represents the manner and timing in which the successful write or update of an object is reflected in a subsequent read operation of that same object.</p>
     #[serde(rename = "ConsistencyLevel")]
@@ -1928,7 +1928,7 @@ pub struct ListObjectChildrenRequest {
     pub object_reference: ObjectReference,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListObjectChildrenResponse {
     /// <p>Children structure, which is a map with key as the <code>LinkName</code> and <code>ObjectIdentifier</code> as the value.</p>
     #[serde(rename = "Children")]
@@ -1940,7 +1940,7 @@ pub struct ListObjectChildrenResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListObjectParentPathsRequest {
     /// <p>The ARN of the directory to which the parent path applies.</p>
     #[serde(rename = "DirectoryArn")]
@@ -1958,7 +1958,7 @@ pub struct ListObjectParentPathsRequest {
     pub object_reference: ObjectReference,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListObjectParentPathsResponse {
     /// <p>The pagination token.</p>
     #[serde(rename = "NextToken")]
@@ -1970,7 +1970,7 @@ pub struct ListObjectParentPathsResponse {
     pub path_to_object_identifiers_list: Option<Vec<PathToObjectIdentifiers>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListObjectParentsRequest {
     /// <p>Represents the manner and timing in which the successful write or update of an object is reflected in a subsequent read operation of that same object.</p>
     #[serde(rename = "ConsistencyLevel")]
@@ -1992,7 +1992,7 @@ pub struct ListObjectParentsRequest {
     pub object_reference: ObjectReference,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListObjectParentsResponse {
     /// <p>The pagination token.</p>
     #[serde(rename = "NextToken")]
@@ -2004,7 +2004,7 @@ pub struct ListObjectParentsResponse {
     pub parents: Option<::std::collections::HashMap<String, String>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListObjectPoliciesRequest {
     /// <p>Represents the manner and timing in which the successful write or update of an object is reflected in a subsequent read operation of that same object.</p>
     #[serde(rename = "ConsistencyLevel")]
@@ -2026,7 +2026,7 @@ pub struct ListObjectPoliciesRequest {
     pub object_reference: ObjectReference,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListObjectPoliciesResponse {
     /// <p>A list of policy <code>ObjectIdentifiers</code>, that are attached to the object.</p>
     #[serde(rename = "AttachedPolicyIds")]
@@ -2038,7 +2038,7 @@ pub struct ListObjectPoliciesResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListOutgoingTypedLinksRequest {
     /// <p>The consistency level to execute the request at.</p>
     #[serde(rename = "ConsistencyLevel")]
@@ -2068,7 +2068,7 @@ pub struct ListOutgoingTypedLinksRequest {
     pub object_reference: ObjectReference,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListOutgoingTypedLinksResponse {
     /// <p>The pagination token.</p>
     #[serde(rename = "NextToken")]
@@ -2080,7 +2080,7 @@ pub struct ListOutgoingTypedLinksResponse {
     pub typed_link_specifiers: Option<Vec<TypedLinkSpecifier>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListPolicyAttachmentsRequest {
     /// <p>Represents the manner and timing in which the successful write or update of an object is reflected in a subsequent read operation of that same object.</p>
     #[serde(rename = "ConsistencyLevel")]
@@ -2102,7 +2102,7 @@ pub struct ListPolicyAttachmentsRequest {
     pub policy_reference: ObjectReference,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListPolicyAttachmentsResponse {
     /// <p>The pagination token.</p>
     #[serde(rename = "NextToken")]
@@ -2114,7 +2114,7 @@ pub struct ListPolicyAttachmentsResponse {
     pub object_identifiers: Option<Vec<String>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListPublishedSchemaArnsRequest {
     /// <p>The maximum number of results to retrieve.</p>
     #[serde(rename = "MaxResults")]
@@ -2130,7 +2130,7 @@ pub struct ListPublishedSchemaArnsRequest {
     pub schema_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListPublishedSchemaArnsResponse {
     /// <p>The pagination token.</p>
     #[serde(rename = "NextToken")]
@@ -2142,7 +2142,7 @@ pub struct ListPublishedSchemaArnsResponse {
     pub schema_arns: Option<Vec<String>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListTagsForResourceRequest {
     /// <p>The <code>MaxResults</code> parameter sets the maximum number of results returned in a single page. This is for future use and is not supported currently.</p>
     #[serde(rename = "MaxResults")]
@@ -2157,7 +2157,7 @@ pub struct ListTagsForResourceRequest {
     pub resource_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListTagsForResourceResponse {
     /// <p>The token to use to retrieve the next page of results. This value is null when there are no more results to return.</p>
     #[serde(rename = "NextToken")]
@@ -2169,7 +2169,7 @@ pub struct ListTagsForResourceResponse {
     pub tags: Option<Vec<Tag>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListTypedLinkFacetAttributesRequest {
     /// <p>The maximum number of results to retrieve.</p>
     #[serde(rename = "MaxResults")]
@@ -2187,7 +2187,7 @@ pub struct ListTypedLinkFacetAttributesRequest {
     pub schema_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListTypedLinkFacetAttributesResponse {
     /// <p>An ordered set of attributes associate with the typed link.</p>
     #[serde(rename = "Attributes")]
@@ -2199,7 +2199,7 @@ pub struct ListTypedLinkFacetAttributesResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListTypedLinkFacetNamesRequest {
     /// <p>The maximum number of results to retrieve.</p>
     #[serde(rename = "MaxResults")]
@@ -2214,7 +2214,7 @@ pub struct ListTypedLinkFacetNamesRequest {
     pub schema_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListTypedLinkFacetNamesResponse {
     /// <p>The names of typed link facets that exist within the schema.</p>
     #[serde(rename = "FacetNames")]
@@ -2226,7 +2226,7 @@ pub struct ListTypedLinkFacetNamesResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct LookupPolicyRequest {
     /// <p>The Amazon Resource Name (ARN) that is associated with the <a>Directory</a>. For more information, see <a>arns</a>.</p>
     #[serde(rename = "DirectoryArn")]
@@ -2244,7 +2244,7 @@ pub struct LookupPolicyRequest {
     pub object_reference: ObjectReference,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct LookupPolicyResponse {
     /// <p>The pagination token.</p>
     #[serde(rename = "NextToken")]
@@ -2257,7 +2257,7 @@ pub struct LookupPolicyResponse {
 }
 
 /// <p>The action to take on the object attribute.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ObjectAttributeAction {
     /// <p>A type that can be either <code>Update</code> or <code>Delete</code>.</p>
     #[serde(rename = "ObjectAttributeActionType")]
@@ -2270,7 +2270,7 @@ pub struct ObjectAttributeAction {
 }
 
 /// <p>A range of attributes.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ObjectAttributeRange {
     /// <p>The key of the attribute that the attribute range covers.</p>
     #[serde(rename = "AttributeKey")]
@@ -2283,7 +2283,7 @@ pub struct ObjectAttributeRange {
 }
 
 /// <p>Structure that contains attribute update information.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ObjectAttributeUpdate {
     /// <p>The action to perform as part of the attribute update.</p>
     #[serde(rename = "ObjectAttributeAction")]
@@ -2296,7 +2296,7 @@ pub struct ObjectAttributeUpdate {
 }
 
 /// <p>The reference that identifies an object.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ObjectReference {
     /// <p><p>A path selector supports easy selection of an object by the parent/child links leading to it from the directory root. Use the link names from each parent/child link to construct the path. Path selectors start with a slash (/) and link names are separated by slashes. For more information about paths, see <a href="http://docs.aws.amazon.com/directoryservice/latest/admin-guide/objectsandlinks.html#accessingobjects">Accessing Objects</a>. You can identify an object in one of the following ways:</p> <ul> <li> <p> <i>$ObjectIdentifier</i> - An object identifier is an opaque string provided by Amazon Cloud Directory. When creating objects, the system will provide you with the identifier of the created object. An object’s identifier is immutable and no two objects will ever share the same object identifier</p> </li> <li> <p> <i>/some/path</i> - Identifies the object based on path</p> </li> <li> <p> <i>#SomeBatchReference</i> - Identifies the object in a batch call</p> </li> </ul></p>
     #[serde(rename = "Selector")]
@@ -2305,7 +2305,7 @@ pub struct ObjectReference {
 }
 
 /// <p>Returns the path to the <code>ObjectIdentifiers</code> that is associated with the directory.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PathToObjectIdentifiers {
     /// <p>Lists <code>ObjectIdentifiers</code> starting from directory root to the object in the request.</p>
     #[serde(rename = "ObjectIdentifiers")]
@@ -2318,7 +2318,7 @@ pub struct PathToObjectIdentifiers {
 }
 
 /// <p>Contains the <code>PolicyType</code>, <code>PolicyId</code>, and the <code>ObjectIdentifier</code> to which it is attached. For more information, see <a href="http://docs.aws.amazon.com/directoryservice/latest/admin-guide/cd_key_concepts.html#policies">Policies</a>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PolicyAttachment {
     /// <p>The <code>ObjectIdentifier</code> that is associated with <code>PolicyAttachment</code>.</p>
     #[serde(rename = "ObjectIdentifier")]
@@ -2335,7 +2335,7 @@ pub struct PolicyAttachment {
 }
 
 /// <p>Used when a regular object exists in a <a>Directory</a> and you want to find all of the policies that are associated with that object and the parent to that object.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PolicyToPath {
     /// <p>The path that is referenced from the root.</p>
     #[serde(rename = "Path")]
@@ -2347,7 +2347,7 @@ pub struct PolicyToPath {
     pub policies: Option<Vec<PolicyAttachment>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PublishSchemaRequest {
     /// <p>The Amazon Resource Name (ARN) that is associated with the development schema. For more information, see <a>arns</a>.</p>
     #[serde(rename = "DevelopmentSchemaArn")]
@@ -2365,7 +2365,7 @@ pub struct PublishSchemaRequest {
     pub version: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PublishSchemaResponse {
     /// <p>The ARN that is associated with the published schema. For more information, see <a>arns</a>.</p>
     #[serde(rename = "PublishedSchemaArn")]
@@ -2373,7 +2373,7 @@ pub struct PublishSchemaResponse {
     pub published_schema_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PutSchemaFromJsonRequest {
     /// <p>The replacement JSON schema.</p>
     #[serde(rename = "Document")]
@@ -2383,7 +2383,7 @@ pub struct PutSchemaFromJsonRequest {
     pub schema_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PutSchemaFromJsonResponse {
     /// <p>The ARN of the schema to update.</p>
     #[serde(rename = "Arn")]
@@ -2391,7 +2391,7 @@ pub struct PutSchemaFromJsonResponse {
     pub arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RemoveFacetFromObjectRequest {
     /// <p>The ARN of the directory in which the object resides.</p>
     #[serde(rename = "DirectoryArn")]
@@ -2404,11 +2404,11 @@ pub struct RemoveFacetFromObjectRequest {
     pub schema_facet: SchemaFacet,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RemoveFacetFromObjectResponse {}
 
 /// <p>Contains an Amazon Resource Name (ARN) and parameters that are associated with the rule.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Rule {
     /// <p>The minimum and maximum parameters that are associated with the rule.</p>
     #[serde(rename = "Parameters")]
@@ -2421,7 +2421,7 @@ pub struct Rule {
 }
 
 /// <p>A facet.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SchemaFacet {
     /// <p>The name of the facet.</p>
     #[serde(rename = "FacetName")]
@@ -2434,7 +2434,7 @@ pub struct SchemaFacet {
 }
 
 /// <p>The tag structure that contains a tag key and value.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Tag {
     /// <p>The key that is associated with the tag.</p>
     #[serde(rename = "Key")]
@@ -2446,7 +2446,7 @@ pub struct Tag {
     pub value: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct TagResourceRequest {
     /// <p>The Amazon Resource Name (ARN) of the resource. Tagging is only supported for directories.</p>
     #[serde(rename = "ResourceArn")]
@@ -2456,11 +2456,11 @@ pub struct TagResourceRequest {
     pub tags: Vec<Tag>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct TagResourceResponse {}
 
 /// <p>Represents the data for a typed attribute. You can set one, and only one, of the elements. Each attribute in an item is a name-value pair. Attributes have a single value.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TypedAttributeValue {
     /// <p>A binary data value.</p>
     #[serde(rename = "BinaryValue")]
@@ -2489,7 +2489,7 @@ pub struct TypedAttributeValue {
 }
 
 /// <p>A range of attribute values.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct TypedAttributeValueRange {
     /// <p>The inclusive or exclusive range end.</p>
     #[serde(rename = "EndMode")]
@@ -2508,7 +2508,7 @@ pub struct TypedAttributeValueRange {
 }
 
 /// <p>A typed link attribute definition.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TypedLinkAttributeDefinition {
     /// <p>The default value of the attribute (if configured).</p>
     #[serde(rename = "DefaultValue")]
@@ -2534,7 +2534,7 @@ pub struct TypedLinkAttributeDefinition {
 }
 
 /// <p>Identifies the range of attributes that are used by a specified filter.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct TypedLinkAttributeRange {
     /// <p>The unique name of the typed link attribute.</p>
     #[serde(rename = "AttributeName")]
@@ -2546,7 +2546,7 @@ pub struct TypedLinkAttributeRange {
 }
 
 /// <p>Defines the typed links structure and its attributes. To create a typed link facet, use the <a>CreateTypedLinkFacet</a> API.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct TypedLinkFacet {
     /// <p>A set of key-value pairs associated with the typed link. Typed link attributes are used when you have data values that are related to the link itself, and not to one of the two objects being linked. Identity attributes also serve to distinguish the link from others of the same type between the same objects.</p>
     #[serde(rename = "Attributes")]
@@ -2560,7 +2560,7 @@ pub struct TypedLinkFacet {
 }
 
 /// <p>A typed link facet attribute update.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct TypedLinkFacetAttributeUpdate {
     /// <p>The action to perform when updating the attribute.</p>
     #[serde(rename = "Action")]
@@ -2571,7 +2571,7 @@ pub struct TypedLinkFacetAttributeUpdate {
 }
 
 /// <p>Identifies the schema Amazon Resource Name (ARN) and facet name for the typed link.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TypedLinkSchemaAndFacetName {
     /// <p>The Amazon Resource Name (ARN) that is associated with the schema. For more information, see <a>arns</a>.</p>
     #[serde(rename = "SchemaArn")]
@@ -2582,7 +2582,7 @@ pub struct TypedLinkSchemaAndFacetName {
 }
 
 /// <p>Contains all the information that is used to uniquely identify a typed link. The parameters discussed in this topic are used to uniquely specify the typed link being operated on. The <a>AttachTypedLink</a> API returns a typed link specifier while the <a>DetachTypedLink</a> API accepts one as input. Similarly, the <a>ListIncomingTypedLinks</a> and <a>ListOutgoingTypedLinks</a> API operations provide typed link specifiers as output. You can also construct a typed link specifier from scratch.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TypedLinkSpecifier {
     /// <p>Identifies the attribute value to update.</p>
     #[serde(rename = "IdentityAttributeValues")]
@@ -2598,7 +2598,7 @@ pub struct TypedLinkSpecifier {
     pub typed_link_facet: TypedLinkSchemaAndFacetName,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UntagResourceRequest {
     /// <p>The Amazon Resource Name (ARN) of the resource. Tagging is only supported for directories.</p>
     #[serde(rename = "ResourceArn")]
@@ -2608,10 +2608,10 @@ pub struct UntagResourceRequest {
     pub tag_keys: Vec<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UntagResourceResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateFacetRequest {
     /// <p>List of attributes that need to be updated in a given schema <a>Facet</a>. Each attribute is followed by <code>AttributeAction</code>, which specifies the type of update operation to perform. </p>
     #[serde(rename = "AttributeUpdates")]
@@ -2629,10 +2629,10 @@ pub struct UpdateFacetRequest {
     pub schema_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateFacetResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateObjectAttributesRequest {
     /// <p>The attributes update structure.</p>
     #[serde(rename = "AttributeUpdates")]
@@ -2645,7 +2645,7 @@ pub struct UpdateObjectAttributesRequest {
     pub object_reference: ObjectReference,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateObjectAttributesResponse {
     /// <p>The <code>ObjectIdentifier</code> of the updated object.</p>
     #[serde(rename = "ObjectIdentifier")]
@@ -2653,7 +2653,7 @@ pub struct UpdateObjectAttributesResponse {
     pub object_identifier: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateSchemaRequest {
     /// <p>The name of the schema.</p>
     #[serde(rename = "Name")]
@@ -2663,7 +2663,7 @@ pub struct UpdateSchemaRequest {
     pub schema_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateSchemaResponse {
     /// <p>The ARN that is associated with the updated schema. For more information, see <a>arns</a>.</p>
     #[serde(rename = "SchemaArn")]
@@ -2671,7 +2671,7 @@ pub struct UpdateSchemaResponse {
     pub schema_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateTypedLinkFacetRequest {
     /// <p>Attributes update structure.</p>
     #[serde(rename = "AttributeUpdates")]
@@ -2687,10 +2687,10 @@ pub struct UpdateTypedLinkFacetRequest {
     pub schema_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateTypedLinkFacetResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpgradeAppliedSchemaRequest {
     /// <p>The ARN for the directory to which the upgraded schema will be applied.</p>
     #[serde(rename = "DirectoryArn")]
@@ -2704,7 +2704,7 @@ pub struct UpgradeAppliedSchemaRequest {
     pub published_schema_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpgradeAppliedSchemaResponse {
     /// <p>The ARN of the directory that is returned as part of the response.</p>
     #[serde(rename = "DirectoryArn")]
@@ -2716,7 +2716,7 @@ pub struct UpgradeAppliedSchemaResponse {
     pub upgraded_schema_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpgradePublishedSchemaRequest {
     /// <p>The ARN of the development schema with the changes used for the upgrade.</p>
     #[serde(rename = "DevelopmentSchemaArn")]
@@ -2733,7 +2733,7 @@ pub struct UpgradePublishedSchemaRequest {
     pub published_schema_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpgradePublishedSchemaResponse {
     /// <p>The ARN of the upgraded schema that is returned as part of the response.</p>
     #[serde(rename = "UpgradedSchemaArn")]

--- a/rusoto/services/clouddirectory/src/generated.rs
+++ b/rusoto/services/clouddirectory/src/generated.rs
@@ -2774,7 +2774,8 @@ impl AddFacetToObjectError {
     pub fn from_body(body: &str) -> AddFacetToObjectError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2892,7 +2893,8 @@ impl ApplySchemaError {
     pub fn from_body(body: &str) -> ApplySchemaError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3012,7 +3014,8 @@ impl AttachObjectError {
     pub fn from_body(body: &str) -> AttachObjectError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3140,7 +3143,8 @@ impl AttachPolicyError {
     pub fn from_body(body: &str) -> AttachPolicyError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3264,7 +3268,8 @@ impl AttachToIndexError {
     pub fn from_body(body: &str) -> AttachToIndexError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3394,7 +3399,8 @@ impl AttachTypedLinkError {
     pub fn from_body(body: &str) -> AttachTypedLinkError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3514,7 +3520,8 @@ impl BatchReadError {
     pub fn from_body(body: &str) -> BatchReadError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3622,7 +3629,8 @@ impl BatchWriteError {
     pub fn from_body(body: &str) -> BatchWriteError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3734,7 +3742,8 @@ impl CreateDirectoryError {
     pub fn from_body(body: &str) -> CreateDirectoryError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3852,7 +3861,8 @@ impl CreateFacetError {
     pub fn from_body(body: &str) -> CreateFacetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3980,7 +3990,8 @@ impl CreateIndexError {
     pub fn from_body(body: &str) -> CreateIndexError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4112,7 +4123,8 @@ impl CreateObjectError {
     pub fn from_body(body: &str) -> CreateObjectError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4236,7 +4248,8 @@ impl CreateSchemaError {
     pub fn from_body(body: &str) -> CreateSchemaError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4350,7 +4363,8 @@ impl CreateTypedLinkFacetError {
     pub fn from_body(body: &str) -> CreateTypedLinkFacetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4476,7 +4490,8 @@ impl DeleteDirectoryError {
     pub fn from_body(body: &str) -> DeleteDirectoryError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4596,7 +4611,8 @@ impl DeleteFacetError {
     pub fn from_body(body: &str) -> DeleteFacetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4716,7 +4732,8 @@ impl DeleteObjectError {
     pub fn from_body(body: &str) -> DeleteObjectError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4834,7 +4851,8 @@ impl DeleteSchemaError {
     pub fn from_body(body: &str) -> DeleteSchemaError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4948,7 +4966,8 @@ impl DeleteTypedLinkFacetError {
     pub fn from_body(body: &str) -> DeleteTypedLinkFacetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5068,7 +5087,8 @@ impl DetachFromIndexError {
     pub fn from_body(body: &str) -> DetachFromIndexError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5190,7 +5210,8 @@ impl DetachObjectError {
     pub fn from_body(body: &str) -> DetachObjectError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5306,7 +5327,8 @@ impl DetachPolicyError {
     pub fn from_body(body: &str) -> DetachPolicyError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5426,7 +5448,8 @@ impl DetachTypedLinkError {
     pub fn from_body(body: &str) -> DetachTypedLinkError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5544,7 +5567,8 @@ impl DisableDirectoryError {
     pub fn from_body(body: &str) -> DisableDirectoryError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5658,7 +5682,8 @@ impl EnableDirectoryError {
     pub fn from_body(body: &str) -> EnableDirectoryError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5770,7 +5795,8 @@ impl GetAppliedSchemaVersionError {
     pub fn from_body(body: &str) -> GetAppliedSchemaVersionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5878,7 +5904,8 @@ impl GetDirectoryError {
     pub fn from_body(body: &str) -> GetDirectoryError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5984,7 +6011,8 @@ impl GetFacetError {
     pub fn from_body(body: &str) -> GetFacetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6094,7 +6122,8 @@ impl GetObjectInformationError {
     pub fn from_body(body: &str) -> GetObjectInformationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6208,7 +6237,8 @@ impl GetSchemaAsJsonError {
     pub fn from_body(body: &str) -> GetSchemaAsJsonError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6320,7 +6350,8 @@ impl GetTypedLinkFacetInformationError {
     pub fn from_body(body: &str) -> GetTypedLinkFacetInformationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6448,7 +6479,8 @@ impl ListAppliedSchemaArnsError {
     pub fn from_body(body: &str) -> ListAppliedSchemaArnsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6564,7 +6596,8 @@ impl ListAttachedIndicesError {
     pub fn from_body(body: &str) -> ListAttachedIndicesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6680,7 +6713,8 @@ impl ListDevelopmentSchemaArnsError {
     pub fn from_body(body: &str) -> ListDevelopmentSchemaArnsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6800,7 +6834,8 @@ impl ListDirectoriesError {
     pub fn from_body(body: &str) -> ListDirectoriesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6912,7 +6947,8 @@ impl ListFacetAttributesError {
     pub fn from_body(body: &str) -> ListFacetAttributesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7032,7 +7068,8 @@ impl ListFacetNamesError {
     pub fn from_body(body: &str) -> ListFacetNamesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7150,7 +7187,8 @@ impl ListIncomingTypedLinksError {
     pub fn from_body(body: &str) -> ListIncomingTypedLinksError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7278,7 +7316,8 @@ impl ListIndexError {
     pub fn from_body(body: &str) -> ListIndexError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7396,7 +7435,8 @@ impl ListObjectAttributesError {
     pub fn from_body(body: &str) -> ListObjectAttributesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7524,7 +7564,8 @@ impl ListObjectChildrenError {
     pub fn from_body(body: &str) -> ListObjectChildrenError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7650,7 +7691,8 @@ impl ListObjectParentPathsError {
     pub fn from_body(body: &str) -> ListObjectParentPathsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7774,7 +7816,8 @@ impl ListObjectParentsError {
     pub fn from_body(body: &str) -> ListObjectParentsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7900,7 +7943,8 @@ impl ListObjectPoliciesError {
     pub fn from_body(body: &str) -> ListObjectPoliciesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8024,7 +8068,8 @@ impl ListOutgoingTypedLinksError {
     pub fn from_body(body: &str) -> ListOutgoingTypedLinksError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8154,7 +8199,8 @@ impl ListPolicyAttachmentsError {
     pub fn from_body(body: &str) -> ListPolicyAttachmentsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8278,7 +8324,8 @@ impl ListPublishedSchemaArnsError {
     pub fn from_body(body: &str) -> ListPublishedSchemaArnsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8394,7 +8441,8 @@ impl ListTagsForResourceError {
     pub fn from_body(body: &str) -> ListTagsForResourceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8512,7 +8560,8 @@ impl ListTypedLinkFacetAttributesError {
     pub fn from_body(body: &str) -> ListTypedLinkFacetAttributesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8640,7 +8689,8 @@ impl ListTypedLinkFacetNamesError {
     pub fn from_body(body: &str) -> ListTypedLinkFacetNamesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8758,7 +8808,8 @@ impl LookupPolicyError {
     pub fn from_body(body: &str) -> LookupPolicyError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8876,7 +8927,8 @@ impl PublishSchemaError {
     pub fn from_body(body: &str) -> PublishSchemaError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8990,7 +9042,8 @@ impl PutSchemaFromJsonError {
     pub fn from_body(body: &str) -> PutSchemaFromJsonError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9108,7 +9161,8 @@ impl RemoveFacetFromObjectError {
     pub fn from_body(body: &str) -> RemoveFacetFromObjectError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9228,7 +9282,8 @@ impl TagResourceError {
     pub fn from_body(body: &str) -> TagResourceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9342,7 +9397,8 @@ impl UntagResourceError {
     pub fn from_body(body: &str) -> UntagResourceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9460,7 +9516,8 @@ impl UpdateFacetError {
     pub fn from_body(body: &str) -> UpdateFacetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9584,7 +9641,8 @@ impl UpdateObjectAttributesError {
     pub fn from_body(body: &str) -> UpdateObjectAttributesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9704,7 +9762,8 @@ impl UpdateSchemaError {
     pub fn from_body(body: &str) -> UpdateSchemaError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9820,7 +9879,8 @@ impl UpdateTypedLinkFacetError {
     pub fn from_body(body: &str) -> UpdateTypedLinkFacetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9948,7 +10008,8 @@ impl UpgradeAppliedSchemaError {
     pub fn from_body(body: &str) -> UpgradeAppliedSchemaError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -10066,7 +10127,8 @@ impl UpgradePublishedSchemaError {
     pub fn from_body(body: &str) -> UpgradePublishedSchemaError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/cloudformation/src/generated.rs
+++ b/rusoto/services/cloudformation/src/generated.rs
@@ -58,7 +58,7 @@ impl AccountDeserializer {
     }
 }
 /// <p>Structure that contains the results of the account gate function which AWS CloudFormation invokes, if present, before proceeding with a stack set operation in an account and region.</p> <p>For each account and region, AWS CloudFormation lets you specify a Lamdba function that encapsulates any requirements that must be met before CloudFormation can proceed with a stack set operation in that account and region. CloudFormation invokes the function each time a stack set operation is requested for that account and region; if the function returns <code>FAILED</code>, CloudFormation cancels the operation in that account and region, and sets the stack set operation result status for that account and region to <code>FAILED</code>. </p> <p>For more information, see <a href="http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-account-gating.html">Configuring a target account gate</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AccountGateResult {
     /// <p><p>The status of the account gate function.</p> <ul> <li> <p> <code>SUCCEEDED</code>: The account gate function has determined that the account and region passes any requirements for a stack set operation to occur. AWS CloudFormation proceeds with the stack operation in that account and region. </p> </li> <li> <p> <code>FAILED</code>: The account gate function has determined that the account and region does not meet the requirements for a stack set operation to occur. AWS CloudFormation cancels the stack set operation in that account and region, and sets the stack set operation result status for that account and region to <code>FAILED</code>. </p> </li> <li> <p> <code>SKIPPED</code>: AWS CloudFormation has skipped calling the account gate function for this account and region, for one of the following reasons:</p> <ul> <li> <p>An account gate function has not been specified for the account and region. AWS CloudFormation proceeds with the stack set operation in this account and region.</p> </li> <li> <p>The <code>AWSCloudFormationStackSetExecutionRole</code> of the stack set adminstration account lacks permissions to invoke the function. AWS CloudFormation proceeds with the stack set operation in this account and region.</p> </li> <li> <p>Either no action is necessary, or no action is possible, on the stack. AWS CloudFormation skips the stack set operation in this account and region.</p> </li> </ul> </li> </ul></p>
     pub status: Option<String>,
@@ -141,7 +141,7 @@ impl AccountGateStatusReasonDeserializer {
     }
 }
 /// <p>The AccountLimit data type.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AccountLimit {
     /// <p>The name of the account limit. Currently, the only account limit is <code>StackLimit</code>.</p>
     pub name: Option<String>,
@@ -312,7 +312,7 @@ impl ArnDeserializer {
     }
 }
 /// <p>The input for the <a>CancelUpdateStack</a> action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CancelUpdateStackInput {
     /// <p>A unique identifier for this <code>CancelUpdateStack</code> request. Specify this token if you plan to retry requests so that AWS CloudFormation knows that you're not attempting to cancel an update on a stack with the same name. You might retry <code>CancelUpdateStack</code> requests to ensure that AWS CloudFormation successfully received them.</p>
     pub client_request_token: Option<String>,
@@ -437,7 +437,7 @@ impl CausingEntityDeserializer {
     }
 }
 /// <p>The <code>Change</code> structure describes the changes AWS CloudFormation will perform if you execute the change set.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Change {
     /// <p>A <code>ResourceChange</code> structure that describes the resource and action that AWS CloudFormation will perform.</p>
     pub resource_change: Option<ResourceChange>,
@@ -603,7 +603,7 @@ impl ChangeSetSummariesDeserializer {
     }
 }
 /// <p>The <code>ChangeSetSummary</code> structure describes a change set, its status, and the stack with which it's associated.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ChangeSetSummary {
     /// <p>The ID of the change set.</p>
     pub change_set_id: Option<String>,
@@ -791,7 +791,7 @@ impl ClientRequestTokenDeserializer {
     }
 }
 /// <p>The input for the <a>ContinueUpdateRollback</a> action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ContinueUpdateRollbackInput {
     /// <p>A unique identifier for this <code>ContinueUpdateRollback</code> request. Specify this token if you plan to retry requests so that AWS CloudFormation knows that you're not attempting to continue the rollback to a stack with the same name. You might retry <code>ContinueUpdateRollback</code> requests to ensure that AWS CloudFormation successfully received them.</p>
     pub client_request_token: Option<String>,
@@ -839,7 +839,7 @@ impl ContinueUpdateRollbackInputSerializer {
 }
 
 /// <p>The output for a <a>ContinueUpdateRollback</a> action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ContinueUpdateRollbackOutput {}
 
 struct ContinueUpdateRollbackOutputDeserializer;
@@ -859,7 +859,7 @@ impl ContinueUpdateRollbackOutputDeserializer {
     }
 }
 /// <p>The input for the <a>CreateChangeSet</a> action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateChangeSetInput {
     /// <p>A list of values that you must specify before AWS CloudFormation can update certain stacks. Some stack templates might include resources that can affect permissions in your AWS account, for example, by creating new AWS Identity and Access Management (IAM) users. For those stacks, you must explicitly acknowledge their capabilities by specifying this parameter.</p> <p>The only valid values are <code>CAPABILITY_IAM</code> and <code>CAPABILITY_NAMED_IAM</code>. The following resources require you to specify this parameter: <a href="http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-accesskey.html"> AWS::IAM::AccessKey</a>, <a href="http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-group.html"> AWS::IAM::Group</a>, <a href="http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-instanceprofile.html"> AWS::IAM::InstanceProfile</a>, <a href="http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html"> AWS::IAM::Policy</a>, <a href="http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html"> AWS::IAM::Role</a>, <a href="http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-user.html"> AWS::IAM::User</a>, and <a href="http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-addusertogroup.html"> AWS::IAM::UserToGroupAddition</a>. If your stack template contains these resources, we recommend that you review all permissions associated with them and edit their permissions if necessary.</p> <p>If you have IAM resources, you can specify either capability. If you have IAM resources with custom names, you must specify <code>CAPABILITY_NAMED_IAM</code>. If you don't specify this parameter, this action returns an <code>InsufficientCapabilities</code> error.</p> <p>For more information, see <a href="http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-iam-template.html#capabilities">Acknowledging IAM Resources in AWS CloudFormation Templates</a>.</p>
     pub capabilities: Option<Vec<String>>,
@@ -994,7 +994,7 @@ impl CreateChangeSetInputSerializer {
 }
 
 /// <p>The output for the <a>CreateChangeSet</a> action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateChangeSetOutput {
     /// <p>The Amazon Resource Name (ARN) of the change set.</p>
     pub id: Option<String>,
@@ -1046,7 +1046,7 @@ impl CreateChangeSetOutputDeserializer {
     }
 }
 /// <p>The input for <a>CreateStack</a> action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateStackInput {
     /// <p>A list of values that you must specify before AWS CloudFormation can create certain stacks. Some stack templates might include resources that can affect permissions in your AWS account, for example, by creating new AWS Identity and Access Management (IAM) users. For those stacks, you must explicitly acknowledge their capabilities by specifying this parameter.</p> <p>The only valid values are <code>CAPABILITY_IAM</code> and <code>CAPABILITY_NAMED_IAM</code>. The following resources require you to specify this parameter: <a href="http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-accesskey.html"> AWS::IAM::AccessKey</a>, <a href="http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-group.html"> AWS::IAM::Group</a>, <a href="http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-instanceprofile.html"> AWS::IAM::InstanceProfile</a>, <a href="http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html"> AWS::IAM::Policy</a>, <a href="http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html"> AWS::IAM::Role</a>, <a href="http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-user.html"> AWS::IAM::User</a>, and <a href="http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-addusertogroup.html"> AWS::IAM::UserToGroupAddition</a>. If your stack template contains these resources, we recommend that you review all permissions associated with them and edit their permissions if necessary.</p> <p>If you have IAM resources, you can specify either capability. If you have IAM resources with custom names, you must specify <code>CAPABILITY_NAMED_IAM</code>. If you don't specify this parameter, this action returns an <code>InsufficientCapabilities</code> error.</p> <p>For more information, see <a href="http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-iam-template.html#capabilities">Acknowledging IAM Resources in AWS CloudFormation Templates</a>.</p>
     pub capabilities: Option<Vec<String>>,
@@ -1198,7 +1198,7 @@ impl CreateStackInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateStackInstancesInput {
     /// <p>The names of one or more AWS accounts that you want to create stack instances in the specified region(s) for.</p>
     pub accounts: Vec<String>,
@@ -1256,7 +1256,7 @@ impl CreateStackInstancesInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateStackInstancesOutput {
     /// <p>The unique identifier for this stack set operation.</p>
     pub operation_id: Option<String>,
@@ -1305,7 +1305,7 @@ impl CreateStackInstancesOutputDeserializer {
     }
 }
 /// <p>The output for a <a>CreateStack</a> action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateStackOutput {
     /// <p>Unique identifier of the stack.</p>
     pub stack_id: Option<String>,
@@ -1351,7 +1351,7 @@ impl CreateStackOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateStackSetInput {
     /// <p>The Amazon Resource Number (ARN) of the IAM role to use to create this stack set. </p> <p>Specify an IAM role only if you are using customized administrator roles to control which users or groups can manage specific stack sets within the same administrator account. For more information, see <a href="http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-prereqs.html">Define Permissions for Multiple Administrators</a> in the <i>AWS CloudFormation User Guide</i>.</p>
     pub administration_role_arn: Option<String>,
@@ -1436,7 +1436,7 @@ impl CreateStackSetInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateStackSetOutput {
     /// <p>The ID of the stack set that you're creating.</p>
     pub stack_set_id: Option<String>,
@@ -1499,7 +1499,7 @@ impl CreationTimeDeserializer {
     }
 }
 /// <p>The input for the <a>DeleteChangeSet</a> action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteChangeSetInput {
     /// <p>The name or Amazon Resource Name (ARN) of the change set that you want to delete.</p>
     pub change_set_name: String,
@@ -1530,7 +1530,7 @@ impl DeleteChangeSetInputSerializer {
 }
 
 /// <p>The output for the <a>DeleteChangeSet</a> action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteChangeSetOutput {}
 
 struct DeleteChangeSetOutputDeserializer;
@@ -1550,7 +1550,7 @@ impl DeleteChangeSetOutputDeserializer {
     }
 }
 /// <p>The input for <a>DeleteStack</a> action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteStackInput {
     /// <p>A unique identifier for this <code>DeleteStack</code> request. Specify this token if you plan to retry requests so that AWS CloudFormation knows that you're not attempting to delete a stack with the same name. You might retry <code>DeleteStack</code> requests to ensure that AWS CloudFormation successfully received them.</p> <p>All events triggered by a given stack operation are assigned the same client request token, which you can use to track operations. For example, if you execute a <code>CreateStack</code> operation with the token <code>token1</code>, then all the <code>StackEvents</code> generated by that operation will have <code>ClientRequestToken</code> set as <code>token1</code>.</p> <p>In the console, stack operations display the client request token on the Events tab. Stack operations that are initiated from the console use the token format <i>Console-StackOperation-ID</i>, which helps you easily identify the stack operation . For example, if you create a stack using the console, each stack event would be assigned the same token in the following format: <code>Console-CreateStack-7f59c3cf-00d2-40c7-b2ff-e75db0987002</code>. </p>
     pub client_request_token: Option<String>,
@@ -1597,7 +1597,7 @@ impl DeleteStackInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteStackInstancesInput {
     /// <p>The names of the AWS accounts that you want to delete stack instances for.</p>
     pub accounts: Vec<String>,
@@ -1652,7 +1652,7 @@ impl DeleteStackInstancesInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteStackInstancesOutput {
     /// <p>The unique identifier for this stack set operation.</p>
     pub operation_id: Option<String>,
@@ -1700,7 +1700,7 @@ impl DeleteStackInstancesOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteStackSetInput {
     /// <p>The name or unique ID of the stack set that you're deleting. You can obtain this value by running <a>ListStackSets</a>.</p>
     pub stack_set_name: String,
@@ -1722,7 +1722,7 @@ impl DeleteStackSetInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteStackSetOutput {}
 
 struct DeleteStackSetOutputDeserializer;
@@ -1756,7 +1756,7 @@ impl DeletionTimeDeserializer {
     }
 }
 /// <p>The input for the <a>DescribeAccountLimits</a> action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeAccountLimitsInput {
     /// <p>A string that identifies the next page of limits that you want to retrieve.</p>
     pub next_token: Option<String>,
@@ -1781,7 +1781,7 @@ impl DescribeAccountLimitsInputSerializer {
 }
 
 /// <p>The output for the <a>DescribeAccountLimits</a> action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeAccountLimitsOutput {
     /// <p>An account limit structure that contain a list of AWS CloudFormation account limits and their values.</p>
     pub account_limits: Option<Vec<AccountLimit>>,
@@ -1836,7 +1836,7 @@ impl DescribeAccountLimitsOutputDeserializer {
     }
 }
 /// <p>The input for the <a>DescribeChangeSet</a> action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeChangeSetInput {
     /// <p>The name or Amazon Resource Name (ARN) of the change set that you want to describe.</p>
     pub change_set_name: String,
@@ -1875,7 +1875,7 @@ impl DescribeChangeSetInputSerializer {
 }
 
 /// <p>The output for the <a>DescribeChangeSet</a> action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeChangeSetOutput {
     /// <p>If you execute the change set, the list of capabilities that were explicitly acknowledged when the change set was created.</p>
     pub capabilities: Option<Vec<String>>,
@@ -2030,7 +2030,7 @@ impl DescribeChangeSetOutputDeserializer {
     }
 }
 /// <p>The input for <a>DescribeStackEvents</a> action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeStackEventsInput {
     /// <p>A string that identifies the next page of events that you want to retrieve.</p>
     pub next_token: Option<String>,
@@ -2063,7 +2063,7 @@ impl DescribeStackEventsInputSerializer {
 }
 
 /// <p>The output for a <a>DescribeStackEvents</a> action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeStackEventsOutput {
     /// <p>If the output exceeds 1 MB in size, a string that identifies the next page of events. If no additional page exists, this value is null.</p>
     pub next_token: Option<String>,
@@ -2117,7 +2117,7 @@ impl DescribeStackEventsOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeStackInstanceInput {
     /// <p>The ID of an AWS account that's associated with this stack instance.</p>
     pub stack_instance_account: String,
@@ -2151,7 +2151,7 @@ impl DescribeStackInstanceInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeStackInstanceOutput {
     /// <p>The stack instance that matches the specified request parameters.</p>
     pub stack_instance: Option<StackInstance>,
@@ -2200,7 +2200,7 @@ impl DescribeStackInstanceOutputDeserializer {
     }
 }
 /// <p>The input for <a>DescribeStackResource</a> action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeStackResourceInput {
     /// <p>The logical name of the resource as specified in the template.</p> <p>Default: There is no default value.</p>
     pub logical_resource_id: String,
@@ -2229,7 +2229,7 @@ impl DescribeStackResourceInputSerializer {
 }
 
 /// <p>The output for a <a>DescribeStackResource</a> action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeStackResourceOutput {
     /// <p>A <code>StackResourceDetail</code> structure containing the description of the specified resource in the specified stack.</p>
     pub stack_resource_detail: Option<StackResourceDetail>,
@@ -2279,7 +2279,7 @@ impl DescribeStackResourceOutputDeserializer {
     }
 }
 /// <p>The input for <a>DescribeStackResources</a> action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeStackResourcesInput {
     /// <p>The logical name of the resource as specified in the template.</p> <p>Default: There is no default value.</p>
     pub logical_resource_id: Option<String>,
@@ -2320,7 +2320,7 @@ impl DescribeStackResourcesInputSerializer {
 }
 
 /// <p>The output for a <a>DescribeStackResources</a> action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeStackResourcesOutput {
     /// <p>A list of <code>StackResource</code> structures.</p>
     pub stack_resources: Option<Vec<StackResource>>,
@@ -2368,7 +2368,7 @@ impl DescribeStackResourcesOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeStackSetInput {
     /// <p>The name or unique ID of the stack set whose description you want.</p>
     pub stack_set_name: String,
@@ -2390,7 +2390,7 @@ impl DescribeStackSetInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeStackSetOperationInput {
     /// <p>The unique ID of the stack set operation. </p>
     pub operation_id: String,
@@ -2418,7 +2418,7 @@ impl DescribeStackSetOperationInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeStackSetOperationOutput {
     /// <p>The specified stack set operation.</p>
     pub stack_set_operation: Option<StackSetOperation>,
@@ -2465,7 +2465,7 @@ impl DescribeStackSetOperationOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeStackSetOutput {
     /// <p>The specified stack set.</p>
     pub stack_set: Option<StackSet>,
@@ -2512,7 +2512,7 @@ impl DescribeStackSetOutputDeserializer {
     }
 }
 /// <p>The input for <a>DescribeStacks</a> action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeStacksInput {
     /// <p>A string that identifies the next page of stacks that you want to retrieve.</p>
     pub next_token: Option<String>,
@@ -2545,7 +2545,7 @@ impl DescribeStacksInputSerializer {
 }
 
 /// <p>The output for a <a>DescribeStacks</a> action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeStacksOutput {
     /// <p>If the output exceeds 1 MB in size, a string that identifies the next page of stacks. If no additional page exists, this value is null.</p>
     pub next_token: Option<String>,
@@ -2639,7 +2639,7 @@ impl EnableTerminationProtectionDeserializer {
     }
 }
 /// <p>The input for an <a>EstimateTemplateCost</a> action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct EstimateTemplateCostInput {
     /// <p>A list of <code>Parameter</code> structures that specify input parameters.</p>
     pub parameters: Option<Vec<Parameter>>,
@@ -2681,7 +2681,7 @@ impl EstimateTemplateCostInputSerializer {
 }
 
 /// <p>The output for a <a>EstimateTemplateCost</a> action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct EstimateTemplateCostOutput {
     /// <p>An AWS Simple Monthly Calculator URL with a query string that describes the resources required to run the template.</p>
     pub url: Option<String>,
@@ -2755,7 +2755,7 @@ impl EventIdDeserializer {
     }
 }
 /// <p>The input for the <a>ExecuteChangeSet</a> action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ExecuteChangeSetInput {
     /// <p>The name or ARN of the change set that you want use to update the specified stack.</p>
     pub change_set_name: String,
@@ -2794,7 +2794,7 @@ impl ExecuteChangeSetInputSerializer {
 }
 
 /// <p>The output for the <a>ExecuteChangeSet</a> action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ExecuteChangeSetOutput {}
 
 struct ExecuteChangeSetOutputDeserializer;
@@ -2828,7 +2828,7 @@ impl ExecutionStatusDeserializer {
     }
 }
 /// <p>The <code>Export</code> structure describes the exported output values for a stack.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Export {
     /// <p>The stack that contains the exported output name and value.</p>
     pub exporting_stack_id: Option<String>,
@@ -2984,7 +2984,7 @@ impl FailureTolerancePercentageDeserializer {
     }
 }
 /// <p>The input for the <a>GetStackPolicy</a> action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetStackPolicyInput {
     /// <p>The name or unique stack ID that is associated with the stack whose policy you want to get.</p>
     pub stack_name: String,
@@ -3007,7 +3007,7 @@ impl GetStackPolicyInputSerializer {
 }
 
 /// <p>The output for the <a>GetStackPolicy</a> action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetStackPolicyOutput {
     /// <p>Structure containing the stack policy body. (For more information, go to <a href="http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/protect-stack-resources.html"> Prevent Updates to Stack Resources</a> in the AWS CloudFormation User Guide.)</p>
     pub stack_policy_body: Option<String>,
@@ -3055,7 +3055,7 @@ impl GetStackPolicyOutputDeserializer {
     }
 }
 /// <p>The input for a <a>GetTemplate</a> action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetTemplateInput {
     /// <p>The name or Amazon Resource Name (ARN) of a change set for which AWS CloudFormation returns the associated template. If you specify a name, you must also specify the <code>StackName</code>.</p>
     pub change_set_name: Option<String>,
@@ -3096,7 +3096,7 @@ impl GetTemplateInputSerializer {
 }
 
 /// <p>The output for <a>GetTemplate</a> action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetTemplateOutput {
     /// <p>The stage of the template that you can retrieve. For stacks, the <code>Original</code> and <code>Processed</code> templates are always available. For change sets, the <code>Original</code> template is always available. After AWS CloudFormation finishes creating the change set, the <code>Processed</code> template becomes available.</p>
     pub stages_available: Option<Vec<String>>,
@@ -3153,7 +3153,7 @@ impl GetTemplateOutputDeserializer {
     }
 }
 /// <p>The input for the <a>GetTemplateSummary</a> action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetTemplateSummaryInput {
     /// <p>The name or the stack ID that is associated with the stack, which are not always interchangeable. For running stacks, you can specify either the stack's name or its unique stack ID. For deleted stack, you must specify the unique stack ID.</p> <p>Conditional: You must specify only one of the following parameters: <code>StackName</code>, <code>StackSetName</code>, <code>TemplateBody</code>, or <code>TemplateURL</code>.</p>
     pub stack_name: Option<String>,
@@ -3202,7 +3202,7 @@ impl GetTemplateSummaryInputSerializer {
 }
 
 /// <p>The output for the <a>GetTemplateSummary</a> action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetTemplateSummaryOutput {
     /// <p>The capabilities found within the template. If your template contains IAM resources, you must specify the CAPABILITY_IAM or CAPABILITY_NAMED_IAM value for this parameter when you use the <a>CreateStack</a> or <a>UpdateStack</a> actions with your template; otherwise, those actions return an InsufficientCapabilities error.</p> <p>For more information, see <a href="http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-iam-template.html#capabilities">Acknowledging IAM Resources in AWS CloudFormation Templates</a>.</p>
     pub capabilities: Option<Vec<String>>,
@@ -3384,7 +3384,7 @@ impl LimitValueDeserializer {
     }
 }
 /// <p>The input for the <a>ListChangeSets</a> action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListChangeSetsInput {
     /// <p>A string (provided by the <a>ListChangeSets</a> response output) that identifies the next page of change sets that you want to retrieve.</p>
     pub next_token: Option<String>,
@@ -3415,7 +3415,7 @@ impl ListChangeSetsInputSerializer {
 }
 
 /// <p>The output for the <a>ListChangeSets</a> action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListChangeSetsOutput {
     /// <p>If the output exceeds 1 MB, a string that identifies the next page of change sets. If there is no additional page, this value is null.</p>
     pub next_token: Option<String>,
@@ -3469,7 +3469,7 @@ impl ListChangeSetsOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListExportsInput {
     /// <p>A string (provided by the <a>ListExports</a> response output) that identifies the next page of exported output values that you asked to retrieve.</p>
     pub next_token: Option<String>,
@@ -3493,7 +3493,7 @@ impl ListExportsInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListExportsOutput {
     /// <p>The output for the <a>ListExports</a> action.</p>
     pub exports: Option<Vec<Export>>,
@@ -3545,7 +3545,7 @@ impl ListExportsOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListImportsInput {
     /// <p>The name of the exported output value. AWS CloudFormation returns the stack names that are importing this value. </p>
     pub export_name: String,
@@ -3575,7 +3575,7 @@ impl ListImportsInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListImportsOutput {
     /// <p>A list of stack names that are importing the specified exported output value. </p>
     pub imports: Option<Vec<String>>,
@@ -3627,7 +3627,7 @@ impl ListImportsOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListStackInstancesInput {
     /// <p>The maximum number of results to be returned with a single call. If the number of available results exceeds this maximum, the response includes a <code>NextToken</code> value that you can assign to the <code>NextToken</code> request parameter to get the next set of results.</p>
     pub max_results: Option<i64>,
@@ -3681,7 +3681,7 @@ impl ListStackInstancesInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListStackInstancesOutput {
     /// <p>If the request doesn't return all of the remaining results, <code>NextToken</code> is set to a token. To retrieve the next set of results, call <code>ListStackInstances</code> again and assign that token to the request object's <code>NextToken</code> parameter. If the request returns all results, <code>NextToken</code> is set to <code>null</code>.</p>
     pub next_token: Option<String>,
@@ -3735,7 +3735,7 @@ impl ListStackInstancesOutputDeserializer {
     }
 }
 /// <p>The input for the <a>ListStackResource</a> action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListStackResourcesInput {
     /// <p>A string that identifies the next page of stack resources that you want to retrieve.</p>
     pub next_token: Option<String>,
@@ -3766,7 +3766,7 @@ impl ListStackResourcesInputSerializer {
 }
 
 /// <p>The output for a <a>ListStackResources</a> action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListStackResourcesOutput {
     /// <p>If the output exceeds 1 MB, a string that identifies the next page of stack resources. If no additional page exists, this value is null.</p>
     pub next_token: Option<String>,
@@ -3821,7 +3821,7 @@ impl ListStackResourcesOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListStackSetOperationResultsInput {
     /// <p>The maximum number of results to be returned with a single call. If the number of available results exceeds this maximum, the response includes a <code>NextToken</code> value that you can assign to the <code>NextToken</code> request parameter to get the next set of results.</p>
     pub max_results: Option<i64>,
@@ -3865,7 +3865,7 @@ impl ListStackSetOperationResultsInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListStackSetOperationResultsOutput {
     /// <p>If the request doesn't return all results, <code>NextToken</code> is set to a token. To retrieve the next set of results, call <code>ListOperationResults</code> again and assign that token to the request object's <code>NextToken</code> parameter. If there are no remaining results, <code>NextToken</code> is set to <code>null</code>.</p>
     pub next_token: Option<String>,
@@ -3921,7 +3921,7 @@ impl ListStackSetOperationResultsOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListStackSetOperationsInput {
     /// <p>The maximum number of results to be returned with a single call. If the number of available results exceeds this maximum, the response includes a <code>NextToken</code> value that you can assign to the <code>NextToken</code> request parameter to get the next set of results.</p>
     pub max_results: Option<i64>,
@@ -3959,7 +3959,7 @@ impl ListStackSetOperationsInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListStackSetOperationsOutput {
     /// <p>If the request doesn't return all results, <code>NextToken</code> is set to a token. To retrieve the next set of results, call <code>ListOperationResults</code> again and assign that token to the request object's <code>NextToken</code> parameter. If there are no remaining results, <code>NextToken</code> is set to <code>null</code>.</p>
     pub next_token: Option<String>,
@@ -4012,7 +4012,7 @@ impl ListStackSetOperationsOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListStackSetsInput {
     /// <p>The maximum number of results to be returned with a single call. If the number of available results exceeds this maximum, the response includes a <code>NextToken</code> value that you can assign to the <code>NextToken</code> request parameter to get the next set of results.</p>
     pub max_results: Option<i64>,
@@ -4052,7 +4052,7 @@ impl ListStackSetsInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListStackSetsOutput {
     /// <p>If the request doesn't return all of the remaining results, <code>NextToken</code> is set to a token. To retrieve the next set of results, call <code>ListStackInstances</code> again and assign that token to the request object's <code>NextToken</code> parameter. If the request returns all results, <code>NextToken</code> is set to <code>null</code>.</p>
     pub next_token: Option<String>,
@@ -4107,7 +4107,7 @@ impl ListStackSetsOutputDeserializer {
     }
 }
 /// <p>The input for <a>ListStacks</a> action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListStacksInput {
     /// <p>A string that identifies the next page of stacks that you want to retrieve.</p>
     pub next_token: Option<String>,
@@ -4141,7 +4141,7 @@ impl ListStacksInputSerializer {
 }
 
 /// <p>The output for <a>ListStacks</a> action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListStacksOutput {
     /// <p>If the output exceeds 1 MB in size, a string that identifies the next page of stacks. If no additional page exists, this value is null.</p>
     pub next_token: Option<String>,
@@ -4362,7 +4362,7 @@ impl NotificationARNsSerializer {
 }
 
 /// <p>The Output data type.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Output {
     /// <p>User defined description associated with the output.</p>
     pub description: Option<String>,
@@ -4501,7 +4501,7 @@ impl OutputsDeserializer {
     }
 }
 /// <p>The Parameter data type.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Parameter {
     /// <p>The key associated with the parameter. If you don't specify a key and value for a particular parameter, AWS CloudFormation uses the default value that is specified in your template.</p>
     pub parameter_key: Option<String>,
@@ -4610,7 +4610,7 @@ impl ParameterSerializer {
 }
 
 /// <p>A set of criteria that AWS CloudFormation uses to validate parameter values. Although other constraints might be defined in the stack template, AWS CloudFormation returns only the <code>AllowedValues</code> property.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ParameterConstraints {
     /// <p>A list of values that are permitted for a parameter.</p>
     pub allowed_values: Option<Vec<String>>,
@@ -4659,7 +4659,7 @@ impl ParameterConstraintsDeserializer {
     }
 }
 /// <p>The ParameterDeclaration data type.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ParameterDeclaration {
     /// <p>The default value of the parameter.</p>
     pub default_value: Option<String>,
@@ -5032,7 +5032,7 @@ impl ResourceAttributeDeserializer {
     }
 }
 /// <p>The <code>ResourceChange</code> structure describes the resource and the action that AWS CloudFormation will perform on it if you execute this change set.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ResourceChange {
     /// <p>The action that AWS CloudFormation takes on the resource, such as <code>Add</code> (adds a new resource), <code>Modify</code> (changes a resource), or <code>Remove</code> (deletes a resource).</p>
     pub action: Option<String>,
@@ -5123,7 +5123,7 @@ impl ResourceChangeDeserializer {
     }
 }
 /// <p>For a resource with <code>Modify</code> as the action, the <code>ResourceChange</code> structure describes the changes AWS CloudFormation will make to that resource.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ResourceChangeDetail {
     /// <p>The identity of the entity that triggered this change. This entity is a member of the group that is specified by the <code>ChangeSource</code> field. For example, if you modified the value of the <code>KeyPairName</code> parameter, the <code>CausingEntity</code> is the name of the parameter (<code>KeyPairName</code>).</p> <p>If the <code>ChangeSource</code> value is <code>DirectModification</code>, no value is given for <code>CausingEntity</code>.</p>
     pub causing_entity: Option<String>,
@@ -5279,7 +5279,7 @@ impl ResourceStatusReasonDeserializer {
     }
 }
 /// <p>The field that AWS CloudFormation will change, such as the name of a resource's property, and whether the resource will be recreated.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ResourceTargetDefinition {
     /// <p>Indicates which resource attribute is triggering this update, such as a change in the resource attribute's <code>Metadata</code>, <code>Properties</code>, or <code>Tags</code>.</p>
     pub attribute: Option<String>,
@@ -5458,7 +5458,7 @@ impl RoleARNDeserializer {
     }
 }
 /// <p>Structure containing the rollback triggers for AWS CloudFormation to monitor during stack creation and updating operations, and for the specified monitoring period afterwards.</p> <p>Rollback triggers enable you to have AWS CloudFormation monitor the state of your application during stack creation and updating, and to roll back that operation if the application breaches the threshold of any of the alarms you've specified. For more information, see <a href="http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-rollback-triggers.html">Monitor and Roll Back Stack Operations</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RollbackConfiguration {
     /// <p>The amount of time, in minutes, during which CloudFormation should monitor all the rollback triggers after the stack creation or update operation deploys all necessary resources.</p> <p>The default is 0 minutes.</p> <p>If you specify a monitoring period but do not specify any rollback triggers, CloudFormation still waits the specified period of time before cleaning up old resources after update operations. You can use this monitoring period to perform any manual stack validation desired, and manually cancel the stack creation or update (using <a href="http://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_CancelUpdateStack.html">CancelUpdateStack</a>, for example) as necessary.</p> <p>If you specify 0 for this parameter, CloudFormation still monitors the specified rollback triggers during stack creation and update operations. Then, for update operations, it begins disposing of old resources immediately once the operation completes.</p>
     pub monitoring_time_in_minutes: Option<i64>,
@@ -5541,7 +5541,7 @@ impl RollbackConfigurationSerializer {
 }
 
 /// <p>A rollback trigger AWS CloudFormation monitors during creation and updating of stacks. If any of the alarms you specify goes to ALARM state during the stack operation or within the specified monitoring period afterwards, CloudFormation rolls back the entire stack operation. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RollbackTrigger {
     /// <p>The Amazon Resource Name (ARN) of the rollback trigger.</p> <p>If a specified trigger is missing, the entire stack operation fails and is rolled back. </p>
     pub arn: String,
@@ -5709,7 +5709,7 @@ impl ScopeDeserializer {
     }
 }
 /// <p>The input for the <a>SetStackPolicy</a> action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SetStackPolicyInput {
     /// <p>The name or unique stack ID that you want to associate a policy with.</p>
     pub stack_name: String,
@@ -5748,7 +5748,7 @@ impl SetStackPolicyInputSerializer {
 }
 
 /// <p>The input for the <a>SignalResource</a> action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SignalResourceInput {
     /// <p>The logical ID of the resource that you want to signal. The logical ID is the name of the resource that given in the template.</p>
     pub logical_resource_id: String,
@@ -5789,7 +5789,7 @@ impl SignalResourceInputSerializer {
 }
 
 /// <p>The Stack data type.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Stack {
     /// <p>The capabilities allowed in the stack.</p>
     pub capabilities: Option<Vec<String>>,
@@ -5975,7 +5975,7 @@ impl StackDeserializer {
     }
 }
 /// <p>The StackEvent data type.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct StackEvent {
     /// <p>The token passed to the operation that generated this event.</p> <p>All events triggered by a given stack operation are assigned the same client request token, which you can use to track operations. For example, if you execute a <code>CreateStack</code> operation with the token <code>token1</code>, then all the <code>StackEvents</code> generated by that operation will have <code>ClientRequestToken</code> set as <code>token1</code>.</p> <p>In the console, stack operations display the client request token on the Events tab. Stack operations that are initiated from the console use the token format <i>Console-StackOperation-ID</i>, which helps you easily identify the stack operation . For example, if you create a stack using the console, each stack event would be assigned the same token in the following format: <code>Console-CreateStack-7f59c3cf-00d2-40c7-b2ff-e75db0987002</code>. </p>
     pub client_request_token: Option<String>,
@@ -6151,7 +6151,7 @@ impl StackIdDeserializer {
     }
 }
 /// <p>An AWS CloudFormation stack, in a specific account and region, that's part of a stack set operation. A stack instance is a reference to an attempted or actual stack in a given account within a given region. A stack instance can exist without a stack—for example, if the stack couldn't be created for some reason. A stack instance is associated with only one stack set. Each stack instance contains the ID of its associated stack set, as well as the ID of the actual stack and the stack status.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct StackInstance {
     /// <p>The name of the AWS account that the stack instance is associated with.</p>
     pub account: Option<String>,
@@ -6294,7 +6294,7 @@ impl StackInstanceSummariesDeserializer {
     }
 }
 /// <p>The structure that contains summary information about a stack instance.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct StackInstanceSummary {
     /// <p>The name of the AWS account that the stack instance is associated with.</p>
     pub account: Option<String>,
@@ -6401,7 +6401,7 @@ impl StackPolicyBodyDeserializer {
     }
 }
 /// <p>The StackResource data type.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct StackResource {
     /// <p>User defined description associated with the resource.</p>
     pub description: Option<String>,
@@ -6508,7 +6508,7 @@ impl StackResourceDeserializer {
     }
 }
 /// <p>Contains detailed information about the specified stack resource.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct StackResourceDetail {
     /// <p>User defined description associated with the resource.</p>
     pub description: Option<String>,
@@ -6665,7 +6665,7 @@ impl StackResourceSummariesDeserializer {
     }
 }
 /// <p>Contains high-level information about the specified stack resource.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct StackResourceSummary {
     /// <p>Time the status was updated.</p>
     pub last_updated_timestamp: String,
@@ -6796,7 +6796,7 @@ impl StackResourcesDeserializer {
     }
 }
 /// <p>A structure that contains information about a stack set. A stack set enables you to provision stacks into AWS accounts and across regions by using a single CloudFormation template. In the stack set, you specify the template to use, as well as any parameters and capabilities that the template requires. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct StackSet {
     /// <p>The Amazon Resource Number (ARN) of the IAM role used to create or update the stack set.</p> <p>Use customized administrator roles to control which users or groups can manage specific stack sets within the same administrator account. For more information, see <a href="http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-prereqs.html">Define Permissions for Multiple Administrators</a> in the <i>AWS CloudFormation User Guide</i>.</p>
     pub administration_role_arn: Option<String>,
@@ -6955,7 +6955,7 @@ impl StackSetNameDeserializer {
     }
 }
 /// <p>The structure that contains information about a stack set operation. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct StackSetOperation {
     /// <p>The type of stack set operation: <code>CREATE</code>, <code>UPDATE</code>, or <code>DELETE</code>. Create and delete operations affect only the specified stack set instances that are associated with the specified stack set. Update operations affect both the stack set itself, as well as <i>all</i> associated stack set instances.</p>
     pub action: Option<String>,
@@ -7080,7 +7080,7 @@ impl StackSetOperationActionDeserializer {
     }
 }
 /// <p>The user-specified preferences for how AWS CloudFormation performs a stack set operation. </p> <p>For more information on maximum concurrent accounts and failure tolerance, see <a href="http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-concepts.html#stackset-ops-options">Stack set operation options</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct StackSetOperationPreferences {
     /// <p>The number of accounts, per region, for which this operation can fail before AWS CloudFormation stops the operation in that region. If the operation is stopped in a region, AWS CloudFormation doesn't attempt the operation in any subsequent regions.</p> <p>Conditional: You must specify either <code>FailureToleranceCount</code> or <code>FailureTolerancePercentage</code> (but not both).</p>
     pub failure_tolerance_count: Option<i64>,
@@ -7267,7 +7267,7 @@ impl StackSetOperationResultSummariesDeserializer {
     }
 }
 /// <p>The structure that contains information about a specified operation's results for a given account in a given region.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct StackSetOperationResultSummary {
     /// <p>The name of the AWS account for this operation result.</p>
     pub account: Option<String>,
@@ -7395,7 +7395,7 @@ impl StackSetOperationSummariesDeserializer {
     }
 }
 /// <p>The structures that contain summary information about the specified operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct StackSetOperationSummary {
     /// <p>The type of operation: <code>CREATE</code>, <code>UPDATE</code>, or <code>DELETE</code>. Create and delete operations affect only the specified stack instances that are associated with the specified stack set. Update operations affect both the stack set itself as well as <i>all</i> associated stack set instances.</p>
     pub action: Option<String>,
@@ -7530,7 +7530,7 @@ impl StackSetSummariesDeserializer {
     }
 }
 /// <p>The structures that contain summary information about the specified stack set.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct StackSetSummary {
     /// <p>A description of the stack set that you specify when the stack set is created or updated.</p>
     pub description: Option<String>,
@@ -7682,7 +7682,7 @@ impl StackSummariesDeserializer {
     }
 }
 /// <p>The StackSummary Data Type</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct StackSummary {
     /// <p>The time the stack was created.</p>
     pub creation_time: String,
@@ -7870,7 +7870,7 @@ impl StageListDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct StopStackSetOperationInput {
     /// <p>The ID of the stack operation. </p>
     pub operation_id: String,
@@ -7898,7 +7898,7 @@ impl StopStackSetOperationInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct StopStackSetOperationOutput {}
 
 struct StopStackSetOperationOutputDeserializer;
@@ -7918,7 +7918,7 @@ impl StopStackSetOperationOutputDeserializer {
     }
 }
 /// <p>The Tag type enables you to specify a key-value pair that can be used to store information about an AWS CloudFormation stack.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Tag {
     /// <p> <i>Required</i>. A string used to identify this tag. You can specify a maximum of 128 characters for a tag key. Tags owned by Amazon Web Services (AWS) have the reserved prefix: <code>aws:</code>.</p>
     pub key: String,
@@ -8098,7 +8098,7 @@ impl TemplateDescriptionDeserializer {
     }
 }
 /// <p>The TemplateParameter data type.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct TemplateParameter {
     /// <p>The default value associated with the parameter.</p>
     pub default_value: Option<String>,
@@ -8322,7 +8322,7 @@ impl TypeDeserializer {
     }
 }
 /// <p>The input for an <a>UpdateStack</a> action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateStackInput {
     /// <p>A list of values that you must specify before AWS CloudFormation can update certain stacks. Some stack templates might include resources that can affect permissions in your AWS account, for example, by creating new AWS Identity and Access Management (IAM) users. For those stacks, you must explicitly acknowledge their capabilities by specifying this parameter.</p> <p>The only valid values are <code>CAPABILITY_IAM</code> and <code>CAPABILITY_NAMED_IAM</code>. The following resources require you to specify this parameter: <a href="http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-accesskey.html"> AWS::IAM::AccessKey</a>, <a href="http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-group.html"> AWS::IAM::Group</a>, <a href="http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-instanceprofile.html"> AWS::IAM::InstanceProfile</a>, <a href="http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html"> AWS::IAM::Policy</a>, <a href="http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html"> AWS::IAM::Role</a>, <a href="http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-user.html"> AWS::IAM::User</a>, and <a href="http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-addusertogroup.html"> AWS::IAM::UserToGroupAddition</a>. If your stack template contains these resources, we recommend that you review all permissions associated with them and edit their permissions if necessary.</p> <p>If you have IAM resources, you can specify either capability. If you have IAM resources with custom names, you must specify <code>CAPABILITY_NAMED_IAM</code>. If you don't specify this parameter, this action returns an <code>InsufficientCapabilities</code> error.</p> <p>For more information, see <a href="http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-iam-template.html#capabilities">Acknowledging IAM Resources in AWS CloudFormation Templates</a>.</p>
     pub capabilities: Option<Vec<String>>,
@@ -8466,7 +8466,7 @@ impl UpdateStackInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateStackInstancesInput {
     /// <p>The names of one or more AWS accounts for which you want to update parameter values for stack instances. The overridden parameter values will be applied to all stack instances in the specified accounts and regions.</p>
     pub accounts: Vec<String>,
@@ -8524,7 +8524,7 @@ impl UpdateStackInstancesInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateStackInstancesOutput {
     /// <p>The unique identifier for this stack set operation. </p>
     pub operation_id: Option<String>,
@@ -8573,7 +8573,7 @@ impl UpdateStackInstancesOutputDeserializer {
     }
 }
 /// <p>The output for an <a>UpdateStack</a> action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateStackOutput {
     /// <p>Unique identifier of the stack.</p>
     pub stack_id: Option<String>,
@@ -8619,7 +8619,7 @@ impl UpdateStackOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateStackSetInput {
     /// <p>The Amazon Resource Number (ARN) of the IAM role to use to update this stack set.</p> <p>Specify an IAM role only if you are using customized administrator roles to control which users or groups can manage specific stack sets within the same administrator account. For more information, see <a href="http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-prereqs.html">Define Permissions for Multiple Administrators</a> in the <i>AWS CloudFormation User Guide</i>.</p> <p> If you specify a customized administrator role, AWS CloudFormation uses that role to update the stack. If you do not specify a customized administrator role, AWS CloudFormation performs the update using the role previously associated with the stack set, so long as you have permissions to perform operations on the stack set.</p>
     pub administration_role_arn: Option<String>,
@@ -8721,7 +8721,7 @@ impl UpdateStackSetInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateStackSetOutput {
     /// <p>The unique ID for this stack set operation.</p>
     pub operation_id: Option<String>,
@@ -8769,7 +8769,7 @@ impl UpdateStackSetOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateTerminationProtectionInput {
     /// <p>Whether to enable termination protection on the specified stack.</p>
     pub enable_termination_protection: bool,
@@ -8799,7 +8799,7 @@ impl UpdateTerminationProtectionInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateTerminationProtectionOutput {
     /// <p>The unique ID of the stack.</p>
     pub stack_id: Option<String>,
@@ -8874,7 +8874,7 @@ impl UsePreviousValueDeserializer {
     }
 }
 /// <p>The input for <a>ValidateTemplate</a> action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ValidateTemplateInput {
     /// <p>Structure containing the template body with a minimum length of 1 byte and a maximum length of 51,200 bytes. For more information, go to <a href="http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-anatomy.html">Template Anatomy</a> in the AWS CloudFormation User Guide.</p> <p>Conditional: You must pass <code>TemplateURL</code> or <code>TemplateBody</code>. If both are passed, only <code>TemplateBody</code> is used.</p>
     pub template_body: Option<String>,
@@ -8907,7 +8907,7 @@ impl ValidateTemplateInputSerializer {
 }
 
 /// <p>The output for <a>ValidateTemplate</a> action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ValidateTemplateOutput {
     /// <p>The capabilities found within the template. If your template contains IAM resources, you must specify the CAPABILITY_IAM or CAPABILITY_NAMED_IAM value for this parameter when you use the <a>CreateStack</a> or <a>UpdateStack</a> actions with your template; otherwise, those actions return an InsufficientCapabilities error.</p> <p>For more information, see <a href="http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-iam-template.html#capabilities">Acknowledging IAM Resources in AWS CloudFormation Templates</a>.</p>
     pub capabilities: Option<Vec<String>>,

--- a/rusoto/services/cloudformation/src/generated.rs
+++ b/rusoto/services/cloudformation/src/generated.rs
@@ -29,8 +29,9 @@ use hyper::StatusCode;
 use rusoto_core::param::{Params, ServiceParams};
 use rusoto_core::signature::SignedRequest;
 use rusoto_core::xmlerror::*;
-use rusoto_core::xmlutil::{characters, end_element, find_start_element, peek_at_name, skip_tree,
-                           start_element};
+use rusoto_core::xmlutil::{
+    characters, end_element, find_start_element, peek_at_name, skip_tree, start_element,
+};
 use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
 use std::str::FromStr;
 use xml::reader::ParserConfig;

--- a/rusoto/services/cloudfront/src/generated.rs
+++ b/rusoto/services/cloudfront/src/generated.rs
@@ -29,8 +29,9 @@ use hyper::StatusCode;
 use rusoto_core::param::{Params, ServiceParams};
 use rusoto_core::signature::SignedRequest;
 use rusoto_core::xmlerror::*;
-use rusoto_core::xmlutil::{characters, end_element, find_start_element, peek_at_name, skip_tree,
-                           start_element};
+use rusoto_core::xmlutil::{
+    characters, end_element, find_start_element, peek_at_name, skip_tree, start_element,
+};
 use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
 use std::io::Write;
 use std::str::FromStr;
@@ -11921,7 +11922,8 @@ where
         request.set_payload(Some(writer.into_inner()));
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -11986,7 +11988,8 @@ where
         request.set_payload(Some(writer.into_inner()));
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -12052,7 +12055,8 @@ where
         request.set_payload(Some(writer.into_inner()));
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -12118,7 +12122,8 @@ where
         request.set_payload(Some(writer.into_inner()));
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -12177,7 +12182,8 @@ where
         request.set_payload(Some(writer.into_inner()));
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -12246,7 +12252,8 @@ where
         request.set_payload(Some(writer.into_inner()));
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -12310,7 +12317,8 @@ where
         }
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -12341,7 +12349,8 @@ where
         }
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -12370,7 +12379,8 @@ where
         let mut request = SignedRequest::new("DELETE", "cloudfront", &self.region, &request_uri);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -12401,7 +12411,8 @@ where
         }
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -12432,7 +12443,8 @@ where
         let mut request = SignedRequest::new("GET", "cloudfront", &self.region, &request_uri);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -12491,7 +12503,8 @@ where
         let mut request = SignedRequest::new("GET", "cloudfront", &self.region, &request_uri);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -12544,7 +12557,8 @@ where
         let mut request = SignedRequest::new("GET", "cloudfront", &self.region, &request_uri);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -12595,7 +12609,8 @@ where
         let mut request = SignedRequest::new("GET", "cloudfront", &self.region, &request_uri);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -12650,7 +12665,8 @@ where
         let mut request = SignedRequest::new("GET", "cloudfront", &self.region, &request_uri);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -12697,7 +12713,8 @@ where
         let mut request = SignedRequest::new("GET", "cloudfront", &self.region, &request_uri);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -12752,7 +12769,8 @@ where
         let mut request = SignedRequest::new("GET", "cloudfront", &self.region, &request_uri);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -12817,7 +12835,8 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -12875,7 +12894,8 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -12934,7 +12954,8 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -12993,7 +13014,8 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -13049,7 +13071,8 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -13100,7 +13123,8 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -13152,7 +13176,8 @@ where
         request.set_payload(Some(writer.into_inner()));
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -13184,7 +13209,8 @@ where
         request.set_payload(Some(writer.into_inner()));
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -13229,7 +13255,8 @@ where
         request.set_payload(Some(writer.into_inner()));
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -13294,7 +13321,8 @@ where
         request.set_payload(Some(writer.into_inner()));
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -13360,7 +13388,8 @@ where
         request.set_payload(Some(writer.into_inner()));
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {

--- a/rusoto/services/cloudfront/src/generated.rs
+++ b/rusoto/services/cloudfront/src/generated.rs
@@ -46,7 +46,7 @@ enum DeserializerNext {
     Element(String),
 }
 /// <p>A complex type that lists the AWS accounts, if any, that you included in the <code>TrustedSigners</code> complex type for this distribution. These are the accounts that you want to allow to create signed URLs for private content.</p> <p>The <code>Signer</code> complex type lists the AWS account number of the trusted signer or <code>self</code> if the signer is the AWS account that created the distribution. The <code>Signer</code> element also includes the IDs of any active CloudFront key pairs that are associated with the trusted signer's AWS account. If no <code>KeyPairId</code> element appears for a <code>Signer</code>, that signer can't create signed URLs. </p> <p>For more information, see <a href="http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/PrivateContent.html">Serving Private Content through CloudFront</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ActiveTrustedSigners {
     /// <p>Enabled is <code>true</code> if any of the AWS accounts listed in the <code>TrustedSigners</code> complex type for this RTMP distribution have active CloudFront key pairs. If not, <code>Enabled</code> is <code>false</code>.</p> <p>For more information, see <a>ActiveTrustedSigners</a>.</p>
     pub enabled: bool,
@@ -163,7 +163,7 @@ impl AliasListSerializer {
 }
 
 /// <p>A complex type that contains information about CNAMEs (alternate domain names), if any, for this distribution. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Aliases {
     /// <p>A complex type that contains the CNAME aliases, if any, that you want to associate with this distribution.</p>
     pub items: Option<Vec<String>>,
@@ -240,7 +240,7 @@ impl AliasesSerializer {
 }
 
 /// <p>A complex type that controls which HTTP methods CloudFront processes and forwards to your Amazon S3 bucket or your custom origin. There are three choices:</p> <ul> <li> <p>CloudFront forwards only <code>GET</code> and <code>HEAD</code> requests.</p> </li> <li> <p>CloudFront forwards only <code>GET</code>, <code>HEAD</code>, and <code>OPTIONS</code> requests.</p> </li> <li> <p>CloudFront forwards <code>GET, HEAD, OPTIONS, PUT, PATCH, POST</code>, and <code>DELETE</code> requests.</p> </li> </ul> <p>If you pick the third choice, you may need to restrict access to your Amazon S3 bucket or to your custom origin so users can't perform operations that you don't want them to. For example, you might not want users to have permissions to delete objects from your origin.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AllowedMethods {
     pub cached_methods: Option<CachedMethods>,
     /// <p>A complex type that contains the HTTP methods that you want CloudFront to process and forward to your origin.</p>
@@ -424,7 +424,7 @@ impl BooleanSerializer {
 }
 
 /// <p>A complex type that describes how CloudFront processes requests.</p> <p>You must create at least as many cache behaviors (including the default cache behavior) as you have origins if you want CloudFront to distribute objects from all of the origins. Each cache behavior specifies the one origin from which you want CloudFront to get objects. If you have two origins and only the default cache behavior, the default cache behavior will cause CloudFront to get objects from one of the origins, but the other origin is never used.</p> <p>For the current limit on the number of cache behaviors that you can add to a distribution, see <a href="http://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html#limits_cloudfront">Amazon CloudFront Limits</a> in the <i>AWS General Reference</i>.</p> <p>If you don't want to specify any cache behaviors, include only an empty <code>CacheBehaviors</code> element. Don't include an empty <code>CacheBehavior</code> element, or CloudFront returns a <code>MalformedXML</code> error.</p> <p>To delete all cache behaviors in an existing distribution, update the distribution configuration and include only an empty <code>CacheBehaviors</code> element.</p> <p>To add, change, or remove one or more cache behaviors, update the distribution configuration and specify all of the cache behaviors that you want to include in the updated distribution.</p> <p>For more information about cache behaviors, see <a href="http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-web-values-specify.html#DownloadDistValuesCacheBehavior">Cache Behaviors</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CacheBehavior {
     pub allowed_methods: Option<AllowedMethods>,
     /// <p>Whether you want CloudFront to automatically compress certain files for this cache behavior. If so, specify true; if not, specify false. For more information, see <a href="http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/ServingCompressedFiles.html">Serving Compressed Files</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>
@@ -701,7 +701,7 @@ impl CacheBehaviorListSerializer {
 }
 
 /// <p>A complex type that contains zero or more <code>CacheBehavior</code> elements. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CacheBehaviors {
     /// <p>Optional: A complex type that contains cache behaviors for this distribution. If <code>Quantity</code> is <code>0</code>, you can omit <code>Items</code>.</p>
     pub items: Option<Vec<CacheBehavior>>,
@@ -780,7 +780,7 @@ impl CacheBehaviorsSerializer {
 }
 
 /// <p>A complex type that controls whether CloudFront caches the response to requests using the specified HTTP methods. There are two choices:</p> <ul> <li> <p>CloudFront caches responses to <code>GET</code> and <code>HEAD</code> requests.</p> </li> <li> <p>CloudFront caches responses to <code>GET</code>, <code>HEAD</code>, and <code>OPTIONS</code> requests.</p> </li> </ul> <p>If you pick the second choice for your Amazon S3 Origin, you may need to forward Access-Control-Request-Method, Access-Control-Request-Headers, and Origin headers for the responses to be cached correctly. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CachedMethods {
     /// <p>A complex type that contains the HTTP methods that you want CloudFront to cache responses to.</p>
     pub items: Vec<String>,
@@ -855,7 +855,7 @@ impl CachedMethodsSerializer {
 }
 
 /// <p>CloudFront origin access identity.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CloudFrontOriginAccessIdentity {
     /// <p>The current configuration information for the identity. </p>
     pub cloud_front_origin_access_identity_config: Option<CloudFrontOriginAccessIdentityConfig>,
@@ -917,7 +917,7 @@ impl CloudFrontOriginAccessIdentityDeserializer {
     }
 }
 /// <p>Origin access identity configuration. Send a <code>GET</code> request to the <code>/<i>CloudFront API version</i>/CloudFront/identity ID/config</code> resource. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CloudFrontOriginAccessIdentityConfig {
     /// <p>A unique number that ensures the request can't be replayed.</p> <p>If the <code>CallerReference</code> is new (no matter the content of the <code>CloudFrontOriginAccessIdentityConfig</code> object), a new origin access identity is created.</p> <p>If the <code>CallerReference</code> is a value already sent in a previous identity request, and the content of the <code>CloudFrontOriginAccessIdentityConfig</code> is identical to the original request (ignoring white space), the response includes the same information returned to the original request. </p> <p>If the <code>CallerReference</code> is a value you already sent in a previous request to create an identity, but the content of the <code>CloudFrontOriginAccessIdentityConfig</code> is different from the original request, CloudFront returns a <code>CloudFrontOriginAccessIdentityAlreadyExists</code> error. </p>
     pub caller_reference: String,
@@ -998,7 +998,7 @@ impl CloudFrontOriginAccessIdentityConfigSerializer {
 }
 
 /// <p>Lists the origin access identities for CloudFront.Send a <code>GET</code> request to the <code>/<i>CloudFront API version</i>/origin-access-identity/cloudfront</code> resource. The response includes a <code>CloudFrontOriginAccessIdentityList</code> element with zero or more <code>CloudFrontOriginAccessIdentitySummary</code> child elements. By default, your entire list of origin access identities is returned in one single page. If the list is long, you can paginate it using the <code>MaxItems</code> and <code>Marker</code> parameters.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CloudFrontOriginAccessIdentityList {
     /// <p>A flag that indicates whether more origin access identities remain to be listed. If your results were truncated, you can make a follow-up pagination request using the <code>Marker</code> request parameter to retrieve more items in the list.</p>
     pub is_truncated: bool,
@@ -1075,7 +1075,7 @@ impl CloudFrontOriginAccessIdentityListDeserializer {
     }
 }
 /// <p>Summary of the information about a CloudFront origin access identity.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CloudFrontOriginAccessIdentitySummary {
     /// <p>The comment for this origin access identity, as originally specified when created.</p>
     pub comment: String,
@@ -1238,7 +1238,7 @@ impl CookieNameListSerializer {
 }
 
 /// <p>A complex type that specifies whether you want CloudFront to forward cookies to the origin and, if so, which ones. For more information about forwarding cookies to the origin, see <a href="http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Cookies.html">How CloudFront Forwards, Caches, and Logs Cookies</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CookieNames {
     /// <p>A complex type that contains one <code>Name</code> element for each cookie that you want CloudFront to forward to the origin for this cache behavior.</p>
     pub items: Option<Vec<String>>,
@@ -1317,7 +1317,7 @@ impl CookieNamesSerializer {
 }
 
 /// <p>A complex type that specifies whether you want CloudFront to forward cookies to the origin and, if so, which ones. For more information about forwarding cookies to the origin, see <a href="http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Cookies.html">How CloudFront Forwards, Caches, and Logs Cookies</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CookiePreference {
     /// <p>Specifies which cookies to forward to the origin for this cache behavior: all, none, or the list of cookies specified in the <code>WhitelistedNames</code> complex type.</p> <p>Amazon S3 doesn't process cookies. When the cache behavior is forwarding requests to an Amazon S3 origin, specify none for the <code>Forward</code> element. </p>
     pub forward: String,
@@ -1398,14 +1398,14 @@ impl CookiePreferenceSerializer {
 }
 
 /// <p>The request to create a new origin access identity.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateCloudFrontOriginAccessIdentityRequest {
     /// <p>The current configuration information for the identity.</p>
     pub cloud_front_origin_access_identity_config: CloudFrontOriginAccessIdentityConfig,
 }
 
 /// <p>The returned result of the corresponding request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateCloudFrontOriginAccessIdentityResult {
     /// <p>The origin access identity's information.</p>
     pub cloud_front_origin_access_identity: Option<CloudFrontOriginAccessIdentity>,
@@ -1460,14 +1460,14 @@ impl CreateCloudFrontOriginAccessIdentityResultDeserializer {
     }
 }
 /// <p>The request to create a new distribution.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateDistributionRequest {
     /// <p>The distribution's configuration information.</p>
     pub distribution_config: DistributionConfig,
 }
 
 /// <p>The returned result of the corresponding request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateDistributionResult {
     /// <p>The distribution's information.</p>
     pub distribution: Option<Distribution>,
@@ -1520,14 +1520,14 @@ impl CreateDistributionResultDeserializer {
     }
 }
 /// <p>The request to create a new distribution with tags. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateDistributionWithTagsRequest {
     /// <p>The distribution's configuration information. </p>
     pub distribution_config_with_tags: DistributionConfigWithTags,
 }
 
 /// <p>The returned result of the corresponding request. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateDistributionWithTagsResult {
     /// <p>The distribution's information. </p>
     pub distribution: Option<Distribution>,
@@ -1580,7 +1580,7 @@ impl CreateDistributionWithTagsResultDeserializer {
     }
 }
 /// <p>The request to create an invalidation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateInvalidationRequest {
     /// <p>The distribution's id.</p>
     pub distribution_id: String,
@@ -1589,7 +1589,7 @@ pub struct CreateInvalidationRequest {
 }
 
 /// <p>The returned result of the corresponding request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateInvalidationResult {
     /// <p>The invalidation's information.</p>
     pub invalidation: Option<Invalidation>,
@@ -1640,14 +1640,14 @@ impl CreateInvalidationResultDeserializer {
     }
 }
 /// <p>The request to create a new streaming distribution.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateStreamingDistributionRequest {
     /// <p>The streaming distribution's configuration information.</p>
     pub streaming_distribution_config: StreamingDistributionConfig,
 }
 
 /// <p>The returned result of the corresponding request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateStreamingDistributionResult {
     /// <p>The current version of the streaming distribution created.</p>
     pub e_tag: Option<String>,
@@ -1701,14 +1701,14 @@ impl CreateStreamingDistributionResultDeserializer {
     }
 }
 /// <p>The request to create a new streaming distribution with tags.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateStreamingDistributionWithTagsRequest {
     /// <p> The streaming distribution's configuration information. </p>
     pub streaming_distribution_config_with_tags: StreamingDistributionConfigWithTags,
 }
 
 /// <p>The returned result of the corresponding request. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateStreamingDistributionWithTagsResult {
     pub e_tag: Option<String>,
     /// <p>The fully qualified URI of the new streaming distribution resource just created. For example:<code> https://cloudfront.amazonaws.com/2010-11-01/streaming-distribution/EGTXBD79H29TRA8</code>.</p>
@@ -1761,7 +1761,7 @@ impl CreateStreamingDistributionWithTagsResultDeserializer {
     }
 }
 /// <p>A complex type that controls:</p> <ul> <li> <p>Whether CloudFront replaces HTTP status codes in the 4xx and 5xx range with custom error messages before returning the response to the viewer. </p> </li> <li> <p>How long CloudFront caches HTTP status codes in the 4xx and 5xx range.</p> </li> </ul> <p>For more information about custom error pages, see <a href="http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/custom-error-pages.html">Customizing Error Responses</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CustomErrorResponse {
     /// <p>The minimum amount of time, in seconds, that you want CloudFront to cache the HTTP status code specified in <code>ErrorCode</code>. When this time period has elapsed, CloudFront queries your origin to see whether the problem that caused the error has been resolved and the requested object is now available.</p> <p>If you don't want to specify a value, include an empty element, <code>&lt;ErrorCachingMinTTL&gt;</code>, in the XML document.</p> <p>For more information, see <a href="http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/custom-error-pages.html">Customizing Error Responses</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>
     pub error_caching_min_ttl: Option<i64>,
@@ -1940,7 +1940,7 @@ impl CustomErrorResponseListSerializer {
 }
 
 /// <p>A complex type that controls:</p> <ul> <li> <p>Whether CloudFront replaces HTTP status codes in the 4xx and 5xx range with custom error messages before returning the response to the viewer.</p> </li> <li> <p>How long CloudFront caches HTTP status codes in the 4xx and 5xx range.</p> </li> </ul> <p>For more information about custom error pages, see <a href="http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/custom-error-pages.html">Customizing Error Responses</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CustomErrorResponses {
     /// <p>A complex type that contains a <code>CustomErrorResponse</code> element for each HTTP status code for which you want to specify a custom error page and/or a caching duration. </p>
     pub items: Option<Vec<CustomErrorResponse>>,
@@ -2019,7 +2019,7 @@ impl CustomErrorResponsesSerializer {
 }
 
 /// <p>A complex type that contains the list of Custom Headers for each origin. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CustomHeaders {
     /// <p> <b>Optional</b>: A list that contains one <code>OriginCustomHeader</code> element for each custom header that you want CloudFront to forward to the origin. If Quantity is <code>0</code>, omit <code>Items</code>.</p>
     pub items: Option<Vec<OriginCustomHeader>>,
@@ -2098,7 +2098,7 @@ impl CustomHeadersSerializer {
 }
 
 /// <p>A customer origin.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CustomOriginConfig {
     /// <p>The HTTP port the custom origin listens on.</p>
     pub http_port: i64,
@@ -2238,7 +2238,7 @@ impl CustomOriginConfigSerializer {
 }
 
 /// <p>A complex type that describes the default cache behavior if you don't specify a <code>CacheBehavior</code> element or if files don't match any of the values of <code>PathPattern</code> in <code>CacheBehavior</code> elements. You must create exactly one default cache behavior.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DefaultCacheBehavior {
     pub allowed_methods: Option<AllowedMethods>,
     /// <p>Whether you want CloudFront to automatically compress certain files for this cache behavior. If so, specify <code>true</code>; if not, specify <code>false</code>. For more information, see <a href="http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/ServingCompressedFiles.html">Serving Compressed Files</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>
@@ -2438,7 +2438,7 @@ impl DefaultCacheBehaviorSerializer {
 }
 
 /// <p>Deletes a origin access identity.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteCloudFrontOriginAccessIdentityRequest {
     /// <p>The origin access identity's ID.</p>
     pub id: String,
@@ -2447,7 +2447,7 @@ pub struct DeleteCloudFrontOriginAccessIdentityRequest {
 }
 
 /// <p>This action deletes a web distribution. To delete a web distribution using the CloudFront API, perform the following steps.</p> <p> <b>To delete a web distribution using the CloudFront API:</b> </p> <ol> <li> <p>Disable the web distribution </p> </li> <li> <p>Submit a <code>GET Distribution Config</code> request to get the current configuration and the <code>Etag</code> header for the distribution.</p> </li> <li> <p>Update the XML document that was returned in the response to your <code>GET Distribution Config</code> request to change the value of <code>Enabled</code> to <code>false</code>.</p> </li> <li> <p>Submit a <code>PUT Distribution Config</code> request to update the configuration for your distribution. In the request body, include the XML document that you updated in Step 3. Set the value of the HTTP <code>If-Match</code> header to the value of the <code>ETag</code> header that CloudFront returned when you submitted the <code>GET Distribution Config</code> request in Step 2.</p> </li> <li> <p>Review the response to the <code>PUT Distribution Config</code> request to confirm that the distribution was successfully disabled.</p> </li> <li> <p>Submit a <code>GET Distribution</code> request to confirm that your changes have propagated. When propagation is complete, the value of <code>Status</code> is <code>Deployed</code>.</p> </li> <li> <p>Submit a <code>DELETE Distribution</code> request. Set the value of the HTTP <code>If-Match</code> header to the value of the <code>ETag</code> header that CloudFront returned when you submitted the <code>GET Distribution Config</code> request in Step 6.</p> </li> <li> <p>Review the response to your <code>DELETE Distribution</code> request to confirm that the distribution was successfully deleted.</p> </li> </ol> <p>For information about deleting a distribution using the CloudFront console, see <a href="http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/HowToDeleteDistribution.html">Deleting a Distribution</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteDistributionRequest {
     /// <p>The distribution ID. </p>
     pub id: String,
@@ -2455,13 +2455,13 @@ pub struct DeleteDistributionRequest {
     pub if_match: Option<String>,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteServiceLinkedRoleRequest {
     pub role_name: String,
 }
 
 /// <p>The request to delete a streaming distribution.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteStreamingDistributionRequest {
     /// <p>The distribution ID. </p>
     pub id: String,
@@ -2470,7 +2470,7 @@ pub struct DeleteStreamingDistributionRequest {
 }
 
 /// <p>The distribution's information.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Distribution {
     /// <p>The ARN (Amazon Resource Name) for the distribution. For example: <code>arn:aws:cloudfront::123456789012:distribution/EDFDVBD632BHDS5</code>, where <code>123456789012</code> is your AWS account ID.</p>
     pub arn: String,
@@ -2567,7 +2567,7 @@ impl DistributionDeserializer {
     }
 }
 /// <p>A distribution configuration.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DistributionConfig {
     /// <p>A complex type that contains information about CNAMEs (alternate domain names), if any, for this distribution.</p>
     pub aliases: Option<Aliases>,
@@ -2818,7 +2818,7 @@ impl DistributionConfigSerializer {
 }
 
 /// <p>A distribution Configuration and a list of tags to be associated with the distribution.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DistributionConfigWithTags {
     /// <p>A distribution configuration.</p>
     pub distribution_config: DistributionConfig,
@@ -2849,7 +2849,7 @@ impl DistributionConfigWithTagsSerializer {
 }
 
 /// <p>A distribution list.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DistributionList {
     /// <p>A flag that indicates whether more distributions remain to be listed. If your results were truncated, you can make a follow-up pagination request using the <code>Marker</code> request parameter to retrieve more distributions in the list.</p>
     pub is_truncated: bool,
@@ -2924,7 +2924,7 @@ impl DistributionListDeserializer {
     }
 }
 /// <p>A summary of the information about a CloudFront distribution.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DistributionSummary {
     /// <p>The ARN (Amazon Resource Name) for the distribution. For example: <code>arn:aws:cloudfront::123456789012:distribution/EDFDVBD632BHDS5</code>, where <code>123456789012</code> is your AWS account ID.</p>
     pub arn: String,
@@ -3152,7 +3152,7 @@ impl EventTypeSerializer {
 }
 
 /// <p>A complex type that specifies how CloudFront handles query strings and cookies.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ForwardedValues {
     /// <p>A complex type that specifies whether you want CloudFront to forward cookies to the origin and, if so, which ones. For more information about forwarding cookies to the origin, see <a href="http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Cookies.html">How CloudFront Forwards, Caches, and Logs Cookies</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>
     pub cookies: CookiePreference,
@@ -3250,7 +3250,7 @@ impl ForwardedValuesSerializer {
 }
 
 /// <p>A complex type that controls the countries in which your content is distributed. CloudFront determines the location of your users using <code>MaxMind</code> GeoIP databases. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GeoRestriction {
     /// <p> A complex type that contains a <code>Location</code> element for each country in which you want CloudFront either to distribute your content (<code>whitelist</code>) or not distribute your content (<code>blacklist</code>).</p> <p>The <code>Location</code> element is a two-letter, uppercase country code for a country that you want to include in your <code>blacklist</code> or <code>whitelist</code>. Include one <code>Location</code> element for each country.</p> <p>CloudFront and <code>MaxMind</code> both use <code>ISO 3166</code> country codes. For the current list of countries and the corresponding codes, see <code>ISO 3166-1-alpha-2</code> code on the <i>International Organization for Standardization</i> website. You can also refer to the country list on the CloudFront console, which includes both country names and codes.</p>
     pub items: Option<Vec<String>>,
@@ -3377,14 +3377,14 @@ impl GeoRestrictionTypeSerializer {
 }
 
 /// <p>The origin access identity's configuration information. For more information, see <a>CloudFrontOriginAccessIdentityConfigComplexType</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetCloudFrontOriginAccessIdentityConfigRequest {
     /// <p>The identity's ID. </p>
     pub id: String,
 }
 
 /// <p>The returned result of the corresponding request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetCloudFrontOriginAccessIdentityConfigResult {
     /// <p>The origin access identity's configuration information. </p>
     pub cloud_front_origin_access_identity_config: Option<CloudFrontOriginAccessIdentityConfig>,
@@ -3437,14 +3437,14 @@ impl GetCloudFrontOriginAccessIdentityConfigResultDeserializer {
     }
 }
 /// <p>The request to get an origin access identity's information.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetCloudFrontOriginAccessIdentityRequest {
     /// <p>The identity's ID.</p>
     pub id: String,
 }
 
 /// <p>The returned result of the corresponding request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetCloudFrontOriginAccessIdentityResult {
     /// <p>The origin access identity's information.</p>
     pub cloud_front_origin_access_identity: Option<CloudFrontOriginAccessIdentity>,
@@ -3497,14 +3497,14 @@ impl GetCloudFrontOriginAccessIdentityResultDeserializer {
     }
 }
 /// <p>The request to get a distribution configuration.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetDistributionConfigRequest {
     /// <p>The distribution's ID.</p>
     pub id: String,
 }
 
 /// <p>The returned result of the corresponding request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetDistributionConfigResult {
     /// <p>The distribution's configuration information.</p>
     pub distribution_config: Option<DistributionConfig>,
@@ -3556,14 +3556,14 @@ impl GetDistributionConfigResultDeserializer {
     }
 }
 /// <p>The request to get a distribution's information.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetDistributionRequest {
     /// <p>The distribution's ID.</p>
     pub id: String,
 }
 
 /// <p>The returned result of the corresponding request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetDistributionResult {
     /// <p>The distribution's information.</p>
     pub distribution: Option<Distribution>,
@@ -3614,7 +3614,7 @@ impl GetDistributionResultDeserializer {
     }
 }
 /// <p>The request to get an invalidation's information. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetInvalidationRequest {
     /// <p>The distribution's ID.</p>
     pub distribution_id: String,
@@ -3623,7 +3623,7 @@ pub struct GetInvalidationRequest {
 }
 
 /// <p>The returned result of the corresponding request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetInvalidationResult {
     /// <p>The invalidation's information. For more information, see <a href="http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/InvalidationDatatype.html">Invalidation Complex Type</a>. </p>
     pub invalidation: Option<Invalidation>,
@@ -3672,14 +3672,14 @@ impl GetInvalidationResultDeserializer {
     }
 }
 /// <p>To request to get a streaming distribution configuration.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetStreamingDistributionConfigRequest {
     /// <p>The streaming distribution's ID.</p>
     pub id: String,
 }
 
 /// <p>The returned result of the corresponding request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetStreamingDistributionConfigResult {
     /// <p>The current version of the configuration. For example: <code>E2QWRUHAPOMQZL</code>. </p>
     pub e_tag: Option<String>,
@@ -3731,14 +3731,14 @@ impl GetStreamingDistributionConfigResultDeserializer {
     }
 }
 /// <p>The request to get a streaming distribution's information.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetStreamingDistributionRequest {
     /// <p>The streaming distribution's ID.</p>
     pub id: String,
 }
 
 /// <p>The returned result of the corresponding request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetStreamingDistributionResult {
     /// <p>The current version of the streaming distribution's information. For example: <code>E2QWRUHAPOMQZL</code>.</p>
     pub e_tag: Option<String>,
@@ -3851,7 +3851,7 @@ impl HeaderListSerializer {
 }
 
 /// <p>A complex type that specifies the request headers, if any, that you want CloudFront to base caching on for this cache behavior. </p> <p>For the headers that you specify, CloudFront caches separate versions of a specified object based on the header values in viewer requests. For example, suppose viewer requests for <code>logo.jpg</code> contain a custom <code>product</code> header that has a value of either <code>acme</code> or <code>apex</code>, and you configure CloudFront to cache your content based on values in the <code>product</code> header. CloudFront forwards the <code>product</code> header to the origin and caches the response from the origin once for each header value. For more information about caching based on header values, see <a href="http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/header-caching.html">How CloudFront Forwards and Caches Headers</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Headers {
     /// <p>A list that contains one <code>Name</code> element for each header that you want CloudFront to use for caching in this cache behavior. If <code>Quantity</code> is <code>0</code>, omit <code>Items</code>.</p>
     pub items: Option<Vec<String>>,
@@ -3998,7 +3998,7 @@ impl IntegerSerializer {
 }
 
 /// <p>An invalidation. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Invalidation {
     /// <p>The date and time the invalidation request was first made. </p>
     pub create_time: String,
@@ -4063,7 +4063,7 @@ impl InvalidationDeserializer {
     }
 }
 /// <p>An invalidation batch.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct InvalidationBatch {
     /// <p>A value that you specify to uniquely identify an invalidation request. CloudFront uses the value to prevent you from accidentally resubmitting an identical request. Whenever you create a new invalidation request, you must specify a new value for <code>CallerReference</code> and change other values in the request as applicable. One way to ensure that the value of <code>CallerReference</code> is unique is to use a <code>timestamp</code>, for example, <code>20120301090000</code>.</p> <p>If you make a second invalidation request with the same value for <code>CallerReference</code>, and if the rest of the request is the same, CloudFront doesn't create a new invalidation request. Instead, CloudFront returns information about the invalidation request that you previously created with the same <code>CallerReference</code>.</p> <p>If <code>CallerReference</code> is a value you already sent in a previous invalidation batch request but the content of any <code>Path</code> is different from the original request, CloudFront returns an <code>InvalidationBatchAlreadyExists</code> error.</p>
     pub caller_reference: String,
@@ -4139,7 +4139,7 @@ impl InvalidationBatchSerializer {
 }
 
 /// <p>The <code>InvalidationList</code> complex type describes the list of invalidation objects. For more information about invalidation, see <a href="http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Invalidation.html">Invalidating Objects (Web Distributions Only)</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct InvalidationList {
     /// <p>A flag that indicates whether more invalidation batch requests remain to be listed. If your results were truncated, you can make a follow-up pagination request using the <code>Marker</code> request parameter to retrieve more invalidation batches in the list.</p>
     pub is_truncated: bool,
@@ -4214,7 +4214,7 @@ impl InvalidationListDeserializer {
     }
 }
 /// <p>A summary of an invalidation request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct InvalidationSummary {
     pub create_time: String,
     /// <p>The unique ID for an invalidation request.</p>
@@ -4388,7 +4388,7 @@ impl KeyPairIdListDeserializer {
     }
 }
 /// <p>A complex type that lists the active CloudFront key pairs, if any, that are associated with <code>AwsAccountNumber</code>. </p> <p>For more information, see <a>ActiveTrustedSigners</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct KeyPairIds {
     /// <p>A complex type that lists the active CloudFront key pairs, if any, that are associated with <code>AwsAccountNumber</code>.</p> <p>For more information, see <a>ActiveTrustedSigners</a>.</p>
     pub items: Option<Vec<String>>,
@@ -4440,7 +4440,7 @@ impl KeyPairIdsDeserializer {
     }
 }
 /// <p>A complex type that contains a Lambda function association.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct LambdaFunctionAssociation {
     /// <p><p>Specifies the event type that triggers a Lambda function invocation. You can specify the following values:</p> <ul> <li> <p> <code>viewer-request</code>: The function executes when CloudFront receives a request from a viewer and before it checks to see whether the requested object is in the edge cache. </p> </li> <li> <p> <code>origin-request</code>: The function executes only when CloudFront forwards a request to your origin. When the requested object is in the edge cache, the function doesn&#39;t execute.</p> </li> <li> <p> <code>origin-response</code>: The function executes after CloudFront receives a response from the origin and before it caches the object in the response. When the requested object is in the edge cache, the function doesn&#39;t execute.</p> <p>If the origin returns an HTTP status code other than HTTP 200 (OK), the function doesn&#39;t execute.</p> </li> <li> <p> <code>viewer-response</code>: The function executes before CloudFront returns the requested object to the viewer. The function executes regardless of whether the object was already in the edge cache.</p> <p>If the origin returns an HTTP status code other than HTTP 200 (OK), the function doesn&#39;t execute.</p> </li> </ul></p>
     pub event_type: Option<String>,
@@ -4596,7 +4596,7 @@ impl LambdaFunctionAssociationListSerializer {
 }
 
 /// <p>A complex type that specifies a list of Lambda functions associations for a cache behavior.</p> <p>If you want to invoke one or more Lambda functions triggered by requests that match the <code>PathPattern</code> of the cache behavior, specify the applicable values for <code>Quantity</code> and <code>Items</code>. Note that there can be up to 4 <code>LambdaFunctionAssociation</code> items in this list (one for each possible value of <code>EventType</code>) and each <code>EventType</code> can be associated with the Lambda function only once.</p> <p>If you don't want to invoke any Lambda functions for the requests that match <code>PathPattern</code>, specify <code>0</code> for <code>Quantity</code> and omit <code>Items</code>. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct LambdaFunctionAssociations {
     /// <p> <b>Optional</b>: A complex type that contains <code>LambdaFunctionAssociation</code> items for this cache behavior. If <code>Quantity</code> is <code>0</code>, you can omit <code>Items</code>.</p>
     pub items: Option<Vec<LambdaFunctionAssociation>>,
@@ -4675,7 +4675,7 @@ impl LambdaFunctionAssociationsSerializer {
 }
 
 /// <p>The request to list origin access identities. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListCloudFrontOriginAccessIdentitiesRequest {
     /// <p>Use this when paginating results to indicate where to begin in your list of origin access identities. The results include identities in the list that occur after the marker. To get the next page of results, set the <code>Marker</code> to the value of the <code>NextMarker</code> from the current page's response (which is also the ID of the last identity on that page).</p>
     pub marker: Option<String>,
@@ -4684,7 +4684,7 @@ pub struct ListCloudFrontOriginAccessIdentitiesRequest {
 }
 
 /// <p>The returned result of the corresponding request. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListCloudFrontOriginAccessIdentitiesResult {
     /// <p>The <code>CloudFrontOriginAccessIdentityList</code> type. </p>
     pub cloud_front_origin_access_identity_list: Option<CloudFrontOriginAccessIdentityList>,
@@ -4735,7 +4735,7 @@ impl ListCloudFrontOriginAccessIdentitiesResultDeserializer {
     }
 }
 /// <p>The request to list distributions that are associated with a specified AWS WAF web ACL. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListDistributionsByWebACLIdRequest {
     /// <p>Use <code>Marker</code> and <code>MaxItems</code> to control pagination of results. If you have more than <code>MaxItems</code> distributions that satisfy the request, the response includes a <code>NextMarker</code> element. To get the next page of results, submit another request. For the value of <code>Marker</code>, specify the value of <code>NextMarker</code> from the last response. (For the first request, omit <code>Marker</code>.) </p>
     pub marker: Option<String>,
@@ -4746,7 +4746,7 @@ pub struct ListDistributionsByWebACLIdRequest {
 }
 
 /// <p>The response to a request to list the distributions that are associated with a specified AWS WAF web ACL. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListDistributionsByWebACLIdResult {
     /// <p>The <code>DistributionList</code> type. </p>
     pub distribution_list: Option<DistributionList>,
@@ -4794,7 +4794,7 @@ impl ListDistributionsByWebACLIdResultDeserializer {
     }
 }
 /// <p>The request to list your distributions. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListDistributionsRequest {
     /// <p>Use this when paginating results to indicate where to begin in your list of distributions. The results include distributions in the list that occur after the marker. To get the next page of results, set the <code>Marker</code> to the value of the <code>NextMarker</code> from the current page's response (which is also the ID of the last distribution on that page).</p>
     pub marker: Option<String>,
@@ -4803,7 +4803,7 @@ pub struct ListDistributionsRequest {
 }
 
 /// <p>The returned result of the corresponding request. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListDistributionsResult {
     /// <p>The <code>DistributionList</code> type. </p>
     pub distribution_list: Option<DistributionList>,
@@ -4851,7 +4851,7 @@ impl ListDistributionsResultDeserializer {
     }
 }
 /// <p>The request to list invalidations. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListInvalidationsRequest {
     /// <p>The distribution's ID.</p>
     pub distribution_id: String,
@@ -4862,7 +4862,7 @@ pub struct ListInvalidationsRequest {
 }
 
 /// <p>The returned result of the corresponding request. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListInvalidationsResult {
     /// <p>Information about invalidation batches. </p>
     pub invalidation_list: Option<InvalidationList>,
@@ -4910,7 +4910,7 @@ impl ListInvalidationsResultDeserializer {
     }
 }
 /// <p>The request to list your streaming distributions. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListStreamingDistributionsRequest {
     /// <p>The value that you provided for the <code>Marker</code> request parameter.</p>
     pub marker: Option<String>,
@@ -4919,7 +4919,7 @@ pub struct ListStreamingDistributionsRequest {
 }
 
 /// <p>The returned result of the corresponding request. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListStreamingDistributionsResult {
     /// <p>The <code>StreamingDistributionList</code> type. </p>
     pub streaming_distribution_list: Option<StreamingDistributionList>,
@@ -4969,14 +4969,14 @@ impl ListStreamingDistributionsResultDeserializer {
     }
 }
 /// <p> The request to list tags for a CloudFront resource.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListTagsForResourceRequest {
     /// <p> An ARN of a CloudFront resource.</p>
     pub resource: String,
 }
 
 /// <p> The returned result of the corresponding request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListTagsForResourceResult {
     /// <p> A complex type that contains zero or more <code>Tag</code> elements.</p>
     pub tags: Tags,
@@ -5083,7 +5083,7 @@ impl LocationListSerializer {
 }
 
 /// <p>A complex type that controls whether access logs are written for the distribution.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct LoggingConfig {
     /// <p>The Amazon S3 bucket to store the access logs in, for example, <code>myawslogbucket.s3.amazonaws.com</code>.</p>
     pub bucket: String,
@@ -5352,7 +5352,7 @@ impl MinimumProtocolVersionSerializer {
 }
 
 /// <p>A complex type that describes the Amazon S3 bucket or the HTTP server (for example, a web server) from which CloudFront gets your files. You must create at least one origin.</p> <p>For the current limit on the number of origins that you can create for a distribution, see <a href="http://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html#limits_cloudfront">Amazon CloudFront Limits</a> in the <i>AWS General Reference</i>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Origin {
     /// <p>A complex type that contains names and values for the custom headers that you want.</p>
     pub custom_headers: Option<CustomHeaders>,
@@ -5481,7 +5481,7 @@ impl OriginSerializer {
 }
 
 /// <p>A complex type that contains <code>HeaderName</code> and <code>HeaderValue</code> elements, if any, for this distribution. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct OriginCustomHeader {
     /// <p>The name of a header that you want CloudFront to forward to your origin. For more information, see <a href="http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/forward-custom-headers.html">Forwarding Custom Headers to Your Origin (Web Distributions Only)</a> in the <i>Amazon Amazon CloudFront Developer Guide</i>.</p>
     pub header_name: String,
@@ -5723,7 +5723,7 @@ impl OriginProtocolPolicySerializer {
 }
 
 /// <p>A complex type that contains information about the SSL/TLS protocols that CloudFront can use when establishing an HTTPS connection with your origin. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct OriginSslProtocols {
     /// <p>A list that contains allowed SSL/TLS protocols for this distribution.</p>
     pub items: Vec<String>,
@@ -5798,7 +5798,7 @@ impl OriginSslProtocolsSerializer {
 }
 
 /// <p>A complex type that contains information about origins for this distribution. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Origins {
     /// <p>A complex type that contains origins for this distribution.</p>
     pub items: Option<Vec<Origin>>,
@@ -5936,7 +5936,7 @@ impl PathListSerializer {
 }
 
 /// <p>A complex type that contains information about the objects that you want to invalidate. For more information, see <a href="http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Invalidation.html#invalidation-specifying-objects">Specifying the Objects to Invalidate</a> in the <i>Amazon CloudFront Developer Guide</i>. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Paths {
     /// <p>A complex type that contains a list of the paths that you want to invalidate.</p>
     pub items: Option<Vec<String>>,
@@ -6047,7 +6047,7 @@ impl PriceClassSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct QueryStringCacheKeys {
     /// <p>(Optional) A list that contains the query string parameters that you want CloudFront to use as a basis for caching for this cache behavior. If <code>Quantity</code> is 0, you can omit <code>Items</code>. </p>
     pub items: Option<Vec<String>>,
@@ -6207,7 +6207,7 @@ impl ResourceARNSerializer {
 }
 
 /// <p>A complex type that identifies ways in which you want to restrict distribution of your content.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Restrictions {
     pub geo_restriction: GeoRestriction,
 }
@@ -6273,7 +6273,7 @@ impl RestrictionsSerializer {
 }
 
 /// <p>A complex type that contains information about the Amazon S3 bucket from which you want CloudFront to get your media files for distribution.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct S3Origin {
     /// <p>The DNS name of the Amazon S3 origin. </p>
     pub domain_name: String,
@@ -6357,7 +6357,7 @@ impl S3OriginSerializer {
 }
 
 /// <p>A complex type that contains information about the Amazon S3 origin. If the origin is a custom origin, use the <code>CustomOriginConfig</code> element instead.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct S3OriginConfig {
     /// <p>The CloudFront origin access identity to associate with the origin. Use an origin access identity to configure the origin so that viewers can <i>only</i> access objects in an Amazon S3 bucket through CloudFront. The format of the value is:</p> <p>origin-access-identity/cloudfront/<i>ID-of-origin-access-identity</i> </p> <p>where <code> <i>ID-of-origin-access-identity</i> </code> is the value that CloudFront returned in the <code>ID</code> element when you created the origin access identity.</p> <p>If you want viewers to be able to access objects using either the CloudFront URL or the Amazon S3 URL, specify an empty <code>OriginAccessIdentity</code> element.</p> <p>To delete the origin access identity from an existing distribution, update the distribution configuration and include an empty <code>OriginAccessIdentity</code> element.</p> <p>To replace the origin access identity, update the distribution configuration and specify the new origin access identity.</p> <p>For more information about the origin access identity, see <a href="http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/PrivateContent.html">Serving Private Content through CloudFront</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>
     pub origin_access_identity: String,
@@ -6464,7 +6464,7 @@ impl SSLSupportMethodSerializer {
 }
 
 /// <p>A complex type that lists the AWS accounts that were included in the <code>TrustedSigners</code> complex type, as well as their active CloudFront key pair IDs, if any. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Signer {
     /// <p><p>An AWS account that is included in the <code>TrustedSigners</code> complex type for this RTMP distribution. Valid values include:</p> <ul> <li> <p> <code>self</code>, which is the AWS account used to create the distribution.</p> </li> <li> <p>An AWS account number.</p> </li> </ul></p>
     pub aws_account_number: Option<String>,
@@ -6660,7 +6660,7 @@ impl SslProtocolsListSerializer {
 }
 
 /// <p>A streaming distribution. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct StreamingDistribution {
     pub arn: String,
     /// <p>A complex type that lists the AWS accounts, if any, that you included in the <code>TrustedSigners</code> complex type for this distribution. These are the accounts that you want to allow to create signed URLs for private content.</p> <p>The <code>Signer</code> complex type lists the AWS account number of the trusted signer or <code>self</code> if the signer is the AWS account that created the distribution. The <code>Signer</code> element also includes the IDs of any active CloudFront key pairs that are associated with the trusted signer's AWS account. If no <code>KeyPairId</code> element appears for a <code>Signer</code>, that signer can't create signed URLs.</p> <p>For more information, see <a href="http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/PrivateContent.html">Serving Private Content through CloudFront</a> in the <i>Amazon CloudFront Developer Guide</i>. </p>
@@ -6747,7 +6747,7 @@ impl StreamingDistributionDeserializer {
     }
 }
 /// <p>The RTMP distribution's configuration information.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct StreamingDistributionConfig {
     /// <p>A complex type that contains information about CNAMEs (alternate domain names), if any, for this streaming distribution. </p>
     pub aliases: Option<Aliases>,
@@ -6889,7 +6889,7 @@ impl StreamingDistributionConfigSerializer {
 }
 
 /// <p>A streaming distribution Configuration and a list of tags to be associated with the streaming distribution.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct StreamingDistributionConfigWithTags {
     /// <p>A streaming distribution Configuration.</p>
     pub streaming_distribution_config: StreamingDistributionConfig,
@@ -6920,7 +6920,7 @@ impl StreamingDistributionConfigWithTagsSerializer {
 }
 
 /// <p>A streaming distribution list. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct StreamingDistributionList {
     /// <p>A flag that indicates whether more streaming distributions remain to be listed. If your results were truncated, you can make a follow-up pagination request using the <code>Marker</code> request parameter to retrieve more distributions in the list. </p>
     pub is_truncated: bool,
@@ -6997,7 +6997,7 @@ impl StreamingDistributionListDeserializer {
     }
 }
 /// <p> A summary of the information for an Amazon CloudFront streaming distribution.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct StreamingDistributionSummary {
     /// <p> The ARN (Amazon Resource Name) for the streaming distribution. For example: <code>arn:aws:cloudfront::123456789012:streaming-distribution/EDFDVBD632BHDS5</code>, where <code>123456789012</code> is your AWS account ID.</p>
     pub arn: String,
@@ -7143,7 +7143,7 @@ impl StreamingDistributionSummaryListDeserializer {
     }
 }
 /// <p>A complex type that controls whether access logs are written for this streaming distribution.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct StreamingLoggingConfig {
     /// <p>The Amazon S3 bucket to store the access logs in, for example, <code>myawslogbucket.s3.amazonaws.com</code>.</p>
     pub bucket: String,
@@ -7269,7 +7269,7 @@ impl StringSerializer {
 }
 
 /// <p> A complex type that contains <code>Tag</code> key and <code>Tag</code> value.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Tag {
     /// <p> A string that contains <code>Tag</code> key.</p> <p>The string length should be between 1 and 128 characters. Valid characters include <code>a-z</code>, <code>A-Z</code>, <code>0-9</code>, space, and the special characters <code>_ - . : / = + @</code>.</p>
     pub key: String,
@@ -7406,7 +7406,7 @@ impl TagKeyListSerializer {
 }
 
 /// <p> A complex type that contains zero or more <code>Tag</code> elements.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct TagKeys {
     /// <p> A complex type that contains <code>Tag</code> key elements.</p>
     pub items: Option<Vec<String>>,
@@ -7493,7 +7493,7 @@ impl TagListSerializer {
 }
 
 /// <p> The request to add tags to a CloudFront resource.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct TagResourceRequest {
     /// <p> An ARN of a CloudFront resource.</p>
     pub resource: String,
@@ -7537,7 +7537,7 @@ impl TagValueSerializer {
 }
 
 /// <p> A complex type that contains zero or more <code>Tag</code> elements.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Tags {
     /// <p> A complex type that contains <code>Tag</code> elements.</p>
     pub items: Option<Vec<Tag>>,
@@ -7617,7 +7617,7 @@ impl TimestampDeserializer {
     }
 }
 /// <p>A complex type that specifies the AWS accounts, if any, that you want to allow to create signed URLs for private content.</p> <p>If you want to require signed URLs in requests for objects in the target origin that match the <code>PathPattern</code> for this cache behavior, specify <code>true</code> for <code>Enabled</code>, and specify the applicable values for <code>Quantity</code> and <code>Items</code>. For more information, see <a href="http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/PrivateContent.html">Serving Private Content through CloudFront</a> in the <i>Amazon Amazon CloudFront Developer Guide</i>.</p> <p>If you don't want to require signed URLs in requests for objects that match <code>PathPattern</code>, specify <code>false</code> for <code>Enabled</code> and <code>0</code> for <code>Quantity</code>. Omit <code>Items</code>.</p> <p>To add, change, or remove one or more trusted signers, change <code>Enabled</code> to <code>true</code> (if it's currently <code>false</code>), change <code>Quantity</code> as applicable, and specify all of the trusted signers that you want to include in the updated distribution.</p> <p>For more information about updating the distribution configuration, see <a>DistributionConfig</a> .</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct TrustedSigners {
     /// <p>Specifies whether you want to require viewers to use signed URLs to access the files specified by <code>PathPattern</code> and <code>TargetOriginId</code>.</p>
     pub enabled: bool,
@@ -7707,7 +7707,7 @@ impl TrustedSignersSerializer {
 }
 
 /// <p> The request to remove tags from a CloudFront resource.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UntagResourceRequest {
     /// <p> An ARN of a CloudFront resource.</p>
     pub resource: String,
@@ -7716,7 +7716,7 @@ pub struct UntagResourceRequest {
 }
 
 /// <p>The request to update an origin access identity.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateCloudFrontOriginAccessIdentityRequest {
     /// <p>The identity's configuration information.</p>
     pub cloud_front_origin_access_identity_config: CloudFrontOriginAccessIdentityConfig,
@@ -7727,7 +7727,7 @@ pub struct UpdateCloudFrontOriginAccessIdentityRequest {
 }
 
 /// <p>The returned result of the corresponding request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateCloudFrontOriginAccessIdentityResult {
     /// <p>The origin access identity's information.</p>
     pub cloud_front_origin_access_identity: Option<CloudFrontOriginAccessIdentity>,
@@ -7780,7 +7780,7 @@ impl UpdateCloudFrontOriginAccessIdentityResultDeserializer {
     }
 }
 /// <p>The request to update a distribution.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateDistributionRequest {
     /// <p>The distribution's configuration information.</p>
     pub distribution_config: DistributionConfig,
@@ -7791,7 +7791,7 @@ pub struct UpdateDistributionRequest {
 }
 
 /// <p>The returned result of the corresponding request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateDistributionResult {
     /// <p>The distribution's information.</p>
     pub distribution: Option<Distribution>,
@@ -7842,7 +7842,7 @@ impl UpdateDistributionResultDeserializer {
     }
 }
 /// <p>The request to update a streaming distribution.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateStreamingDistributionRequest {
     /// <p>The streaming distribution's id.</p>
     pub id: String,
@@ -7853,7 +7853,7 @@ pub struct UpdateStreamingDistributionRequest {
 }
 
 /// <p>The returned result of the corresponding request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateStreamingDistributionResult {
     /// <p>The current version of the configuration. For example: <code>E2QWRUHAPOMQZL</code>.</p>
     pub e_tag: Option<String>,
@@ -7905,7 +7905,7 @@ impl UpdateStreamingDistributionResultDeserializer {
     }
 }
 /// <p>A complex type that specifies the following:</p> <ul> <li> <p>Whether you want viewers to use HTTP or HTTPS to request your objects.</p> </li> <li> <p>If you want viewers to use HTTPS, whether you're using an alternate domain name such as <code>example.com</code> or the CloudFront domain name for your distribution, such as <code>d111111abcdef8.cloudfront.net</code>.</p> </li> <li> <p>If you're using an alternate domain name, whether AWS Certificate Manager (ACM) provided the certificate, or you purchased a certificate from a third-party certificate authority and imported it into ACM or uploaded it to the IAM certificate store.</p> </li> </ul> <p>You must specify only one of the following values: </p> <ul> <li> <p> <a>ViewerCertificate$ACMCertificateArn</a> </p> </li> <li> <p> <a>ViewerCertificate$IAMCertificateId</a> </p> </li> <li> <p> <a>ViewerCertificate$CloudFrontDefaultCertificate</a> </p> </li> </ul> <p>Don't specify <code>false</code> for <code>CloudFrontDefaultCertificate</code>.</p> <p> <b>If you want viewers to use HTTP instead of HTTPS to request your objects</b>: Specify the following value:</p> <p> <code>&lt;CloudFrontDefaultCertificate&gt;true&lt;CloudFrontDefaultCertificate&gt;</code> </p> <p>In addition, specify <code>allow-all</code> for <code>ViewerProtocolPolicy</code> for all of your cache behaviors.</p> <p> <b>If you want viewers to use HTTPS to request your objects</b>: Choose the type of certificate that you want to use based on whether you're using an alternate domain name for your objects or the CloudFront domain name:</p> <ul> <li> <p> <b>If you're using an alternate domain name, such as example.com</b>: Specify one of the following values, depending on whether ACM provided your certificate or you purchased your certificate from third-party certificate authority:</p> <ul> <li> <p> <code>&lt;ACMCertificateArn&gt;<i>ARN for ACM SSL/TLS certificate</i>&lt;ACMCertificateArn&gt;</code> where <code> <i>ARN for ACM SSL/TLS certificate</i> </code> is the ARN for the ACM SSL/TLS certificate that you want to use for this distribution.</p> </li> <li> <p> <code>&lt;IAMCertificateId&gt;<i>IAM certificate ID</i>&lt;IAMCertificateId&gt;</code> where <code> <i>IAM certificate ID</i> </code> is the ID that IAM returned when you added the certificate to the IAM certificate store.</p> </li> </ul> <p>If you specify <code>ACMCertificateArn</code> or <code>IAMCertificateId</code>, you must also specify a value for <code>SSLSupportMethod</code>.</p> <p>If you choose to use an ACM certificate or a certificate in the IAM certificate store, we recommend that you use only an alternate domain name in your object URLs (<code>https://example.com/logo.jpg</code>). If you use the domain name that is associated with your CloudFront distribution (such as <code>https://d111111abcdef8.cloudfront.net/logo.jpg</code>) and the viewer supports <code>SNI</code>, then CloudFront behaves normally. However, if the browser does not support SNI, the user's experience depends on the value that you choose for <code>SSLSupportMethod</code>:</p> <ul> <li> <p> <code>vip</code>: The viewer displays a warning because there is a mismatch between the CloudFront domain name and the domain name in your SSL/TLS certificate.</p> </li> <li> <p> <code>sni-only</code>: CloudFront drops the connection with the browser without returning the object.</p> </li> </ul> </li> <li> <p> <b>If you're using the CloudFront domain name for your distribution, such as <code>d111111abcdef8.cloudfront.net</code> </b>: Specify the following value:</p> <p> <code>&lt;CloudFrontDefaultCertificate&gt;true&lt;CloudFrontDefaultCertificate&gt; </code> </p> </li> </ul> <p>If you want viewers to use HTTPS, you must also specify one of the following values in your cache behaviors:</p> <ul> <li> <p> <code> &lt;ViewerProtocolPolicy&gt;https-only&lt;ViewerProtocolPolicy&gt;</code> </p> </li> <li> <p> <code>&lt;ViewerProtocolPolicy&gt;redirect-to-https&lt;ViewerProtocolPolicy&gt;</code> </p> </li> </ul> <p>You can also optionally require that CloudFront use HTTPS to communicate with your origin by specifying one of the following values for the applicable origins:</p> <ul> <li> <p> <code>&lt;OriginProtocolPolicy&gt;https-only&lt;OriginProtocolPolicy&gt; </code> </p> </li> <li> <p> <code>&lt;OriginProtocolPolicy&gt;match-viewer&lt;OriginProtocolPolicy&gt; </code> </p> </li> </ul> <p>For more information, see <a href="http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/SecureConnections.html#CNAMEsAndHTTPS">Using Alternate Domain Names and HTTPS</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ViewerCertificate {
     /// <p>For information about how and when to use <code>ACMCertificateArn</code>, see <a>ViewerCertificate</a>.</p>
     pub acm_certificate_arn: Option<String>,

--- a/rusoto/services/cloudhsm/src/generated.rs
+++ b/rusoto/services/cloudhsm/src/generated.rs
@@ -30,7 +30,7 @@ use rusoto_core::signature::SignedRequest;
 use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AddTagsToResourceRequest {
     /// <p>The Amazon Resource Name (ARN) of the AWS CloudHSM resource to tag.</p>
     #[serde(rename = "ResourceArn")]
@@ -40,7 +40,7 @@ pub struct AddTagsToResourceRequest {
     pub tag_list: Vec<Tag>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AddTagsToResourceResponse {
     /// <p>The status of the operation.</p>
     #[serde(rename = "Status")]
@@ -48,7 +48,7 @@ pub struct AddTagsToResourceResponse {
 }
 
 /// <p>Contains the inputs for the <a>CreateHapgRequest</a> action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateHapgRequest {
     /// <p>The label of the new high-availability partition group.</p>
     #[serde(rename = "Label")]
@@ -56,7 +56,7 @@ pub struct CreateHapgRequest {
 }
 
 /// <p>Contains the output of the <a>CreateHAPartitionGroup</a> action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateHapgResponse {
     /// <p>The ARN of the high-availability partition group.</p>
     #[serde(rename = "HapgArn")]
@@ -65,7 +65,7 @@ pub struct CreateHapgResponse {
 }
 
 /// <p>Contains the inputs for the <code>CreateHsm</code> operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateHsmRequest {
     /// <p>A user-defined token to ensure idempotence. Subsequent calls to this operation with the same token will be ignored.</p>
     #[serde(rename = "ClientToken")]
@@ -97,7 +97,7 @@ pub struct CreateHsmRequest {
 }
 
 /// <p>Contains the output of the <code>CreateHsm</code> operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateHsmResponse {
     /// <p>The ARN of the HSM.</p>
     #[serde(rename = "HsmArn")]
@@ -106,7 +106,7 @@ pub struct CreateHsmResponse {
 }
 
 /// <p>Contains the inputs for the <a>CreateLunaClient</a> action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateLunaClientRequest {
     /// <p>The contents of a Base64-Encoded X.509 v3 certificate to be installed on the HSMs used by this client.</p>
     #[serde(rename = "Certificate")]
@@ -118,7 +118,7 @@ pub struct CreateLunaClientRequest {
 }
 
 /// <p>Contains the output of the <a>CreateLunaClient</a> action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateLunaClientResponse {
     /// <p>The ARN of the client.</p>
     #[serde(rename = "ClientArn")]
@@ -127,7 +127,7 @@ pub struct CreateLunaClientResponse {
 }
 
 /// <p>Contains the inputs for the <a>DeleteHapg</a> action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteHapgRequest {
     /// <p>The ARN of the high-availability partition group to delete.</p>
     #[serde(rename = "HapgArn")]
@@ -135,7 +135,7 @@ pub struct DeleteHapgRequest {
 }
 
 /// <p>Contains the output of the <a>DeleteHapg</a> action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteHapgResponse {
     /// <p>The status of the action.</p>
     #[serde(rename = "Status")]
@@ -143,7 +143,7 @@ pub struct DeleteHapgResponse {
 }
 
 /// <p>Contains the inputs for the <a>DeleteHsm</a> operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteHsmRequest {
     /// <p>The ARN of the HSM to delete.</p>
     #[serde(rename = "HsmArn")]
@@ -151,21 +151,21 @@ pub struct DeleteHsmRequest {
 }
 
 /// <p>Contains the output of the <a>DeleteHsm</a> operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteHsmResponse {
     /// <p>The status of the operation.</p>
     #[serde(rename = "Status")]
     pub status: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteLunaClientRequest {
     /// <p>The ARN of the client to delete.</p>
     #[serde(rename = "ClientArn")]
     pub client_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteLunaClientResponse {
     /// <p>The status of the action.</p>
     #[serde(rename = "Status")]
@@ -173,7 +173,7 @@ pub struct DeleteLunaClientResponse {
 }
 
 /// <p>Contains the inputs for the <a>DescribeHapg</a> action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeHapgRequest {
     /// <p>The ARN of the high-availability partition group to describe.</p>
     #[serde(rename = "HapgArn")]
@@ -181,7 +181,7 @@ pub struct DescribeHapgRequest {
 }
 
 /// <p>Contains the output of the <a>DescribeHapg</a> action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeHapgResponse {
     /// <p>The ARN of the high-availability partition group.</p>
     #[serde(rename = "HapgArn")]
@@ -222,7 +222,7 @@ pub struct DescribeHapgResponse {
 }
 
 /// <p>Contains the inputs for the <a>DescribeHsm</a> operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeHsmRequest {
     /// <p>The ARN of the HSM. Either the <code>HsmArn</code> or the <code>SerialNumber</code> parameter must be specified.</p>
     #[serde(rename = "HsmArn")]
@@ -235,7 +235,7 @@ pub struct DescribeHsmRequest {
 }
 
 /// <p>Contains the output of the <a>DescribeHsm</a> operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeHsmResponse {
     /// <p>The Availability Zone that the HSM is in.</p>
     #[serde(rename = "AvailabilityZone")]
@@ -322,7 +322,7 @@ pub struct DescribeHsmResponse {
     pub vpc_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeLunaClientRequest {
     /// <p>The certificate fingerprint.</p>
     #[serde(rename = "CertificateFingerprint")]
@@ -334,7 +334,7 @@ pub struct DescribeLunaClientRequest {
     pub client_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeLunaClientResponse {
     /// <p>The certificate installed on the HSMs used by this client.</p>
     #[serde(rename = "Certificate")]
@@ -358,7 +358,7 @@ pub struct DescribeLunaClientResponse {
     pub last_modified_timestamp: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetConfigRequest {
     /// <p>The ARN of the client.</p>
     #[serde(rename = "ClientArn")]
@@ -371,7 +371,7 @@ pub struct GetConfigRequest {
     pub hapg_list: Vec<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetConfigResponse {
     /// <p>The certificate file containing the server.pem files of the HSMs.</p>
     #[serde(rename = "ConfigCred")]
@@ -388,10 +388,10 @@ pub struct GetConfigResponse {
 }
 
 /// <p>Contains the inputs for the <a>ListAvailableZones</a> action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListAvailableZonesRequest {}
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListAvailableZonesResponse {
     /// <p>The list of Availability Zones that have available AWS CloudHSM capacity.</p>
     #[serde(rename = "AZList")]
@@ -399,7 +399,7 @@ pub struct ListAvailableZonesResponse {
     pub az_list: Option<Vec<String>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListHapgsRequest {
     /// <p>The <code>NextToken</code> value from a previous call to <code>ListHapgs</code>. Pass null if this is the first call.</p>
     #[serde(rename = "NextToken")]
@@ -407,7 +407,7 @@ pub struct ListHapgsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListHapgsResponse {
     /// <p>The list of high-availability partition groups.</p>
     #[serde(rename = "HapgList")]
@@ -418,7 +418,7 @@ pub struct ListHapgsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListHsmsRequest {
     /// <p>The <code>NextToken</code> value from a previous call to <code>ListHsms</code>. Pass null if this is the first call.</p>
     #[serde(rename = "NextToken")]
@@ -427,7 +427,7 @@ pub struct ListHsmsRequest {
 }
 
 /// <p>Contains the output of the <code>ListHsms</code> operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListHsmsResponse {
     /// <p>The list of ARNs that identify the HSMs.</p>
     #[serde(rename = "HsmList")]
@@ -439,7 +439,7 @@ pub struct ListHsmsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListLunaClientsRequest {
     /// <p>The <code>NextToken</code> value from a previous call to <code>ListLunaClients</code>. Pass null if this is the first call.</p>
     #[serde(rename = "NextToken")]
@@ -447,7 +447,7 @@ pub struct ListLunaClientsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListLunaClientsResponse {
     /// <p>The list of clients.</p>
     #[serde(rename = "ClientList")]
@@ -458,21 +458,21 @@ pub struct ListLunaClientsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListTagsForResourceRequest {
     /// <p>The Amazon Resource Name (ARN) of the AWS CloudHSM resource.</p>
     #[serde(rename = "ResourceArn")]
     pub resource_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListTagsForResourceResponse {
     /// <p>One or more tags.</p>
     #[serde(rename = "TagList")]
     pub tag_list: Vec<Tag>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ModifyHapgRequest {
     /// <p>The ARN of the high-availability partition group to modify.</p>
     #[serde(rename = "HapgArn")]
@@ -487,7 +487,7 @@ pub struct ModifyHapgRequest {
     pub partition_serial_list: Option<Vec<String>>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ModifyHapgResponse {
     /// <p>The ARN of the high-availability partition group.</p>
     #[serde(rename = "HapgArn")]
@@ -496,7 +496,7 @@ pub struct ModifyHapgResponse {
 }
 
 /// <p>Contains the inputs for the <a>ModifyHsm</a> operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ModifyHsmRequest {
     /// <p>The new IP address for the elastic network interface (ENI) attached to the HSM.</p> <p>If the HSM is moved to a different subnet, and an IP address is not specified, an IP address will be randomly chosen from the CIDR range of the new subnet.</p>
     #[serde(rename = "EniIp")]
@@ -524,7 +524,7 @@ pub struct ModifyHsmRequest {
 }
 
 /// <p>Contains the output of the <a>ModifyHsm</a> operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ModifyHsmResponse {
     /// <p>The ARN of the HSM.</p>
     #[serde(rename = "HsmArn")]
@@ -532,7 +532,7 @@ pub struct ModifyHsmResponse {
     pub hsm_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ModifyLunaClientRequest {
     /// <p>The new certificate for the client.</p>
     #[serde(rename = "Certificate")]
@@ -542,7 +542,7 @@ pub struct ModifyLunaClientRequest {
     pub client_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ModifyLunaClientResponse {
     /// <p>The ARN of the client.</p>
     #[serde(rename = "ClientArn")]
@@ -550,7 +550,7 @@ pub struct ModifyLunaClientResponse {
     pub client_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RemoveTagsFromResourceRequest {
     /// <p>The Amazon Resource Name (ARN) of the AWS CloudHSM resource.</p>
     #[serde(rename = "ResourceArn")]
@@ -560,7 +560,7 @@ pub struct RemoveTagsFromResourceRequest {
     pub tag_key_list: Vec<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RemoveTagsFromResourceResponse {
     /// <p>The status of the operation.</p>
     #[serde(rename = "Status")]
@@ -568,7 +568,7 @@ pub struct RemoveTagsFromResourceResponse {
 }
 
 /// <p>A key-value pair that identifies or specifies metadata about an AWS CloudHSM resource.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Tag {
     /// <p>The key of the tag.</p>
     #[serde(rename = "Key")]

--- a/rusoto/services/cloudhsm/src/generated.rs
+++ b/rusoto/services/cloudhsm/src/generated.rs
@@ -601,7 +601,8 @@ impl AddTagsToResourceError {
     pub fn from_body(body: &str) -> AddTagsToResourceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -693,7 +694,8 @@ impl CreateHapgError {
     pub fn from_body(body: &str) -> CreateHapgError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -781,7 +783,8 @@ impl CreateHsmError {
     pub fn from_body(body: &str) -> CreateHsmError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -869,7 +872,8 @@ impl CreateLunaClientError {
     pub fn from_body(body: &str) -> CreateLunaClientError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -959,7 +963,8 @@ impl DeleteHapgError {
     pub fn from_body(body: &str) -> DeleteHapgError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1047,7 +1052,8 @@ impl DeleteHsmError {
     pub fn from_body(body: &str) -> DeleteHsmError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1135,7 +1141,8 @@ impl DeleteLunaClientError {
     pub fn from_body(body: &str) -> DeleteLunaClientError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1225,7 +1232,8 @@ impl DescribeHapgError {
     pub fn from_body(body: &str) -> DescribeHapgError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1315,7 +1323,8 @@ impl DescribeHsmError {
     pub fn from_body(body: &str) -> DescribeHsmError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1405,7 +1414,8 @@ impl DescribeLunaClientError {
     pub fn from_body(body: &str) -> DescribeLunaClientError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1497,7 +1507,8 @@ impl GetConfigError {
     pub fn from_body(body: &str) -> GetConfigError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1585,7 +1596,8 @@ impl ListAvailableZonesError {
     pub fn from_body(body: &str) -> ListAvailableZonesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1677,7 +1689,8 @@ impl ListHapgsError {
     pub fn from_body(body: &str) -> ListHapgsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1765,7 +1778,8 @@ impl ListHsmsError {
     pub fn from_body(body: &str) -> ListHsmsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1853,7 +1867,8 @@ impl ListLunaClientsError {
     pub fn from_body(body: &str) -> ListLunaClientsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1943,7 +1958,8 @@ impl ListTagsForResourceError {
     pub fn from_body(body: &str) -> ListTagsForResourceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2035,7 +2051,8 @@ impl ModifyHapgError {
     pub fn from_body(body: &str) -> ModifyHapgError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2123,7 +2140,8 @@ impl ModifyHsmError {
     pub fn from_body(body: &str) -> ModifyHsmError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2207,7 +2225,8 @@ impl ModifyLunaClientError {
     pub fn from_body(body: &str) -> ModifyLunaClientError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2289,7 +2308,8 @@ impl RemoveTagsFromResourceError {
     pub fn from_body(body: &str) -> RemoveTagsFromResourceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/cloudhsmv2/src/generated.rs
+++ b/rusoto/services/cloudhsmv2/src/generated.rs
@@ -31,7 +31,7 @@ use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 /// <p>Contains information about a backup of an AWS CloudHSM cluster.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Backup {
     /// <p>The identifier (ID) of the backup.</p>
     #[serde(rename = "BackupId")]
@@ -51,7 +51,7 @@ pub struct Backup {
 }
 
 /// <p>Contains one or more certificates or a certificate signing request (CSR).</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Certificates {
     /// <p>The HSM hardware certificate issued (signed) by AWS CloudHSM.</p>
     #[serde(rename = "AwsHardwareCertificate")]
@@ -76,7 +76,7 @@ pub struct Certificates {
 }
 
 /// <p>Contains information about an AWS CloudHSM cluster.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Cluster {
     /// <p>The cluster's backup policy.</p>
     #[serde(rename = "BackupPolicy")]
@@ -132,7 +132,7 @@ pub struct Cluster {
     pub vpc_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateClusterRequest {
     /// <p>The type of HSM to use in the cluster. Currently the only allowed value is <code>hsm1.medium</code>.</p>
     #[serde(rename = "HsmType")]
@@ -146,7 +146,7 @@ pub struct CreateClusterRequest {
     pub subnet_ids: Vec<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateClusterResponse {
     /// <p>Information about the cluster that was created.</p>
     #[serde(rename = "Cluster")]
@@ -154,7 +154,7 @@ pub struct CreateClusterResponse {
     pub cluster: Option<Cluster>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateHsmRequest {
     /// <p>The Availability Zone where you are creating the HSM. To find the cluster's Availability Zones, use <a>DescribeClusters</a>.</p>
     #[serde(rename = "AvailabilityZone")]
@@ -168,7 +168,7 @@ pub struct CreateHsmRequest {
     pub ip_address: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateHsmResponse {
     /// <p>Information about the HSM that was created.</p>
     #[serde(rename = "Hsm")]
@@ -176,14 +176,14 @@ pub struct CreateHsmResponse {
     pub hsm: Option<Hsm>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteClusterRequest {
     /// <p>The identifier (ID) of the cluster that you are deleting. To find the cluster ID, use <a>DescribeClusters</a>.</p>
     #[serde(rename = "ClusterId")]
     pub cluster_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteClusterResponse {
     /// <p>Information about the cluster that was deleted.</p>
     #[serde(rename = "Cluster")]
@@ -191,7 +191,7 @@ pub struct DeleteClusterResponse {
     pub cluster: Option<Cluster>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteHsmRequest {
     /// <p>The identifier (ID) of the cluster that contains the HSM that you are deleting.</p>
     #[serde(rename = "ClusterId")]
@@ -210,7 +210,7 @@ pub struct DeleteHsmRequest {
     pub hsm_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteHsmResponse {
     /// <p>The identifier (ID) of the HSM that was deleted.</p>
     #[serde(rename = "HsmId")]
@@ -218,7 +218,7 @@ pub struct DeleteHsmResponse {
     pub hsm_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeBackupsRequest {
     /// <p>One or more filters to limit the items returned in the response.</p> <p>Use the <code>backupIds</code> filter to return only the specified backups. Specify backups by their backup identifier (ID).</p> <p>Use the <code>clusterIds</code> filter to return only the backups for the specified clusters. Specify clusters by their cluster identifier (ID).</p> <p>Use the <code>states</code> filter to return only backups that match the specified state.</p>
     #[serde(rename = "Filters")]
@@ -234,7 +234,7 @@ pub struct DescribeBackupsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeBackupsResponse {
     /// <p>A list of backups.</p>
     #[serde(rename = "Backups")]
@@ -246,7 +246,7 @@ pub struct DescribeBackupsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeClustersRequest {
     /// <p>One or more filters to limit the items returned in the response.</p> <p>Use the <code>clusterIds</code> filter to return only the specified clusters. Specify clusters by their cluster identifier (ID).</p> <p>Use the <code>vpcIds</code> filter to return only the clusters in the specified virtual private clouds (VPCs). Specify VPCs by their VPC identifier (ID).</p> <p>Use the <code>states</code> filter to return only clusters that match the specified state.</p>
     #[serde(rename = "Filters")]
@@ -262,7 +262,7 @@ pub struct DescribeClustersRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeClustersResponse {
     /// <p>A list of clusters.</p>
     #[serde(rename = "Clusters")]
@@ -275,7 +275,7 @@ pub struct DescribeClustersResponse {
 }
 
 /// <p>Contains information about a hardware security module (HSM) in an AWS CloudHSM cluster.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Hsm {
     /// <p>The Availability Zone that contains the HSM.</p>
     #[serde(rename = "AvailabilityZone")]
@@ -310,7 +310,7 @@ pub struct Hsm {
     pub subnet_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct InitializeClusterRequest {
     /// <p>The identifier (ID) of the cluster that you are claiming. To find the cluster ID, use <a>DescribeClusters</a>.</p>
     #[serde(rename = "ClusterId")]
@@ -323,7 +323,7 @@ pub struct InitializeClusterRequest {
     pub trust_anchor: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct InitializeClusterResponse {
     /// <p>The cluster's state.</p>
     #[serde(rename = "State")]
@@ -335,7 +335,7 @@ pub struct InitializeClusterResponse {
     pub state_message: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListTagsRequest {
     /// <p>The maximum number of tags to return in the response. When there are more tags than the number you specify, the response contains a <code>NextToken</code> value.</p>
     #[serde(rename = "MaxResults")]
@@ -350,7 +350,7 @@ pub struct ListTagsRequest {
     pub resource_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListTagsResponse {
     /// <p>An opaque string that indicates that the response contains only a subset of tags. Use this value in a subsequent <code>ListTags</code> request to get more tags.</p>
     #[serde(rename = "NextToken")]
@@ -362,7 +362,7 @@ pub struct ListTagsResponse {
 }
 
 /// <p>Contains a tag. A tag is a key-value pair.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Tag {
     /// <p>The key of the tag.</p>
     #[serde(rename = "Key")]
@@ -372,7 +372,7 @@ pub struct Tag {
     pub value: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct TagResourceRequest {
     /// <p>The cluster identifier (ID) for the cluster that you are tagging. To find the cluster ID, use <a>DescribeClusters</a>.</p>
     #[serde(rename = "ResourceId")]
@@ -382,10 +382,10 @@ pub struct TagResourceRequest {
     pub tag_list: Vec<Tag>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct TagResourceResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UntagResourceRequest {
     /// <p>The cluster identifier (ID) for the cluster whose tags you are removing. To find the cluster ID, use <a>DescribeClusters</a>.</p>
     #[serde(rename = "ResourceId")]
@@ -395,7 +395,7 @@ pub struct UntagResourceRequest {
     pub tag_key_list: Vec<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UntagResourceResponse {}
 
 /// Errors returned by CreateCluster

--- a/rusoto/services/cloudhsmv2/src/generated.rs
+++ b/rusoto/services/cloudhsmv2/src/generated.rs
@@ -425,7 +425,8 @@ impl CreateClusterError {
     pub fn from_body(body: &str) -> CreateClusterError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -527,7 +528,8 @@ impl CreateHsmError {
     pub fn from_body(body: &str) -> CreateHsmError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -627,7 +629,8 @@ impl DeleteClusterError {
     pub fn from_body(body: &str) -> DeleteClusterError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -729,7 +732,8 @@ impl DeleteHsmError {
     pub fn from_body(body: &str) -> DeleteHsmError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -829,7 +833,8 @@ impl DescribeBackupsError {
     pub fn from_body(body: &str) -> DescribeBackupsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -929,7 +934,8 @@ impl DescribeClustersError {
     pub fn from_body(body: &str) -> DescribeClustersError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1027,7 +1033,8 @@ impl InitializeClusterError {
     pub fn from_body(body: &str) -> InitializeClusterError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1133,7 +1140,8 @@ impl ListTagsError {
     pub fn from_body(body: &str) -> ListTagsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1233,7 +1241,8 @@ impl TagResourceError {
     pub fn from_body(body: &str) -> TagResourceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1335,7 +1344,8 @@ impl UntagResourceError {
     pub fn from_body(body: &str) -> UntagResourceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/cloudsearch/src/generated.rs
+++ b/rusoto/services/cloudsearch/src/generated.rs
@@ -72,7 +72,7 @@ impl ARNDeserializer {
     }
 }
 /// <p>The configured access rules for the domain's document and search endpoints, and the current status of those rules.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AccessPoliciesStatus {
     pub options: String,
     pub status: OptionStatus,
@@ -136,7 +136,7 @@ impl AlgorithmicStemmingDeserializer {
     }
 }
 /// <p>Synonyms, stopwords, and stemming options for an analysis scheme. Includes tokenization dictionary for Japanese.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AnalysisOptions {
     /// <p>The level of algorithmic stemming to perform: <code>none</code>, <code>minimal</code>, <code>light</code>, or <code>full</code>. The available levels vary depending on the language. For more information, see <a href="http://docs.aws.amazon.com/cloudsearch/latest/developerguide/text-processing.html#text-processing-settings" target="_blank">Language Specific Text Processing Settings</a> in the <i>Amazon CloudSearch Developer Guide</i> </p>
     pub algorithmic_stemming: Option<String>,
@@ -258,7 +258,7 @@ impl AnalysisOptionsSerializer {
 }
 
 /// <p>Configuration information for an analysis scheme. Each analysis scheme has a unique name and specifies the language of the text to be processed. The following options can be configured for an analysis scheme: <code>Synonyms</code>, <code>Stopwords</code>, <code>StemmingDictionary</code>, <code>JapaneseTokenizationDictionary</code> and <code>AlgorithmicStemming</code>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AnalysisScheme {
     pub analysis_options: Option<AnalysisOptions>,
     pub analysis_scheme_language: String,
@@ -362,7 +362,7 @@ impl AnalysisSchemeLanguageDeserializer {
     }
 }
 /// <p>The status and configuration of an <code>AnalysisScheme</code>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AnalysisSchemeStatus {
     pub options: AnalysisScheme,
     pub status: OptionStatus,
@@ -454,7 +454,7 @@ impl AnalysisSchemeStatusListDeserializer {
     }
 }
 /// <p>The status and configuration of the domain's availability options.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AvailabilityOptionsStatus {
     /// <p>The availability options configured for the domain.</p>
     pub options: bool,
@@ -518,7 +518,7 @@ impl BooleanDeserializer {
     }
 }
 /// <p>Container for the parameters to the <code><a>BuildSuggester</a></code> operation. Specifies the name of the domain you want to update.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct BuildSuggestersRequest {
     pub domain_name: String,
 }
@@ -540,7 +540,7 @@ impl BuildSuggestersRequestSerializer {
 }
 
 /// <p>The result of a <code>BuildSuggester</code> request. Contains a list of the fields used for suggestions.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct BuildSuggestersResponse {
     pub field_names: Option<Vec<String>>,
 }
@@ -588,7 +588,7 @@ impl BuildSuggestersResponseDeserializer {
     }
 }
 /// <p>Container for the parameters to the <code><a>CreateDomain</a></code> operation. Specifies a name for the new search domain.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateDomainRequest {
     /// <p>A name for the domain you are creating. Allowed characters are a-z (lower-case letters), 0-9, and hyphen (-). Domain names must start with a letter or number and be at least 3 and no more than 28 characters long.</p>
     pub domain_name: String,
@@ -611,7 +611,7 @@ impl CreateDomainRequestSerializer {
 }
 
 /// <p>The result of a <code>CreateDomainRequest</code>. Contains the status of a newly created domain.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateDomainResponse {
     pub domain_status: Option<DomainStatus>,
 }
@@ -659,7 +659,7 @@ impl CreateDomainResponseDeserializer {
     }
 }
 /// <p>Options for a field that contains an array of dates. Present if <code>IndexFieldType</code> specifies the field is of type <code>date-array</code>. All options are enabled by default.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DateArrayOptions {
     /// <p>A value to use for the field if the field isn&#39;t specified for a document.</p>
     pub default_value: Option<String>,
@@ -782,7 +782,7 @@ impl DateArrayOptionsSerializer {
 }
 
 /// <p>Options for a date field. Dates and times are specified in UTC (Coordinated Universal Time) according to IETF RFC3339: yyyy-mm-ddT00:00:00Z. Present if <code>IndexFieldType</code> specifies the field is of type <code>date</code>. All options are enabled by default.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DateOptions {
     /// <p>A value to use for the field if the field isn&#39;t specified for a document.</p>
     pub default_value: Option<String>,
@@ -917,7 +917,7 @@ impl DateOptionsSerializer {
 }
 
 /// <p>Container for the parameters to the <code><a>DefineAnalysisScheme</a></code> operation. Specifies the name of the domain you want to update and the analysis scheme configuration.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DefineAnalysisSchemeRequest {
     pub analysis_scheme: AnalysisScheme,
     pub domain_name: String,
@@ -945,7 +945,7 @@ impl DefineAnalysisSchemeRequestSerializer {
 }
 
 /// <p>The result of a <code><a>DefineAnalysisScheme</a></code> request. Contains the status of the newly-configured analysis scheme.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DefineAnalysisSchemeResponse {
     pub analysis_scheme: AnalysisSchemeStatus,
 }
@@ -993,7 +993,7 @@ impl DefineAnalysisSchemeResponseDeserializer {
     }
 }
 /// <p>Container for the parameters to the <code><a>DefineExpression</a></code> operation. Specifies the name of the domain you want to update and the expression you want to configure.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DefineExpressionRequest {
     pub domain_name: String,
     pub expression: Expression,
@@ -1021,7 +1021,7 @@ impl DefineExpressionRequestSerializer {
 }
 
 /// <p>The result of a <code>DefineExpression</code> request. Contains the status of the newly-configured expression.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DefineExpressionResponse {
     pub expression: ExpressionStatus,
 }
@@ -1069,7 +1069,7 @@ impl DefineExpressionResponseDeserializer {
     }
 }
 /// <p>Container for the parameters to the <code><a>DefineIndexField</a></code> operation. Specifies the name of the domain you want to update and the index field configuration.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DefineIndexFieldRequest {
     pub domain_name: String,
     /// <p>The index field and field options you want to configure. </p>
@@ -1098,7 +1098,7 @@ impl DefineIndexFieldRequestSerializer {
 }
 
 /// <p>The result of a <code><a>DefineIndexField</a></code> request. Contains the status of the newly-configured index field.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DefineIndexFieldResponse {
     pub index_field: IndexFieldStatus,
 }
@@ -1146,7 +1146,7 @@ impl DefineIndexFieldResponseDeserializer {
     }
 }
 /// <p>Container for the parameters to the <code><a>DefineSuggester</a></code> operation. Specifies the name of the domain you want to update and the suggester configuration.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DefineSuggesterRequest {
     pub domain_name: String,
     pub suggester: Suggester,
@@ -1174,7 +1174,7 @@ impl DefineSuggesterRequestSerializer {
 }
 
 /// <p>The result of a <code>DefineSuggester</code> request. Contains the status of the newly-configured suggester.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DefineSuggesterResponse {
     pub suggester: SuggesterStatus,
 }
@@ -1220,7 +1220,7 @@ impl DefineSuggesterResponseDeserializer {
     }
 }
 /// <p>Container for the parameters to the <code><a>DeleteAnalysisScheme</a></code> operation. Specifies the name of the domain you want to update and the analysis scheme you want to delete. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteAnalysisSchemeRequest {
     /// <p>The name of the analysis scheme you want to delete.</p>
     pub analysis_scheme_name: String,
@@ -1248,7 +1248,7 @@ impl DeleteAnalysisSchemeRequestSerializer {
 }
 
 /// <p>The result of a <code>DeleteAnalysisScheme</code> request. Contains the status of the deleted analysis scheme.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteAnalysisSchemeResponse {
     /// <p>The status of the analysis scheme being deleted.</p>
     pub analysis_scheme: AnalysisSchemeStatus,
@@ -1297,7 +1297,7 @@ impl DeleteAnalysisSchemeResponseDeserializer {
     }
 }
 /// <p>Container for the parameters to the <code><a>DeleteDomain</a></code> operation. Specifies the name of the domain you want to delete.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteDomainRequest {
     /// <p>The name of the domain you want to permanently delete.</p>
     pub domain_name: String,
@@ -1320,7 +1320,7 @@ impl DeleteDomainRequestSerializer {
 }
 
 /// <p>The result of a <code>DeleteDomain</code> request. Contains the status of a newly deleted domain, or no status if the domain has already been completely deleted.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteDomainResponse {
     pub domain_status: Option<DomainStatus>,
 }
@@ -1368,7 +1368,7 @@ impl DeleteDomainResponseDeserializer {
     }
 }
 /// <p>Container for the parameters to the <code><a>DeleteExpression</a></code> operation. Specifies the name of the domain you want to update and the name of the expression you want to delete.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteExpressionRequest {
     pub domain_name: String,
     /// <p>The name of the <code><a>Expression</a></code> to delete.</p>
@@ -1396,7 +1396,7 @@ impl DeleteExpressionRequestSerializer {
 }
 
 /// <p>The result of a <code><a>DeleteExpression</a></code> request. Specifies the expression being deleted.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteExpressionResponse {
     /// <p>The status of the expression being deleted.</p>
     pub expression: ExpressionStatus,
@@ -1445,7 +1445,7 @@ impl DeleteExpressionResponseDeserializer {
     }
 }
 /// <p>Container for the parameters to the <code><a>DeleteIndexField</a></code> operation. Specifies the name of the domain you want to update and the name of the index field you want to delete.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteIndexFieldRequest {
     pub domain_name: String,
     /// <p>The name of the index field your want to remove from the domain's indexing options.</p>
@@ -1473,7 +1473,7 @@ impl DeleteIndexFieldRequestSerializer {
 }
 
 /// <p>The result of a <code><a>DeleteIndexField</a></code> request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteIndexFieldResponse {
     /// <p>The status of the index field being deleted.</p>
     pub index_field: IndexFieldStatus,
@@ -1522,7 +1522,7 @@ impl DeleteIndexFieldResponseDeserializer {
     }
 }
 /// <p>Container for the parameters to the <code><a>DeleteSuggester</a></code> operation. Specifies the name of the domain you want to update and name of the suggester you want to delete.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteSuggesterRequest {
     pub domain_name: String,
     /// <p>Specifies the name of the suggester you want to delete.</p>
@@ -1550,7 +1550,7 @@ impl DeleteSuggesterRequestSerializer {
 }
 
 /// <p>The result of a <code>DeleteSuggester</code> request. Contains the status of the deleted suggester.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteSuggesterResponse {
     /// <p>The status of the suggester being deleted.</p>
     pub suggester: SuggesterStatus,
@@ -1597,7 +1597,7 @@ impl DeleteSuggesterResponseDeserializer {
     }
 }
 /// <p>Container for the parameters to the <code><a>DescribeAnalysisSchemes</a></code> operation. Specifies the name of the domain you want to describe. To limit the response to particular analysis schemes, specify the names of the analysis schemes you want to describe. To show the active configuration and exclude any pending changes, set the <code>Deployed</code> option to <code>true</code>. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeAnalysisSchemesRequest {
     /// <p>The analysis schemes you want to describe.</p>
     pub analysis_scheme_names: Option<Vec<String>>,
@@ -1637,7 +1637,7 @@ impl DescribeAnalysisSchemesRequestSerializer {
 }
 
 /// <p>The result of a <code>DescribeAnalysisSchemes</code> request. Contains the analysis schemes configured for the domain specified in the request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeAnalysisSchemesResponse {
     /// <p>The analysis scheme descriptions.</p>
     pub analysis_schemes: Vec<AnalysisSchemeStatus>,
@@ -1687,7 +1687,7 @@ impl DescribeAnalysisSchemesResponseDeserializer {
     }
 }
 /// <p>Container for the parameters to the <code><a>DescribeAvailabilityOptions</a></code> operation. Specifies the name of the domain you want to describe. To show the active configuration and exclude any pending changes, set the Deployed option to <code>true</code>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeAvailabilityOptionsRequest {
     /// <p>Whether to display the deployed configuration (<code>true</code>) or include any pending changes (<code>false</code>). Defaults to <code>false</code>.</p>
     pub deployed: Option<bool>,
@@ -1718,7 +1718,7 @@ impl DescribeAvailabilityOptionsRequestSerializer {
 }
 
 /// <p>The result of a <code>DescribeAvailabilityOptions</code> request. Indicates whether or not the Multi-AZ option is enabled for the domain specified in the request. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeAvailabilityOptionsResponse {
     /// <p>The availability options configured for the domain. Indicates whether Multi-AZ is enabled for the domain. </p>
     pub availability_options: Option<AvailabilityOptionsStatus>,
@@ -1768,7 +1768,7 @@ impl DescribeAvailabilityOptionsResponseDeserializer {
     }
 }
 /// <p>Container for the parameters to the <code><a>DescribeDomains</a></code> operation. By default shows the status of all domains. To restrict the response to particular domains, specify the names of the domains you want to describe.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeDomainsRequest {
     /// <p>The names of the domains you want to include in the response.</p>
     pub domain_names: Option<Vec<String>>,
@@ -1794,7 +1794,7 @@ impl DescribeDomainsRequestSerializer {
 }
 
 /// <p>The result of a <code>DescribeDomains</code> request. Contains the status of the domains specified in the request or all domains owned by the account.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeDomainsResponse {
     pub domain_status_list: Vec<DomainStatus>,
 }
@@ -1842,7 +1842,7 @@ impl DescribeDomainsResponseDeserializer {
     }
 }
 /// <p>Container for the parameters to the <code><a>DescribeDomains</a></code> operation. Specifies the name of the domain you want to describe. To restrict the response to particular expressions, specify the names of the expressions you want to describe. To show the active configuration and exclude any pending changes, set the <code>Deployed</code> option to <code>true</code>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeExpressionsRequest {
     /// <p>Whether to display the deployed configuration (<code>true</code>) or include any pending changes (<code>false</code>). Defaults to <code>false</code>.</p>
     pub deployed: Option<bool>,
@@ -1882,7 +1882,7 @@ impl DescribeExpressionsRequestSerializer {
 }
 
 /// <p>The result of a <code>DescribeExpressions</code> request. Contains the expressions configured for the domain specified in the request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeExpressionsResponse {
     /// <p>The expressions configured for the domain.</p>
     pub expressions: Vec<ExpressionStatus>,
@@ -1931,7 +1931,7 @@ impl DescribeExpressionsResponseDeserializer {
     }
 }
 /// <p>Container for the parameters to the <code><a>DescribeIndexFields</a></code> operation. Specifies the name of the domain you want to describe. To restrict the response to particular index fields, specify the names of the index fields you want to describe. To show the active configuration and exclude any pending changes, set the <code>Deployed</code> option to <code>true</code>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeIndexFieldsRequest {
     /// <p>Whether to display the deployed configuration (<code>true</code>) or include any pending changes (<code>false</code>). Defaults to <code>false</code>.</p>
     pub deployed: Option<bool>,
@@ -1971,7 +1971,7 @@ impl DescribeIndexFieldsRequestSerializer {
 }
 
 /// <p>The result of a <code>DescribeIndexFields</code> request. Contains the index fields configured for the domain specified in the request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeIndexFieldsResponse {
     /// <p>The index fields configured for the domain.</p>
     pub index_fields: Vec<IndexFieldStatus>,
@@ -2020,7 +2020,7 @@ impl DescribeIndexFieldsResponseDeserializer {
     }
 }
 /// <p>Container for the parameters to the <code><a>DescribeScalingParameters</a></code> operation. Specifies the name of the domain you want to describe. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeScalingParametersRequest {
     pub domain_name: String,
 }
@@ -2042,7 +2042,7 @@ impl DescribeScalingParametersRequestSerializer {
 }
 
 /// <p>The result of a <code>DescribeScalingParameters</code> request. Contains the scaling parameters configured for the domain specified in the request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeScalingParametersResponse {
     pub scaling_parameters: ScalingParametersStatus,
 }
@@ -2091,7 +2091,7 @@ impl DescribeScalingParametersResponseDeserializer {
     }
 }
 /// <p>Container for the parameters to the <code><a>DescribeServiceAccessPolicies</a></code> operation. Specifies the name of the domain you want to describe. To show the active configuration and exclude any pending changes, set the <code>Deployed</code> option to <code>true</code>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeServiceAccessPoliciesRequest {
     /// <p>Whether to display the deployed configuration (<code>true</code>) or include any pending changes (<code>false</code>). Defaults to <code>false</code>.</p>
     pub deployed: Option<bool>,
@@ -2122,7 +2122,7 @@ impl DescribeServiceAccessPoliciesRequestSerializer {
 }
 
 /// <p>The result of a <code>DescribeServiceAccessPolicies</code> request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeServiceAccessPoliciesResponse {
     /// <p>The access rules configured for the domain specified in the request.</p>
     pub access_policies: AccessPoliciesStatus,
@@ -2171,7 +2171,7 @@ impl DescribeServiceAccessPoliciesResponseDeserializer {
     }
 }
 /// <p>Container for the parameters to the <code><a>DescribeSuggester</a></code> operation. Specifies the name of the domain you want to describe. To restrict the response to particular suggesters, specify the names of the suggesters you want to describe. To show the active configuration and exclude any pending changes, set the <code>Deployed</code> option to <code>true</code>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeSuggestersRequest {
     /// <p>Whether to display the deployed configuration (<code>true</code>) or include any pending changes (<code>false</code>). Defaults to <code>false</code>.</p>
     pub deployed: Option<bool>,
@@ -2211,7 +2211,7 @@ impl DescribeSuggestersRequestSerializer {
 }
 
 /// <p>The result of a <code>DescribeSuggesters</code> request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeSuggestersResponse {
     /// <p>The suggesters configured for the domain specified in the request.</p>
     pub suggesters: Vec<SuggesterStatus>,
@@ -2260,7 +2260,7 @@ impl DescribeSuggestersResponseDeserializer {
     }
 }
 /// <p>Options for a search suggester.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DocumentSuggesterOptions {
     /// <p>The level of fuzziness allowed when suggesting matches for a string: <code>none</code>, <code>low</code>, or <code>high</code>. With none, the specified string is treated as an exact prefix. With low, suggestions must differ from the specified string by no more than one character. With high, suggestions can differ by up to two characters. The default is none. </p>
     pub fuzzy_matching: Option<String>,
@@ -2414,7 +2414,7 @@ impl DomainNameMapDeserializer {
     }
 }
 /// <p>The current status of the search domain.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DomainStatus {
     pub arn: Option<String>,
     /// <p>True if the search domain is created. It can take several minutes to initialize a domain when <a>CreateDomain</a> is called. Newly created search domains are returned from <a>DescribeDomains</a> with a false value for Created until domain creation is complete.</p>
@@ -2591,7 +2591,7 @@ impl DoubleDeserializer {
     }
 }
 /// <p>Options for a field that contains an array of double-precision 64-bit floating point values. Present if <code>IndexFieldType</code> specifies the field is of type <code>double-array</code>. All options are enabled by default.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DoubleArrayOptions {
     /// <p>A value to use for the field if the field isn&#39;t specified for a document.</p>
     pub default_value: Option<f64>,
@@ -2712,7 +2712,7 @@ impl DoubleArrayOptionsSerializer {
 }
 
 /// <p>Options for a double-precision 64-bit floating point field. Present if <code>IndexFieldType</code> specifies the field is of type <code>double</code>. All options are enabled by default.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DoubleOptions {
     /// <p>A value to use for the field if the field isn't specified for a document. This can be important if you are using the field in an expression and that field is not present in every document.</p>
     pub default_value: Option<f64>,
@@ -2872,7 +2872,7 @@ impl DynamicFieldNameListSerializer {
 }
 
 /// <p>A named expression that can be evaluated at search time. Can be used to sort the search results, define other expressions, or return computed information in the search results. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Expression {
     pub expression_name: String,
     pub expression_value: String,
@@ -2948,7 +2948,7 @@ impl ExpressionSerializer {
 }
 
 /// <p>The value of an <code>Expression</code> and its current status.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ExpressionStatus {
     /// <p>The expression that is evaluated for sorting while processing a search request.</p>
     pub options: Expression,
@@ -3136,7 +3136,7 @@ impl FieldValueDeserializer {
     }
 }
 /// <p>Container for the parameters to the <code><a>IndexDocuments</a></code> operation. Specifies the name of the domain you want to re-index.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct IndexDocumentsRequest {
     pub domain_name: String,
 }
@@ -3158,7 +3158,7 @@ impl IndexDocumentsRequestSerializer {
 }
 
 /// <p>The result of an <code>IndexDocuments</code> request. Contains the status of the indexing operation, including the fields being indexed.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct IndexDocumentsResponse {
     /// <p>The names of the fields that are currently being indexed.</p>
     pub field_names: Option<Vec<String>>,
@@ -3207,7 +3207,7 @@ impl IndexDocumentsResponseDeserializer {
     }
 }
 /// <p>Configuration information for a field in the index, including its name, type, and options. The supported options depend on the <code><a>IndexFieldType</a></code>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct IndexField {
     pub date_array_options: Option<DateArrayOptions>,
     pub date_options: Option<DateOptions>,
@@ -3437,7 +3437,7 @@ impl IndexFieldSerializer {
 }
 
 /// <p>The value of an <code>IndexField</code> and its current status.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct IndexFieldStatus {
     pub options: IndexField,
     pub status: OptionStatus,
@@ -3556,7 +3556,7 @@ impl InstanceCountDeserializer {
     }
 }
 /// <p>Options for a field that contains an array of 64-bit signed integers. Present if <code>IndexFieldType</code> specifies the field is of type <code>int-array</code>. All options are enabled by default.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct IntArrayOptions {
     /// <p>A value to use for the field if the field isn&#39;t specified for a document.</p>
     pub default_value: Option<i64>,
@@ -3677,7 +3677,7 @@ impl IntArrayOptionsSerializer {
 }
 
 /// <p>Options for a 64-bit signed integer field. Present if <code>IndexFieldType</code> specifies the field is of type <code>int</code>. All options are enabled by default.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct IntOptions {
     /// <p>A value to use for the field if the field isn&#39;t specified for a document. This can be important if you are using the field in an expression and that field is not present in every document.</p>
     pub default_value: Option<i64>,
@@ -3811,7 +3811,7 @@ impl IntOptionsSerializer {
 }
 
 /// <p>Options for a latlon field. A latlon field contains a location stored as a latitude and longitude value pair. Present if <code>IndexFieldType</code> specifies the field is of type <code>latlon</code>. All options are enabled by default.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct LatLonOptions {
     /// <p>A value to use for the field if the field isn&#39;t specified for a document.</p>
     pub default_value: Option<String>,
@@ -3945,7 +3945,7 @@ impl LatLonOptionsSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Limits {
     pub maximum_partition_count: i64,
     pub maximum_replication_count: i64,
@@ -4002,7 +4002,7 @@ impl LimitsDeserializer {
     }
 }
 /// <p>The result of a <code>ListDomainNames</code> request. Contains a list of the domains owned by an account.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListDomainNamesResponse {
     /// <p>The names of the search domains owned by an account.</p>
     pub domain_names: Option<::std::collections::HashMap<String, String>>,
@@ -4051,7 +4051,7 @@ impl ListDomainNamesResponseDeserializer {
     }
 }
 /// <p>Options for a field that contains an array of literal strings. Present if <code>IndexFieldType</code> specifies the field is of type <code>literal-array</code>. All options are enabled by default.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct LiteralArrayOptions {
     /// <p>A value to use for the field if the field isn&#39;t specified for a document.</p>
     pub default_value: Option<String>,
@@ -4174,7 +4174,7 @@ impl LiteralArrayOptionsSerializer {
 }
 
 /// <p>Options for literal field. Present if <code>IndexFieldType</code> specifies the field is of type <code>literal</code>. All options are enabled by default.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct LiteralOptions {
     /// <p>A value to use for the field if the field isn&#39;t specified for a document.</p>
     pub default_value: Option<String>,
@@ -4379,7 +4379,7 @@ impl OptionStateDeserializer {
     }
 }
 /// <p>The status of domain configuration option.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct OptionStatus {
     /// <p>A timestamp for when this option was created.</p>
     pub creation_date: String,
@@ -4499,7 +4499,7 @@ impl PolicyDocumentDeserializer {
     }
 }
 /// <p>The desired instance type and desired number of replicas of each index partition.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ScalingParameters {
     /// <p>The instance type that you want to preconfigure for your domain. For example, <code>search.m1.small</code>.</p>
     pub desired_instance_type: Option<String>,
@@ -4594,7 +4594,7 @@ impl ScalingParametersSerializer {
 }
 
 /// <p>The status and configuration of a search domain's scaling parameters. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ScalingParametersStatus {
     pub options: ScalingParameters,
     pub status: OptionStatus,
@@ -4658,7 +4658,7 @@ impl SearchInstanceTypeDeserializer {
     }
 }
 /// <p>The endpoint to which service requests can be submitted.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ServiceEndpoint {
     pub endpoint: Option<String>,
 }
@@ -4758,7 +4758,7 @@ impl StringDeserializer {
     }
 }
 /// <p>Configuration information for a search suggester. Each suggester has a unique name and specifies the text field you want to use for suggestions. The following options can be configured for a suggester: <code>FuzzyMatching</code>, <code>SortExpression</code>. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Suggester {
     pub document_suggester_options: DocumentSuggesterOptions,
     pub suggester_name: String,
@@ -4850,7 +4850,7 @@ impl SuggesterFuzzyMatchingDeserializer {
     }
 }
 /// <p>The value of a <code>Suggester</code> and its current status.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SuggesterStatus {
     pub options: Suggester,
     pub status: OptionStatus,
@@ -4941,7 +4941,7 @@ impl SuggesterStatusListDeserializer {
     }
 }
 /// <p>Options for a field that contains an array of text strings. Present if <code>IndexFieldType</code> specifies the field is of type <code>text-array</code>. A <code>text-array</code> field is always searchable. All options are enabled by default.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct TextArrayOptions {
     /// <p>The name of an analysis scheme for a <code>text-array</code> field.</p>
     pub analysis_scheme: Option<String>,
@@ -5062,7 +5062,7 @@ impl TextArrayOptionsSerializer {
 }
 
 /// <p>Options for text field. Present if <code>IndexFieldType</code> specifies the field is of type <code>text</code>. A <code>text</code> field is always searchable. All options are enabled by default.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct TextOptions {
     /// <p>The name of an analysis scheme for a <code>text</code> field.</p>
     pub analysis_scheme: Option<String>,
@@ -5209,7 +5209,7 @@ impl UIntValueDeserializer {
     }
 }
 /// <p>Container for the parameters to the <code><a>UpdateAvailabilityOptions</a></code> operation. Specifies the name of the domain you want to update and the Multi-AZ availability option.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateAvailabilityOptionsRequest {
     pub domain_name: String,
     /// <p>You expand an existing search domain to a second Availability Zone by setting the Multi-AZ option to true. Similarly, you can turn off the Multi-AZ option to downgrade the domain to a single Availability Zone by setting the Multi-AZ option to <code>false</code>. </p>
@@ -5237,7 +5237,7 @@ impl UpdateAvailabilityOptionsRequestSerializer {
 }
 
 /// <p>The result of a <code>UpdateAvailabilityOptions</code> request. Contains the status of the domain's availability options. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateAvailabilityOptionsResponse {
     /// <p>The newly-configured availability options. Indicates whether Multi-AZ is enabled for the domain. </p>
     pub availability_options: Option<AvailabilityOptionsStatus>,
@@ -5287,7 +5287,7 @@ impl UpdateAvailabilityOptionsResponseDeserializer {
     }
 }
 /// <p>Container for the parameters to the <code><a>UpdateScalingParameters</a></code> operation. Specifies the name of the domain you want to update and the scaling parameters you want to configure.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateScalingParametersRequest {
     pub domain_name: String,
     pub scaling_parameters: ScalingParameters,
@@ -5315,7 +5315,7 @@ impl UpdateScalingParametersRequestSerializer {
 }
 
 /// <p>The result of a <code>UpdateScalingParameters</code> request. Contains the status of the newly-configured scaling parameters.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateScalingParametersResponse {
     pub scaling_parameters: ScalingParametersStatus,
 }
@@ -5364,7 +5364,7 @@ impl UpdateScalingParametersResponseDeserializer {
     }
 }
 /// <p>Container for the parameters to the <code><a>UpdateServiceAccessPolicies</a></code> operation. Specifies the name of the domain you want to update and the access rules you want to configure.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateServiceAccessPoliciesRequest {
     /// <p>The access rules you want to configure. These rules replace any existing rules. </p>
     pub access_policies: String,
@@ -5392,7 +5392,7 @@ impl UpdateServiceAccessPoliciesRequestSerializer {
 }
 
 /// <p>The result of an <code>UpdateServiceAccessPolicies</code> request. Contains the new access policies.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateServiceAccessPoliciesResponse {
     /// <p>The access rules configured for the domain.</p>
     pub access_policies: AccessPoliciesStatus,

--- a/rusoto/services/cloudsearch/src/generated.rs
+++ b/rusoto/services/cloudsearch/src/generated.rs
@@ -29,8 +29,9 @@ use hyper::StatusCode;
 use rusoto_core::param::{Params, ServiceParams};
 use rusoto_core::signature::SignedRequest;
 use rusoto_core::xmlerror::*;
-use rusoto_core::xmlutil::{characters, end_element, find_start_element, peek_at_name, skip_tree,
-                           start_element};
+use rusoto_core::xmlutil::{
+    characters, end_element, find_start_element, peek_at_name, skip_tree, start_element,
+};
 use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
 use std::str::FromStr;
 use xml::reader::ParserConfig;

--- a/rusoto/services/cloudsearchdomain/src/generated.rs
+++ b/rusoto/services/cloudsearchdomain/src/generated.rs
@@ -365,7 +365,8 @@ impl SearchError {
     pub fn from_body(body: &str) -> SearchError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -439,7 +440,8 @@ impl SuggestError {
     pub fn from_body(body: &str) -> SuggestError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -513,7 +515,8 @@ impl UploadDocumentsError {
     pub fn from_body(body: &str) -> UploadDocumentsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/cloudsearchdomain/src/generated.rs
+++ b/rusoto/services/cloudsearchdomain/src/generated.rs
@@ -31,7 +31,7 @@ use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 /// <p>A container for facet information. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Bucket {
     /// <p>The number of hits that contain the facet value in the specified facet field.</p>
     #[serde(rename = "count")]
@@ -44,7 +44,7 @@ pub struct Bucket {
 }
 
 /// <p>A container for the calculated facet values and counts.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BucketInfo {
     /// <p>A list of the calculated facet values and counts.</p>
     #[serde(rename = "buckets")]
@@ -53,7 +53,7 @@ pub struct BucketInfo {
 }
 
 /// <p>A warning returned by the document service when an issue is discovered while processing an upload request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DocumentServiceWarning {
     /// <p>The description for a warning returned by the document service.</p>
     #[serde(rename = "message")]
@@ -62,7 +62,7 @@ pub struct DocumentServiceWarning {
 }
 
 /// <p>The statistics for a field calculated in the request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct FieldStats {
     /// <p>The number of documents that contain a value in the specified field in the result set.</p>
     #[serde(rename = "count")]
@@ -99,7 +99,7 @@ pub struct FieldStats {
 }
 
 /// <p>Information about a document that matches the search request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Hit {
     /// <p>The expressions returned from a document that matches the search request.</p>
     #[serde(rename = "exprs")]
@@ -120,7 +120,7 @@ pub struct Hit {
 }
 
 /// <p>The collection of documents that match the search request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Hits {
     /// <p>A cursor that can be used to retrieve the next set of matching documents when you want to page through a large result set.</p>
     #[serde(rename = "cursor")]
@@ -141,7 +141,7 @@ pub struct Hits {
 }
 
 /// <p>Container for the parameters to the <code>Search</code> request.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SearchRequest {
     /// <p>Retrieves a cursor value you can use to page through large result sets. Use the <code>size</code> parameter to control the number of hits to include in each response. You can specify either the <code>cursor</code> or <code>start</code> parameter in a request; they are mutually exclusive. To get the first cursor, set the cursor value to <code>initial</code>. In subsequent requests, specify the cursor value returned in the hits section of the response. </p> <p>For more information, see <a href="http://docs.aws.amazon.com/cloudsearch/latest/developerguide/paginating-results.html">Paginating Results</a> in the <i>Amazon CloudSearch Developer Guide</i>.</p>
     #[serde(rename = "cursor")]
@@ -201,7 +201,7 @@ pub struct SearchRequest {
 }
 
 /// <p>The result of a <code>Search</code> request. Contains the documents that match the specified search criteria and any requested fields, highlights, and facet information.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SearchResponse {
     /// <p>The requested facet information.</p>
     #[serde(rename = "facets")]
@@ -222,7 +222,7 @@ pub struct SearchResponse {
 }
 
 /// <p>Contains the resource id (<code>rid</code>) and the time it took to process the request (<code>timems</code>).</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SearchStatus {
     /// <p>The encrypted resource ID for the request.</p>
     #[serde(rename = "rid")]
@@ -235,7 +235,7 @@ pub struct SearchStatus {
 }
 
 /// <p>Container for the suggestion information returned in a <code>SuggestResponse</code>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SuggestModel {
     /// <p>The number of documents that were found to match the query string.</p>
     #[serde(rename = "found")]
@@ -252,7 +252,7 @@ pub struct SuggestModel {
 }
 
 /// <p>Container for the parameters to the <code>Suggest</code> request.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SuggestRequest {
     /// <p>Specifies the string for which you want to get suggestions.</p>
     #[serde(rename = "query")]
@@ -267,7 +267,7 @@ pub struct SuggestRequest {
 }
 
 /// <p>Contains the response to a <code>Suggest</code> request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SuggestResponse {
     /// <p>The status of a <code>SuggestRequest</code>. Contains the resource ID (<code>rid</code>) and how long it took to process the request (<code>timems</code>).</p>
     #[serde(rename = "status")]
@@ -280,7 +280,7 @@ pub struct SuggestResponse {
 }
 
 /// <p>Contains the resource id (<code>rid</code>) and the time it took to process the request (<code>timems</code>).</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SuggestStatus {
     /// <p>The encrypted resource ID for the request.</p>
     #[serde(rename = "rid")]
@@ -293,7 +293,7 @@ pub struct SuggestStatus {
 }
 
 /// <p>An autocomplete suggestion that matches the query string specified in a <code>SuggestRequest</code>. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SuggestionMatch {
     /// <p>The document ID of the suggested document.</p>
     #[serde(rename = "id")]
@@ -310,7 +310,7 @@ pub struct SuggestionMatch {
 }
 
 /// <p>Container for the parameters to the <code>UploadDocuments</code> request.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UploadDocumentsRequest {
     /// <p><p>The format of the batch you are uploading. Amazon CloudSearch supports two document batch formats:</p> <ul> <li>application/json</li> <li>application/xml</li> </ul></p>
     #[serde(rename = "contentType")]
@@ -326,7 +326,7 @@ pub struct UploadDocumentsRequest {
 }
 
 /// <p>Contains the response to an <code>UploadDocuments</code> request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UploadDocumentsResponse {
     /// <p>The number of documents that were added to the search domain.</p>
     #[serde(rename = "adds")]

--- a/rusoto/services/cloudtrail/src/generated.rs
+++ b/rusoto/services/cloudtrail/src/generated.rs
@@ -747,7 +747,8 @@ impl AddTagsError {
     pub fn from_body(body: &str) -> AddTagsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -891,7 +892,8 @@ impl CreateTrailError {
     pub fn from_body(body: &str) -> CreateTrailError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1055,7 +1057,8 @@ impl DeleteTrailError {
     pub fn from_body(body: &str) -> DeleteTrailError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1143,7 +1146,8 @@ impl DescribeTrailsError {
     pub fn from_body(body: &str) -> DescribeTrailsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1231,7 +1235,8 @@ impl GetEventSelectorsError {
     pub fn from_body(body: &str) -> GetEventSelectorsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1325,7 +1330,8 @@ impl GetTrailStatusError {
     pub fn from_body(body: &str) -> GetTrailStatusError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1413,7 +1419,8 @@ impl ListPublicKeysError {
     pub fn from_body(body: &str) -> ListPublicKeysError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1515,7 +1522,8 @@ impl ListTagsError {
     pub fn from_body(body: &str) -> ListTagsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1621,7 +1629,8 @@ impl LookupEventsError {
     pub fn from_body(body: &str) -> LookupEventsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1721,7 +1730,8 @@ impl PutEventSelectorsError {
     pub fn from_body(body: &str) -> PutEventSelectorsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1833,7 +1843,8 @@ impl RemoveTagsError {
     pub fn from_body(body: &str) -> RemoveTagsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1937,7 +1948,8 @@ impl StartLoggingError {
     pub fn from_body(body: &str) -> StartLoggingError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2027,7 +2039,8 @@ impl StopLoggingError {
     pub fn from_body(body: &str) -> StopLoggingError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2153,7 +2166,8 @@ impl UpdateTrailError {
     pub fn from_body(body: &str) -> UpdateTrailError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/cloudtrail/src/generated.rs
+++ b/rusoto/services/cloudtrail/src/generated.rs
@@ -31,7 +31,7 @@ use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 /// <p>Specifies the tags to add to a trail.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AddTagsRequest {
     /// <p>Specifies the ARN of the trail to which one or more tags will be added. The format of a trail ARN is:</p> <p> <code>arn:aws:cloudtrail:us-east-1:123456789012:trail/MyTrail</code> </p>
     #[serde(rename = "ResourceId")]
@@ -43,11 +43,11 @@ pub struct AddTagsRequest {
 }
 
 /// <p>Returns the objects or data listed below if successful. Otherwise, returns an error.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AddTagsResponse {}
 
 /// <p>Specifies the settings for each trail.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateTrailRequest {
     /// <p>Specifies a log group name using an Amazon Resource Name (ARN), a unique identifier that represents the log group to which CloudTrail logs will be delivered. Not required unless you specify CloudWatchLogsRoleArn.</p>
     #[serde(rename = "CloudWatchLogsLogGroupArn")]
@@ -90,7 +90,7 @@ pub struct CreateTrailRequest {
 }
 
 /// <p>Returns the objects or data listed below if successful. Otherwise, returns an error.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateTrailResponse {
     /// <p>Specifies the Amazon Resource Name (ARN) of the log group to which CloudTrail logs will be delivered.</p>
     #[serde(rename = "CloudWatchLogsLogGroupArn")]
@@ -139,7 +139,7 @@ pub struct CreateTrailResponse {
 }
 
 /// <p><p>The Amazon S3 objects that you specify in your event selectors for your trail to log data events. Data events are object-level API operations that access S3 objects, such as <code>GetObject</code>, <code>DeleteObject</code>, and <code>PutObject</code>. You can specify up to 250 S3 buckets and object prefixes for a trail. </p> <p>Example</p> <ol> <li> <p>You create an event selector for a trail and specify an S3 bucket and an empty prefix, such as <code>arn:aws:s3:::bucket-1/</code>.</p> </li> <li> <p>You upload an image file to <code>bucket-1</code>.</p> </li> <li> <p>The <code>PutObject</code> API operation occurs on an object in the S3 bucket that you specified in the event selector. The trail processes and logs the event.</p> </li> <li> <p>You upload another image file to a different S3 bucket named <code>arn:aws:s3:::bucket-2</code>.</p> </li> <li> <p>The event occurs on an object in an S3 bucket that you didn&#39;t specify in the event selector. The trail doesn’t log the event.</p> </li> </ol></p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct DataResource {
     /// <p>The resource type in which you want to log data events. You can specify only the following value: <code>AWS::S3::Object</code>.</p>
     #[serde(rename = "Type")]
@@ -152,7 +152,7 @@ pub struct DataResource {
 }
 
 /// <p>The request that specifies the name of a trail to delete.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteTrailRequest {
     /// <p>Specifies the name or the CloudTrail ARN of the trail to be deleted. The format of a trail ARN is: <code>arn:aws:cloudtrail:us-east-1:123456789012:trail/MyTrail</code> </p>
     #[serde(rename = "Name")]
@@ -160,11 +160,11 @@ pub struct DeleteTrailRequest {
 }
 
 /// <p>Returns the objects or data listed below if successful. Otherwise, returns an error.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteTrailResponse {}
 
 /// <p>Returns information about the trail.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeTrailsRequest {
     /// <p>Specifies whether to include shadow trails in the response. A shadow trail is the replication in a region of a trail that was created in a different region. The default is true.</p>
     #[serde(rename = "includeShadowTrails")]
@@ -177,7 +177,7 @@ pub struct DescribeTrailsRequest {
 }
 
 /// <p>Returns the objects or data listed below if successful. Otherwise, returns an error.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeTrailsResponse {
     /// <p>The list of trail objects.</p>
     #[serde(rename = "trailList")]
@@ -186,7 +186,7 @@ pub struct DescribeTrailsResponse {
 }
 
 /// <p>Contains information about an event that was returned by a lookup request. The result includes a representation of a CloudTrail event.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Event {
     /// <p>A JSON string that contains a representation of the event returned.</p>
     #[serde(rename = "CloudTrailEvent")]
@@ -219,7 +219,7 @@ pub struct Event {
 }
 
 /// <p>Use event selectors to specify whether you want your trail to log management and/or data events. When an event occurs in your account, CloudTrail evaluates the event selector for all trails. For each trail, if the event matches any event selector, the trail processes and logs the event. If the event doesn't match any event selector, the trail doesn't log the event.</p> <p>You can configure up to five event selectors for a trail.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct EventSelector {
     /// <p>CloudTrail supports logging only data events for S3 objects. You can specify up to 250 S3 buckets and object prefixes for a trail.</p> <p>For more information, see <a href="http://docs.aws.amazon.com/awscloudtrail/latest/userguide/logging-management-and-data-events-with-cloudtrail.html#logging-data-events">Data Events</a> in the <i>AWS CloudTrail User Guide</i>.</p>
     #[serde(rename = "DataResources")]
@@ -235,14 +235,14 @@ pub struct EventSelector {
     pub read_write_type: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetEventSelectorsRequest {
     /// <p>Specifies the name of the trail or trail ARN. If you specify a trail name, the string must meet the following requirements:</p> <ul> <li> <p>Contain only ASCII letters (a-z, A-Z), numbers (0-9), periods (.), underscores (_), or dashes (-)</p> </li> <li> <p>Start with a letter or number, and end with a letter or number</p> </li> <li> <p>Be between 3 and 128 characters</p> </li> <li> <p>Have no adjacent periods, underscores or dashes. Names like <code>my-_namespace</code> and <code>my--namespace</code> are invalid.</p> </li> <li> <p>Not be in IP address format (for example, 192.168.5.4)</p> </li> </ul> <p>If you specify a trail ARN, it must be in the format:</p> <p> <code>arn:aws:cloudtrail:us-east-1:123456789012:trail/MyTrail</code> </p>
     #[serde(rename = "TrailName")]
     pub trail_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetEventSelectorsResponse {
     /// <p>The event selectors that are configured for the trail.</p>
     #[serde(rename = "EventSelectors")]
@@ -255,7 +255,7 @@ pub struct GetEventSelectorsResponse {
 }
 
 /// <p>The name of a trail about which you want the current status.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetTrailStatusRequest {
     /// <p>Specifies the name or the CloudTrail ARN of the trail for which you are requesting status. To get the status of a shadow trail (a replication of the trail in another region), you must specify its ARN. The format of a trail ARN is:</p> <p> <code>arn:aws:cloudtrail:us-east-1:123456789012:trail/MyTrail</code> </p>
     #[serde(rename = "Name")]
@@ -263,7 +263,7 @@ pub struct GetTrailStatusRequest {
 }
 
 /// <p>Returns the objects or data listed below if successful. Otherwise, returns an error.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetTrailStatusResponse {
     /// <p>Whether the CloudTrail is currently logging AWS API calls.</p>
     #[serde(rename = "IsLogging")]
@@ -336,7 +336,7 @@ pub struct GetTrailStatusResponse {
 }
 
 /// <p>Requests the public keys for a specified time range.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListPublicKeysRequest {
     /// <p>Optionally specifies, in UTC, the end of the time range to look up public keys for CloudTrail digest files. If not specified, the current time is used.</p>
     #[serde(rename = "EndTime")]
@@ -353,7 +353,7 @@ pub struct ListPublicKeysRequest {
 }
 
 /// <p>Returns the objects or data listed below if successful. Otherwise, returns an error.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListPublicKeysResponse {
     /// <p>Reserved for future use.</p>
     #[serde(rename = "NextToken")]
@@ -366,7 +366,7 @@ pub struct ListPublicKeysResponse {
 }
 
 /// <p>Specifies a list of trail tags to return.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListTagsRequest {
     /// <p>Reserved for future use.</p>
     #[serde(rename = "NextToken")]
@@ -378,7 +378,7 @@ pub struct ListTagsRequest {
 }
 
 /// <p>Returns the objects or data listed below if successful. Otherwise, returns an error.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListTagsResponse {
     /// <p>Reserved for future use.</p>
     #[serde(rename = "NextToken")]
@@ -391,7 +391,7 @@ pub struct ListTagsResponse {
 }
 
 /// <p>Specifies an attribute and value that filter the events returned.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct LookupAttribute {
     /// <p>Specifies an attribute on which to filter the events returned.</p>
     #[serde(rename = "AttributeKey")]
@@ -402,7 +402,7 @@ pub struct LookupAttribute {
 }
 
 /// <p>Contains a request for LookupEvents.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct LookupEventsRequest {
     /// <p>Specifies that only events that occur before or at the specified time are returned. If the specified end time is before the specified start time, an error is returned.</p>
     #[serde(rename = "EndTime")]
@@ -427,7 +427,7 @@ pub struct LookupEventsRequest {
 }
 
 /// <p>Contains a response to a LookupEvents action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct LookupEventsResponse {
     /// <p>A list of events returned based on the lookup attributes specified and the CloudTrail event. The events list is sorted by time. The most recent event is listed first.</p>
     #[serde(rename = "Events")]
@@ -440,7 +440,7 @@ pub struct LookupEventsResponse {
 }
 
 /// <p>Contains information about a returned public key.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PublicKey {
     /// <p>The fingerprint of the public key.</p>
     #[serde(rename = "Fingerprint")]
@@ -464,7 +464,7 @@ pub struct PublicKey {
     pub value: Option<Vec<u8>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PutEventSelectorsRequest {
     /// <p>Specifies the settings for your event selectors. You can configure up to five event selectors for a trail.</p>
     #[serde(rename = "EventSelectors")]
@@ -474,7 +474,7 @@ pub struct PutEventSelectorsRequest {
     pub trail_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PutEventSelectorsResponse {
     /// <p>Specifies the event selectors configured for your trail.</p>
     #[serde(rename = "EventSelectors")]
@@ -487,7 +487,7 @@ pub struct PutEventSelectorsResponse {
 }
 
 /// <p>Specifies the tags to remove from a trail.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RemoveTagsRequest {
     /// <p>Specifies the ARN of the trail from which tags should be removed. The format of a trail ARN is:</p> <p> <code>arn:aws:cloudtrail:us-east-1:123456789012:trail/MyTrail</code> </p>
     #[serde(rename = "ResourceId")]
@@ -499,11 +499,11 @@ pub struct RemoveTagsRequest {
 }
 
 /// <p>Returns the objects or data listed below if successful. Otherwise, returns an error.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RemoveTagsResponse {}
 
 /// <p>Specifies the type and name of a resource referenced by an event.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Resource {
     /// <p>The name of the resource referenced by the event returned. These are user-created names whose values will depend on the environment. For example, the resource name might be "auto-scaling-test-group" for an Auto Scaling Group or "i-1234567" for an EC2 Instance.</p>
     #[serde(rename = "ResourceName")]
@@ -516,7 +516,7 @@ pub struct Resource {
 }
 
 /// <p>A resource tag.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ResourceTag {
     /// <p>Specifies the ARN of the resource.</p>
     #[serde(rename = "ResourceId")]
@@ -529,7 +529,7 @@ pub struct ResourceTag {
 }
 
 /// <p>The request to CloudTrail to start logging AWS API calls for an account.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StartLoggingRequest {
     /// <p>Specifies the name or the CloudTrail ARN of the trail for which CloudTrail logs AWS API calls. The format of a trail ARN is:</p> <p> <code>arn:aws:cloudtrail:us-east-1:123456789012:trail/MyTrail</code> </p>
     #[serde(rename = "Name")]
@@ -537,11 +537,11 @@ pub struct StartLoggingRequest {
 }
 
 /// <p>Returns the objects or data listed below if successful. Otherwise, returns an error.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StartLoggingResponse {}
 
 /// <p>Passes the request to CloudTrail to stop logging AWS API calls for the specified account.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StopLoggingRequest {
     /// <p>Specifies the name or the CloudTrail ARN of the trail for which CloudTrail will stop logging AWS API calls. The format of a trail ARN is:</p> <p> <code>arn:aws:cloudtrail:us-east-1:123456789012:trail/MyTrail</code> </p>
     #[serde(rename = "Name")]
@@ -549,11 +549,11 @@ pub struct StopLoggingRequest {
 }
 
 /// <p>Returns the objects or data listed below if successful. Otherwise, returns an error.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StopLoggingResponse {}
 
 /// <p>A custom key-value pair associated with a resource such as a CloudTrail trail.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Tag {
     /// <p>The key in a key-value pair. The key must be must be no longer than 128 Unicode characters. The key must be unique for the resource to which it applies.</p>
     #[serde(rename = "Key")]
@@ -565,7 +565,7 @@ pub struct Tag {
 }
 
 /// <p>The settings for a trail.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Trail {
     /// <p>Specifies an Amazon Resource Name (ARN), a unique identifier that represents the log group to which CloudTrail logs will be delivered.</p>
     #[serde(rename = "CloudWatchLogsLogGroupArn")]
@@ -622,7 +622,7 @@ pub struct Trail {
 }
 
 /// <p>Specifies settings to update for the trail.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateTrailRequest {
     /// <p>Specifies a log group name using an Amazon Resource Name (ARN), a unique identifier that represents the log group to which CloudTrail logs will be delivered. Not required unless you specify CloudWatchLogsRoleArn.</p>
     #[serde(rename = "CloudWatchLogsLogGroupArn")]
@@ -666,7 +666,7 @@ pub struct UpdateTrailRequest {
 }
 
 /// <p>Returns the objects or data listed below if successful. Otherwise, returns an error.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateTrailResponse {
     /// <p>Specifies the Amazon Resource Name (ARN) of the log group to which CloudTrail logs will be delivered.</p>
     #[serde(rename = "CloudWatchLogsLogGroupArn")]

--- a/rusoto/services/cloudwatch/src/generated.rs
+++ b/rusoto/services/cloudwatch/src/generated.rs
@@ -86,7 +86,7 @@ impl AlarmDescriptionDeserializer {
     }
 }
 /// <p>Represents the history of a specific alarm.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AlarmHistoryItem {
     /// <p>The descriptive name for the alarm.</p>
     pub alarm_name: Option<String>,
@@ -314,7 +314,7 @@ impl DashboardEntriesDeserializer {
     }
 }
 /// <p>Represents a specific dashboard.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DashboardEntry {
     /// <p>The Amazon Resource Name (ARN) of the dashboard.</p>
     pub dashboard_arn: Option<String>,
@@ -410,7 +410,7 @@ impl DashboardNamesSerializer {
 }
 
 /// <p>An error or warning for the operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DashboardValidationMessage {
     /// <p>The data path related to the message.</p>
     pub data_path: Option<String>,
@@ -519,7 +519,7 @@ impl DataPathDeserializer {
     }
 }
 /// <p>Encapsulates the statistical data that CloudWatch computes from metric data.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Datapoint {
     /// <p>The average of the metric values that correspond to the data point.</p>
     pub average: Option<f64>,
@@ -744,7 +744,7 @@ impl DatapointsToAlarmDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteAlarmsInput {
     /// <p>The alarms to be deleted.</p>
     pub alarm_names: Vec<String>,
@@ -767,7 +767,7 @@ impl DeleteAlarmsInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteDashboardsInput {
     /// <p>The dashboards to be deleted. This parameter is required.</p>
     pub dashboard_names: Vec<String>,
@@ -790,7 +790,7 @@ impl DeleteDashboardsInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteDashboardsOutput {}
 
 struct DeleteDashboardsOutputDeserializer;
@@ -809,7 +809,7 @@ impl DeleteDashboardsOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeAlarmHistoryInput {
     /// <p>The name of the alarm.</p>
     pub alarm_name: Option<String>,
@@ -873,7 +873,7 @@ impl DescribeAlarmHistoryInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeAlarmHistoryOutput {
     /// <p>The alarm histories, in JSON format.</p>
     pub alarm_history_items: Option<Vec<AlarmHistoryItem>>,
@@ -926,7 +926,7 @@ impl DescribeAlarmHistoryOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeAlarmsForMetricInput {
     /// <p>The dimensions associated with the metric. If the metric has any associated dimensions, you must specify them in order for the call to succeed.</p>
     pub dimensions: Option<Vec<Dimension>>,
@@ -995,7 +995,7 @@ impl DescribeAlarmsForMetricInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeAlarmsForMetricOutput {
     /// <p>The information for each alarm with the specified metric.</p>
     pub metric_alarms: Option<Vec<MetricAlarm>>,
@@ -1043,7 +1043,7 @@ impl DescribeAlarmsForMetricOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeAlarmsInput {
     /// <p>The action name prefix.</p>
     pub action_prefix: Option<String>,
@@ -1108,7 +1108,7 @@ impl DescribeAlarmsInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeAlarmsOutput {
     /// <p>The information for the specified alarms.</p>
     pub metric_alarms: Option<Vec<MetricAlarm>>,
@@ -1163,7 +1163,7 @@ impl DescribeAlarmsOutputDeserializer {
     }
 }
 /// <p>Expands the identity of a metric.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Dimension {
     /// <p>The name of the dimension.</p>
     pub name: String,
@@ -1235,7 +1235,7 @@ impl DimensionSerializer {
 }
 
 /// <p>Represents filters for a dimension.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DimensionFilter {
     /// <p>The dimension name to be matched.</p>
     pub name: String,
@@ -1356,7 +1356,7 @@ impl DimensionsSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DisableAlarmActionsInput {
     /// <p>The names of the alarms.</p>
     pub alarm_names: Vec<String>,
@@ -1379,7 +1379,7 @@ impl DisableAlarmActionsInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct EnableAlarmActionsInput {
     /// <p>The names of the alarms.</p>
     pub alarm_names: Vec<String>,
@@ -1456,7 +1456,7 @@ impl ExtendedStatisticsSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetDashboardInput {
     /// <p>The name of the dashboard to be described.</p>
     pub dashboard_name: String,
@@ -1478,7 +1478,7 @@ impl GetDashboardInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetDashboardOutput {
     /// <p>The Amazon Resource Name (ARN) of the dashboard.</p>
     pub dashboard_arn: Option<String>,
@@ -1542,7 +1542,7 @@ impl GetDashboardOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetMetricDataInput {
     /// <p>The time stamp indicating the latest data to be returned.</p>
     pub end_time: String,
@@ -1601,7 +1601,7 @@ impl GetMetricDataInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetMetricDataOutput {
     /// <p>The metrics that are returned, including the metric name, namespace, and dimensions.</p>
     pub metric_data_results: Option<Vec<MetricDataResult>>,
@@ -1654,7 +1654,7 @@ impl GetMetricDataOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetMetricStatisticsInput {
     /// <p>The dimensions. If the metric contains multiple dimensions, you must include a value for each dimension. CloudWatch treats each unique combination of dimensions as a separate metric. If a specific combination of dimensions was not published, you can't retrieve statistics for it. You must specify the same dimensions that were used when the metrics were created. For an example, see <a href="http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_concepts.html#dimension-combinations">Dimension Combinations</a> in the <i>Amazon CloudWatch User Guide</i>. For more information about specifying dimensions, see <a href="http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/publishingMetrics.html">Publishing Metrics</a> in the <i>Amazon CloudWatch User Guide</i>.</p>
     pub dimensions: Option<Vec<Dimension>>,
@@ -1735,7 +1735,7 @@ impl GetMetricStatisticsInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetMetricStatisticsOutput {
     /// <p>The data points for the specified metric.</p>
     pub datapoints: Option<Vec<Datapoint>>,
@@ -1845,7 +1845,7 @@ impl LastModifiedDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListDashboardsInput {
     /// <p>If you specify this parameter, only the dashboards with names starting with the specified string are listed. The maximum length is 255, and valid characters are A-Z, a-z, 0-9, ".", "-", and "_". </p>
     pub dashboard_name_prefix: Option<String>,
@@ -1877,7 +1877,7 @@ impl ListDashboardsInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListDashboardsOutput {
     /// <p>The list of matching dashboards.</p>
     pub dashboard_entries: Option<Vec<DashboardEntry>>,
@@ -1930,7 +1930,7 @@ impl ListDashboardsOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListMetricsInput {
     /// <p>The dimensions to filter against.</p>
     pub dimensions: Option<Vec<DimensionFilter>>,
@@ -1979,7 +1979,7 @@ impl ListMetricsInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListMetricsOutput {
     /// <p>The metrics.</p>
     pub metrics: Option<Vec<Metric>>,
@@ -2046,7 +2046,7 @@ impl MessageDeserializer {
     }
 }
 /// <p>A message returned by the <code>GetMetricData</code>API, including a code and a description.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct MessageData {
     /// <p>The error code or status code associated with the message.</p>
     pub code: Option<String>,
@@ -2129,7 +2129,7 @@ impl MessageDataValueDeserializer {
     }
 }
 /// <p>Represents a specific metric.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Metric {
     /// <p>The dimensions for the metric.</p>
     pub dimensions: Option<Vec<Dimension>>,
@@ -2224,7 +2224,7 @@ impl MetricSerializer {
 }
 
 /// <p>Represents an alarm.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct MetricAlarm {
     /// <p>Indicates whether actions should be executed during any changes to the alarm state.</p>
     pub actions_enabled: Option<bool>,
@@ -2508,7 +2508,7 @@ impl MetricDataQueriesSerializer {
 }
 
 /// <p>This structure indicates the metric data to return, and whether this call is just retrieving a batch set of data for one metric, or is performing a math expression on metric data. A single <code>GetMetricData</code> call can include up to 100 <code>MetricDataQuery</code> structures.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct MetricDataQuery {
     /// <p>The math expression to be performed on the returned data, if this structure is performing a math expression. For more information about metric math expressions, see <a href="http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/using-metric-math.html#metric-math-syntax">Metric Math Syntax and Functions</a> in the <i>Amazon CloudWatch User Guide</i>.</p> <p>Within one MetricDataQuery structure, you must specify either <code>Expression</code> or <code>MetricStat</code> but not both.</p>
     pub expression: Option<String>,
@@ -2561,7 +2561,7 @@ impl MetricDataQuerySerializer {
 }
 
 /// <p>A <code>GetMetricData</code> call returns an array of <code>MetricDataResult</code> structures. Each of these structures includes the data points for that metric, along with the time stamps of those data points and other identifying information.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct MetricDataResult {
     /// <p>The short name you specified to represent this metric.</p>
     pub id: Option<String>,
@@ -2725,7 +2725,7 @@ impl MetricDataResultsDeserializer {
     }
 }
 /// <p>Encapsulates the information sent to either create a metric or add new values to be aggregated into an existing metric.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct MetricDatum {
     /// <p>The dimensions associated with the metric.</p>
     pub dimensions: Option<Vec<Dimension>>,
@@ -2840,7 +2840,7 @@ impl MetricNameDeserializer {
     }
 }
 /// <p>This structure defines the metric to be returned, along with the statistics, period, and units.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct MetricStat {
     /// <p>The metric to return, including the metric name, namespace, and dimensions.</p>
     pub metric: Metric,
@@ -2961,7 +2961,7 @@ impl PeriodDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PutDashboardInput {
     /// <p>The detailed information about the dashboard in JSON format, including the widgets to include and their location on the dashboard. This parameter is required.</p> <p>For more information about the syntax, see <a>CloudWatch-Dashboard-Body-Structure</a>.</p>
     pub dashboard_body: String,
@@ -2989,7 +2989,7 @@ impl PutDashboardInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PutDashboardOutput {
     /// <p>If the input for <code>PutDashboard</code> was correct and the dashboard was successfully created or modified, this result is empty.</p> <p>If this result includes only warning messages, then the input was valid enough for the dashboard to be created or modified, but some elements of the dashboard may not render.</p> <p>If this result includes error messages, the input was not valid and the operation failed.</p>
     pub dashboard_validation_messages: Option<Vec<DashboardValidationMessage>>,
@@ -3038,7 +3038,7 @@ impl PutDashboardOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PutMetricAlarmInput {
     /// <p>Indicates whether actions should be executed during any changes to the alarm state.</p>
     pub actions_enabled: Option<bool>,
@@ -3196,7 +3196,7 @@ impl PutMetricAlarmInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PutMetricDataInput {
     /// <p>The data for the metric.</p>
     pub metric_data: Vec<MetricDatum>,
@@ -3291,7 +3291,7 @@ impl ResourceNameDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SetAlarmStateInput {
     /// <p>The name for the alarm. This name must be unique within the AWS account. The maximum length is 255 characters.</p>
     pub alarm_name: String,
@@ -3418,7 +3418,7 @@ impl StatisticDeserializer {
     }
 }
 /// <p>Represents a set of statistics that describes a specific metric. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct StatisticSet {
     /// <p>The maximum value of the sample set.</p>
     pub maximum: f64,

--- a/rusoto/services/cloudwatch/src/generated.rs
+++ b/rusoto/services/cloudwatch/src/generated.rs
@@ -29,8 +29,9 @@ use hyper::StatusCode;
 use rusoto_core::param::{Params, ServiceParams};
 use rusoto_core::signature::SignedRequest;
 use rusoto_core::xmlerror::*;
-use rusoto_core::xmlutil::{characters, end_element, find_start_element, peek_at_name, skip_tree,
-                           start_element};
+use rusoto_core::xmlutil::{
+    characters, end_element, find_start_element, peek_at_name, skip_tree, start_element,
+};
 use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
 use std::str::FromStr;
 use xml::reader::ParserConfig;

--- a/rusoto/services/codebuild/src/generated.rs
+++ b/rusoto/services/codebuild/src/generated.rs
@@ -30,14 +30,14 @@ use rusoto_core::signature::SignedRequest;
 use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct BatchDeleteBuildsInput {
     /// <p>The IDs of the builds to delete.</p>
     #[serde(rename = "ids")]
     pub ids: Vec<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BatchDeleteBuildsOutput {
     /// <p>The IDs of the builds that were successfully deleted.</p>
     #[serde(rename = "buildsDeleted")]
@@ -49,14 +49,14 @@ pub struct BatchDeleteBuildsOutput {
     pub builds_not_deleted: Option<Vec<BuildNotDeleted>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct BatchGetBuildsInput {
     /// <p>The IDs of the builds.</p>
     #[serde(rename = "ids")]
     pub ids: Vec<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BatchGetBuildsOutput {
     /// <p>Information about the requested builds.</p>
     #[serde(rename = "builds")]
@@ -68,14 +68,14 @@ pub struct BatchGetBuildsOutput {
     pub builds_not_found: Option<Vec<String>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct BatchGetProjectsInput {
     /// <p>The names of the build projects.</p>
     #[serde(rename = "names")]
     pub names: Vec<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BatchGetProjectsOutput {
     /// <p>Information about the requested build projects.</p>
     #[serde(rename = "projects")]
@@ -88,7 +88,7 @@ pub struct BatchGetProjectsOutput {
 }
 
 /// <p>Information about a build.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Build {
     /// <p>The Amazon Resource Name (ARN) of the build.</p>
     #[serde(rename = "arn")]
@@ -169,7 +169,7 @@ pub struct Build {
 }
 
 /// <p>Information about build output artifacts.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BuildArtifacts {
     /// <p>Information about the location of the build artifacts.</p>
     #[serde(rename = "location")]
@@ -186,7 +186,7 @@ pub struct BuildArtifacts {
 }
 
 /// <p>Information about a build that could not be successfully deleted.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BuildNotDeleted {
     /// <p>The ID of the build that could not be successfully deleted.</p>
     #[serde(rename = "id")]
@@ -199,7 +199,7 @@ pub struct BuildNotDeleted {
 }
 
 /// <p>Information about a stage for a build.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BuildPhase {
     /// <p>Additional information about a build phase, especially to help troubleshoot a failed build.</p>
     #[serde(rename = "contexts")]
@@ -227,7 +227,7 @@ pub struct BuildPhase {
     pub start_time: Option<f64>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateProjectInput {
     /// <p>Information about the build output artifacts for the build project.</p>
     #[serde(rename = "artifacts")]
@@ -275,7 +275,7 @@ pub struct CreateProjectInput {
     pub vpc_config: Option<VpcConfig>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateProjectOutput {
     /// <p>Information about the build project that was created.</p>
     #[serde(rename = "project")]
@@ -283,7 +283,7 @@ pub struct CreateProjectOutput {
     pub project: Option<Project>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateWebhookInput {
     /// <p>A regular expression used to determine which branches in a repository are built when a webhook is triggered. If the name of a branch matches the regular expression, then it is built. If it doesn't match, then it is not. If branchFilter is empty, then all branches are built.</p>
     #[serde(rename = "branchFilter")]
@@ -294,7 +294,7 @@ pub struct CreateWebhookInput {
     pub project_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateWebhookOutput {
     /// <p>Information about a webhook in GitHub that connects repository events to a build project in AWS CodeBuild.</p>
     #[serde(rename = "webhook")]
@@ -302,28 +302,28 @@ pub struct CreateWebhookOutput {
     pub webhook: Option<Webhook>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteProjectInput {
     /// <p>The name of the build project.</p>
     #[serde(rename = "name")]
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteProjectOutput {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteWebhookInput {
     /// <p>The name of the AWS CodeBuild project.</p>
     #[serde(rename = "projectName")]
     pub project_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteWebhookOutput {}
 
 /// <p>Information about a Docker image that is managed by AWS CodeBuild.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct EnvironmentImage {
     /// <p>The description of the Docker image.</p>
     #[serde(rename = "description")]
@@ -340,7 +340,7 @@ pub struct EnvironmentImage {
 }
 
 /// <p>A set of Docker images that are related by programming language and are managed by AWS CodeBuild.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct EnvironmentLanguage {
     /// <p>The list of Docker images that are related by the specified programming language.</p>
     #[serde(rename = "images")]
@@ -353,7 +353,7 @@ pub struct EnvironmentLanguage {
 }
 
 /// <p>A set of Docker images that are related by platform and are managed by AWS CodeBuild.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct EnvironmentPlatform {
     /// <p>The list of programming languages that are available for the specified platform.</p>
     #[serde(rename = "languages")]
@@ -366,7 +366,7 @@ pub struct EnvironmentPlatform {
 }
 
 /// <p>Information about an environment variable for a build project or a build.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct EnvironmentVariable {
     /// <p>The name or key of the environment variable.</p>
     #[serde(rename = "name")]
@@ -380,17 +380,17 @@ pub struct EnvironmentVariable {
     pub value: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct InvalidateProjectCacheInput {
     /// <p>The name of the AWS CodeBuild build project that the cache will be reset for.</p>
     #[serde(rename = "projectName")]
     pub project_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct InvalidateProjectCacheOutput {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListBuildsForProjectInput {
     /// <p>During a previous call, if there are more than 100 items in the list, only the first 100 items are returned, along with a unique string called a <i>next token</i>. To get the next batch of items in the list, call this operation again, adding the next token to the call. To get all of the items in the list, keep calling this operation with each subsequent next token that is returned, until no more next tokens are returned.</p>
     #[serde(rename = "nextToken")]
@@ -405,7 +405,7 @@ pub struct ListBuildsForProjectInput {
     pub sort_order: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListBuildsForProjectOutput {
     /// <p>A list of build IDs for the specified build project, with each build ID representing a single build.</p>
     #[serde(rename = "ids")]
@@ -417,7 +417,7 @@ pub struct ListBuildsForProjectOutput {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListBuildsInput {
     /// <p>During a previous call, if there are more than 100 items in the list, only the first 100 items are returned, along with a unique string called a <i>next token</i>. To get the next batch of items in the list, call this operation again, adding the next token to the call. To get all of the items in the list, keep calling this operation with each subsequent next token that is returned, until no more next tokens are returned.</p>
     #[serde(rename = "nextToken")]
@@ -429,7 +429,7 @@ pub struct ListBuildsInput {
     pub sort_order: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListBuildsOutput {
     /// <p>A list of build IDs, with each build ID representing a single build.</p>
     #[serde(rename = "ids")]
@@ -441,10 +441,10 @@ pub struct ListBuildsOutput {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListCuratedEnvironmentImagesInput {}
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListCuratedEnvironmentImagesOutput {
     /// <p>Information about supported platforms for Docker images that are managed by AWS CodeBuild.</p>
     #[serde(rename = "platforms")]
@@ -452,7 +452,7 @@ pub struct ListCuratedEnvironmentImagesOutput {
     pub platforms: Option<Vec<EnvironmentPlatform>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListProjectsInput {
     /// <p>During a previous call, if there are more than 100 items in the list, only the first 100 items are returned, along with a unique string called a <i>next token</i>. To get the next batch of items in the list, call this operation again, adding the next token to the call. To get all of the items in the list, keep calling this operation with each subsequent next token that is returned, until no more next tokens are returned.</p>
     #[serde(rename = "nextToken")]
@@ -468,7 +468,7 @@ pub struct ListProjectsInput {
     pub sort_order: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListProjectsOutput {
     /// <p>If there are more than 100 items in the list, only the first 100 items are returned, along with a unique string called a <i>next token</i>. To get the next batch of items in the list, call this operation again, adding the next token to the call.</p>
     #[serde(rename = "nextToken")]
@@ -481,7 +481,7 @@ pub struct ListProjectsOutput {
 }
 
 /// <p>Information about build logs in Amazon CloudWatch Logs.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct LogsLocation {
     /// <p>The URL to an individual build log in Amazon CloudWatch Logs.</p>
     #[serde(rename = "deepLink")]
@@ -498,7 +498,7 @@ pub struct LogsLocation {
 }
 
 /// <p>Describes a network interface.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct NetworkInterface {
     /// <p>The ID of the network interface.</p>
     #[serde(rename = "networkInterfaceId")]
@@ -511,7 +511,7 @@ pub struct NetworkInterface {
 }
 
 /// <p>Additional information about a build phase that has an error. You can use this information to help troubleshoot a failed build.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PhaseContext {
     /// <p>An explanation of the build phase's context. This explanation might include a command ID and an exit code.</p>
     #[serde(rename = "message")]
@@ -524,7 +524,7 @@ pub struct PhaseContext {
 }
 
 /// <p>Information about a build project.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Project {
     /// <p>The Amazon Resource Name (ARN) of the build project.</p>
     #[serde(rename = "arn")]
@@ -593,7 +593,7 @@ pub struct Project {
 }
 
 /// <p>Information about the build output artifacts for the build project.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ProjectArtifacts {
     /// <p><p>Information about the build output artifact location, as follows:</p> <ul> <li> <p>If <code>type</code> is set to <code>CODEPIPELINE</code>, then AWS CodePipeline will ignore this value if specified. This is because AWS CodePipeline manages its build output locations instead of AWS CodeBuild.</p> </li> <li> <p>If <code>type</code> is set to <code>NO_ARTIFACTS</code>, then this value will be ignored if specified, because no build output will be produced.</p> </li> <li> <p>If <code>type</code> is set to <code>S3</code>, this is the name of the output bucket.</p> </li> </ul></p>
     #[serde(rename = "location")]
@@ -621,7 +621,7 @@ pub struct ProjectArtifacts {
 }
 
 /// <p>Information about the build badge for the build project.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ProjectBadge {
     /// <p>Set this to true to generate a publicly-accessible URL for your project's build badge.</p>
     #[serde(rename = "badgeEnabled")]
@@ -634,7 +634,7 @@ pub struct ProjectBadge {
 }
 
 /// <p>Information about the cache for the build project.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ProjectCache {
     /// <p><p>Information about the cache location, as follows: </p> <ul> <li> <p> <code>NO_CACHE</code>: This value will be ignored.</p> </li> <li> <p> <code>S3</code>: This is the S3 bucket name/prefix.</p> </li> </ul></p>
     #[serde(rename = "location")]
@@ -646,7 +646,7 @@ pub struct ProjectCache {
 }
 
 /// <p>Information about the build environment of the build project.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ProjectEnvironment {
     /// <p>The certificate to use with this build project.</p>
     #[serde(rename = "certificate")]
@@ -672,7 +672,7 @@ pub struct ProjectEnvironment {
 }
 
 /// <p>Information about the build input source code for the build project.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ProjectSource {
     /// <p>Information about the authorization settings for AWS CodeBuild to access the source code to be built.</p> <p>This information is for the AWS CodeBuild console's use only. Your code should not get or set this information directly (unless the build project's source <code>type</code> value is <code>BITBUCKET</code> or <code>GITHUB</code>).</p>
     #[serde(rename = "auth")]
@@ -700,7 +700,7 @@ pub struct ProjectSource {
 }
 
 /// <p>Information about the authorization settings for AWS CodeBuild to access the source code to be built.</p> <p>This information is for the AWS CodeBuild console's use only. Your code should not get or set this information directly (unless the build project's source <code>type</code> value is <code>BITBUCKET</code> or <code>GITHUB</code>).</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SourceAuth {
     /// <p>The resource value that applies to the specified authorization type.</p>
     #[serde(rename = "resource")]
@@ -711,7 +711,7 @@ pub struct SourceAuth {
     pub type_: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StartBuildInput {
     /// <p>Build output artifact settings that override, for this build only, the latest ones already defined in the build project.</p>
     #[serde(rename = "artifactsOverride")]
@@ -742,7 +742,7 @@ pub struct StartBuildInput {
     pub timeout_in_minutes_override: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StartBuildOutput {
     /// <p>Information about the build to be run.</p>
     #[serde(rename = "build")]
@@ -750,14 +750,14 @@ pub struct StartBuildOutput {
     pub build: Option<Build>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StopBuildInput {
     /// <p>The ID of the build.</p>
     #[serde(rename = "id")]
     pub id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StopBuildOutput {
     /// <p>Information about the build.</p>
     #[serde(rename = "build")]
@@ -766,7 +766,7 @@ pub struct StopBuildOutput {
 }
 
 /// <p>A tag, consisting of a key and a value.</p> <p>This tag is available for use by AWS services that support tags in AWS CodeBuild.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Tag {
     /// <p>The tag's key.</p>
     #[serde(rename = "key")]
@@ -778,7 +778,7 @@ pub struct Tag {
     pub value: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateProjectInput {
     /// <p>Information to be changed about the build output artifacts for the build project.</p>
     #[serde(rename = "artifacts")]
@@ -829,7 +829,7 @@ pub struct UpdateProjectInput {
     pub vpc_config: Option<VpcConfig>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateProjectOutput {
     /// <p>Information about the build project that was changed.</p>
     #[serde(rename = "project")]
@@ -837,7 +837,7 @@ pub struct UpdateProjectOutput {
     pub project: Option<Project>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateWebhookInput {
     /// <p>A regular expression used to determine which branches in a repository are built when a webhook is triggered. If the name of a branch matches the regular expression, then it is built. If it doesn't match, then it is not. If branchFilter is empty, then all branches are built.</p>
     #[serde(rename = "branchFilter")]
@@ -852,7 +852,7 @@ pub struct UpdateWebhookInput {
     pub rotate_secret: Option<bool>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateWebhookOutput {
     /// <p> Information about a repository's webhook that is associated with a project in AWS CodeBuild. </p>
     #[serde(rename = "webhook")]
@@ -861,7 +861,7 @@ pub struct UpdateWebhookOutput {
 }
 
 /// <p>Information about the VPC configuration that AWS CodeBuild will access.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct VpcConfig {
     /// <p>A list of one or more security groups IDs in your Amazon VPC.</p>
     #[serde(rename = "securityGroupIds")]
@@ -878,7 +878,7 @@ pub struct VpcConfig {
 }
 
 /// <p>Information about a webhook in GitHub that connects repository events to a build project in AWS CodeBuild.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Webhook {
     /// <p>A regular expression used to determine which branches in a repository are built when a webhook is triggered. If the name of a branch matches the regular expression, then it is built. If it doesn't match, then it is not. If branchFilter is empty, then all branches are built.</p>
     #[serde(rename = "branchFilter")]

--- a/rusoto/services/codebuild/src/generated.rs
+++ b/rusoto/services/codebuild/src/generated.rs
@@ -921,7 +921,8 @@ impl BatchDeleteBuildsError {
     pub fn from_body(body: &str) -> BatchDeleteBuildsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1001,7 +1002,8 @@ impl BatchGetBuildsError {
     pub fn from_body(body: &str) -> BatchGetBuildsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1079,7 +1081,8 @@ impl BatchGetProjectsError {
     pub fn from_body(body: &str) -> BatchGetProjectsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1161,7 +1164,8 @@ impl CreateProjectError {
     pub fn from_body(body: &str) -> CreateProjectError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1253,7 +1257,8 @@ impl CreateWebhookError {
     pub fn from_body(body: &str) -> CreateWebhookError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1343,7 +1348,8 @@ impl DeleteProjectError {
     pub fn from_body(body: &str) -> DeleteProjectError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1425,7 +1431,8 @@ impl DeleteWebhookError {
     pub fn from_body(body: &str) -> DeleteWebhookError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1513,7 +1520,8 @@ impl InvalidateProjectCacheError {
     pub fn from_body(body: &str) -> InvalidateProjectCacheError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1597,7 +1605,8 @@ impl ListBuildsError {
     pub fn from_body(body: &str) -> ListBuildsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1675,7 +1684,8 @@ impl ListBuildsForProjectError {
     pub fn from_body(body: &str) -> ListBuildsForProjectError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1757,7 +1767,8 @@ impl ListCuratedEnvironmentImagesError {
     pub fn from_body(body: &str) -> ListCuratedEnvironmentImagesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1833,7 +1844,8 @@ impl ListProjectsError {
     pub fn from_body(body: &str) -> ListProjectsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1915,7 +1927,8 @@ impl StartBuildError {
     pub fn from_body(body: &str) -> StartBuildError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2001,7 +2014,8 @@ impl StopBuildError {
     pub fn from_body(body: &str) -> StopBuildError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2083,7 +2097,8 @@ impl UpdateProjectError {
     pub fn from_body(body: &str) -> UpdateProjectError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2169,7 +2184,8 @@ impl UpdateWebhookError {
     pub fn from_body(body: &str) -> UpdateWebhookError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/codecommit/src/generated.rs
+++ b/rusoto/services/codecommit/src/generated.rs
@@ -31,7 +31,7 @@ use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 /// <p>Represents the input of a batch get repositories operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct BatchGetRepositoriesInput {
     /// <p>The names of the repositories to get information about.</p>
     #[serde(rename = "repositoryNames")]
@@ -39,7 +39,7 @@ pub struct BatchGetRepositoriesInput {
 }
 
 /// <p>Represents the output of a batch get repositories operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BatchGetRepositoriesOutput {
     /// <p>A list of repositories returned by the batch get repositories operation.</p>
     #[serde(rename = "repositories")]
@@ -52,7 +52,7 @@ pub struct BatchGetRepositoriesOutput {
 }
 
 /// <p>Returns information about a specific Git blob object.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BlobMetadata {
     /// <p>The full ID of the blob.</p>
     #[serde(rename = "blobId")]
@@ -69,7 +69,7 @@ pub struct BlobMetadata {
 }
 
 /// <p>Returns information about a branch.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BranchInfo {
     /// <p>The name of the branch.</p>
     #[serde(rename = "branchName")]
@@ -82,7 +82,7 @@ pub struct BranchInfo {
 }
 
 /// <p>Returns information about a specific comment.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Comment {
     /// <p>The Amazon Resource Name (ARN) of the person who posted the comment.</p>
     #[serde(rename = "authorArn")]
@@ -119,7 +119,7 @@ pub struct Comment {
 }
 
 /// <p>Returns information about comments on the comparison between two commits.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CommentsForComparedCommit {
     /// <p>The full blob ID of the commit used to establish the 'after' of the comparison.</p>
     #[serde(rename = "afterBlobId")]
@@ -152,7 +152,7 @@ pub struct CommentsForComparedCommit {
 }
 
 /// <p>Returns information about comments on a pull request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CommentsForPullRequest {
     /// <p>The full blob ID of the file on which you want to comment on the source commit.</p>
     #[serde(rename = "afterBlobId")]
@@ -189,7 +189,7 @@ pub struct CommentsForPullRequest {
 }
 
 /// <p>Returns information about a specific commit.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Commit {
     /// <p>Any additional data associated with the specified commit.</p>
     #[serde(rename = "additionalData")]
@@ -222,7 +222,7 @@ pub struct Commit {
 }
 
 /// <p>Represents the input of a create branch operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateBranchInput {
     /// <p>The name of the new branch to create.</p>
     #[serde(rename = "branchName")]
@@ -235,7 +235,7 @@ pub struct CreateBranchInput {
     pub repository_name: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreatePullRequestInput {
     /// <p><p>A unique, client-generated idempotency token that when provided in a request, ensures the request cannot be repeated with a changed parameter. If a request is received with the same parameters and a token is included, the request will return information about the initial request that used that token.</p> <note> <p>The AWS SDKs prepopulate client request tokens. If using an AWS SDK, you do not have to generate an idempotency token, as this will be done for you.</p> </note></p>
     #[serde(rename = "clientRequestToken")]
@@ -253,7 +253,7 @@ pub struct CreatePullRequestInput {
     pub title: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreatePullRequestOutput {
     /// <p>Information about the newly created pull request.</p>
     #[serde(rename = "pullRequest")]
@@ -261,7 +261,7 @@ pub struct CreatePullRequestOutput {
 }
 
 /// <p>Represents the input of a create repository operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateRepositoryInput {
     /// <p><p>A comment or description about the new repository.</p> <note> <p>The description field for a repository accepts all HTML characters and all valid Unicode characters. Applications that do not HTML-encode the description and display it in a web page could expose users to potentially malicious code. Make sure that you HTML-encode the description field in any application that uses this API to display the repository description on a web page.</p> </note></p>
     #[serde(rename = "repositoryDescription")]
@@ -273,7 +273,7 @@ pub struct CreateRepositoryInput {
 }
 
 /// <p>Represents the output of a create repository operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateRepositoryOutput {
     /// <p>Information about the newly created repository.</p>
     #[serde(rename = "repositoryMetadata")]
@@ -282,7 +282,7 @@ pub struct CreateRepositoryOutput {
 }
 
 /// <p>Represents the input of a delete branch operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteBranchInput {
     /// <p>The name of the branch to delete.</p>
     #[serde(rename = "branchName")]
@@ -293,7 +293,7 @@ pub struct DeleteBranchInput {
 }
 
 /// <p>Represents the output of a delete branch operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteBranchOutput {
     /// <p>Information about the branch deleted by the operation, including the branch name and the commit ID that was the tip of the branch.</p>
     #[serde(rename = "deletedBranch")]
@@ -301,14 +301,14 @@ pub struct DeleteBranchOutput {
     pub deleted_branch: Option<BranchInfo>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteCommentContentInput {
     /// <p>The unique, system-generated ID of the comment. To get this ID, use <a>GetCommentsForComparedCommit</a> or <a>GetCommentsForPullRequest</a>.</p>
     #[serde(rename = "commentId")]
     pub comment_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteCommentContentOutput {
     /// <p>Information about the comment you just deleted.</p>
     #[serde(rename = "comment")]
@@ -317,7 +317,7 @@ pub struct DeleteCommentContentOutput {
 }
 
 /// <p>Represents the input of a delete repository operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteRepositoryInput {
     /// <p>The name of the repository to delete.</p>
     #[serde(rename = "repositoryName")]
@@ -325,7 +325,7 @@ pub struct DeleteRepositoryInput {
 }
 
 /// <p>Represents the output of a delete repository operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteRepositoryOutput {
     /// <p>The ID of the repository that was deleted.</p>
     #[serde(rename = "repositoryId")]
@@ -333,7 +333,7 @@ pub struct DeleteRepositoryOutput {
     pub repository_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribePullRequestEventsInput {
     /// <p>The Amazon Resource Name (ARN) of the user whose actions resulted in the event. Examples include updating the pull request with additional commits or changing the status of a pull request.</p>
     #[serde(rename = "actorArn")]
@@ -356,7 +356,7 @@ pub struct DescribePullRequestEventsInput {
     pub pull_request_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribePullRequestEventsOutput {
     /// <p>An enumeration token that can be used in a request to return the next batch of the results.</p>
     #[serde(rename = "nextToken")]
@@ -368,7 +368,7 @@ pub struct DescribePullRequestEventsOutput {
 }
 
 /// <p>Returns information about a set of differences for a commit specifier.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Difference {
     /// <p>Information about an <code>afterBlob</code> data type object, including the ID, the file mode permission code, and the path.</p>
     #[serde(rename = "afterBlob")]
@@ -385,7 +385,7 @@ pub struct Difference {
 }
 
 /// <p>Represents the input of a get blob operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetBlobInput {
     /// <p>The ID of the blob, which is its SHA-1 pointer.</p>
     #[serde(rename = "blobId")]
@@ -396,7 +396,7 @@ pub struct GetBlobInput {
 }
 
 /// <p>Represents the output of a get blob operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetBlobOutput {
     /// <p>The content of the blob, usually a file.</p>
     #[serde(rename = "content")]
@@ -409,7 +409,7 @@ pub struct GetBlobOutput {
 }
 
 /// <p>Represents the input of a get branch operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetBranchInput {
     /// <p>The name of the branch for which you want to retrieve information.</p>
     #[serde(rename = "branchName")]
@@ -422,7 +422,7 @@ pub struct GetBranchInput {
 }
 
 /// <p>Represents the output of a get branch operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetBranchOutput {
     /// <p>The name of the branch.</p>
     #[serde(rename = "branch")]
@@ -430,14 +430,14 @@ pub struct GetBranchOutput {
     pub branch: Option<BranchInfo>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetCommentInput {
     /// <p>The unique, system-generated ID of the comment. To get this ID, use <a>GetCommentsForComparedCommit</a> or <a>GetCommentsForPullRequest</a>.</p>
     #[serde(rename = "commentId")]
     pub comment_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetCommentOutput {
     /// <p>The contents of the comment.</p>
     #[serde(rename = "comment")]
@@ -445,7 +445,7 @@ pub struct GetCommentOutput {
     pub comment: Option<Comment>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetCommentsForComparedCommitInput {
     /// <p>To establish the directionality of the comparison, the full commit ID of the 'after' commit.</p>
     #[serde(rename = "afterCommitId")]
@@ -467,7 +467,7 @@ pub struct GetCommentsForComparedCommitInput {
     pub repository_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetCommentsForComparedCommitOutput {
     /// <p>A list of comment objects on the compared commit.</p>
     #[serde(rename = "commentsForComparedCommitData")]
@@ -479,7 +479,7 @@ pub struct GetCommentsForComparedCommitOutput {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetCommentsForPullRequestInput {
     /// <p>The full commit ID of the commit in the source branch that was the tip of the branch at the time the comment was made.</p>
     #[serde(rename = "afterCommitId")]
@@ -506,7 +506,7 @@ pub struct GetCommentsForPullRequestInput {
     pub repository_name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetCommentsForPullRequestOutput {
     /// <p>An array of comment objects on the pull request.</p>
     #[serde(rename = "commentsForPullRequestData")]
@@ -519,7 +519,7 @@ pub struct GetCommentsForPullRequestOutput {
 }
 
 /// <p>Represents the input of a get commit operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetCommitInput {
     /// <p>The commit ID. Commit IDs are the full SHA of the commit.</p>
     #[serde(rename = "commitId")]
@@ -530,14 +530,14 @@ pub struct GetCommitInput {
 }
 
 /// <p>Represents the output of a get commit operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetCommitOutput {
     /// <p>A commit data type object that contains information about the specified commit.</p>
     #[serde(rename = "commit")]
     pub commit: Commit,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetDifferencesInput {
     /// <p>A non-negative integer used to limit the number of returned results.</p>
     #[serde(rename = "MaxResults")]
@@ -567,7 +567,7 @@ pub struct GetDifferencesInput {
     pub repository_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetDifferencesOutput {
     /// <p>An enumeration token that can be used in a request to return the next batch of the results.</p>
     #[serde(rename = "NextToken")]
@@ -579,7 +579,7 @@ pub struct GetDifferencesOutput {
     pub differences: Option<Vec<Difference>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetMergeConflictsInput {
     /// <p>The branch, tag, HEAD, or other fully qualified reference used to identify a commit. For example, a branch name or a full commit ID.</p>
     #[serde(rename = "destinationCommitSpecifier")]
@@ -595,7 +595,7 @@ pub struct GetMergeConflictsInput {
     pub source_commit_specifier: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetMergeConflictsOutput {
     /// <p>The commit ID of the destination commit specifier that was used in the merge evaluation.</p>
     #[serde(rename = "destinationCommitId")]
@@ -608,14 +608,14 @@ pub struct GetMergeConflictsOutput {
     pub source_commit_id: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetPullRequestInput {
     /// <p>The system-generated ID of the pull request. To get this ID, use <a>ListPullRequests</a>.</p>
     #[serde(rename = "pullRequestId")]
     pub pull_request_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetPullRequestOutput {
     /// <p>Information about the specified pull request.</p>
     #[serde(rename = "pullRequest")]
@@ -623,7 +623,7 @@ pub struct GetPullRequestOutput {
 }
 
 /// <p>Represents the input of a get repository operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetRepositoryInput {
     /// <p>The name of the repository to get information about.</p>
     #[serde(rename = "repositoryName")]
@@ -631,7 +631,7 @@ pub struct GetRepositoryInput {
 }
 
 /// <p>Represents the output of a get repository operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetRepositoryOutput {
     /// <p>Information about the repository.</p>
     #[serde(rename = "repositoryMetadata")]
@@ -640,7 +640,7 @@ pub struct GetRepositoryOutput {
 }
 
 /// <p>Represents the input of a get repository triggers operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetRepositoryTriggersInput {
     /// <p>The name of the repository for which the trigger is configured.</p>
     #[serde(rename = "repositoryName")]
@@ -648,7 +648,7 @@ pub struct GetRepositoryTriggersInput {
 }
 
 /// <p>Represents the output of a get repository triggers operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetRepositoryTriggersOutput {
     /// <p>The system-generated unique ID for the trigger.</p>
     #[serde(rename = "configurationId")]
@@ -661,7 +661,7 @@ pub struct GetRepositoryTriggersOutput {
 }
 
 /// <p>Represents the input of a list branches operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListBranchesInput {
     /// <p>An enumeration token that allows the operation to batch the results.</p>
     #[serde(rename = "nextToken")]
@@ -673,7 +673,7 @@ pub struct ListBranchesInput {
 }
 
 /// <p>Represents the output of a list branches operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListBranchesOutput {
     /// <p>The list of branch names.</p>
     #[serde(rename = "branches")]
@@ -685,7 +685,7 @@ pub struct ListBranchesOutput {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListPullRequestsInput {
     /// <p>Optional. The Amazon Resource Name (ARN) of the user who created the pull request. If used, this filters the results to pull requests created by that user.</p>
     #[serde(rename = "authorArn")]
@@ -708,7 +708,7 @@ pub struct ListPullRequestsInput {
     pub repository_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListPullRequestsOutput {
     /// <p>An enumeration token that when provided in a request, returns the next batch of the results.</p>
     #[serde(rename = "nextToken")]
@@ -720,7 +720,7 @@ pub struct ListPullRequestsOutput {
 }
 
 /// <p>Represents the input of a list repositories operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListRepositoriesInput {
     /// <p>An enumeration token that allows the operation to batch the results of the operation. Batch sizes are 1,000 for list repository operations. When the client sends the token back to AWS CodeCommit, another page of 1,000 records is retrieved.</p>
     #[serde(rename = "nextToken")]
@@ -737,7 +737,7 @@ pub struct ListRepositoriesInput {
 }
 
 /// <p>Represents the output of a list repositories operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListRepositoriesOutput {
     /// <p>An enumeration token that allows the operation to batch the results of the operation. Batch sizes are 1,000 for list repository operations. When the client sends the token back to AWS CodeCommit, another page of 1,000 records is retrieved.</p>
     #[serde(rename = "nextToken")]
@@ -750,7 +750,7 @@ pub struct ListRepositoriesOutput {
 }
 
 /// <p>Returns information about the location of a change or comment in the comparison between two commits or a pull request.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Location {
     /// <p>The name of the file being compared, including its extension and subdirectory, if any.</p>
     #[serde(rename = "filePath")]
@@ -767,7 +767,7 @@ pub struct Location {
 }
 
 /// <p>Returns information about a merge or potential merge between a source reference and a destination reference in a pull request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct MergeMetadata {
     /// <p>A Boolean value indicating whether the merge has been made.</p>
     #[serde(rename = "isMerged")]
@@ -779,7 +779,7 @@ pub struct MergeMetadata {
     pub merged_by: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct MergePullRequestByFastForwardInput {
     /// <p>The system-generated ID of the pull request. To get this ID, use <a>ListPullRequests</a>.</p>
     #[serde(rename = "pullRequestId")]
@@ -793,7 +793,7 @@ pub struct MergePullRequestByFastForwardInput {
     pub source_commit_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct MergePullRequestByFastForwardOutput {
     /// <p>Information about the specified pull request, including information about the merge.</p>
     #[serde(rename = "pullRequest")]
@@ -801,7 +801,7 @@ pub struct MergePullRequestByFastForwardOutput {
     pub pull_request: Option<PullRequest>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PostCommentForComparedCommitInput {
     /// <p>To establish the directionality of the comparison, the full commit ID of the 'after' commit.</p>
     #[serde(rename = "afterCommitId")]
@@ -826,7 +826,7 @@ pub struct PostCommentForComparedCommitInput {
     pub repository_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PostCommentForComparedCommitOutput {
     /// <p>In the directionality you established, the blob ID of the 'after' blob.</p>
     #[serde(rename = "afterBlobId")]
@@ -858,7 +858,7 @@ pub struct PostCommentForComparedCommitOutput {
     pub repository_name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PostCommentForPullRequestInput {
     /// <p>The full commit ID of the commit in the source branch that is the current tip of the branch for the pull request when you post the comment.</p>
     #[serde(rename = "afterCommitId")]
@@ -885,7 +885,7 @@ pub struct PostCommentForPullRequestInput {
     pub repository_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PostCommentForPullRequestOutput {
     /// <p>In the directionality of the pull request, the blob ID of the 'after' blob.</p>
     #[serde(rename = "afterBlobId")]
@@ -921,7 +921,7 @@ pub struct PostCommentForPullRequestOutput {
     pub repository_name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PostCommentReplyInput {
     /// <p>A unique, client-generated idempotency token that when provided in a request, ensures the request cannot be repeated with a changed parameter. If a request is received with the same parameters and a token is included, the request will return information about the initial request that used that token.</p>
     #[serde(rename = "clientRequestToken")]
@@ -935,7 +935,7 @@ pub struct PostCommentReplyInput {
     pub in_reply_to: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PostCommentReplyOutput {
     /// <p>Information about the reply to a comment.</p>
     #[serde(rename = "comment")]
@@ -944,7 +944,7 @@ pub struct PostCommentReplyOutput {
 }
 
 /// <p>Returns information about a pull request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PullRequest {
     /// <p>The Amazon Resource Name (ARN) of the user who created the pull request.</p>
     #[serde(rename = "authorArn")]
@@ -985,7 +985,7 @@ pub struct PullRequest {
 }
 
 /// <p>Returns information about a pull request event.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PullRequestEvent {
     /// <p>The Amazon Resource Name (ARN) of the user whose actions resulted in the event. Examples include updating the pull request with additional commits or changing the status of a pull request.</p>
     #[serde(rename = "actorArn")]
@@ -1020,7 +1020,7 @@ pub struct PullRequestEvent {
 }
 
 /// <p>Returns information about the change in the merge state for a pull request event. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PullRequestMergedStateChangedEventMetadata {
     /// <p>The name of the branch that the pull request will be merged into.</p>
     #[serde(rename = "destinationReference")]
@@ -1037,7 +1037,7 @@ pub struct PullRequestMergedStateChangedEventMetadata {
 }
 
 /// <p>Information about an update to the source branch of a pull request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PullRequestSourceReferenceUpdatedEventMetadata {
     /// <p>The full commit ID of the commit in the source branch that was the tip of the branch at the time the pull request was updated.</p>
     #[serde(rename = "afterCommitId")]
@@ -1054,7 +1054,7 @@ pub struct PullRequestSourceReferenceUpdatedEventMetadata {
 }
 
 /// <p>Information about a change to the status of a pull request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PullRequestStatusChangedEventMetadata {
     /// <p>The changed status of the pull request.</p>
     #[serde(rename = "pullRequestStatus")]
@@ -1063,7 +1063,7 @@ pub struct PullRequestStatusChangedEventMetadata {
 }
 
 /// <p>Returns information about a pull request target.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PullRequestTarget {
     /// <p>The full commit ID that is the tip of the destination branch. This is the commit where the pull request was or will be merged.</p>
     #[serde(rename = "destinationCommit")]
@@ -1091,7 +1091,7 @@ pub struct PullRequestTarget {
     pub source_reference: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PutFileInput {
     /// <p>The name of the branch where you want to add or update the file.</p>
     #[serde(rename = "branchName")]
@@ -1132,7 +1132,7 @@ pub struct PutFileInput {
     pub repository_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PutFileOutput {
     /// <p>The ID of the blob, which is its SHA-1 pointer.</p>
     #[serde(rename = "blobId")]
@@ -1146,7 +1146,7 @@ pub struct PutFileOutput {
 }
 
 /// <p>Represents the input ofa put repository triggers operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PutRepositoryTriggersInput {
     /// <p>The name of the repository where you want to create or update the trigger.</p>
     #[serde(rename = "repositoryName")]
@@ -1157,7 +1157,7 @@ pub struct PutRepositoryTriggersInput {
 }
 
 /// <p>Represents the output of a put repository triggers operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PutRepositoryTriggersOutput {
     /// <p>The system-generated unique ID for the create or update operation.</p>
     #[serde(rename = "configurationId")]
@@ -1166,7 +1166,7 @@ pub struct PutRepositoryTriggersOutput {
 }
 
 /// <p>Information about a repository.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RepositoryMetadata {
     /// <p>The Amazon Resource Name (ARN) of the repository.</p>
     #[serde(rename = "Arn")]
@@ -1211,7 +1211,7 @@ pub struct RepositoryMetadata {
 }
 
 /// <p>Information about a repository name and ID.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RepositoryNameIdPair {
     /// <p>The ID associated with the repository.</p>
     #[serde(rename = "repositoryId")]
@@ -1224,7 +1224,7 @@ pub struct RepositoryNameIdPair {
 }
 
 /// <p>Information about a trigger for a repository.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RepositoryTrigger {
     /// <p><p>The branches that will be included in the trigger configuration. If you specify an empty array, the trigger will apply to all branches.</p> <note> <p>While no content is required in the array, you must include the array itself.</p> </note></p>
     #[serde(rename = "branches")]
@@ -1246,7 +1246,7 @@ pub struct RepositoryTrigger {
 }
 
 /// <p>A trigger failed to run.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RepositoryTriggerExecutionFailure {
     /// <p>Additional message information about the trigger that did not run.</p>
     #[serde(rename = "failureMessage")]
@@ -1259,7 +1259,7 @@ pub struct RepositoryTriggerExecutionFailure {
 }
 
 /// <p>Returns information about a target for a pull request.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct Target {
     /// <p>The branch of the repository where the pull request changes will be merged into. Also known as the destination branch.</p>
     #[serde(rename = "destinationReference")]
@@ -1274,7 +1274,7 @@ pub struct Target {
 }
 
 /// <p>Represents the input of a test repository triggers operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct TestRepositoryTriggersInput {
     /// <p>The name of the repository in which to test the triggers.</p>
     #[serde(rename = "repositoryName")]
@@ -1285,7 +1285,7 @@ pub struct TestRepositoryTriggersInput {
 }
 
 /// <p>Represents the output of a test repository triggers operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct TestRepositoryTriggersOutput {
     /// <p>The list of triggers that were not able to be tested. This list provides the names of the triggers that could not be tested, separated by commas.</p>
     #[serde(rename = "failedExecutions")]
@@ -1297,7 +1297,7 @@ pub struct TestRepositoryTriggersOutput {
     pub successful_executions: Option<Vec<String>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateCommentInput {
     /// <p>The system-generated ID of the comment you want to update. To get this ID, use <a>GetCommentsForComparedCommit</a> or <a>GetCommentsForPullRequest</a>.</p>
     #[serde(rename = "commentId")]
@@ -1307,7 +1307,7 @@ pub struct UpdateCommentInput {
     pub content: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateCommentOutput {
     /// <p>Information about the updated comment.</p>
     #[serde(rename = "comment")]
@@ -1316,7 +1316,7 @@ pub struct UpdateCommentOutput {
 }
 
 /// <p>Represents the input of an update default branch operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateDefaultBranchInput {
     /// <p>The name of the branch to set as the default.</p>
     #[serde(rename = "defaultBranchName")]
@@ -1326,7 +1326,7 @@ pub struct UpdateDefaultBranchInput {
     pub repository_name: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdatePullRequestDescriptionInput {
     /// <p>The updated content of the description for the pull request. This content will replace the existing description.</p>
     #[serde(rename = "description")]
@@ -1336,14 +1336,14 @@ pub struct UpdatePullRequestDescriptionInput {
     pub pull_request_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdatePullRequestDescriptionOutput {
     /// <p>Information about the updated pull request.</p>
     #[serde(rename = "pullRequest")]
     pub pull_request: PullRequest,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdatePullRequestStatusInput {
     /// <p>The system-generated ID of the pull request. To get this ID, use <a>ListPullRequests</a>.</p>
     #[serde(rename = "pullRequestId")]
@@ -1353,14 +1353,14 @@ pub struct UpdatePullRequestStatusInput {
     pub pull_request_status: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdatePullRequestStatusOutput {
     /// <p>Information about the pull request.</p>
     #[serde(rename = "pullRequest")]
     pub pull_request: PullRequest,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdatePullRequestTitleInput {
     /// <p>The system-generated ID of the pull request. To get this ID, use <a>ListPullRequests</a>.</p>
     #[serde(rename = "pullRequestId")]
@@ -1370,7 +1370,7 @@ pub struct UpdatePullRequestTitleInput {
     pub title: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdatePullRequestTitleOutput {
     /// <p>Information about the updated pull request.</p>
     #[serde(rename = "pullRequest")]
@@ -1378,7 +1378,7 @@ pub struct UpdatePullRequestTitleOutput {
 }
 
 /// <p>Represents the input of an update repository description operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateRepositoryDescriptionInput {
     /// <p>The new comment or description for the specified repository. Repository descriptions are limited to 1,000 characters.</p>
     #[serde(rename = "repositoryDescription")]
@@ -1390,7 +1390,7 @@ pub struct UpdateRepositoryDescriptionInput {
 }
 
 /// <p>Represents the input of an update repository description operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateRepositoryNameInput {
     /// <p>The new name for the repository.</p>
     #[serde(rename = "newName")]
@@ -1401,7 +1401,7 @@ pub struct UpdateRepositoryNameInput {
 }
 
 /// <p>Information about the user who made a specified commit.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UserInfo {
     /// <p>The date when the specified commit was commited, in timestamp format with GMT offset.</p>
     #[serde(rename = "date")]

--- a/rusoto/services/codecommit/src/generated.rs
+++ b/rusoto/services/codecommit/src/generated.rs
@@ -1450,7 +1450,8 @@ impl BatchGetRepositoriesError {
     pub fn from_body(body: &str) -> BatchGetRepositoriesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1600,7 +1601,8 @@ impl CreateBranchError {
     pub fn from_body(body: &str) -> CreateBranchError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1780,7 +1782,8 @@ impl CreatePullRequestError {
     pub fn from_body(body: &str) -> CreatePullRequestError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1994,7 +1997,8 @@ impl CreateRepositoryError {
     pub fn from_body(body: &str) -> CreateRepositoryError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2134,7 +2138,8 @@ impl DeleteBranchError {
     pub fn from_body(body: &str) -> DeleteBranchError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2260,7 +2265,8 @@ impl DeleteCommentContentError {
     pub fn from_body(body: &str) -> DeleteCommentContentError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2364,7 +2370,8 @@ impl DeleteRepositoryError {
     pub fn from_body(body: &str) -> DeleteRepositoryError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2494,7 +2501,8 @@ impl DescribePullRequestEventsError {
     pub fn from_body(body: &str) -> DescribePullRequestEventsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2668,7 +2676,8 @@ impl GetBlobError {
     pub fn from_body(body: &str) -> GetBlobError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2808,7 +2817,8 @@ impl GetBranchError {
     pub fn from_body(body: &str) -> GetBranchError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2930,7 +2940,8 @@ impl GetCommentError {
     pub fn from_body(body: &str) -> GetCommentError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3042,7 +3053,8 @@ impl GetCommentsForComparedCommitError {
     pub fn from_body(body: &str) -> GetCommentsForComparedCommitError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3228,7 +3240,8 @@ impl GetCommentsForPullRequestError {
     pub fn from_body(body: &str) -> GetCommentsForPullRequestError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3426,7 +3439,8 @@ impl GetCommitError {
     pub fn from_body(body: &str) -> GetCommitError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3572,7 +3586,8 @@ impl GetDifferencesError {
     pub fn from_body(body: &str) -> GetDifferencesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3742,7 +3757,8 @@ impl GetMergeConflictsError {
     pub fn from_body(body: &str) -> GetMergeConflictsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3906,7 +3922,8 @@ impl GetPullRequestError {
     pub fn from_body(body: &str) -> GetPullRequestError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4028,7 +4045,8 @@ impl GetRepositoryError {
     pub fn from_body(body: &str) -> GetRepositoryError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4150,7 +4168,8 @@ impl GetRepositoryTriggersError {
     pub fn from_body(body: &str) -> GetRepositoryTriggersError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4290,7 +4309,8 @@ impl ListBranchesError {
     pub fn from_body(body: &str) -> ListBranchesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4426,7 +4446,8 @@ impl ListPullRequestsError {
     pub fn from_body(body: &str) -> ListPullRequestsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4560,7 +4581,8 @@ impl ListRepositoriesError {
     pub fn from_body(body: &str) -> ListRepositoriesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4676,7 +4698,8 @@ impl MergePullRequestByFastForwardError {
     pub fn from_body(body: &str) -> MergePullRequestByFastForwardError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4892,7 +4915,8 @@ impl PostCommentForComparedCommitError {
     pub fn from_body(body: &str) -> PostCommentForComparedCommitError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5156,7 +5180,8 @@ impl PostCommentForPullRequestError {
     pub fn from_body(body: &str) -> PostCommentForPullRequestError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5406,7 +5431,8 @@ impl PostCommentReplyError {
     pub fn from_body(body: &str) -> PostCommentReplyError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5572,7 +5598,8 @@ impl PutFileError {
     pub fn from_body(body: &str) -> PutFileError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5796,7 +5823,8 @@ impl PutRepositoryTriggersError {
     pub fn from_body(body: &str) -> PutRepositoryTriggersError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6038,7 +6066,8 @@ impl TestRepositoryTriggersError {
     pub fn from_body(body: &str) -> TestRepositoryTriggersError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6256,7 +6285,8 @@ impl UpdateCommentError {
     pub fn from_body(body: &str) -> UpdateCommentError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6380,7 +6410,8 @@ impl UpdateDefaultBranchError {
     pub fn from_body(body: &str) -> UpdateDefaultBranchError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6518,7 +6549,8 @@ impl UpdatePullRequestDescriptionError {
     pub fn from_body(body: &str) -> UpdatePullRequestDescriptionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6644,7 +6676,8 @@ impl UpdatePullRequestStatusError {
     pub fn from_body(body: &str) -> UpdatePullRequestStatusError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6796,7 +6829,8 @@ impl UpdatePullRequestTitleError {
     pub fn from_body(body: &str) -> UpdatePullRequestTitleError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6920,7 +6954,8 @@ impl UpdateRepositoryDescriptionError {
     pub fn from_body(body: &str) -> UpdateRepositoryDescriptionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7056,7 +7091,8 @@ impl UpdateRepositoryNameError {
     pub fn from_body(body: &str) -> UpdateRepositoryNameError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/codedeploy/src/generated.rs
+++ b/rusoto/services/codedeploy/src/generated.rs
@@ -31,7 +31,7 @@ use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 /// <p>Represents the input of, and adds tags to, an on-premises instance operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AddTagsToOnPremisesInstancesInput {
     /// <p>The names of the on-premises instances to which to add tags.</p>
     #[serde(rename = "instanceNames")]
@@ -42,7 +42,7 @@ pub struct AddTagsToOnPremisesInstancesInput {
 }
 
 /// <p>Information about an alarm.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Alarm {
     /// <p>The name of the alarm. Maximum length is 255 characters. Each alarm name can be used only once in a list of alarms.</p>
     #[serde(rename = "name")]
@@ -51,7 +51,7 @@ pub struct Alarm {
 }
 
 /// <p>Information about alarms associated with the deployment group.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct AlarmConfiguration {
     /// <p>A list of alarms configured for the deployment group. A maximum of 10 alarms can be added to a deployment group.</p>
     #[serde(rename = "alarms")]
@@ -68,7 +68,7 @@ pub struct AlarmConfiguration {
 }
 
 /// <p>Information about an application.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ApplicationInfo {
     /// <p>The application ID.</p>
     #[serde(rename = "applicationId")]
@@ -97,7 +97,7 @@ pub struct ApplicationInfo {
 }
 
 /// <p>Information about a configuration for automatically rolling back to a previous version of an application revision when a deployment doesn't complete successfully.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct AutoRollbackConfiguration {
     /// <p>Indicates whether a defined automatic rollback configuration is currently enabled.</p>
     #[serde(rename = "enabled")]
@@ -110,7 +110,7 @@ pub struct AutoRollbackConfiguration {
 }
 
 /// <p>Information about an Auto Scaling group.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AutoScalingGroup {
     /// <p>An Auto Scaling lifecycle event hook name.</p>
     #[serde(rename = "hook")]
@@ -123,7 +123,7 @@ pub struct AutoScalingGroup {
 }
 
 /// <p>Represents the input of a BatchGetApplicationRevisions operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct BatchGetApplicationRevisionsInput {
     /// <p>The name of an AWS CodeDeploy application about which to get revision information.</p>
     #[serde(rename = "applicationName")]
@@ -134,7 +134,7 @@ pub struct BatchGetApplicationRevisionsInput {
 }
 
 /// <p>Represents the output of a BatchGetApplicationRevisions operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BatchGetApplicationRevisionsOutput {
     /// <p>The name of the application that corresponds to the revisions.</p>
     #[serde(rename = "applicationName")]
@@ -151,7 +151,7 @@ pub struct BatchGetApplicationRevisionsOutput {
 }
 
 /// <p>Represents the input of a BatchGetApplications operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct BatchGetApplicationsInput {
     /// <p>A list of application names separated by spaces.</p>
     #[serde(rename = "applicationNames")]
@@ -159,7 +159,7 @@ pub struct BatchGetApplicationsInput {
 }
 
 /// <p>Represents the output of a BatchGetApplications operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BatchGetApplicationsOutput {
     /// <p>Information about the applications.</p>
     #[serde(rename = "applicationsInfo")]
@@ -168,7 +168,7 @@ pub struct BatchGetApplicationsOutput {
 }
 
 /// <p>Represents the input of a BatchGetDeploymentGroups operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct BatchGetDeploymentGroupsInput {
     /// <p>The name of an AWS CodeDeploy application associated with the applicable IAM user or AWS account.</p>
     #[serde(rename = "applicationName")]
@@ -179,7 +179,7 @@ pub struct BatchGetDeploymentGroupsInput {
 }
 
 /// <p>Represents the output of a BatchGetDeploymentGroups operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BatchGetDeploymentGroupsOutput {
     /// <p>Information about the deployment groups.</p>
     #[serde(rename = "deploymentGroupsInfo")]
@@ -192,7 +192,7 @@ pub struct BatchGetDeploymentGroupsOutput {
 }
 
 /// <p>Represents the input of a BatchGetDeploymentInstances operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct BatchGetDeploymentInstancesInput {
     /// <p>The unique ID of a deployment.</p>
     #[serde(rename = "deploymentId")]
@@ -203,7 +203,7 @@ pub struct BatchGetDeploymentInstancesInput {
 }
 
 /// <p>Represents the output of a BatchGetDeploymentInstances operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BatchGetDeploymentInstancesOutput {
     /// <p>Information about errors that may have occurred during the API call.</p>
     #[serde(rename = "errorMessage")]
@@ -216,7 +216,7 @@ pub struct BatchGetDeploymentInstancesOutput {
 }
 
 /// <p>Represents the input of a BatchGetDeployments operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct BatchGetDeploymentsInput {
     /// <p>A list of deployment IDs, separated by spaces.</p>
     #[serde(rename = "deploymentIds")]
@@ -224,7 +224,7 @@ pub struct BatchGetDeploymentsInput {
 }
 
 /// <p>Represents the output of a BatchGetDeployments operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BatchGetDeploymentsOutput {
     /// <p>Information about the deployments.</p>
     #[serde(rename = "deploymentsInfo")]
@@ -233,7 +233,7 @@ pub struct BatchGetDeploymentsOutput {
 }
 
 /// <p>Represents the input of a BatchGetOnPremisesInstances operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct BatchGetOnPremisesInstancesInput {
     /// <p>The names of the on-premises instances about which to get information.</p>
     #[serde(rename = "instanceNames")]
@@ -241,7 +241,7 @@ pub struct BatchGetOnPremisesInstancesInput {
 }
 
 /// <p>Represents the output of a BatchGetOnPremisesInstances operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BatchGetOnPremisesInstancesOutput {
     /// <p>Information about the on-premises instances.</p>
     #[serde(rename = "instanceInfos")]
@@ -250,7 +250,7 @@ pub struct BatchGetOnPremisesInstancesOutput {
 }
 
 /// <p>Information about blue/green deployment options for a deployment group.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct BlueGreenDeploymentConfiguration {
     /// <p>Information about the action to take when newly provisioned instances are ready to receive traffic in a blue/green deployment.</p>
     #[serde(rename = "deploymentReadyOption")]
@@ -267,7 +267,7 @@ pub struct BlueGreenDeploymentConfiguration {
 }
 
 /// <p>Information about whether instances in the original environment are terminated when a blue/green deployment is successful.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct BlueInstanceTerminationOption {
     /// <p><p>The action to take on instances in the original environment after a successful blue/green deployment.</p> <ul> <li> <p>TERMINATE: Instances are terminated after a specified wait time.</p> </li> <li> <p>KEEP_ALIVE: Instances are left running after they are deregistered from the load balancer and removed from the deployment group.</p> </li> </ul></p>
     #[serde(rename = "action")]
@@ -279,7 +279,7 @@ pub struct BlueInstanceTerminationOption {
     pub termination_wait_time_in_minutes: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ContinueDeploymentInput {
     /// <p>The deployment ID of the blue/green deployment for which you want to start rerouting traffic to the replacement environment.</p>
     #[serde(rename = "deploymentId")]
@@ -288,7 +288,7 @@ pub struct ContinueDeploymentInput {
 }
 
 /// <p>Represents the input of a CreateApplication operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateApplicationInput {
     /// <p>The name of the application. This name must be unique with the applicable IAM user or AWS account.</p>
     #[serde(rename = "applicationName")]
@@ -300,7 +300,7 @@ pub struct CreateApplicationInput {
 }
 
 /// <p>Represents the output of a CreateApplication operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateApplicationOutput {
     /// <p>A unique application ID.</p>
     #[serde(rename = "applicationId")]
@@ -309,7 +309,7 @@ pub struct CreateApplicationOutput {
 }
 
 /// <p>Represents the input of a CreateDeploymentConfig operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateDeploymentConfigInput {
     /// <p>The destination platform type for the deployment (<code>Lambda</code> or <code>Server</code>&gt;).</p>
     #[serde(rename = "computePlatform")]
@@ -329,7 +329,7 @@ pub struct CreateDeploymentConfigInput {
 }
 
 /// <p>Represents the output of a CreateDeploymentConfig operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateDeploymentConfigOutput {
     /// <p>A unique deployment configuration ID.</p>
     #[serde(rename = "deploymentConfigId")]
@@ -338,7 +338,7 @@ pub struct CreateDeploymentConfigOutput {
 }
 
 /// <p>Represents the input of a CreateDeploymentGroup operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateDeploymentGroupInput {
     /// <p>Information to add about Amazon CloudWatch alarms when the deployment group is created.</p>
     #[serde(rename = "alarmConfiguration")]
@@ -400,7 +400,7 @@ pub struct CreateDeploymentGroupInput {
 }
 
 /// <p>Represents the output of a CreateDeploymentGroup operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateDeploymentGroupOutput {
     /// <p>A unique deployment group ID.</p>
     #[serde(rename = "deploymentGroupId")]
@@ -409,7 +409,7 @@ pub struct CreateDeploymentGroupOutput {
 }
 
 /// <p>Represents the input of a CreateDeployment operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateDeploymentInput {
     /// <p>The name of an AWS CodeDeploy application associated with the applicable IAM user or AWS account.</p>
     #[serde(rename = "applicationName")]
@@ -453,7 +453,7 @@ pub struct CreateDeploymentInput {
 }
 
 /// <p>Represents the output of a CreateDeployment operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateDeploymentOutput {
     /// <p>A unique deployment ID.</p>
     #[serde(rename = "deploymentId")]
@@ -462,7 +462,7 @@ pub struct CreateDeploymentOutput {
 }
 
 /// <p>Represents the input of a DeleteApplication operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteApplicationInput {
     /// <p>The name of an AWS CodeDeploy application associated with the applicable IAM user or AWS account.</p>
     #[serde(rename = "applicationName")]
@@ -470,7 +470,7 @@ pub struct DeleteApplicationInput {
 }
 
 /// <p>Represents the input of a DeleteDeploymentConfig operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteDeploymentConfigInput {
     /// <p>The name of a deployment configuration associated with the applicable IAM user or AWS account.</p>
     #[serde(rename = "deploymentConfigName")]
@@ -478,7 +478,7 @@ pub struct DeleteDeploymentConfigInput {
 }
 
 /// <p>Represents the input of a DeleteDeploymentGroup operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteDeploymentGroupInput {
     /// <p>The name of an AWS CodeDeploy application associated with the applicable IAM user or AWS account.</p>
     #[serde(rename = "applicationName")]
@@ -489,7 +489,7 @@ pub struct DeleteDeploymentGroupInput {
 }
 
 /// <p>Represents the output of a DeleteDeploymentGroup operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteDeploymentGroupOutput {
     /// <p>If the output contains no data, and the corresponding deployment group contained at least one Auto Scaling group, AWS CodeDeploy successfully removed all corresponding Auto Scaling lifecycle event hooks from the Amazon EC2 instances in the Auto Scaling group. If the output contains data, AWS CodeDeploy could not remove some Auto Scaling lifecycle event hooks from the Amazon EC2 instances in the Auto Scaling group.</p>
     #[serde(rename = "hooksNotCleanedUp")]
@@ -498,7 +498,7 @@ pub struct DeleteDeploymentGroupOutput {
 }
 
 /// <p>Represents the input of a DeleteGitHubAccount operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteGitHubAccountTokenInput {
     /// <p>The name of the GitHub account connection to delete.</p>
     #[serde(rename = "tokenName")]
@@ -507,7 +507,7 @@ pub struct DeleteGitHubAccountTokenInput {
 }
 
 /// <p>Represents the output of a DeleteGitHubAccountToken operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteGitHubAccountTokenOutput {
     /// <p>The name of the GitHub account connection that was deleted.</p>
     #[serde(rename = "tokenName")]
@@ -516,7 +516,7 @@ pub struct DeleteGitHubAccountTokenOutput {
 }
 
 /// <p>Information about a deployment configuration.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeploymentConfigInfo {
     /// <p>The destination platform type for the deployment (<code>Lambda</code> or <code>Server</code>).</p>
     #[serde(rename = "computePlatform")]
@@ -545,7 +545,7 @@ pub struct DeploymentConfigInfo {
 }
 
 /// <p>Information about a deployment group.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeploymentGroupInfo {
     /// <p>A list of alarms associated with the deployment group.</p>
     #[serde(rename = "alarmConfiguration")]
@@ -630,7 +630,7 @@ pub struct DeploymentGroupInfo {
 }
 
 /// <p>Information about a deployment.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeploymentInfo {
     /// <p>Provides information about the results of a deployment, such as whether instances in the original environment in a blue/green deployment were not terminated.</p>
     #[serde(rename = "additionalDeploymentStatusInfo")]
@@ -743,7 +743,7 @@ pub struct DeploymentInfo {
 }
 
 /// <p>Information about the deployment status of the instances in the deployment.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeploymentOverview {
     /// <p>The number of instances in the deployment in a failed state.</p>
     #[serde(rename = "Failed")]
@@ -772,7 +772,7 @@ pub struct DeploymentOverview {
 }
 
 /// <p>Information about how traffic is rerouted to instances in a replacement environment in a blue/green deployment.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct DeploymentReadyOption {
     /// <p><p>Information about when to reroute traffic from an original environment to a replacement environment in a blue/green deployment.</p> <ul> <li> <p>CONTINUE<em>DEPLOYMENT: Register new instances with the load balancer immediately after the new application revision is installed on the instances in the replacement environment.</p> </li> <li> <p>STOP</em>DEPLOYMENT: Do not register new instances with load balancer unless traffic is rerouted manually. If traffic is not rerouted manually before the end of the specified wait period, the deployment status is changed to Stopped.</p> </li> </ul></p>
     #[serde(rename = "actionOnTimeout")]
@@ -785,7 +785,7 @@ pub struct DeploymentReadyOption {
 }
 
 /// <p>Information about the type of deployment, either in-place or blue/green, you want to run and whether to route deployment traffic behind a load balancer.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct DeploymentStyle {
     /// <p>Indicates whether to route deployment traffic behind a load balancer.</p>
     #[serde(rename = "deploymentOption")]
@@ -798,7 +798,7 @@ pub struct DeploymentStyle {
 }
 
 /// <p>Represents the input of a DeregisterOnPremisesInstance operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeregisterOnPremisesInstanceInput {
     /// <p>The name of the on-premises instance to deregister.</p>
     #[serde(rename = "instanceName")]
@@ -806,7 +806,7 @@ pub struct DeregisterOnPremisesInstanceInput {
 }
 
 /// <p>Diagnostic information about executable scripts that are part of a deployment.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Diagnostics {
     /// <p><p>The associated error code:</p> <ul> <li> <p>Success: The specified script ran.</p> </li> <li> <p>ScriptMissing: The specified script was not found in the specified location.</p> </li> <li> <p>ScriptNotExecutable: The specified script is not a recognized executable file type.</p> </li> <li> <p>ScriptTimedOut: The specified script did not finish running in the specified time period.</p> </li> <li> <p>ScriptFailed: The specified script failed to run as expected.</p> </li> <li> <p>UnknownError: The specified script did not run for an unknown reason.</p> </li> </ul></p>
     #[serde(rename = "errorCode")]
@@ -827,7 +827,7 @@ pub struct Diagnostics {
 }
 
 /// <p>Information about an EC2 tag filter.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct EC2TagFilter {
     /// <p>The tag filter key.</p>
     #[serde(rename = "Key")]
@@ -844,7 +844,7 @@ pub struct EC2TagFilter {
 }
 
 /// <p>Information about groups of EC2 instance tags.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct EC2TagSet {
     /// <p>A list containing other lists of EC2 instance tag groups. In order for an instance to be included in the deployment group, it must be identified by all the tag groups in the list.</p>
     #[serde(rename = "ec2TagSetList")]
@@ -853,7 +853,7 @@ pub struct EC2TagSet {
 }
 
 /// <p>Information about a load balancer in Elastic Load Balancing to use in a deployment. Instances are registered directly with a load balancer, and traffic is routed to the load balancer.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ELBInfo {
     /// <p>For blue/green deployments, the name of the load balancer that will be used to route traffic from original instances to replacement instances in a blue/green deployment. For in-place deployments, the name of the load balancer that instances are deregistered from so they are not serving traffic during a deployment, and then re-registered with after the deployment completes.</p>
     #[serde(rename = "name")]
@@ -862,7 +862,7 @@ pub struct ELBInfo {
 }
 
 /// <p>Information about a deployment error.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ErrorInformation {
     /// <p><p>For information about additional error codes, see <a href="http://docs.aws.amazon.com/codedeploy/latest/userguide/error-codes.html">Error Codes for AWS CodeDeploy</a> in the <a href="http://docs.aws.amazon.com/codedeploy/latest/userguide">AWS CodeDeploy User Guide</a>.</p> <p>The error code:</p> <ul> <li> <p>APPLICATION<em>MISSING: The application was missing. This error code will most likely be raised if the application is deleted after the deployment is created but before it is started.</p> </li> <li> <p>DEPLOYMENT</em>GROUP<em>MISSING: The deployment group was missing. This error code will most likely be raised if the deployment group is deleted after the deployment is created but before it is started.</p> </li> <li> <p>HEALTH</em>CONSTRAINTS: The deployment failed on too many instances to be successfully deployed within the instance health constraints specified.</p> </li> <li> <p>HEALTH<em>CONSTRAINTS</em>INVALID: The revision cannot be successfully deployed within the instance health constraints specified.</p> </li> <li> <p>IAM<em>ROLE</em>MISSING: The service role cannot be accessed.</p> </li> <li> <p>IAM<em>ROLE</em>PERMISSIONS: The service role does not have the correct permissions.</p> </li> <li> <p>INTERNAL<em>ERROR: There was an internal error.</p> </li> <li> <p>NO</em>EC2<em>SUBSCRIPTION: The calling account is not subscribed to the Amazon EC2 service.</p> </li> <li> <p>NO</em>INSTANCES: No instance were specified, or no instance can be found.</p> </li> <li> <p>OVER<em>MAX</em>INSTANCES: The maximum number of instance was exceeded.</p> </li> <li> <p>THROTTLED: The operation was throttled because the calling account exceeded the throttling limits of one or more AWS services.</p> </li> <li> <p>TIMEOUT: The deployment has timed out.</p> </li> <li> <p>REVISION_MISSING: The revision ID was missing. This error code will most likely be raised if the revision is deleted after the deployment is created but before it is started.</p> </li> </ul></p>
     #[serde(rename = "code")]
@@ -875,7 +875,7 @@ pub struct ErrorInformation {
 }
 
 /// <p>Information about an application revision.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GenericRevisionInfo {
     /// <p>The deployment groups for which this is the current target revision.</p>
     #[serde(rename = "deploymentGroups")]
@@ -900,7 +900,7 @@ pub struct GenericRevisionInfo {
 }
 
 /// <p>Represents the input of a GetApplication operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetApplicationInput {
     /// <p>The name of an AWS CodeDeploy application associated with the applicable IAM user or AWS account.</p>
     #[serde(rename = "applicationName")]
@@ -908,7 +908,7 @@ pub struct GetApplicationInput {
 }
 
 /// <p>Represents the output of a GetApplication operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetApplicationOutput {
     /// <p>Information about the application.</p>
     #[serde(rename = "application")]
@@ -917,7 +917,7 @@ pub struct GetApplicationOutput {
 }
 
 /// <p>Represents the input of a GetApplicationRevision operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetApplicationRevisionInput {
     /// <p>The name of the application that corresponds to the revision.</p>
     #[serde(rename = "applicationName")]
@@ -928,7 +928,7 @@ pub struct GetApplicationRevisionInput {
 }
 
 /// <p>Represents the output of a GetApplicationRevision operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetApplicationRevisionOutput {
     /// <p>The name of the application that corresponds to the revision.</p>
     #[serde(rename = "applicationName")]
@@ -945,7 +945,7 @@ pub struct GetApplicationRevisionOutput {
 }
 
 /// <p>Represents the input of a GetDeploymentConfig operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetDeploymentConfigInput {
     /// <p>The name of a deployment configuration associated with the applicable IAM user or AWS account.</p>
     #[serde(rename = "deploymentConfigName")]
@@ -953,7 +953,7 @@ pub struct GetDeploymentConfigInput {
 }
 
 /// <p>Represents the output of a GetDeploymentConfig operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetDeploymentConfigOutput {
     /// <p>Information about the deployment configuration.</p>
     #[serde(rename = "deploymentConfigInfo")]
@@ -962,7 +962,7 @@ pub struct GetDeploymentConfigOutput {
 }
 
 /// <p>Represents the input of a GetDeploymentGroup operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetDeploymentGroupInput {
     /// <p>The name of an AWS CodeDeploy application associated with the applicable IAM user or AWS account.</p>
     #[serde(rename = "applicationName")]
@@ -973,7 +973,7 @@ pub struct GetDeploymentGroupInput {
 }
 
 /// <p>Represents the output of a GetDeploymentGroup operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetDeploymentGroupOutput {
     /// <p>Information about the deployment group.</p>
     #[serde(rename = "deploymentGroupInfo")]
@@ -982,7 +982,7 @@ pub struct GetDeploymentGroupOutput {
 }
 
 /// <p>Represents the input of a GetDeployment operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetDeploymentInput {
     /// <p>A deployment ID associated with the applicable IAM user or AWS account.</p>
     #[serde(rename = "deploymentId")]
@@ -990,7 +990,7 @@ pub struct GetDeploymentInput {
 }
 
 /// <p>Represents the input of a GetDeploymentInstance operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetDeploymentInstanceInput {
     /// <p>The unique ID of a deployment.</p>
     #[serde(rename = "deploymentId")]
@@ -1001,7 +1001,7 @@ pub struct GetDeploymentInstanceInput {
 }
 
 /// <p>Represents the output of a GetDeploymentInstance operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetDeploymentInstanceOutput {
     /// <p>Information about the instance.</p>
     #[serde(rename = "instanceSummary")]
@@ -1010,7 +1010,7 @@ pub struct GetDeploymentInstanceOutput {
 }
 
 /// <p>Represents the output of a GetDeployment operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetDeploymentOutput {
     /// <p>Information about the deployment.</p>
     #[serde(rename = "deploymentInfo")]
@@ -1019,7 +1019,7 @@ pub struct GetDeploymentOutput {
 }
 
 /// <p>Represents the input of a GetOnPremisesInstance operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetOnPremisesInstanceInput {
     /// <p>The name of the on-premises instance about which to get information.</p>
     #[serde(rename = "instanceName")]
@@ -1027,7 +1027,7 @@ pub struct GetOnPremisesInstanceInput {
 }
 
 /// <p>Represents the output of a GetOnPremisesInstance operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetOnPremisesInstanceOutput {
     /// <p>Information about the on-premises instance.</p>
     #[serde(rename = "instanceInfo")]
@@ -1036,7 +1036,7 @@ pub struct GetOnPremisesInstanceOutput {
 }
 
 /// <p>Information about the location of application artifacts stored in GitHub.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct GitHubLocation {
     /// <p>The SHA1 commit ID of the GitHub commit that represents the bundled artifacts for the application revision.</p>
     #[serde(rename = "commitId")]
@@ -1049,7 +1049,7 @@ pub struct GitHubLocation {
 }
 
 /// <p>Information about the instances that belong to the replacement environment in a blue/green deployment.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct GreenFleetProvisioningOption {
     /// <p><p>The method used to add instances to a replacement environment.</p> <ul> <li> <p>DISCOVER<em>EXISTING: Use instances that already exist or will be created manually.</p> </li> <li> <p>COPY</em>AUTO<em>SCALING</em>GROUP: Use settings from a specified Auto Scaling group to define and create instances in a new Auto Scaling group.</p> </li> </ul></p>
     #[serde(rename = "action")]
@@ -1058,7 +1058,7 @@ pub struct GreenFleetProvisioningOption {
 }
 
 /// <p>Information about an on-premises instance.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct InstanceInfo {
     /// <p>If the on-premises instance was deregistered, the time at which the on-premises instance was deregistered.</p>
     #[serde(rename = "deregisterTime")]
@@ -1091,7 +1091,7 @@ pub struct InstanceInfo {
 }
 
 /// <p>Information about an instance in a deployment.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct InstanceSummary {
     /// <p>The deployment ID.</p>
     #[serde(rename = "deploymentId")]
@@ -1120,7 +1120,7 @@ pub struct InstanceSummary {
 }
 
 /// <p>Information about the most recent attempted or successful deployment to a deployment group.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct LastDeploymentInfo {
     /// <p>A timestamp indicating when the most recent deployment to the deployment group started.</p>
     #[serde(rename = "createTime")]
@@ -1141,7 +1141,7 @@ pub struct LastDeploymentInfo {
 }
 
 /// <p>Information about a deployment lifecycle event.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct LifecycleEvent {
     /// <p>Diagnostic information about the deployment lifecycle event.</p>
     #[serde(rename = "diagnostics")]
@@ -1166,7 +1166,7 @@ pub struct LifecycleEvent {
 }
 
 /// <p>Represents the input of a ListApplicationRevisions operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListApplicationRevisionsInput {
     /// <p>The name of an AWS CodeDeploy application associated with the applicable IAM user or AWS account.</p>
     #[serde(rename = "applicationName")]
@@ -1198,7 +1198,7 @@ pub struct ListApplicationRevisionsInput {
 }
 
 /// <p>Represents the output of a ListApplicationRevisions operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListApplicationRevisionsOutput {
     /// <p>If a large amount of information is returned, an identifier will also be returned. It can be used in a subsequent list application revisions call to return the next set of application revisions in the list.</p>
     #[serde(rename = "nextToken")]
@@ -1211,7 +1211,7 @@ pub struct ListApplicationRevisionsOutput {
 }
 
 /// <p>Represents the input of a ListApplications operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListApplicationsInput {
     /// <p>An identifier returned from the previous list applications call. It can be used to return the next set of applications in the list.</p>
     #[serde(rename = "nextToken")]
@@ -1220,7 +1220,7 @@ pub struct ListApplicationsInput {
 }
 
 /// <p>Represents the output of a ListApplications operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListApplicationsOutput {
     /// <p>A list of application names.</p>
     #[serde(rename = "applications")]
@@ -1233,7 +1233,7 @@ pub struct ListApplicationsOutput {
 }
 
 /// <p>Represents the input of a ListDeploymentConfigs operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListDeploymentConfigsInput {
     /// <p>An identifier returned from the previous list deployment configurations call. It can be used to return the next set of deployment configurations in the list. </p>
     #[serde(rename = "nextToken")]
@@ -1242,7 +1242,7 @@ pub struct ListDeploymentConfigsInput {
 }
 
 /// <p>Represents the output of a ListDeploymentConfigs operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListDeploymentConfigsOutput {
     /// <p>A list of deployment configurations, including built-in configurations such as CodeDeployDefault.OneAtATime.</p>
     #[serde(rename = "deploymentConfigsList")]
@@ -1255,7 +1255,7 @@ pub struct ListDeploymentConfigsOutput {
 }
 
 /// <p>Represents the input of a ListDeploymentGroups operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListDeploymentGroupsInput {
     /// <p>The name of an AWS CodeDeploy application associated with the applicable IAM user or AWS account.</p>
     #[serde(rename = "applicationName")]
@@ -1267,7 +1267,7 @@ pub struct ListDeploymentGroupsInput {
 }
 
 /// <p>Represents the output of a ListDeploymentGroups operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListDeploymentGroupsOutput {
     /// <p>The application name.</p>
     #[serde(rename = "applicationName")]
@@ -1284,7 +1284,7 @@ pub struct ListDeploymentGroupsOutput {
 }
 
 /// <p>Represents the input of a ListDeploymentInstances operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListDeploymentInstancesInput {
     /// <p>The unique ID of a deployment.</p>
     #[serde(rename = "deploymentId")]
@@ -1304,7 +1304,7 @@ pub struct ListDeploymentInstancesInput {
 }
 
 /// <p>Represents the output of a ListDeploymentInstances operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListDeploymentInstancesOutput {
     /// <p>A list of instance IDs.</p>
     #[serde(rename = "instancesList")]
@@ -1317,7 +1317,7 @@ pub struct ListDeploymentInstancesOutput {
 }
 
 /// <p>Represents the input of a ListDeployments operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListDeploymentsInput {
     /// <p>The name of an AWS CodeDeploy application associated with the applicable IAM user or AWS account.</p>
     #[serde(rename = "applicationName")]
@@ -1342,7 +1342,7 @@ pub struct ListDeploymentsInput {
 }
 
 /// <p>Represents the output of a ListDeployments operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListDeploymentsOutput {
     /// <p>A list of deployment IDs.</p>
     #[serde(rename = "deployments")]
@@ -1355,7 +1355,7 @@ pub struct ListDeploymentsOutput {
 }
 
 /// <p>Represents the input of a ListGitHubAccountTokenNames operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListGitHubAccountTokenNamesInput {
     /// <p>An identifier returned from the previous ListGitHubAccountTokenNames call. It can be used to return the next set of names in the list. </p>
     #[serde(rename = "nextToken")]
@@ -1364,7 +1364,7 @@ pub struct ListGitHubAccountTokenNamesInput {
 }
 
 /// <p>Represents the output of a ListGitHubAccountTokenNames operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListGitHubAccountTokenNamesOutput {
     /// <p>If a large amount of information is returned, an identifier is also returned. It can be used in a subsequent ListGitHubAccountTokenNames call to return the next set of names in the list. </p>
     #[serde(rename = "nextToken")]
@@ -1377,7 +1377,7 @@ pub struct ListGitHubAccountTokenNamesOutput {
 }
 
 /// <p>Represents the input of a ListOnPremisesInstances operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListOnPremisesInstancesInput {
     /// <p>An identifier returned from the previous list on-premises instances call. It can be used to return the next set of on-premises instances in the list.</p>
     #[serde(rename = "nextToken")]
@@ -1394,7 +1394,7 @@ pub struct ListOnPremisesInstancesInput {
 }
 
 /// <p>Represents the output of list on-premises instances operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListOnPremisesInstancesOutput {
     /// <p>The list of matching on-premises instance names.</p>
     #[serde(rename = "instanceNames")]
@@ -1407,7 +1407,7 @@ pub struct ListOnPremisesInstancesOutput {
 }
 
 /// <p>Information about the Elastic Load Balancing load balancer or target group used in a deployment.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct LoadBalancerInfo {
     /// <p>An array containing information about the load balancer to use for load balancing in a deployment. In Elastic Load Balancing, load balancers are used with Classic Load Balancers.</p>
     #[serde(rename = "elbInfoList")]
@@ -1420,7 +1420,7 @@ pub struct LoadBalancerInfo {
 }
 
 /// <p>Information about minimum healthy instance.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct MinimumHealthyHosts {
     /// <p>The minimum healthy instance type:</p> <ul> <li> <p>HOST_COUNT: The minimum number of healthy instance as an absolute value.</p> </li> <li> <p>FLEET_PERCENT: The minimum number of healthy instance as a percentage of the total number of instance in the deployment.</p> </li> </ul> <p>In an example of nine instance, if a HOST_COUNT of six is specified, deploy to up to three instances at a time. The deployment will be successful if six or more instances are deployed to successfully; otherwise, the deployment fails. If a FLEET_PERCENT of 40 is specified, deploy to up to five instance at a time. The deployment will be successful if four or more instance are deployed to successfully; otherwise, the deployment fails.</p> <note> <p>In a call to the get deployment configuration operation, CodeDeployDefault.OneAtATime will return a minimum healthy instance type of MOST_CONCURRENCY and a value of 1. This means a deployment to only one instance at a time. (You cannot set the type to MOST_CONCURRENCY, only to HOST_COUNT or FLEET_PERCENT.) In addition, with CodeDeployDefault.OneAtATime, AWS CodeDeploy will try to ensure that all instances but one are kept in a healthy state during the deployment. Although this allows one instance at a time to be taken offline for a new deployment, it also means that if the deployment to the last instance fails, the overall deployment still succeeds.</p> </note> <p>For more information, see <a href="http://docs.aws.amazon.com/codedeploy/latest/userguide/instances-health.html">AWS CodeDeploy Instance Health</a> in the <i>AWS CodeDeploy User Guide</i>.</p>
     #[serde(rename = "type")]
@@ -1433,7 +1433,7 @@ pub struct MinimumHealthyHosts {
 }
 
 /// <p>Information about groups of on-premises instance tags.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct OnPremisesTagSet {
     /// <p>A list containing other lists of on-premises instance tag groups. In order for an instance to be included in the deployment group, it must be identified by all the tag groups in the list.</p>
     #[serde(rename = "onPremisesTagSetList")]
@@ -1441,7 +1441,7 @@ pub struct OnPremisesTagSet {
     pub on_premises_tag_set_list: Option<Vec<Vec<TagFilter>>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PutLifecycleEventHookExecutionStatusInput {
     /// <p>The ID of the deployment. Pass this ID to a Lambda function that validates a deployment lifecycle event.</p>
     #[serde(rename = "deploymentId")]
@@ -1457,7 +1457,7 @@ pub struct PutLifecycleEventHookExecutionStatusInput {
     pub status: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PutLifecycleEventHookExecutionStatusOutput {
     /// <p>The execution ID of the lifecycle event hook. A hook is specified in the <code>hooks</code> section of the deployment's AppSpec file.</p>
     #[serde(rename = "lifecycleEventHookExecutionId")]
@@ -1466,7 +1466,7 @@ pub struct PutLifecycleEventHookExecutionStatusOutput {
 }
 
 /// <p>A revision for an AWS Lambda deployment that is a YAML-formatted or JSON-formatted string. For AWS Lambda deployments, the revision is the same as the AppSpec file.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RawString {
     /// <p>The YAML-formatted or JSON-formatted revision string. It includes information about which Lambda function to update and optional Lambda functions that validate deployment lifecycle events.</p>
     #[serde(rename = "content")]
@@ -1479,7 +1479,7 @@ pub struct RawString {
 }
 
 /// <p>Represents the input of a RegisterApplicationRevision operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RegisterApplicationRevisionInput {
     /// <p>The name of an AWS CodeDeploy application associated with the applicable IAM user or AWS account.</p>
     #[serde(rename = "applicationName")]
@@ -1494,7 +1494,7 @@ pub struct RegisterApplicationRevisionInput {
 }
 
 /// <p>Represents the input of the register on-premises instance operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RegisterOnPremisesInstanceInput {
     /// <p>The ARN of the IAM session to associate with the on-premises instance.</p>
     #[serde(rename = "iamSessionArn")]
@@ -1510,7 +1510,7 @@ pub struct RegisterOnPremisesInstanceInput {
 }
 
 /// <p>Represents the input of a RemoveTagsFromOnPremisesInstances operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RemoveTagsFromOnPremisesInstancesInput {
     /// <p>The names of the on-premises instances from which to remove tags.</p>
     #[serde(rename = "instanceNames")]
@@ -1521,7 +1521,7 @@ pub struct RemoveTagsFromOnPremisesInstancesInput {
 }
 
 /// <p>Information about an application revision.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RevisionInfo {
     /// <p>Information about an application revision, including usage details and associated deployment groups.</p>
     #[serde(rename = "genericRevisionInfo")]
@@ -1534,7 +1534,7 @@ pub struct RevisionInfo {
 }
 
 /// <p>Information about the location of an application revision.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RevisionLocation {
     /// <p>Information about the location of application artifacts stored in GitHub.</p>
     #[serde(rename = "gitHubLocation")]
@@ -1555,7 +1555,7 @@ pub struct RevisionLocation {
 }
 
 /// <p>Information about a deployment rollback.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RollbackInfo {
     /// <p>The ID of the deployment rollback.</p>
     #[serde(rename = "rollbackDeploymentId")]
@@ -1572,7 +1572,7 @@ pub struct RollbackInfo {
 }
 
 /// <p>Information about the location of application artifacts stored in Amazon S3.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct S3Location {
     /// <p>The name of the Amazon S3 bucket where the application revision is stored.</p>
     #[serde(rename = "bucket")]
@@ -1596,7 +1596,7 @@ pub struct S3Location {
     pub version: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SkipWaitTimeForInstanceTerminationInput {
     /// <p>The ID of the blue/green deployment for which you want to skip the instance termination wait time.</p>
     #[serde(rename = "deploymentId")]
@@ -1605,7 +1605,7 @@ pub struct SkipWaitTimeForInstanceTerminationInput {
 }
 
 /// <p>Represents the input of a StopDeployment operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StopDeploymentInput {
     /// <p>Indicates, when a deployment is stopped, whether instances that have been updated should be rolled back to the previous version of the application revision.</p>
     #[serde(rename = "autoRollbackEnabled")]
@@ -1617,7 +1617,7 @@ pub struct StopDeploymentInput {
 }
 
 /// <p>Represents the output of a StopDeployment operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StopDeploymentOutput {
     /// <p><p>The status of the stop deployment operation:</p> <ul> <li> <p>Pending: The stop operation is pending.</p> </li> <li> <p>Succeeded: The stop operation was successful.</p> </li> </ul></p>
     #[serde(rename = "status")]
@@ -1630,7 +1630,7 @@ pub struct StopDeploymentOutput {
 }
 
 /// <p>Information about a tag.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Tag {
     /// <p>The tag's key.</p>
     #[serde(rename = "Key")]
@@ -1643,7 +1643,7 @@ pub struct Tag {
 }
 
 /// <p>Information about an on-premises instance tag filter.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TagFilter {
     /// <p>The on-premises instance tag filter key.</p>
     #[serde(rename = "Key")]
@@ -1660,7 +1660,7 @@ pub struct TagFilter {
 }
 
 /// <p>Information about a target group in Elastic Load Balancing to use in a deployment. Instances are registered as targets in a target group, and traffic is routed to the target group.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TargetGroupInfo {
     /// <p>For blue/green deployments, the name of the target group that instances in the original environment are deregistered from, and instances in the replacement environment registered with. For in-place deployments, the name of the target group that instances are deregistered from, so they are not serving traffic during a deployment, and then re-registered with after the deployment completes. </p>
     #[serde(rename = "name")]
@@ -1669,7 +1669,7 @@ pub struct TargetGroupInfo {
 }
 
 /// <p>Information about the instances to be used in the replacement environment in a blue/green deployment.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TargetInstances {
     /// <p>The names of one or more Auto Scaling groups to identify a replacement environment for a blue/green deployment.</p>
     #[serde(rename = "autoScalingGroups")]
@@ -1686,7 +1686,7 @@ pub struct TargetInstances {
 }
 
 /// <p>A configuration that shifts traffic from one version of a Lambda function to another in two increments. The original and target Lambda function versions are specified in the deployment's AppSpec file.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TimeBasedCanary {
     /// <p>The number of minutes between the first and second traffic shifts of a <code>TimeBasedCanary</code> deployment.</p>
     #[serde(rename = "canaryInterval")]
@@ -1699,7 +1699,7 @@ pub struct TimeBasedCanary {
 }
 
 /// <p>A configuration that shifts traffic from one version of a Lambda function to another in equal increments, with an equal number of minutes between each increment. The original and target Lambda function versions are specified in the deployment's AppSpec file.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TimeBasedLinear {
     /// <p>The number of minutes between each incremental traffic shift of a <code>TimeBasedLinear</code> deployment.</p>
     #[serde(rename = "linearInterval")]
@@ -1712,7 +1712,7 @@ pub struct TimeBasedLinear {
 }
 
 /// <p>Information about a time range.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct TimeRange {
     /// <p><p>The end time of the time range.</p> <note> <p>Specify null to leave the end time open-ended.</p> </note></p>
     #[serde(rename = "end")]
@@ -1725,7 +1725,7 @@ pub struct TimeRange {
 }
 
 /// <p>The configuration that specifies how traffic is shifted from one version of a Lambda function to another version during an AWS Lambda deployment.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TrafficRoutingConfig {
     /// <p>A configuration that shifts traffic from one version of a Lambda function to another in two increments. The original and target Lambda function versions are specified in the deployment's AppSpec file.</p>
     #[serde(rename = "timeBasedCanary")]
@@ -1742,7 +1742,7 @@ pub struct TrafficRoutingConfig {
 }
 
 /// <p>Information about notification triggers for the deployment group.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TriggerConfig {
     /// <p>The event type or types for which notifications are triggered.</p>
     #[serde(rename = "triggerEvents")]
@@ -1759,7 +1759,7 @@ pub struct TriggerConfig {
 }
 
 /// <p>Represents the input of an UpdateApplication operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateApplicationInput {
     /// <p>The current name of the application you want to change.</p>
     #[serde(rename = "applicationName")]
@@ -1772,7 +1772,7 @@ pub struct UpdateApplicationInput {
 }
 
 /// <p>Represents the input of an UpdateDeploymentGroup operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateDeploymentGroupInput {
     /// <p>Information to add or change about Amazon CloudWatch alarms when the deployment group is updated.</p>
     #[serde(rename = "alarmConfiguration")]
@@ -1839,7 +1839,7 @@ pub struct UpdateDeploymentGroupInput {
 }
 
 /// <p>Represents the output of an UpdateDeploymentGroup operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateDeploymentGroupOutput {
     /// <p>If the output contains no data, and the corresponding deployment group contained at least one Auto Scaling group, AWS CodeDeploy successfully removed all corresponding Auto Scaling lifecycle event hooks from the AWS account. If the output contains data, AWS CodeDeploy could not remove some Auto Scaling lifecycle event hooks from the AWS account.</p>
     #[serde(rename = "hooksNotCleanedUp")]

--- a/rusoto/services/codedeploy/src/generated.rs
+++ b/rusoto/services/codedeploy/src/generated.rs
@@ -1878,7 +1878,8 @@ impl AddTagsToOnPremisesInstancesError {
     pub fn from_body(body: &str) -> AddTagsToOnPremisesInstancesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2002,7 +2003,8 @@ impl BatchGetApplicationRevisionsError {
     pub fn from_body(body: &str) -> BatchGetApplicationRevisionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2120,7 +2122,8 @@ impl BatchGetApplicationsError {
     pub fn from_body(body: &str) -> BatchGetApplicationsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2228,7 +2231,8 @@ impl BatchGetDeploymentGroupsError {
     pub fn from_body(body: &str) -> BatchGetDeploymentGroupsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2350,7 +2354,8 @@ impl BatchGetDeploymentInstancesError {
     pub fn from_body(body: &str) -> BatchGetDeploymentInstancesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2466,7 +2471,8 @@ impl BatchGetDeploymentsError {
     pub fn from_body(body: &str) -> BatchGetDeploymentsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2558,7 +2564,8 @@ impl BatchGetOnPremisesInstancesError {
     pub fn from_body(body: &str) -> BatchGetOnPremisesInstancesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2662,7 +2669,8 @@ impl ContinueDeploymentError {
     pub fn from_body(body: &str) -> ContinueDeploymentError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2776,7 +2784,8 @@ impl CreateApplicationError {
     pub fn from_body(body: &str) -> CreateApplicationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2918,7 +2927,8 @@ impl CreateDeploymentError {
     pub fn from_body(body: &str) -> CreateDeploymentError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3110,7 +3120,8 @@ impl CreateDeploymentConfigError {
     pub fn from_body(body: &str) -> CreateDeploymentConfigError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3280,7 +3291,8 @@ impl CreateDeploymentGroupError {
     pub fn from_body(body: &str) -> CreateDeploymentGroupError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3506,7 +3518,8 @@ impl DeleteApplicationError {
     pub fn from_body(body: &str) -> DeleteApplicationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3596,7 +3609,8 @@ impl DeleteDeploymentConfigError {
     pub fn from_body(body: &str) -> DeleteDeploymentConfigError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3702,7 +3716,8 @@ impl DeleteDeploymentGroupError {
     pub fn from_body(body: &str) -> DeleteDeploymentGroupError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3814,7 +3829,8 @@ impl DeleteGitHubAccountTokenError {
     pub fn from_body(body: &str) -> DeleteGitHubAccountTokenError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3922,7 +3938,8 @@ impl DeregisterOnPremisesInstanceError {
     pub fn from_body(body: &str) -> DeregisterOnPremisesInstanceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4014,7 +4031,8 @@ impl GetApplicationError {
     pub fn from_body(body: &str) -> GetApplicationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4110,7 +4128,8 @@ impl GetApplicationRevisionError {
     pub fn from_body(body: &str) -> GetApplicationRevisionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4222,7 +4241,8 @@ impl GetDeploymentError {
     pub fn from_body(body: &str) -> GetDeploymentError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4312,7 +4332,8 @@ impl GetDeploymentConfigError {
     pub fn from_body(body: &str) -> GetDeploymentConfigError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4416,7 +4437,8 @@ impl GetDeploymentGroupError {
     pub fn from_body(body: &str) -> GetDeploymentGroupError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4536,7 +4558,8 @@ impl GetDeploymentInstanceError {
     pub fn from_body(body: &str) -> GetDeploymentInstanceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4646,7 +4669,8 @@ impl GetOnPremisesInstanceError {
     pub fn from_body(body: &str) -> GetOnPremisesInstanceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4756,7 +4780,8 @@ impl ListApplicationRevisionsError {
     pub fn from_body(body: &str) -> ListApplicationRevisionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4886,7 +4911,8 @@ impl ListApplicationsError {
     pub fn from_body(body: &str) -> ListApplicationsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4964,7 +4990,8 @@ impl ListDeploymentConfigsError {
     pub fn from_body(body: &str) -> ListDeploymentConfigsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5050,7 +5077,8 @@ impl ListDeploymentGroupsError {
     pub fn from_body(body: &str) -> ListDeploymentGroupsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5162,7 +5190,8 @@ impl ListDeploymentInstancesError {
     pub fn from_body(body: &str) -> ListDeploymentInstancesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5300,7 +5329,8 @@ impl ListDeploymentsError {
     pub fn from_body(body: &str) -> ListDeploymentsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5420,7 +5450,8 @@ impl ListGitHubAccountTokenNamesError {
     pub fn from_body(body: &str) -> ListGitHubAccountTokenNamesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5518,7 +5549,8 @@ impl ListOnPremisesInstancesError {
     pub fn from_body(body: &str) -> ListOnPremisesInstancesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5620,7 +5652,8 @@ impl PutLifecycleEventHookExecutionStatusError {
     pub fn from_body(body: &str) -> PutLifecycleEventHookExecutionStatusError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5726,7 +5759,8 @@ impl RegisterApplicationRevisionError {
     pub fn from_body(body: &str) -> RegisterApplicationRevisionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5856,7 +5890,8 @@ impl RegisterOnPremisesInstanceError {
     pub fn from_body(body: &str) -> RegisterOnPremisesInstanceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6002,7 +6037,8 @@ impl RemoveTagsFromOnPremisesInstancesError {
     pub fn from_body(body: &str) -> RemoveTagsFromOnPremisesInstancesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6126,7 +6162,8 @@ impl SkipWaitTimeForInstanceTerminationError {
     pub fn from_body(body: &str) -> SkipWaitTimeForInstanceTerminationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6246,7 +6283,8 @@ impl StopDeploymentError {
     pub fn from_body(body: &str) -> StopDeploymentError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6342,7 +6380,8 @@ impl UpdateApplicationError {
     pub fn from_body(body: &str) -> UpdateApplicationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6486,7 +6525,8 @@ impl UpdateDeploymentGroupError {
     pub fn from_body(body: &str) -> UpdateDeploymentGroupError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/codepipeline/src/generated.rs
+++ b/rusoto/services/codepipeline/src/generated.rs
@@ -1406,7 +1406,8 @@ impl AcknowledgeJobError {
     pub fn from_body(body: &str) -> AcknowledgeJobError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1492,7 +1493,8 @@ impl AcknowledgeThirdPartyJobError {
     pub fn from_body(body: &str) -> AcknowledgeThirdPartyJobError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1582,7 +1584,8 @@ impl CreateCustomActionTypeError {
     pub fn from_body(body: &str) -> CreateCustomActionTypeError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1672,7 +1675,8 @@ impl CreatePipelineError {
     pub fn from_body(body: &str) -> CreatePipelineError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1768,7 +1772,8 @@ impl DeleteCustomActionTypeError {
     pub fn from_body(body: &str) -> DeleteCustomActionTypeError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1842,7 +1847,8 @@ impl DeletePipelineError {
     pub fn from_body(body: &str) -> DeletePipelineError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1918,7 +1924,8 @@ impl DisableStageTransitionError {
     pub fn from_body(body: &str) -> DisableStageTransitionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2004,7 +2011,8 @@ impl EnableStageTransitionError {
     pub fn from_body(body: &str) -> EnableStageTransitionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2088,7 +2096,8 @@ impl GetJobDetailsError {
     pub fn from_body(body: &str) -> GetJobDetailsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2168,7 +2177,8 @@ impl GetPipelineError {
     pub fn from_body(body: &str) -> GetPipelineError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2252,7 +2262,8 @@ impl GetPipelineExecutionError {
     pub fn from_body(body: &str) -> GetPipelineExecutionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2338,7 +2349,8 @@ impl GetPipelineStateError {
     pub fn from_body(body: &str) -> GetPipelineStateError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2420,7 +2432,8 @@ impl GetThirdPartyJobDetailsError {
     pub fn from_body(body: &str) -> GetThirdPartyJobDetailsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2510,7 +2523,8 @@ impl ListActionTypesError {
     pub fn from_body(body: &str) -> ListActionTypesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2590,7 +2604,8 @@ impl ListPipelineExecutionsError {
     pub fn from_body(body: &str) -> ListPipelineExecutionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2674,7 +2689,8 @@ impl ListPipelinesError {
     pub fn from_body(body: &str) -> ListPipelinesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2752,7 +2768,8 @@ impl PollForJobsError {
     pub fn from_body(body: &str) -> PollForJobsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2830,7 +2847,8 @@ impl PollForThirdPartyJobsError {
     pub fn from_body(body: &str) -> PollForThirdPartyJobsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2914,7 +2932,8 @@ impl PutActionRevisionError {
     pub fn from_body(body: &str) -> PutActionRevisionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3010,7 +3029,8 @@ impl PutApprovalResultError {
     pub fn from_body(body: &str) -> PutApprovalResultError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3110,7 +3130,8 @@ impl PutJobFailureResultError {
     pub fn from_body(body: &str) -> PutJobFailureResultError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3196,7 +3217,8 @@ impl PutJobSuccessResultError {
     pub fn from_body(body: &str) -> PutJobSuccessResultError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3284,7 +3306,8 @@ impl PutThirdPartyJobFailureResultError {
     pub fn from_body(body: &str) -> PutThirdPartyJobFailureResultError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3380,7 +3403,8 @@ impl PutThirdPartyJobSuccessResultError {
     pub fn from_body(body: &str) -> PutThirdPartyJobSuccessResultError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3478,7 +3502,8 @@ impl RetryStageExecutionError {
     pub fn from_body(body: &str) -> RetryStageExecutionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3572,7 +3597,8 @@ impl StartPipelineExecutionError {
     pub fn from_body(body: &str) -> StartPipelineExecutionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3658,7 +3684,8 @@ impl UpdatePipelineError {
     pub fn from_body(body: &str) -> UpdatePipelineError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/codepipeline/src/generated.rs
+++ b/rusoto/services/codepipeline/src/generated.rs
@@ -31,7 +31,7 @@ use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 /// <p>Represents an AWS session credentials object. These credentials are temporary credentials that are issued by AWS Secure Token Service (STS). They can be used to access input and output artifacts in the Amazon S3 bucket used to store artifact for the pipeline in AWS CodePipeline.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AWSSessionCredentials {
     /// <p>The access key for the session.</p>
     #[serde(rename = "accessKeyId")]
@@ -45,7 +45,7 @@ pub struct AWSSessionCredentials {
 }
 
 /// <p>Represents the input of an AcknowledgeJob action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AcknowledgeJobInput {
     /// <p>The unique system-generated ID of the job for which you want to confirm receipt.</p>
     #[serde(rename = "jobId")]
@@ -56,7 +56,7 @@ pub struct AcknowledgeJobInput {
 }
 
 /// <p>Represents the output of an AcknowledgeJob action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AcknowledgeJobOutput {
     /// <p>Whether the job worker has received the specified job.</p>
     #[serde(rename = "status")]
@@ -65,7 +65,7 @@ pub struct AcknowledgeJobOutput {
 }
 
 /// <p>Represents the input of an AcknowledgeThirdPartyJob action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AcknowledgeThirdPartyJobInput {
     /// <p>The clientToken portion of the clientId and clientToken pair used to verify that the calling entity is allowed access to the job and its details.</p>
     #[serde(rename = "clientToken")]
@@ -79,7 +79,7 @@ pub struct AcknowledgeThirdPartyJobInput {
 }
 
 /// <p>Represents the output of an AcknowledgeThirdPartyJob action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AcknowledgeThirdPartyJobOutput {
     /// <p>The status information for the third party job, if any.</p>
     #[serde(rename = "status")]
@@ -88,7 +88,7 @@ pub struct AcknowledgeThirdPartyJobOutput {
 }
 
 /// <p>Represents information about an action configuration.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ActionConfiguration {
     /// <p>The configuration data for the action.</p>
     #[serde(rename = "configuration")]
@@ -97,7 +97,7 @@ pub struct ActionConfiguration {
 }
 
 /// <p>Represents information about an action configuration property.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ActionConfigurationProperty {
     /// <p>The description of the action configuration property that will be displayed to users.</p>
     #[serde(rename = "description")]
@@ -126,7 +126,7 @@ pub struct ActionConfigurationProperty {
 }
 
 /// <p>Represents the context of an action within the stage of a pipeline to a job worker.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ActionContext {
     /// <p>The name of the action within the context of a job.</p>
     #[serde(rename = "name")]
@@ -135,7 +135,7 @@ pub struct ActionContext {
 }
 
 /// <p>Represents information about an action declaration.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ActionDeclaration {
     /// <p>The configuration information for the action type.</p>
     #[serde(rename = "actionTypeId")]
@@ -166,7 +166,7 @@ pub struct ActionDeclaration {
 }
 
 /// <p>Represents information about the run of an action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ActionExecution {
     /// <p>The details of an error returned by a URL external to AWS.</p>
     #[serde(rename = "errorDetails")]
@@ -207,7 +207,7 @@ pub struct ActionExecution {
 }
 
 /// <p>Represents information about the version (or revision) of an action.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ActionRevision {
     /// <p>The date and time when the most recent version of the action was created, in timestamp format.</p>
     #[serde(rename = "created")]
@@ -221,7 +221,7 @@ pub struct ActionRevision {
 }
 
 /// <p>Represents information about the state of an action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ActionState {
     /// <p>The name of the action.</p>
     #[serde(rename = "actionName")]
@@ -246,7 +246,7 @@ pub struct ActionState {
 }
 
 /// <p>Returns information about the details of an action type.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ActionType {
     /// <p>The configuration properties for the action type.</p>
     #[serde(rename = "actionConfigurationProperties")]
@@ -268,7 +268,7 @@ pub struct ActionType {
 }
 
 /// <p>Represents information about an action type.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ActionTypeId {
     /// <p>A category defines what kind of action can be taken in the stage, and constrains the provider type for the action. Valid categories are limited to one of the values below.</p>
     #[serde(rename = "category")]
@@ -285,7 +285,7 @@ pub struct ActionTypeId {
 }
 
 /// <p>Returns information about the settings for an action type.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ActionTypeSettings {
     /// <p>The URL returned to the AWS CodePipeline console that provides a deep link to the resources of the external system, such as the configuration page for an AWS CodeDeploy deployment group. This link is provided as part of the action display within the pipeline.</p>
     #[serde(rename = "entityUrlTemplate")]
@@ -306,7 +306,7 @@ pub struct ActionTypeSettings {
 }
 
 /// <p>Represents information about the result of an approval request.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ApprovalResult {
     /// <p>The response submitted by a reviewer assigned to an approval action request.</p>
     #[serde(rename = "status")]
@@ -317,7 +317,7 @@ pub struct ApprovalResult {
 }
 
 /// <p>Represents information about an artifact that will be worked upon by actions in the pipeline.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Artifact {
     /// <p>The location of an artifact.</p>
     #[serde(rename = "location")]
@@ -334,7 +334,7 @@ pub struct Artifact {
 }
 
 /// <p>Returns information about the details of an artifact.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ArtifactDetails {
     /// <p>The maximum number of artifacts allowed for the action type.</p>
     #[serde(rename = "maximumCount")]
@@ -345,7 +345,7 @@ pub struct ArtifactDetails {
 }
 
 /// <p>Represents information about the location of an artifact.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ArtifactLocation {
     /// <p>The Amazon S3 bucket that contains the artifact.</p>
     #[serde(rename = "s3Location")]
@@ -358,7 +358,7 @@ pub struct ArtifactLocation {
 }
 
 /// <p>Represents revision details of an artifact. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ArtifactRevision {
     /// <p>The date and time when the most recent revision of the artifact was created, in timestamp format.</p>
     #[serde(rename = "created")]
@@ -387,7 +387,7 @@ pub struct ArtifactRevision {
 }
 
 /// <p>The Amazon S3 bucket where artifacts are stored for the pipeline.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ArtifactStore {
     /// <p>The encryption key used to encrypt the data in the artifact store, such as an AWS Key Management Service (AWS KMS) key. If this is undefined, the default key for Amazon S3 is used.</p>
     #[serde(rename = "encryptionKey")]
@@ -402,7 +402,7 @@ pub struct ArtifactStore {
 }
 
 /// <p>Reserved for future use.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct BlockerDeclaration {
     /// <p>Reserved for future use.</p>
     #[serde(rename = "name")]
@@ -413,7 +413,7 @@ pub struct BlockerDeclaration {
 }
 
 /// <p>Represents the input of a CreateCustomActionType operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateCustomActionTypeInput {
     /// <p><p>The category of the custom action, such as a build action or a test action.</p> <note> <p>Although Source and Approval are listed as valid values, they are not currently functional. These values are reserved for future use.</p> </note></p>
     #[serde(rename = "category")]
@@ -441,7 +441,7 @@ pub struct CreateCustomActionTypeInput {
 }
 
 /// <p>Represents the output of a CreateCustomActionType operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateCustomActionTypeOutput {
     /// <p>Returns information about the details of an action type.</p>
     #[serde(rename = "actionType")]
@@ -449,7 +449,7 @@ pub struct CreateCustomActionTypeOutput {
 }
 
 /// <p>Represents the input of a CreatePipeline action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreatePipelineInput {
     /// <p>Represents the structure of actions and stages to be performed in the pipeline. </p>
     #[serde(rename = "pipeline")]
@@ -457,7 +457,7 @@ pub struct CreatePipelineInput {
 }
 
 /// <p>Represents the output of a CreatePipeline action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreatePipelineOutput {
     /// <p>Represents the structure of actions and stages to be performed in the pipeline. </p>
     #[serde(rename = "pipeline")]
@@ -466,7 +466,7 @@ pub struct CreatePipelineOutput {
 }
 
 /// <p>Represents information about a current revision.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CurrentRevision {
     /// <p>The change identifier for the current revision.</p>
     #[serde(rename = "changeIdentifier")]
@@ -485,7 +485,7 @@ pub struct CurrentRevision {
 }
 
 /// <p>Represents the input of a DeleteCustomActionType operation. The custom action will be marked as deleted.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteCustomActionTypeInput {
     /// <p>The category of the custom action that you want to delete, such as source or deploy.</p>
     #[serde(rename = "category")]
@@ -499,7 +499,7 @@ pub struct DeleteCustomActionTypeInput {
 }
 
 /// <p>Represents the input of a DeletePipeline action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeletePipelineInput {
     /// <p>The name of the pipeline to be deleted.</p>
     #[serde(rename = "name")]
@@ -507,7 +507,7 @@ pub struct DeletePipelineInput {
 }
 
 /// <p>Represents the input of a DisableStageTransition action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DisableStageTransitionInput {
     /// <p>The name of the pipeline in which you want to disable the flow of artifacts from one stage to another.</p>
     #[serde(rename = "pipelineName")]
@@ -524,7 +524,7 @@ pub struct DisableStageTransitionInput {
 }
 
 /// <p>Represents the input of an EnableStageTransition action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct EnableStageTransitionInput {
     /// <p>The name of the pipeline in which you want to enable the flow of artifacts from one stage to another.</p>
     #[serde(rename = "pipelineName")]
@@ -538,7 +538,7 @@ pub struct EnableStageTransitionInput {
 }
 
 /// <p>Represents information about the key used to encrypt data in the artifact store, such as an AWS Key Management Service (AWS KMS) key.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct EncryptionKey {
     /// <p>The ID used to identify the key. For an AWS KMS key, this is the key ID or key ARN.</p>
     #[serde(rename = "id")]
@@ -549,7 +549,7 @@ pub struct EncryptionKey {
 }
 
 /// <p>Represents information about an error in AWS CodePipeline.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ErrorDetails {
     /// <p>The system ID or error number code of the error.</p>
     #[serde(rename = "code")]
@@ -562,7 +562,7 @@ pub struct ErrorDetails {
 }
 
 /// <p>The details of the actions taken and results produced on an artifact as it passes through stages in the pipeline.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ExecutionDetails {
     /// <p>The system-generated unique ID of this action used to identify this job worker in any external systems, such as AWS CodeDeploy.</p>
     #[serde(rename = "externalExecutionId")]
@@ -579,7 +579,7 @@ pub struct ExecutionDetails {
 }
 
 /// <p>Represents information about failure details.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct FailureDetails {
     /// <p>The external ID of the run of the action that failed.</p>
     #[serde(rename = "externalExecutionId")]
@@ -594,7 +594,7 @@ pub struct FailureDetails {
 }
 
 /// <p>Represents the input of a GetJobDetails action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetJobDetailsInput {
     /// <p>The unique system-generated ID for the job.</p>
     #[serde(rename = "jobId")]
@@ -602,7 +602,7 @@ pub struct GetJobDetailsInput {
 }
 
 /// <p>Represents the output of a GetJobDetails action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetJobDetailsOutput {
     /// <p><p>The details of the job.</p> <note> <p>If AWSSessionCredentials is used, a long-running job can call GetJobDetails again to obtain new credentials.</p> </note></p>
     #[serde(rename = "jobDetails")]
@@ -611,7 +611,7 @@ pub struct GetJobDetailsOutput {
 }
 
 /// <p>Represents the input of a GetPipelineExecution action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetPipelineExecutionInput {
     /// <p>The ID of the pipeline execution about which you want to get execution details.</p>
     #[serde(rename = "pipelineExecutionId")]
@@ -622,7 +622,7 @@ pub struct GetPipelineExecutionInput {
 }
 
 /// <p>Represents the output of a GetPipelineExecution action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetPipelineExecutionOutput {
     /// <p>Represents information about the execution of a pipeline.</p>
     #[serde(rename = "pipelineExecution")]
@@ -631,7 +631,7 @@ pub struct GetPipelineExecutionOutput {
 }
 
 /// <p>Represents the input of a GetPipeline action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetPipelineInput {
     /// <p>The name of the pipeline for which you want to get information. Pipeline names must be unique under an Amazon Web Services (AWS) user account.</p>
     #[serde(rename = "name")]
@@ -643,7 +643,7 @@ pub struct GetPipelineInput {
 }
 
 /// <p>Represents the output of a GetPipeline action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetPipelineOutput {
     /// <p>Represents the pipeline metadata information returned as part of the output of a GetPipeline action.</p>
     #[serde(rename = "metadata")]
@@ -656,7 +656,7 @@ pub struct GetPipelineOutput {
 }
 
 /// <p>Represents the input of a GetPipelineState action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetPipelineStateInput {
     /// <p>The name of the pipeline about which you want to get information.</p>
     #[serde(rename = "name")]
@@ -664,7 +664,7 @@ pub struct GetPipelineStateInput {
 }
 
 /// <p>Represents the output of a GetPipelineState action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetPipelineStateOutput {
     /// <p>The date and time the pipeline was created, in timestamp format.</p>
     #[serde(rename = "created")]
@@ -689,7 +689,7 @@ pub struct GetPipelineStateOutput {
 }
 
 /// <p>Represents the input of a GetThirdPartyJobDetails action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetThirdPartyJobDetailsInput {
     /// <p>The clientToken portion of the clientId and clientToken pair used to verify that the calling entity is allowed access to the job and its details.</p>
     #[serde(rename = "clientToken")]
@@ -700,7 +700,7 @@ pub struct GetThirdPartyJobDetailsInput {
 }
 
 /// <p>Represents the output of a GetThirdPartyJobDetails action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetThirdPartyJobDetailsOutput {
     /// <p>The details of the job, including any protected values defined for the job.</p>
     #[serde(rename = "jobDetails")]
@@ -709,7 +709,7 @@ pub struct GetThirdPartyJobDetailsOutput {
 }
 
 /// <p>Represents information about an artifact to be worked on, such as a test or build artifact.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct InputArtifact {
     /// <p>The name of the artifact to be worked on, for example, "My App".</p> <p>The input artifact of an action must exactly match the output artifact declared in a preceding action, but the input artifact does not have to be the next action in strict sequence from the action that provided the output artifact. Actions in parallel can declare different output artifacts, which are in turn consumed by different following actions.</p>
     #[serde(rename = "name")]
@@ -717,7 +717,7 @@ pub struct InputArtifact {
 }
 
 /// <p>Represents information about a job.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Job {
     /// <p>The ID of the AWS account to use when performing the job.</p>
     #[serde(rename = "accountId")]
@@ -738,7 +738,7 @@ pub struct Job {
 }
 
 /// <p>Represents additional information about a job required for a job worker to complete the job.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct JobData {
     /// <p>Represents information about an action configuration.</p>
     #[serde(rename = "actionConfiguration")]
@@ -775,7 +775,7 @@ pub struct JobData {
 }
 
 /// <p>Represents information about the details of a job.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct JobDetails {
     /// <p>The AWS account ID associated with the job.</p>
     #[serde(rename = "accountId")]
@@ -792,7 +792,7 @@ pub struct JobDetails {
 }
 
 /// <p>Represents the input of a ListActionTypes action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListActionTypesInput {
     /// <p>Filters the list of action types to those created by a specified entity.</p>
     #[serde(rename = "actionOwnerFilter")]
@@ -805,7 +805,7 @@ pub struct ListActionTypesInput {
 }
 
 /// <p>Represents the output of a ListActionTypes action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListActionTypesOutput {
     /// <p>Provides details of the action types.</p>
     #[serde(rename = "actionTypes")]
@@ -817,7 +817,7 @@ pub struct ListActionTypesOutput {
 }
 
 /// <p>Represents the input of a ListPipelineExecutions action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListPipelineExecutionsInput {
     /// <p>The maximum number of results to return in a single call. To retrieve the remaining results, make another call with the returned nextToken value. The available pipeline execution history is limited to the most recent 12 months, based on pipeline execution start times. Default value is 100.</p>
     #[serde(rename = "maxResults")]
@@ -833,7 +833,7 @@ pub struct ListPipelineExecutionsInput {
 }
 
 /// <p>Represents the output of a ListPipelineExecutions action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListPipelineExecutionsOutput {
     /// <p>A token that can be used in the next ListPipelineExecutions call. To view all items in the list, continue to call this operation with each subsequent token until no more nextToken values are returned.</p>
     #[serde(rename = "nextToken")]
@@ -846,7 +846,7 @@ pub struct ListPipelineExecutionsOutput {
 }
 
 /// <p>Represents the input of a ListPipelines action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListPipelinesInput {
     /// <p>An identifier that was returned from the previous list pipelines call, which can be used to return the next set of pipelines in the list.</p>
     #[serde(rename = "nextToken")]
@@ -855,7 +855,7 @@ pub struct ListPipelinesInput {
 }
 
 /// <p>Represents the output of a ListPipelines action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListPipelinesOutput {
     /// <p>If the amount of returned information is significantly large, an identifier is also returned which can be used in a subsequent list pipelines call to return the next set of pipelines in the list.</p>
     #[serde(rename = "nextToken")]
@@ -868,7 +868,7 @@ pub struct ListPipelinesOutput {
 }
 
 /// <p>Represents information about the output of an action.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct OutputArtifact {
     /// <p>The name of the output of an artifact, such as "My App".</p> <p>The input artifact of an action must exactly match the output artifact declared in a preceding action, but the input artifact does not have to be the next action in strict sequence from the action that provided the output artifact. Actions in parallel can declare different output artifacts, which are in turn consumed by different following actions.</p> <p>Output artifact names must be unique within a pipeline.</p>
     #[serde(rename = "name")]
@@ -876,7 +876,7 @@ pub struct OutputArtifact {
 }
 
 /// <p>Represents information about a pipeline to a job worker.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PipelineContext {
     /// <p>The context of an action to a job worker within the stage of a pipeline.</p>
     #[serde(rename = "action")]
@@ -893,7 +893,7 @@ pub struct PipelineContext {
 }
 
 /// <p>Represents the structure of actions and stages to be performed in the pipeline.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct PipelineDeclaration {
     /// <p>Represents information about the Amazon S3 bucket where artifacts are stored for the pipeline. </p>
     #[serde(rename = "artifactStore")]
@@ -914,7 +914,7 @@ pub struct PipelineDeclaration {
 }
 
 /// <p>Represents information about an execution of a pipeline.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PipelineExecution {
     /// <p>A list of ArtifactRevision objects included in a pipeline execution.</p>
     #[serde(rename = "artifactRevisions")]
@@ -939,7 +939,7 @@ pub struct PipelineExecution {
 }
 
 /// <p>Summary information about a pipeline execution.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PipelineExecutionSummary {
     /// <p>The date and time of the last change to the pipeline execution, in timestamp format.</p>
     #[serde(rename = "lastUpdateTime")]
@@ -960,7 +960,7 @@ pub struct PipelineExecutionSummary {
 }
 
 /// <p>Information about a pipeline.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PipelineMetadata {
     /// <p>The date and time the pipeline was created, in timestamp format.</p>
     #[serde(rename = "created")]
@@ -977,7 +977,7 @@ pub struct PipelineMetadata {
 }
 
 /// <p>Returns a summary of a pipeline.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PipelineSummary {
     /// <p>The date and time the pipeline was created, in timestamp format.</p>
     #[serde(rename = "created")]
@@ -998,7 +998,7 @@ pub struct PipelineSummary {
 }
 
 /// <p>Represents the input of a PollForJobs action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PollForJobsInput {
     /// <p>Represents information about an action type.</p>
     #[serde(rename = "actionTypeId")]
@@ -1014,7 +1014,7 @@ pub struct PollForJobsInput {
 }
 
 /// <p>Represents the output of a PollForJobs action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PollForJobsOutput {
     /// <p>Information about the jobs to take action on.</p>
     #[serde(rename = "jobs")]
@@ -1023,7 +1023,7 @@ pub struct PollForJobsOutput {
 }
 
 /// <p>Represents the input of a PollForThirdPartyJobs action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PollForThirdPartyJobsInput {
     /// <p>Represents information about an action type.</p>
     #[serde(rename = "actionTypeId")]
@@ -1035,7 +1035,7 @@ pub struct PollForThirdPartyJobsInput {
 }
 
 /// <p>Represents the output of a PollForThirdPartyJobs action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PollForThirdPartyJobsOutput {
     /// <p>Information about the jobs to take action on.</p>
     #[serde(rename = "jobs")]
@@ -1044,7 +1044,7 @@ pub struct PollForThirdPartyJobsOutput {
 }
 
 /// <p>Represents the input of a PutActionRevision action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PutActionRevisionInput {
     /// <p>The name of the action that will process the revision.</p>
     #[serde(rename = "actionName")]
@@ -1061,7 +1061,7 @@ pub struct PutActionRevisionInput {
 }
 
 /// <p>Represents the output of a PutActionRevision action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PutActionRevisionOutput {
     /// <p>Indicates whether the artifact revision was previously used in an execution of the specified pipeline.</p>
     #[serde(rename = "newRevision")]
@@ -1074,7 +1074,7 @@ pub struct PutActionRevisionOutput {
 }
 
 /// <p>Represents the input of a PutApprovalResult action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PutApprovalResultInput {
     /// <p>The name of the action for which approval is requested.</p>
     #[serde(rename = "actionName")]
@@ -1094,7 +1094,7 @@ pub struct PutApprovalResultInput {
 }
 
 /// <p>Represents the output of a PutApprovalResult action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PutApprovalResultOutput {
     /// <p>The timestamp showing when the approval or rejection was submitted.</p>
     #[serde(rename = "approvedAt")]
@@ -1103,7 +1103,7 @@ pub struct PutApprovalResultOutput {
 }
 
 /// <p>Represents the input of a PutJobFailureResult action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PutJobFailureResultInput {
     /// <p>The details about the failure of a job.</p>
     #[serde(rename = "failureDetails")]
@@ -1114,7 +1114,7 @@ pub struct PutJobFailureResultInput {
 }
 
 /// <p>Represents the input of a PutJobSuccessResult action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PutJobSuccessResultInput {
     /// <p>A token generated by a job worker, such as an AWS CodeDeploy deployment ID, that a successful job provides to identify a custom action in progress. Future jobs will use this token in order to identify the running instance of the action. It can be reused to return additional information about the progress of the custom action. When the action is complete, no continuation token should be supplied.</p>
     #[serde(rename = "continuationToken")]
@@ -1134,7 +1134,7 @@ pub struct PutJobSuccessResultInput {
 }
 
 /// <p>Represents the input of a PutThirdPartyJobFailureResult action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PutThirdPartyJobFailureResultInput {
     /// <p>The clientToken portion of the clientId and clientToken pair used to verify that the calling entity is allowed access to the job and its details.</p>
     #[serde(rename = "clientToken")]
@@ -1148,7 +1148,7 @@ pub struct PutThirdPartyJobFailureResultInput {
 }
 
 /// <p>Represents the input of a PutThirdPartyJobSuccessResult action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PutThirdPartyJobSuccessResultInput {
     /// <p>The clientToken portion of the clientId and clientToken pair used to verify that the calling entity is allowed access to the job and its details.</p>
     #[serde(rename = "clientToken")]
@@ -1171,7 +1171,7 @@ pub struct PutThirdPartyJobSuccessResultInput {
 }
 
 /// <p>Represents the input of a RetryStageExecution action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RetryStageExecutionInput {
     /// <p>The ID of the pipeline execution in the failed stage to be retried. Use the <a>GetPipelineState</a> action to retrieve the current pipelineExecutionId of the failed stage</p>
     #[serde(rename = "pipelineExecutionId")]
@@ -1188,7 +1188,7 @@ pub struct RetryStageExecutionInput {
 }
 
 /// <p>Represents the output of a RetryStageExecution action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RetryStageExecutionOutput {
     /// <p>The ID of the current workflow execution in the failed stage.</p>
     #[serde(rename = "pipelineExecutionId")]
@@ -1197,7 +1197,7 @@ pub struct RetryStageExecutionOutput {
 }
 
 /// <p>The location of the Amazon S3 bucket that contains a revision.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct S3ArtifactLocation {
     /// <p>The name of the Amazon S3 bucket.</p>
     #[serde(rename = "bucketName")]
@@ -1208,7 +1208,7 @@ pub struct S3ArtifactLocation {
 }
 
 /// <p>Represents information about a stage to a job worker.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StageContext {
     /// <p>The name of the stage.</p>
     #[serde(rename = "name")]
@@ -1217,7 +1217,7 @@ pub struct StageContext {
 }
 
 /// <p>Represents information about a stage and its definition.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct StageDeclaration {
     /// <p>The actions included in a stage.</p>
     #[serde(rename = "actions")]
@@ -1232,7 +1232,7 @@ pub struct StageDeclaration {
 }
 
 /// <p>Represents information about the run of a stage.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StageExecution {
     /// <p>The ID of the pipeline execution associated with the stage.</p>
     #[serde(rename = "pipelineExecutionId")]
@@ -1243,7 +1243,7 @@ pub struct StageExecution {
 }
 
 /// <p>Represents information about the state of the stage.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StageState {
     /// <p>The state of the stage.</p>
     #[serde(rename = "actionStates")]
@@ -1264,7 +1264,7 @@ pub struct StageState {
 }
 
 /// <p>Represents the input of a StartPipelineExecution action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StartPipelineExecutionInput {
     /// <p>The name of the pipeline to start.</p>
     #[serde(rename = "name")]
@@ -1272,7 +1272,7 @@ pub struct StartPipelineExecutionInput {
 }
 
 /// <p>Represents the output of a StartPipelineExecution action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StartPipelineExecutionOutput {
     /// <p>The unique system-generated ID of the pipeline execution that was started.</p>
     #[serde(rename = "pipelineExecutionId")]
@@ -1281,7 +1281,7 @@ pub struct StartPipelineExecutionOutput {
 }
 
 /// <p>A response to a PollForThirdPartyJobs request returned by AWS CodePipeline when there is a job to be worked upon by a partner action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ThirdPartyJob {
     /// <p>The clientToken portion of the clientId and clientToken pair used to verify that the calling entity is allowed access to the job and its details.</p>
     #[serde(rename = "clientId")]
@@ -1294,7 +1294,7 @@ pub struct ThirdPartyJob {
 }
 
 /// <p>Represents information about the job data for a partner action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ThirdPartyJobData {
     /// <p>Represents information about an action configuration.</p>
     #[serde(rename = "actionConfiguration")]
@@ -1331,7 +1331,7 @@ pub struct ThirdPartyJobData {
 }
 
 /// <p>The details of a job sent in response to a GetThirdPartyJobDetails request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ThirdPartyJobDetails {
     /// <p>The data to be returned by the third party job worker.</p>
     #[serde(rename = "data")]
@@ -1348,7 +1348,7 @@ pub struct ThirdPartyJobDetails {
 }
 
 /// <p>Represents information about the state of transitions between one stage and another stage.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct TransitionState {
     /// <p>The user-specified reason why the transition between two stages of a pipeline was disabled.</p>
     #[serde(rename = "disabledReason")]
@@ -1369,7 +1369,7 @@ pub struct TransitionState {
 }
 
 /// <p>Represents the input of an UpdatePipeline action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdatePipelineInput {
     /// <p>The name of the pipeline to be updated.</p>
     #[serde(rename = "pipeline")]
@@ -1377,7 +1377,7 @@ pub struct UpdatePipelineInput {
 }
 
 /// <p>Represents the output of an UpdatePipeline action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdatePipelineOutput {
     /// <p>The structure of the updated pipeline.</p>
     #[serde(rename = "pipeline")]

--- a/rusoto/services/codestar/src/generated.rs
+++ b/rusoto/services/codestar/src/generated.rs
@@ -30,7 +30,7 @@ use rusoto_core::signature::SignedRequest;
 use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AssociateTeamMemberRequest {
     /// <p>A user- or system-generated token that identifies the entity that requested the team member association to the project. This token can be used to repeat the request.</p>
     #[serde(rename = "clientRequestToken")]
@@ -51,7 +51,7 @@ pub struct AssociateTeamMemberRequest {
     pub user_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AssociateTeamMemberResult {
     /// <p>The user- or system-generated token from the initial request that can be used to repeat the request.</p>
     #[serde(rename = "clientRequestToken")]
@@ -59,7 +59,7 @@ pub struct AssociateTeamMemberResult {
     pub client_request_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateProjectRequest {
     /// <p>Reserved for future use.</p>
     #[serde(rename = "clientRequestToken")]
@@ -77,7 +77,7 @@ pub struct CreateProjectRequest {
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateProjectResult {
     /// <p>Reserved for future use.</p>
     #[serde(rename = "arn")]
@@ -95,7 +95,7 @@ pub struct CreateProjectResult {
     pub project_template_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateUserProfileRequest {
     /// <p>The name that will be displayed as the friendly name for the user in AWS CodeStar. </p>
     #[serde(rename = "displayName")]
@@ -112,7 +112,7 @@ pub struct CreateUserProfileRequest {
     pub user_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateUserProfileResult {
     /// <p>The date the user profile was created, in timestamp format.</p>
     #[serde(rename = "createdTimestamp")]
@@ -139,7 +139,7 @@ pub struct CreateUserProfileResult {
     pub user_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteProjectRequest {
     /// <p>A user- or system-generated token that identifies the entity that requested project deletion. This token can be used to repeat the request. </p>
     #[serde(rename = "clientRequestToken")]
@@ -154,7 +154,7 @@ pub struct DeleteProjectRequest {
     pub id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteProjectResult {
     /// <p>The Amazon Resource Name (ARN) of the deleted project.</p>
     #[serde(rename = "projectArn")]
@@ -166,28 +166,28 @@ pub struct DeleteProjectResult {
     pub stack_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteUserProfileRequest {
     /// <p>The Amazon Resource Name (ARN) of the user to delete from AWS CodeStar.</p>
     #[serde(rename = "userArn")]
     pub user_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteUserProfileResult {
     /// <p>The Amazon Resource Name (ARN) of the user deleted from AWS CodeStar.</p>
     #[serde(rename = "userArn")]
     pub user_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeProjectRequest {
     /// <p>The ID of the project.</p>
     #[serde(rename = "id")]
     pub id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeProjectResult {
     /// <p>The Amazon Resource Name (ARN) for the project.</p>
     #[serde(rename = "arn")]
@@ -223,14 +223,14 @@ pub struct DescribeProjectResult {
     pub stack_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeUserProfileRequest {
     /// <p>The Amazon Resource Name (ARN) of the user.</p>
     #[serde(rename = "userArn")]
     pub user_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeUserProfileResult {
     /// <p>The date and time when the user profile was created in AWS CodeStar, in timestamp format.</p>
     #[serde(rename = "createdTimestamp")]
@@ -255,7 +255,7 @@ pub struct DescribeUserProfileResult {
     pub user_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DisassociateTeamMemberRequest {
     /// <p>The ID of the AWS CodeStar project from which you want to remove a team member.</p>
     #[serde(rename = "projectId")]
@@ -265,10 +265,10 @@ pub struct DisassociateTeamMemberRequest {
     pub user_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DisassociateTeamMemberResult {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListProjectsRequest {
     /// <p>The maximum amount of data that can be contained in a single set of results.</p>
     #[serde(rename = "maxResults")]
@@ -280,7 +280,7 @@ pub struct ListProjectsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListProjectsResult {
     /// <p>The continuation token to use when requesting the next set of results, if there are more results to be returned.</p>
     #[serde(rename = "nextToken")]
@@ -291,7 +291,7 @@ pub struct ListProjectsResult {
     pub projects: Vec<ProjectSummary>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListResourcesRequest {
     /// <p>The maximum amount of data that can be contained in a single set of results.</p>
     #[serde(rename = "maxResults")]
@@ -306,7 +306,7 @@ pub struct ListResourcesRequest {
     pub project_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListResourcesResult {
     /// <p>The continuation token to use when requesting the next set of results, if there are more results to be returned.</p>
     #[serde(rename = "nextToken")]
@@ -318,7 +318,7 @@ pub struct ListResourcesResult {
     pub resources: Option<Vec<Resource>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListTagsForProjectRequest {
     /// <p>The ID of the project to get tags for.</p>
     #[serde(rename = "id")]
@@ -333,7 +333,7 @@ pub struct ListTagsForProjectRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListTagsForProjectResult {
     /// <p>Reserved for future use.</p>
     #[serde(rename = "nextToken")]
@@ -345,7 +345,7 @@ pub struct ListTagsForProjectResult {
     pub tags: Option<::std::collections::HashMap<String, String>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListTeamMembersRequest {
     /// <p>The maximum number of team members you want returned in a response.</p>
     #[serde(rename = "maxResults")]
@@ -360,7 +360,7 @@ pub struct ListTeamMembersRequest {
     pub project_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListTeamMembersResult {
     /// <p>The continuation token to use when requesting the next set of results, if there are more results to be returned.</p>
     #[serde(rename = "nextToken")]
@@ -371,7 +371,7 @@ pub struct ListTeamMembersResult {
     pub team_members: Vec<TeamMember>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListUserProfilesRequest {
     /// <p>The maximum number of results to return in a response.</p>
     #[serde(rename = "maxResults")]
@@ -383,7 +383,7 @@ pub struct ListUserProfilesRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListUserProfilesResult {
     /// <p>The continuation token to use when requesting the next set of results, if there are more results to be returned.</p>
     #[serde(rename = "nextToken")]
@@ -395,7 +395,7 @@ pub struct ListUserProfilesResult {
 }
 
 /// <p>Information about the metadata for a project.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ProjectSummary {
     /// <p>The Amazon Resource Name (ARN) of the project.</p>
     #[serde(rename = "projectArn")]
@@ -408,14 +408,14 @@ pub struct ProjectSummary {
 }
 
 /// <p>Information about a resource for a project.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Resource {
     /// <p>The Amazon Resource Name (ARN) of the resource.</p>
     #[serde(rename = "id")]
     pub id: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct TagProjectRequest {
     /// <p>The ID of the project you want to add a tag to.</p>
     #[serde(rename = "id")]
@@ -425,7 +425,7 @@ pub struct TagProjectRequest {
     pub tags: ::std::collections::HashMap<String, String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct TagProjectResult {
     /// <p>The tags for the project.</p>
     #[serde(rename = "tags")]
@@ -434,7 +434,7 @@ pub struct TagProjectResult {
 }
 
 /// <p>Information about a team member in a project.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct TeamMember {
     /// <p>The role assigned to the user in the project. Project roles have different levels of access. For more information, see <a href="http://docs.aws.amazon.com/codestar/latest/userguide/working-with-teams.html">Working with Teams</a> in the <i>AWS CodeStar User Guide</i>. </p>
     #[serde(rename = "projectRole")]
@@ -448,7 +448,7 @@ pub struct TeamMember {
     pub user_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UntagProjectRequest {
     /// <p>The ID of the project to remove tags from.</p>
     #[serde(rename = "id")]
@@ -458,10 +458,10 @@ pub struct UntagProjectRequest {
     pub tags: Vec<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UntagProjectResult {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateProjectRequest {
     /// <p>The description of the project, if any.</p>
     #[serde(rename = "description")]
@@ -476,10 +476,10 @@ pub struct UpdateProjectRequest {
     pub name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateProjectResult {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateTeamMemberRequest {
     /// <p>The ID of the project.</p>
     #[serde(rename = "projectId")]
@@ -497,7 +497,7 @@ pub struct UpdateTeamMemberRequest {
     pub user_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateTeamMemberResult {
     /// <p>The project role granted to the user.</p>
     #[serde(rename = "projectRole")]
@@ -513,7 +513,7 @@ pub struct UpdateTeamMemberResult {
     pub user_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateUserProfileRequest {
     /// <p>The name that is displayed as the friendly name for the user in AWS CodeStar.</p>
     #[serde(rename = "displayName")]
@@ -532,7 +532,7 @@ pub struct UpdateUserProfileRequest {
     pub user_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateUserProfileResult {
     /// <p>The date the user profile was created, in timestamp format.</p>
     #[serde(rename = "createdTimestamp")]
@@ -560,7 +560,7 @@ pub struct UpdateUserProfileResult {
 }
 
 /// <p>Information about a user's profile in AWS CodeStar.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UserProfileSummary {
     /// <p>The display name of a user in AWS CodeStar. For example, this could be set to both first and last name ("Mary Major") or a single name ("Mary"). The display name is also used to generate the initial icon associated with the user in AWS CodeStar projects. If spaces are included in the display name, the first character that appears after the space will be used as the second character in the user initial icon. The initial icon displays a maximum of two characters, so a display name with more than one space (for example "Mary Jane Major") would generate an initial icon using the first character and the first character after the space ("MJ", not "MM").</p>
     #[serde(rename = "displayName")]

--- a/rusoto/services/codestar/src/generated.rs
+++ b/rusoto/services/codestar/src/generated.rs
@@ -609,7 +609,8 @@ impl AssociateTeamMemberError {
     pub fn from_body(body: &str) -> AssociateTeamMemberError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -723,7 +724,8 @@ impl CreateProjectError {
     pub fn from_body(body: &str) -> CreateProjectError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -821,7 +823,8 @@ impl CreateUserProfileError {
     pub fn from_body(body: &str) -> CreateUserProfileError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -905,7 +908,8 @@ impl DeleteProjectError {
     pub fn from_body(body: &str) -> DeleteProjectError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -985,7 +989,8 @@ impl DeleteUserProfileError {
     pub fn from_body(body: &str) -> DeleteUserProfileError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1067,7 +1072,8 @@ impl DescribeProjectError {
     pub fn from_body(body: &str) -> DescribeProjectError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1157,7 +1163,8 @@ impl DescribeUserProfileError {
     pub fn from_body(body: &str) -> DescribeUserProfileError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1241,7 +1248,8 @@ impl DisassociateTeamMemberError {
     pub fn from_body(body: &str) -> DisassociateTeamMemberError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1331,7 +1339,8 @@ impl ListProjectsError {
     pub fn from_body(body: &str) -> ListProjectsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1411,7 +1420,8 @@ impl ListResourcesError {
     pub fn from_body(body: &str) -> ListResourcesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1495,7 +1505,8 @@ impl ListTagsForProjectError {
     pub fn from_body(body: &str) -> ListTagsForProjectError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1581,7 +1592,8 @@ impl ListTeamMembersError {
     pub fn from_body(body: &str) -> ListTeamMembersError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1663,7 +1675,8 @@ impl ListUserProfilesError {
     pub fn from_body(body: &str) -> ListUserProfilesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1745,7 +1758,8 @@ impl TagProjectError {
     pub fn from_body(body: &str) -> TagProjectError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1833,7 +1847,8 @@ impl UntagProjectError {
     pub fn from_body(body: &str) -> UntagProjectError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1919,7 +1934,8 @@ impl UpdateProjectError {
     pub fn from_body(body: &str) -> UpdateProjectError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2007,7 +2023,8 @@ impl UpdateTeamMemberError {
     pub fn from_body(body: &str) -> UpdateTeamMemberError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2105,7 +2122,8 @@ impl UpdateUserProfileError {
     pub fn from_body(body: &str) -> UpdateUserProfileError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/cognito-identity/src/generated.rs
+++ b/rusoto/services/cognito-identity/src/generated.rs
@@ -31,7 +31,7 @@ use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 /// <p>A provider representing an Amazon Cognito Identity User Pool and its client ID.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CognitoIdentityProvider {
     /// <p>The client ID for the Amazon Cognito Identity User Pool.</p>
     #[serde(rename = "ClientId")]
@@ -48,7 +48,7 @@ pub struct CognitoIdentityProvider {
 }
 
 /// <p>Input to the CreateIdentityPool action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateIdentityPoolInput {
     /// <p>TRUE if the identity pool supports unauthenticated logins.</p>
     #[serde(rename = "AllowUnauthenticatedIdentities")]
@@ -79,7 +79,7 @@ pub struct CreateIdentityPoolInput {
 }
 
 /// <p>Credentials for the provided identity ID.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Credentials {
     /// <p>The Access Key portion of the credentials.</p>
     #[serde(rename = "AccessKeyId")]
@@ -100,7 +100,7 @@ pub struct Credentials {
 }
 
 /// <p>Input to the <code>DeleteIdentities</code> action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteIdentitiesInput {
     /// <p>A list of 1-60 identities that you want to delete.</p>
     #[serde(rename = "IdentityIdsToDelete")]
@@ -108,7 +108,7 @@ pub struct DeleteIdentitiesInput {
 }
 
 /// <p>Returned in response to a successful <code>DeleteIdentities</code> operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteIdentitiesResponse {
     /// <p>An array of UnprocessedIdentityId objects, each of which contains an ErrorCode and IdentityId.</p>
     #[serde(rename = "UnprocessedIdentityIds")]
@@ -117,7 +117,7 @@ pub struct DeleteIdentitiesResponse {
 }
 
 /// <p>Input to the DeleteIdentityPool action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteIdentityPoolInput {
     /// <p>An identity pool ID in the format REGION:GUID.</p>
     #[serde(rename = "IdentityPoolId")]
@@ -125,7 +125,7 @@ pub struct DeleteIdentityPoolInput {
 }
 
 /// <p>Input to the <code>DescribeIdentity</code> action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeIdentityInput {
     /// <p>A unique identifier in the format REGION:GUID.</p>
     #[serde(rename = "IdentityId")]
@@ -133,7 +133,7 @@ pub struct DescribeIdentityInput {
 }
 
 /// <p>Input to the DescribeIdentityPool action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeIdentityPoolInput {
     /// <p>An identity pool ID in the format REGION:GUID.</p>
     #[serde(rename = "IdentityPoolId")]
@@ -141,7 +141,7 @@ pub struct DescribeIdentityPoolInput {
 }
 
 /// <p>Input to the <code>GetCredentialsForIdentity</code> action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetCredentialsForIdentityInput {
     /// <p>The Amazon Resource Name (ARN) of the role to be assumed when multiple roles were received in the token from the identity provider. For example, a SAML-based identity provider. This parameter is optional for identity providers that do not support role customization.</p>
     #[serde(rename = "CustomRoleArn")]
@@ -157,7 +157,7 @@ pub struct GetCredentialsForIdentityInput {
 }
 
 /// <p>Returned in response to a successful <code>GetCredentialsForIdentity</code> operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetCredentialsForIdentityResponse {
     /// <p>Credentials for the provided identity ID.</p>
     #[serde(rename = "Credentials")]
@@ -170,7 +170,7 @@ pub struct GetCredentialsForIdentityResponse {
 }
 
 /// <p>Input to the GetId action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetIdInput {
     /// <p>A standard AWS account ID (9+ digits).</p>
     #[serde(rename = "AccountId")]
@@ -186,7 +186,7 @@ pub struct GetIdInput {
 }
 
 /// <p>Returned in response to a GetId request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetIdResponse {
     /// <p>A unique identifier in the format REGION:GUID.</p>
     #[serde(rename = "IdentityId")]
@@ -195,7 +195,7 @@ pub struct GetIdResponse {
 }
 
 /// <p>Input to the <code>GetIdentityPoolRoles</code> action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetIdentityPoolRolesInput {
     /// <p>An identity pool ID in the format REGION:GUID.</p>
     #[serde(rename = "IdentityPoolId")]
@@ -203,7 +203,7 @@ pub struct GetIdentityPoolRolesInput {
 }
 
 /// <p>Returned in response to a successful <code>GetIdentityPoolRoles</code> operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetIdentityPoolRolesResponse {
     /// <p>An identity pool ID in the format REGION:GUID.</p>
     #[serde(rename = "IdentityPoolId")]
@@ -220,7 +220,7 @@ pub struct GetIdentityPoolRolesResponse {
 }
 
 /// <p>Input to the <code>GetOpenIdTokenForDeveloperIdentity</code> action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetOpenIdTokenForDeveloperIdentityInput {
     /// <p>A unique identifier in the format REGION:GUID.</p>
     #[serde(rename = "IdentityId")]
@@ -239,7 +239,7 @@ pub struct GetOpenIdTokenForDeveloperIdentityInput {
 }
 
 /// <p>Returned in response to a successful <code>GetOpenIdTokenForDeveloperIdentity</code> request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetOpenIdTokenForDeveloperIdentityResponse {
     /// <p>A unique identifier in the format REGION:GUID.</p>
     #[serde(rename = "IdentityId")]
@@ -252,7 +252,7 @@ pub struct GetOpenIdTokenForDeveloperIdentityResponse {
 }
 
 /// <p>Input to the GetOpenIdToken action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetOpenIdTokenInput {
     /// <p>A unique identifier in the format REGION:GUID.</p>
     #[serde(rename = "IdentityId")]
@@ -264,7 +264,7 @@ pub struct GetOpenIdTokenInput {
 }
 
 /// <p>Returned in response to a successful GetOpenIdToken request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetOpenIdTokenResponse {
     /// <p>A unique identifier in the format REGION:GUID. Note that the IdentityId returned may not match the one passed on input.</p>
     #[serde(rename = "IdentityId")]
@@ -277,7 +277,7 @@ pub struct GetOpenIdTokenResponse {
 }
 
 /// <p>A description of the identity.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct IdentityDescription {
     /// <p>Date on which the identity was created.</p>
     #[serde(rename = "CreationDate")]
@@ -298,7 +298,7 @@ pub struct IdentityDescription {
 }
 
 /// <p>An object representing an Amazon Cognito identity pool.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct IdentityPool {
     /// <p>TRUE if the identity pool supports unauthenticated logins.</p>
     #[serde(rename = "AllowUnauthenticatedIdentities")]
@@ -332,7 +332,7 @@ pub struct IdentityPool {
 }
 
 /// <p>A description of the identity pool.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct IdentityPoolShortDescription {
     /// <p>An identity pool ID in the format REGION:GUID.</p>
     #[serde(rename = "IdentityPoolId")]
@@ -345,7 +345,7 @@ pub struct IdentityPoolShortDescription {
 }
 
 /// <p>Input to the ListIdentities action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListIdentitiesInput {
     /// <p>An optional boolean parameter that allows you to hide disabled identities. If omitted, the ListIdentities API will include disabled identities in the response.</p>
     #[serde(rename = "HideDisabled")]
@@ -364,7 +364,7 @@ pub struct ListIdentitiesInput {
 }
 
 /// <p>The response to a ListIdentities request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListIdentitiesResponse {
     /// <p>An object containing a set of identities and associated mappings.</p>
     #[serde(rename = "Identities")]
@@ -381,7 +381,7 @@ pub struct ListIdentitiesResponse {
 }
 
 /// <p>Input to the ListIdentityPools action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListIdentityPoolsInput {
     /// <p>The maximum number of identities to return.</p>
     #[serde(rename = "MaxResults")]
@@ -393,7 +393,7 @@ pub struct ListIdentityPoolsInput {
 }
 
 /// <p>The result of a successful ListIdentityPools action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListIdentityPoolsResponse {
     /// <p>The identity pools returned by the ListIdentityPools action.</p>
     #[serde(rename = "IdentityPools")]
@@ -406,7 +406,7 @@ pub struct ListIdentityPoolsResponse {
 }
 
 /// <p>Input to the <code>LookupDeveloperIdentityInput</code> action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct LookupDeveloperIdentityInput {
     /// <p>A unique ID used by your backend authentication process to identify a user. Typically, a developer identity provider would issue many developer user identifiers, in keeping with the number of users.</p>
     #[serde(rename = "DeveloperUserIdentifier")]
@@ -430,7 +430,7 @@ pub struct LookupDeveloperIdentityInput {
 }
 
 /// <p>Returned in response to a successful <code>LookupDeveloperIdentity</code> action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct LookupDeveloperIdentityResponse {
     /// <p>This is the list of developer user identifiers associated with an identity ID. Cognito supports the association of multiple developer user identifiers with an identity ID.</p>
     #[serde(rename = "DeveloperUserIdentifierList")]
@@ -447,7 +447,7 @@ pub struct LookupDeveloperIdentityResponse {
 }
 
 /// <p>A rule that maps a claim name, a claim value, and a match type to a role ARN.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct MappingRule {
     /// <p>The claim name that must be present in the token, for example, "isAdmin" or "paid".</p>
     #[serde(rename = "Claim")]
@@ -464,7 +464,7 @@ pub struct MappingRule {
 }
 
 /// <p>Input to the <code>MergeDeveloperIdentities</code> action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct MergeDeveloperIdentitiesInput {
     /// <p>User identifier for the destination user. The value should be a <code>DeveloperUserIdentifier</code>.</p>
     #[serde(rename = "DestinationUserIdentifier")]
@@ -481,7 +481,7 @@ pub struct MergeDeveloperIdentitiesInput {
 }
 
 /// <p>Returned in response to a successful <code>MergeDeveloperIdentities</code> action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct MergeDeveloperIdentitiesResponse {
     /// <p>A unique identifier in the format REGION:GUID.</p>
     #[serde(rename = "IdentityId")]
@@ -490,7 +490,7 @@ pub struct MergeDeveloperIdentitiesResponse {
 }
 
 /// <p>A role mapping.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RoleMapping {
     /// <p>If you specify Token or Rules as the <code>Type</code>, <code>AmbiguousRoleResolution</code> is required.</p> <p>Specifies the action to be taken if either no rules match the claim value for the <code>Rules</code> type, or there is no <code>cognito:preferred_role</code> claim and there are multiple <code>cognito:roles</code> matches for the <code>Token</code> type.</p>
     #[serde(rename = "AmbiguousRoleResolution")]
@@ -506,7 +506,7 @@ pub struct RoleMapping {
 }
 
 /// <p>A container for rules.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RulesConfigurationType {
     /// <p>An array of rules. You can specify up to 25 rules per identity provider.</p> <p>Rules are evaluated in order. The first one to match specifies the role.</p>
     #[serde(rename = "Rules")]
@@ -514,7 +514,7 @@ pub struct RulesConfigurationType {
 }
 
 /// <p>Input to the <code>SetIdentityPoolRoles</code> action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SetIdentityPoolRolesInput {
     /// <p>An identity pool ID in the format REGION:GUID.</p>
     #[serde(rename = "IdentityPoolId")]
@@ -529,7 +529,7 @@ pub struct SetIdentityPoolRolesInput {
 }
 
 /// <p>Input to the <code>UnlinkDeveloperIdentity</code> action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UnlinkDeveloperIdentityInput {
     /// <p>The "domain" by which Cognito will refer to your users.</p>
     #[serde(rename = "DeveloperProviderName")]
@@ -546,7 +546,7 @@ pub struct UnlinkDeveloperIdentityInput {
 }
 
 /// <p>Input to the UnlinkIdentity action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UnlinkIdentityInput {
     /// <p>A unique identifier in the format REGION:GUID.</p>
     #[serde(rename = "IdentityId")]
@@ -560,7 +560,7 @@ pub struct UnlinkIdentityInput {
 }
 
 /// <p>An array of UnprocessedIdentityId objects, each of which contains an ErrorCode and IdentityId.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UnprocessedIdentityId {
     /// <p>The error code indicating the type of error that occurred.</p>
     #[serde(rename = "ErrorCode")]

--- a/rusoto/services/cognito-identity/src/generated.rs
+++ b/rusoto/services/cognito-identity/src/generated.rs
@@ -601,7 +601,8 @@ impl CreateIdentityPoolError {
     pub fn from_body(body: &str) -> CreateIdentityPoolError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -705,7 +706,8 @@ impl DeleteIdentitiesError {
     pub fn from_body(body: &str) -> DeleteIdentitiesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -799,7 +801,8 @@ impl DeleteIdentityPoolError {
     pub fn from_body(body: &str) -> DeleteIdentityPoolError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -903,7 +906,8 @@ impl DescribeIdentityError {
     pub fn from_body(body: &str) -> DescribeIdentityError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1005,7 +1009,8 @@ impl DescribeIdentityPoolError {
     pub fn from_body(body: &str) -> DescribeIdentityPoolError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1115,7 +1120,8 @@ impl GetCredentialsForIdentityError {
     pub fn from_body(body: &str) -> GetCredentialsForIdentityError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1245,7 +1251,8 @@ impl GetIdError {
     pub fn from_body(body: &str) -> GetIdError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1359,7 +1366,8 @@ impl GetIdentityPoolRolesError {
     pub fn from_body(body: &str) -> GetIdentityPoolRolesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1471,7 +1479,8 @@ impl GetOpenIdTokenError {
     pub fn from_body(body: &str) -> GetOpenIdTokenError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1585,7 +1594,8 @@ impl GetOpenIdTokenForDeveloperIdentityError {
     pub fn from_body(body: &str) -> GetOpenIdTokenForDeveloperIdentityError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1713,7 +1723,8 @@ impl ListIdentitiesError {
     pub fn from_body(body: &str) -> ListIdentitiesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1813,7 +1824,8 @@ impl ListIdentityPoolsError {
     pub fn from_body(body: &str) -> ListIdentityPoolsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1915,7 +1927,8 @@ impl LookupDeveloperIdentityError {
     pub fn from_body(body: &str) -> LookupDeveloperIdentityError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2025,7 +2038,8 @@ impl MergeDeveloperIdentitiesError {
     pub fn from_body(body: &str) -> MergeDeveloperIdentitiesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2137,7 +2151,8 @@ impl SetIdentityPoolRolesError {
     pub fn from_body(body: &str) -> SetIdentityPoolRolesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2253,7 +2268,8 @@ impl UnlinkDeveloperIdentityError {
     pub fn from_body(body: &str) -> UnlinkDeveloperIdentityError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2365,7 +2381,8 @@ impl UnlinkIdentityError {
     pub fn from_body(body: &str) -> UnlinkIdentityError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2481,7 +2498,8 @@ impl UpdateIdentityPoolError {
     pub fn from_body(body: &str) -> UpdateIdentityPoolError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/cognito-idp/src/generated.rs
+++ b/rusoto/services/cognito-idp/src/generated.rs
@@ -31,7 +31,7 @@ use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 /// <p>Account takeover action type.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct AccountTakeoverActionType {
     /// <p><p>The event action.</p> <ul> <li> <p> <code>BLOCK</code> Choosing this action will block the request.</p> </li> <li> <p> <code>MFA<em>IF</em>CONFIGURED</code> Throw MFA challenge if user has configured it, else allow the request.</p> </li> <li> <p> <code>MFA<em>REQUIRED</code> Throw MFA challenge if user has configured it, else block the request.</p> </li> <li> <p> <code>NO</em>ACTION</code> Allow the user sign-in.</p> </li> </ul></p>
     #[serde(rename = "EventAction")]
@@ -42,7 +42,7 @@ pub struct AccountTakeoverActionType {
 }
 
 /// <p>Account takeover actions type.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct AccountTakeoverActionsType {
     /// <p>Action to take for a high risk.</p>
     #[serde(rename = "HighAction")]
@@ -59,7 +59,7 @@ pub struct AccountTakeoverActionsType {
 }
 
 /// <p>Configuration for mitigation actions and notification for different levels of risk detected for a potential account takeover.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct AccountTakeoverRiskConfigurationType {
     /// <p>Account takeover risk configuration actions</p>
     #[serde(rename = "Actions")]
@@ -71,7 +71,7 @@ pub struct AccountTakeoverRiskConfigurationType {
 }
 
 /// <p>Represents the request to add custom attributes.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AddCustomAttributesRequest {
     /// <p>An array of custom attributes, such as Mutable and Name.</p>
     #[serde(rename = "CustomAttributes")]
@@ -82,10 +82,10 @@ pub struct AddCustomAttributesRequest {
 }
 
 /// <p>Represents the response from the server for the request to add custom attributes.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AddCustomAttributesResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AdminAddUserToGroupRequest {
     /// <p>The group name.</p>
     #[serde(rename = "GroupName")]
@@ -99,7 +99,7 @@ pub struct AdminAddUserToGroupRequest {
 }
 
 /// <p>Represents the request to confirm user registration.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AdminConfirmSignUpRequest {
     /// <p>The user pool ID for which you want to confirm user registration.</p>
     #[serde(rename = "UserPoolId")]
@@ -110,11 +110,11 @@ pub struct AdminConfirmSignUpRequest {
 }
 
 /// <p>Represents the response from the server for the request to confirm registration.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AdminConfirmSignUpResponse {}
 
 /// <p>The configuration for creating a new user profile.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct AdminCreateUserConfigType {
     /// <p>Set to <code>True</code> if only the administrator is allowed to create user profiles. Set to <code>False</code> if users can sign themselves up via an app.</p>
     #[serde(rename = "AllowAdminCreateUserOnly")]
@@ -131,7 +131,7 @@ pub struct AdminCreateUserConfigType {
 }
 
 /// <p>Represents the request to create a user in the specified user pool.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AdminCreateUserRequest {
     /// <p>Specify <code>"EMAIL"</code> if email will be used to send the welcome message. Specify <code>"SMS"</code> if the phone number will be used. The default value is <code>"SMS"</code>. More than one value can be specified.</p>
     #[serde(rename = "DesiredDeliveryMediums")]
@@ -166,7 +166,7 @@ pub struct AdminCreateUserRequest {
 }
 
 /// <p>Represents the response from the server to the request to create the user.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AdminCreateUserResponse {
     /// <p>The newly created user.</p>
     #[serde(rename = "User")]
@@ -175,7 +175,7 @@ pub struct AdminCreateUserResponse {
 }
 
 /// <p>Represents the request to delete user attributes as an administrator.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AdminDeleteUserAttributesRequest {
     /// <p>An array of strings representing the user attribute names you wish to delete.</p> <p>For custom attributes, you must prepend the <code>custom:</code> prefix to the attribute name.</p>
     #[serde(rename = "UserAttributeNames")]
@@ -189,11 +189,11 @@ pub struct AdminDeleteUserAttributesRequest {
 }
 
 /// <p>Represents the response received from the server for a request to delete user attributes.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AdminDeleteUserAttributesResponse {}
 
 /// <p>Represents the request to delete a user as an administrator.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AdminDeleteUserRequest {
     /// <p>The user pool ID for the user pool where you want to delete the user.</p>
     #[serde(rename = "UserPoolId")]
@@ -203,7 +203,7 @@ pub struct AdminDeleteUserRequest {
     pub username: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AdminDisableProviderForUserRequest {
     /// <p>The user to be disabled.</p>
     #[serde(rename = "User")]
@@ -213,11 +213,11 @@ pub struct AdminDisableProviderForUserRequest {
     pub user_pool_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AdminDisableProviderForUserResponse {}
 
 /// <p>Represents the request to disable any user as an administrator.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AdminDisableUserRequest {
     /// <p>The user pool ID for the user pool where you want to disable the user.</p>
     #[serde(rename = "UserPoolId")]
@@ -228,11 +228,11 @@ pub struct AdminDisableUserRequest {
 }
 
 /// <p>Represents the response received from the server to disable the user as an administrator.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AdminDisableUserResponse {}
 
 /// <p>Represents the request that enables the user as an administrator.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AdminEnableUserRequest {
     /// <p>The user pool ID for the user pool where you want to enable the user.</p>
     #[serde(rename = "UserPoolId")]
@@ -243,11 +243,11 @@ pub struct AdminEnableUserRequest {
 }
 
 /// <p>Represents the response from the server for the request to enable a user as an administrator.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AdminEnableUserResponse {}
 
 /// <p>Sends the forgot device request, as an administrator.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AdminForgetDeviceRequest {
     /// <p>The device key.</p>
     #[serde(rename = "DeviceKey")]
@@ -261,7 +261,7 @@ pub struct AdminForgetDeviceRequest {
 }
 
 /// <p>Represents the request to get the device, as an administrator.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AdminGetDeviceRequest {
     /// <p>The device key.</p>
     #[serde(rename = "DeviceKey")]
@@ -275,7 +275,7 @@ pub struct AdminGetDeviceRequest {
 }
 
 /// <p>Gets the device response, as an administrator.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AdminGetDeviceResponse {
     /// <p>The device.</p>
     #[serde(rename = "Device")]
@@ -283,7 +283,7 @@ pub struct AdminGetDeviceResponse {
 }
 
 /// <p>Represents the request to get the specified user as an administrator.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AdminGetUserRequest {
     /// <p>The user pool ID for the user pool where you want to get information about the user.</p>
     #[serde(rename = "UserPoolId")]
@@ -294,7 +294,7 @@ pub struct AdminGetUserRequest {
 }
 
 /// <p>Represents the response from the server from the request to get the specified user as an administrator.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AdminGetUserResponse {
     /// <p>Indicates that the status is enabled.</p>
     #[serde(rename = "Enabled")]
@@ -334,7 +334,7 @@ pub struct AdminGetUserResponse {
 }
 
 /// <p>Initiates the authorization request, as an administrator.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AdminInitiateAuthRequest {
     /// <p>The analytics metadata for collecting Amazon Pinpoint metrics for <code>AdminInitiateAuth</code> calls.</p>
     #[serde(rename = "AnalyticsMetadata")]
@@ -364,7 +364,7 @@ pub struct AdminInitiateAuthRequest {
 }
 
 /// <p>Initiates the authentication response, as an administrator.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AdminInitiateAuthResponse {
     /// <p>The result of the authentication response. This is only returned if the caller does not need to pass another challenge. If the caller does need to pass another challenge before it gets tokens, <code>ChallengeName</code>, <code>ChallengeParameters</code>, and <code>Session</code> are returned.</p>
     #[serde(rename = "AuthenticationResult")]
@@ -384,7 +384,7 @@ pub struct AdminInitiateAuthResponse {
     pub session: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AdminLinkProviderForUserRequest {
     /// <p>The existing user in the user pool to be linked to the external identity provider user account. Can be a native (Username + Password) Cognito User Pools user or a federated user (for example, a SAML or Facebook user). If the user doesn't exist, an exception is thrown. This is the user that is returned when the new user (with the linked identity provider attribute) signs in.</p> <p>For a native username + password user, the <code>ProviderAttributeValue</code> for the <code>DestinationUser</code> should be the username in the user pool. For a federated user, it should be the provider-specific <code>user_id</code>.</p> <p>The <code>ProviderAttributeName</code> of the <code>DestinationUser</code> is ignored.</p> <p>The <code>ProviderName</code> should be set to <code>Cognito</code> for users in Cognito user pools.</p>
     #[serde(rename = "DestinationUser")]
@@ -397,11 +397,11 @@ pub struct AdminLinkProviderForUserRequest {
     pub user_pool_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AdminLinkProviderForUserResponse {}
 
 /// <p>Represents the request to list devices, as an administrator.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AdminListDevicesRequest {
     /// <p>The limit of the devices request.</p>
     #[serde(rename = "Limit")]
@@ -420,7 +420,7 @@ pub struct AdminListDevicesRequest {
 }
 
 /// <p>Lists the device's response, as an administrator.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AdminListDevicesResponse {
     /// <p>The devices in the list of devices response.</p>
     #[serde(rename = "Devices")]
@@ -432,7 +432,7 @@ pub struct AdminListDevicesResponse {
     pub pagination_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AdminListGroupsForUserRequest {
     /// <p>The limit of the request to list groups.</p>
     #[serde(rename = "Limit")]
@@ -450,7 +450,7 @@ pub struct AdminListGroupsForUserRequest {
     pub username: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AdminListGroupsForUserResponse {
     /// <p>The groups that the user belongs to.</p>
     #[serde(rename = "Groups")]
@@ -462,7 +462,7 @@ pub struct AdminListGroupsForUserResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AdminListUserAuthEventsRequest {
     /// <p>The maximum number of authentication events to return.</p>
     #[serde(rename = "MaxResults")]
@@ -480,7 +480,7 @@ pub struct AdminListUserAuthEventsRequest {
     pub username: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AdminListUserAuthEventsResponse {
     /// <p>The response object. It includes the <code>EventID</code>, <code>EventType</code>, <code>CreationDate</code>, <code>EventRisk</code>, and <code>EventResponse</code>.</p>
     #[serde(rename = "AuthEvents")]
@@ -492,7 +492,7 @@ pub struct AdminListUserAuthEventsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AdminRemoveUserFromGroupRequest {
     /// <p>The group name.</p>
     #[serde(rename = "GroupName")]
@@ -506,7 +506,7 @@ pub struct AdminRemoveUserFromGroupRequest {
 }
 
 /// <p>Represents the request to reset a user's password as an administrator.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AdminResetUserPasswordRequest {
     /// <p>The user pool ID for the user pool where you want to reset the user's password.</p>
     #[serde(rename = "UserPoolId")]
@@ -517,11 +517,11 @@ pub struct AdminResetUserPasswordRequest {
 }
 
 /// <p>Represents the response from the server to reset a user password as an administrator.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AdminResetUserPasswordResponse {}
 
 /// <p>The request to respond to the authentication challenge, as an administrator.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AdminRespondToAuthChallengeRequest {
     /// <p>The analytics metadata for collecting Amazon Pinpoint metrics for <code>AdminRespondToAuthChallenge</code> calls.</p>
     #[serde(rename = "AnalyticsMetadata")]
@@ -551,7 +551,7 @@ pub struct AdminRespondToAuthChallengeRequest {
 }
 
 /// <p>Responds to the authentication challenge, as an administrator.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AdminRespondToAuthChallengeResponse {
     /// <p>The result returned by the server in response to the authentication request.</p>
     #[serde(rename = "AuthenticationResult")]
@@ -571,7 +571,7 @@ pub struct AdminRespondToAuthChallengeResponse {
     pub session: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AdminSetUserMFAPreferenceRequest {
     /// <p>The SMS text message MFA settings.</p>
     #[serde(rename = "SMSMfaSettings")]
@@ -589,11 +589,11 @@ pub struct AdminSetUserMFAPreferenceRequest {
     pub username: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AdminSetUserMFAPreferenceResponse {}
 
 /// <p>Represents the request to set user settings as an administrator.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AdminSetUserSettingsRequest {
     /// <p>Specifies the options for MFA (e.g., email or phone number).</p>
     #[serde(rename = "MFAOptions")]
@@ -607,10 +607,10 @@ pub struct AdminSetUserSettingsRequest {
 }
 
 /// <p>Represents the response from the server to set user settings as an administrator.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AdminSetUserSettingsResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AdminUpdateAuthEventFeedbackRequest {
     /// <p>The authentication event ID.</p>
     #[serde(rename = "EventId")]
@@ -626,11 +626,11 @@ pub struct AdminUpdateAuthEventFeedbackRequest {
     pub username: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AdminUpdateAuthEventFeedbackResponse {}
 
 /// <p>The request to update the device status, as an administrator.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AdminUpdateDeviceStatusRequest {
     /// <p>The device key.</p>
     #[serde(rename = "DeviceKey")]
@@ -648,11 +648,11 @@ pub struct AdminUpdateDeviceStatusRequest {
 }
 
 /// <p>The status response from the request to update the device, as an administrator.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AdminUpdateDeviceStatusResponse {}
 
 /// <p>Represents the request to update the user's attributes as an administrator.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AdminUpdateUserAttributesRequest {
     /// <p>An array of name-value pairs representing user attributes.</p> <p>For custom attributes, you must prepend the <code>custom:</code> prefix to the attribute name.</p>
     #[serde(rename = "UserAttributes")]
@@ -666,11 +666,11 @@ pub struct AdminUpdateUserAttributesRequest {
 }
 
 /// <p>Represents the response from the server for the request to update user attributes as an administrator.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AdminUpdateUserAttributesResponse {}
 
 /// <p>The request to sign out of all devices, as an administrator.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AdminUserGlobalSignOutRequest {
     /// <p>The user pool ID.</p>
     #[serde(rename = "UserPoolId")]
@@ -681,11 +681,11 @@ pub struct AdminUserGlobalSignOutRequest {
 }
 
 /// <p>The global sign-out response, as an administrator.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AdminUserGlobalSignOutResponse {}
 
 /// <p>The Amazon Pinpoint analytics configuration for collecting metrics for a user pool.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct AnalyticsConfigurationType {
     /// <p>The application ID for an Amazon Pinpoint application.</p>
     #[serde(rename = "ApplicationId")]
@@ -703,7 +703,7 @@ pub struct AnalyticsConfigurationType {
 }
 
 /// <p>An Amazon Pinpoint analytics endpoint.</p> <p>An endpoint uniquely identifies a mobile device, email address, or phone number that can receive messages from Amazon Pinpoint analytics.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AnalyticsMetadataType {
     /// <p>The endpoint ID.</p>
     #[serde(rename = "AnalyticsEndpointId")]
@@ -711,7 +711,7 @@ pub struct AnalyticsMetadataType {
     pub analytics_endpoint_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AssociateSoftwareTokenRequest {
     /// <p>The access token.</p>
     #[serde(rename = "AccessToken")]
@@ -723,7 +723,7 @@ pub struct AssociateSoftwareTokenRequest {
     pub session: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AssociateSoftwareTokenResponse {
     /// <p>A unique generated shared secret code that is used in the TOTP algorithm to generate a one time code.</p>
     #[serde(rename = "SecretCode")]
@@ -736,7 +736,7 @@ pub struct AssociateSoftwareTokenResponse {
 }
 
 /// <p>Specifies whether the attribute is standard or custom.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct AttributeType {
     /// <p>The name of the attribute.</p>
     #[serde(rename = "Name")]
@@ -748,7 +748,7 @@ pub struct AttributeType {
 }
 
 /// <p>The authentication event type.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AuthEventType {
     /// <p>The challenge responses.</p>
     #[serde(rename = "ChallengeResponses")]
@@ -785,7 +785,7 @@ pub struct AuthEventType {
 }
 
 /// <p>The authentication result.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AuthenticationResultType {
     /// <p>The access token.</p>
     #[serde(rename = "AccessToken")]
@@ -814,7 +814,7 @@ pub struct AuthenticationResultType {
 }
 
 /// <p>The challenge response type.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ChallengeResponseType {
     /// <p>The challenge name</p>
     #[serde(rename = "ChallengeName")]
@@ -827,7 +827,7 @@ pub struct ChallengeResponseType {
 }
 
 /// <p>Represents the request to change a user password.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ChangePasswordRequest {
     /// <p>The access token.</p>
     #[serde(rename = "AccessToken")]
@@ -841,11 +841,11 @@ pub struct ChangePasswordRequest {
 }
 
 /// <p>The response from the server to the change password request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ChangePasswordResponse {}
 
 /// <p>The code delivery details being returned from the server.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CodeDeliveryDetailsType {
     /// <p>The attribute name.</p>
     #[serde(rename = "AttributeName")]
@@ -862,7 +862,7 @@ pub struct CodeDeliveryDetailsType {
 }
 
 /// <p>The compromised credentials actions type</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CompromisedCredentialsActionsType {
     /// <p>The event action.</p>
     #[serde(rename = "EventAction")]
@@ -870,7 +870,7 @@ pub struct CompromisedCredentialsActionsType {
 }
 
 /// <p>The compromised credentials risk configuration type.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CompromisedCredentialsRiskConfigurationType {
     /// <p>The compromised credentials risk configuration actions.</p>
     #[serde(rename = "Actions")]
@@ -882,7 +882,7 @@ pub struct CompromisedCredentialsRiskConfigurationType {
 }
 
 /// <p>Confirms the device request.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ConfirmDeviceRequest {
     /// <p>The access token.</p>
     #[serde(rename = "AccessToken")]
@@ -901,7 +901,7 @@ pub struct ConfirmDeviceRequest {
 }
 
 /// <p>Confirms the device response.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ConfirmDeviceResponse {
     /// <p>Indicates whether the user confirmation is necessary to confirm the device response.</p>
     #[serde(rename = "UserConfirmationNecessary")]
@@ -910,7 +910,7 @@ pub struct ConfirmDeviceResponse {
 }
 
 /// <p>The request representing the confirmation for a password reset.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ConfirmForgotPasswordRequest {
     /// <p>The Amazon Pinpoint analytics metadata for collecting metrics for <code>ConfirmForgotPassword</code> calls.</p>
     #[serde(rename = "AnalyticsMetadata")]
@@ -939,11 +939,11 @@ pub struct ConfirmForgotPasswordRequest {
 }
 
 /// <p>The response from the server that results from a user's request to retrieve a forgotten password.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ConfirmForgotPasswordResponse {}
 
 /// <p>Represents the request to confirm registration of a user.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ConfirmSignUpRequest {
     /// <p>The Amazon Pinpoint analytics metadata for collecting metrics for <code>ConfirmSignUp</code> calls.</p>
     #[serde(rename = "AnalyticsMetadata")]
@@ -973,11 +973,11 @@ pub struct ConfirmSignUpRequest {
 }
 
 /// <p>Represents the response from the server for the registration confirmation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ConfirmSignUpResponse {}
 
 /// <p>Contextual user data type used for evaluating the risk of an unexpected event by Amazon Cognito advanced security.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ContextDataType {
     /// <p>Encoded data containing device fingerprinting details, collected using the Amazon Cognito context data collection library.</p>
     #[serde(rename = "EncodedData")]
@@ -997,7 +997,7 @@ pub struct ContextDataType {
     pub server_path: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateGroupRequest {
     /// <p>A string containing the description of the group.</p>
     #[serde(rename = "Description")]
@@ -1019,7 +1019,7 @@ pub struct CreateGroupRequest {
     pub user_pool_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateGroupResponse {
     /// <p>The group object for the group.</p>
     #[serde(rename = "Group")]
@@ -1027,7 +1027,7 @@ pub struct CreateGroupResponse {
     pub group: Option<GroupType>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateIdentityProviderRequest {
     /// <p>A mapping of identity provider attributes to standard and custom user pool attributes.</p>
     #[serde(rename = "AttributeMapping")]
@@ -1051,14 +1051,14 @@ pub struct CreateIdentityProviderRequest {
     pub user_pool_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateIdentityProviderResponse {
     /// <p>The newly created identity provider object.</p>
     #[serde(rename = "IdentityProvider")]
     pub identity_provider: IdentityProviderType,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateResourceServerRequest {
     /// <p>A unique resource server identifier for the resource server. This could be an HTTPS endpoint where the resource server is located. For example, <code>https://my-weather-api.example.com</code>.</p>
     #[serde(rename = "Identifier")]
@@ -1075,7 +1075,7 @@ pub struct CreateResourceServerRequest {
     pub user_pool_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateResourceServerResponse {
     /// <p>The newly created resource server.</p>
     #[serde(rename = "ResourceServer")]
@@ -1083,7 +1083,7 @@ pub struct CreateResourceServerResponse {
 }
 
 /// <p>Represents the request to create the user import job.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateUserImportJobRequest {
     /// <p>The role ARN for the Amazon CloudWatch Logging role for the user import job.</p>
     #[serde(rename = "CloudWatchLogsRoleArn")]
@@ -1097,7 +1097,7 @@ pub struct CreateUserImportJobRequest {
 }
 
 /// <p>Represents the response from the server to the request to create the user import job.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateUserImportJobResponse {
     /// <p>The job object that represents the user import job.</p>
     #[serde(rename = "UserImportJob")]
@@ -1106,7 +1106,7 @@ pub struct CreateUserImportJobResponse {
 }
 
 /// <p>Represents the request to create a user pool client.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateUserPoolClientRequest {
     /// <p>Set to <code>code</code> to initiate a code grant flow, which provides an authorization code as the response. This code can be exchanged for access tokens with the token endpoint.</p> <p>Set to <code>token</code> to specify that the client should get the access token (and, optionally, ID token, based on scopes) directly.</p>
     #[serde(rename = "AllowedOAuthFlows")]
@@ -1169,7 +1169,7 @@ pub struct CreateUserPoolClientRequest {
 }
 
 /// <p>Represents the response from the server to create a user pool client.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateUserPoolClientResponse {
     /// <p>The user pool client that was just created.</p>
     #[serde(rename = "UserPoolClient")]
@@ -1177,7 +1177,7 @@ pub struct CreateUserPoolClientResponse {
     pub user_pool_client: Option<UserPoolClientType>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateUserPoolDomainRequest {
     /// <p>The domain string.</p>
     #[serde(rename = "Domain")]
@@ -1187,11 +1187,11 @@ pub struct CreateUserPoolDomainRequest {
     pub user_pool_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateUserPoolDomainResponse {}
 
 /// <p>Represents the request to create a user pool.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateUserPoolRequest {
     /// <p>The configuration for <code>AdminCreateUser</code> requests.</p>
     #[serde(rename = "AdminCreateUserConfig")]
@@ -1271,7 +1271,7 @@ pub struct CreateUserPoolRequest {
 }
 
 /// <p>Represents the response from the server for the request to create a user pool.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateUserPoolResponse {
     /// <p>A container for the user pool details.</p>
     #[serde(rename = "UserPool")]
@@ -1279,7 +1279,7 @@ pub struct CreateUserPoolResponse {
     pub user_pool: Option<UserPoolType>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteGroupRequest {
     /// <p>The name of the group.</p>
     #[serde(rename = "GroupName")]
@@ -1289,7 +1289,7 @@ pub struct DeleteGroupRequest {
     pub user_pool_id: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteIdentityProviderRequest {
     /// <p>The identity provider name.</p>
     #[serde(rename = "ProviderName")]
@@ -1299,7 +1299,7 @@ pub struct DeleteIdentityProviderRequest {
     pub user_pool_id: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteResourceServerRequest {
     /// <p>The identifier for the resource server.</p>
     #[serde(rename = "Identifier")]
@@ -1310,7 +1310,7 @@ pub struct DeleteResourceServerRequest {
 }
 
 /// <p>Represents the request to delete user attributes.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteUserAttributesRequest {
     /// <p>The access token used in the request to delete user attributes.</p>
     #[serde(rename = "AccessToken")]
@@ -1321,11 +1321,11 @@ pub struct DeleteUserAttributesRequest {
 }
 
 /// <p>Represents the response from the server to delete user attributes.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteUserAttributesResponse {}
 
 /// <p>Represents the request to delete a user pool client.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteUserPoolClientRequest {
     /// <p>The app client ID of the app associated with the user pool.</p>
     #[serde(rename = "ClientId")]
@@ -1335,7 +1335,7 @@ pub struct DeleteUserPoolClientRequest {
     pub user_pool_id: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteUserPoolDomainRequest {
     /// <p>The domain string.</p>
     #[serde(rename = "Domain")]
@@ -1345,11 +1345,11 @@ pub struct DeleteUserPoolDomainRequest {
     pub user_pool_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteUserPoolDomainResponse {}
 
 /// <p>Represents the request to delete a user pool.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteUserPoolRequest {
     /// <p>The user pool ID for the user pool you want to delete.</p>
     #[serde(rename = "UserPoolId")]
@@ -1357,14 +1357,14 @@ pub struct DeleteUserPoolRequest {
 }
 
 /// <p>Represents the request to delete a user.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteUserRequest {
     /// <p>The access token from a request to delete a user.</p>
     #[serde(rename = "AccessToken")]
     pub access_token: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeIdentityProviderRequest {
     /// <p>The identity provider name.</p>
     #[serde(rename = "ProviderName")]
@@ -1374,14 +1374,14 @@ pub struct DescribeIdentityProviderRequest {
     pub user_pool_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeIdentityProviderResponse {
     /// <p>The identity provider that was deleted.</p>
     #[serde(rename = "IdentityProvider")]
     pub identity_provider: IdentityProviderType,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeResourceServerRequest {
     /// <p>The identifier for the resource server</p>
     #[serde(rename = "Identifier")]
@@ -1391,14 +1391,14 @@ pub struct DescribeResourceServerRequest {
     pub user_pool_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeResourceServerResponse {
     /// <p>The resource server.</p>
     #[serde(rename = "ResourceServer")]
     pub resource_server: ResourceServerType,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeRiskConfigurationRequest {
     /// <p>The app client ID.</p>
     #[serde(rename = "ClientId")]
@@ -1409,7 +1409,7 @@ pub struct DescribeRiskConfigurationRequest {
     pub user_pool_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeRiskConfigurationResponse {
     /// <p>The risk configuration.</p>
     #[serde(rename = "RiskConfiguration")]
@@ -1417,7 +1417,7 @@ pub struct DescribeRiskConfigurationResponse {
 }
 
 /// <p>Represents the request to describe the user import job.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeUserImportJobRequest {
     /// <p>The job ID for the user import job.</p>
     #[serde(rename = "JobId")]
@@ -1428,7 +1428,7 @@ pub struct DescribeUserImportJobRequest {
 }
 
 /// <p>Represents the response from the server to the request to describe the user import job.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeUserImportJobResponse {
     /// <p>The job object that represents the user import job.</p>
     #[serde(rename = "UserImportJob")]
@@ -1437,7 +1437,7 @@ pub struct DescribeUserImportJobResponse {
 }
 
 /// <p>Represents the request to describe a user pool client.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeUserPoolClientRequest {
     /// <p>The app client ID of the app associated with the user pool.</p>
     #[serde(rename = "ClientId")]
@@ -1448,7 +1448,7 @@ pub struct DescribeUserPoolClientRequest {
 }
 
 /// <p>Represents the response from the server from a request to describe the user pool client.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeUserPoolClientResponse {
     /// <p>The user pool client from a server response to describe the user pool client.</p>
     #[serde(rename = "UserPoolClient")]
@@ -1456,14 +1456,14 @@ pub struct DescribeUserPoolClientResponse {
     pub user_pool_client: Option<UserPoolClientType>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeUserPoolDomainRequest {
     /// <p>The domain string.</p>
     #[serde(rename = "Domain")]
     pub domain: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeUserPoolDomainResponse {
     /// <p>A domain description object containing information about the domain.</p>
     #[serde(rename = "DomainDescription")]
@@ -1472,7 +1472,7 @@ pub struct DescribeUserPoolDomainResponse {
 }
 
 /// <p>Represents the request to describe the user pool.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeUserPoolRequest {
     /// <p>The user pool ID for the user pool you want to describe.</p>
     #[serde(rename = "UserPoolId")]
@@ -1480,7 +1480,7 @@ pub struct DescribeUserPoolRequest {
 }
 
 /// <p>Represents the response to describe the user pool.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeUserPoolResponse {
     /// <p>The container of metadata returned by the server to describe the pool.</p>
     #[serde(rename = "UserPool")]
@@ -1489,7 +1489,7 @@ pub struct DescribeUserPoolResponse {
 }
 
 /// <p>The configuration for the user pool's device tracking.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct DeviceConfigurationType {
     /// <p>Indicates whether a challenge is required on a new device. Only applicable to a new device.</p>
     #[serde(rename = "ChallengeRequiredOnNewDevice")]
@@ -1502,7 +1502,7 @@ pub struct DeviceConfigurationType {
 }
 
 /// <p>The device verifier against which it will be authenticated.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeviceSecretVerifierConfigType {
     /// <p>The password verifier.</p>
     #[serde(rename = "PasswordVerifier")]
@@ -1515,7 +1515,7 @@ pub struct DeviceSecretVerifierConfigType {
 }
 
 /// <p>The device type.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeviceType {
     /// <p>The device attributes.</p>
     #[serde(rename = "DeviceAttributes")]
@@ -1540,7 +1540,7 @@ pub struct DeviceType {
 }
 
 /// <p>A container for information about a domain.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DomainDescriptionType {
     /// <p>The AWS account ID for the user pool owner.</p>
     #[serde(rename = "AWSAccountId")]
@@ -1573,7 +1573,7 @@ pub struct DomainDescriptionType {
 }
 
 /// <p>The email configuration type.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct EmailConfigurationType {
     /// <p>The destination to which the receiver of the email should reply to.</p>
     #[serde(rename = "ReplyToEmailAddress")]
@@ -1586,7 +1586,7 @@ pub struct EmailConfigurationType {
 }
 
 /// <p>Specifies the user context data captured at the time of an event request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct EventContextDataType {
     /// <p>The user's city.</p>
     #[serde(rename = "City")]
@@ -1611,7 +1611,7 @@ pub struct EventContextDataType {
 }
 
 /// <p>Specifies the event feedback type.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct EventFeedbackType {
     /// <p>The event feedback date.</p>
     #[serde(rename = "FeedbackDate")]
@@ -1626,7 +1626,7 @@ pub struct EventFeedbackType {
 }
 
 /// <p>The event risk type.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct EventRiskType {
     /// <p>The risk decision.</p>
     #[serde(rename = "RiskDecision")]
@@ -1639,7 +1639,7 @@ pub struct EventRiskType {
 }
 
 /// <p>Represents the request to forget the device.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ForgetDeviceRequest {
     /// <p>The access token for the forgotten device request.</p>
     #[serde(rename = "AccessToken")]
@@ -1651,7 +1651,7 @@ pub struct ForgetDeviceRequest {
 }
 
 /// <p>Represents the request to reset a user's password.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ForgotPasswordRequest {
     /// <p>The Amazon Pinpoint analytics metadata for collecting metrics for <code>ForgotPassword</code> calls.</p>
     #[serde(rename = "AnalyticsMetadata")]
@@ -1674,7 +1674,7 @@ pub struct ForgotPasswordRequest {
 }
 
 /// <p>Respresents the response from the server regarding the request to reset a password.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ForgotPasswordResponse {
     /// <p>The code delivery details returned by the server in response to the request to reset a password.</p>
     #[serde(rename = "CodeDeliveryDetails")]
@@ -1683,7 +1683,7 @@ pub struct ForgotPasswordResponse {
 }
 
 /// <p>Represents the request to get the header information for the .csv file for the user import job.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetCSVHeaderRequest {
     /// <p>The user pool ID for the user pool that the users are to be imported into.</p>
     #[serde(rename = "UserPoolId")]
@@ -1691,7 +1691,7 @@ pub struct GetCSVHeaderRequest {
 }
 
 /// <p>Represents the response from the server to the request to get the header information for the .csv file for the user import job.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetCSVHeaderResponse {
     /// <p>The header information for the .csv file for the user import job.</p>
     #[serde(rename = "CSVHeader")]
@@ -1704,7 +1704,7 @@ pub struct GetCSVHeaderResponse {
 }
 
 /// <p>Represents the request to get the device.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetDeviceRequest {
     /// <p>The access token.</p>
     #[serde(rename = "AccessToken")]
@@ -1716,14 +1716,14 @@ pub struct GetDeviceRequest {
 }
 
 /// <p>Gets the device response.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetDeviceResponse {
     /// <p>The device.</p>
     #[serde(rename = "Device")]
     pub device: DeviceType,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetGroupRequest {
     /// <p>The name of the group.</p>
     #[serde(rename = "GroupName")]
@@ -1733,7 +1733,7 @@ pub struct GetGroupRequest {
     pub user_pool_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetGroupResponse {
     /// <p>The group object for the group.</p>
     #[serde(rename = "Group")]
@@ -1741,7 +1741,7 @@ pub struct GetGroupResponse {
     pub group: Option<GroupType>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetIdentityProviderByIdentifierRequest {
     /// <p>The identity provider ID.</p>
     #[serde(rename = "IdpIdentifier")]
@@ -1751,7 +1751,7 @@ pub struct GetIdentityProviderByIdentifierRequest {
     pub user_pool_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetIdentityProviderByIdentifierResponse {
     /// <p>The identity provider object.</p>
     #[serde(rename = "IdentityProvider")]
@@ -1759,7 +1759,7 @@ pub struct GetIdentityProviderByIdentifierResponse {
 }
 
 /// <p>Request to get a signing certificate from Cognito.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetSigningCertificateRequest {
     /// <p>The user pool ID.</p>
     #[serde(rename = "UserPoolId")]
@@ -1767,7 +1767,7 @@ pub struct GetSigningCertificateRequest {
 }
 
 /// <p>Response from Cognito for a signing certificate request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetSigningCertificateResponse {
     /// <p>The signing certificate.</p>
     #[serde(rename = "Certificate")]
@@ -1775,7 +1775,7 @@ pub struct GetSigningCertificateResponse {
     pub certificate: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetUICustomizationRequest {
     /// <p>The client ID for the client app.</p>
     #[serde(rename = "ClientId")]
@@ -1786,7 +1786,7 @@ pub struct GetUICustomizationRequest {
     pub user_pool_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetUICustomizationResponse {
     /// <p>The UI customization information.</p>
     #[serde(rename = "UICustomization")]
@@ -1794,7 +1794,7 @@ pub struct GetUICustomizationResponse {
 }
 
 /// <p>Represents the request to get user attribute verification.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetUserAttributeVerificationCodeRequest {
     /// <p>The access token returned by the server response to get the user attribute verification code.</p>
     #[serde(rename = "AccessToken")]
@@ -1805,7 +1805,7 @@ pub struct GetUserAttributeVerificationCodeRequest {
 }
 
 /// <p>The verification code response returned by the server response to get the user attribute verification code.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetUserAttributeVerificationCodeResponse {
     /// <p>The code delivery details returned by the server in response to the request to get the user attribute verification code.</p>
     #[serde(rename = "CodeDeliveryDetails")]
@@ -1813,14 +1813,14 @@ pub struct GetUserAttributeVerificationCodeResponse {
     pub code_delivery_details: Option<CodeDeliveryDetailsType>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetUserPoolMfaConfigRequest {
     /// <p>The user pool ID.</p>
     #[serde(rename = "UserPoolId")]
     pub user_pool_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetUserPoolMfaConfigResponse {
     /// <p>The multi-factor (MFA) configuration.</p>
     #[serde(rename = "MfaConfiguration")]
@@ -1837,7 +1837,7 @@ pub struct GetUserPoolMfaConfigResponse {
 }
 
 /// <p>Represents the request to get information about the user.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetUserRequest {
     /// <p>The access token returned by the server response to get information about the user.</p>
     #[serde(rename = "AccessToken")]
@@ -1845,7 +1845,7 @@ pub struct GetUserRequest {
 }
 
 /// <p>Represents the response from the server from the request to get information about the user.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetUserResponse {
     /// <p>Specifies the options for MFA (e.g., email or phone number).</p>
     #[serde(rename = "MFAOptions")]
@@ -1868,7 +1868,7 @@ pub struct GetUserResponse {
 }
 
 /// <p>Represents the request to sign out all devices.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GlobalSignOutRequest {
     /// <p>The access token.</p>
     #[serde(rename = "AccessToken")]
@@ -1876,11 +1876,11 @@ pub struct GlobalSignOutRequest {
 }
 
 /// <p>The response to the request to sign out all devices.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GlobalSignOutResponse {}
 
 /// <p>The group type.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GroupType {
     /// <p>The date the group was created.</p>
     #[serde(rename = "CreationDate")]
@@ -1913,7 +1913,7 @@ pub struct GroupType {
 }
 
 /// <p>The HTTP header.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct HttpHeader {
     /// <p>The header name</p>
     #[serde(rename = "headerName")]
@@ -1926,7 +1926,7 @@ pub struct HttpHeader {
 }
 
 /// <p>A container for information about an identity provider.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct IdentityProviderType {
     /// <p>A mapping of identity provider attributes to standard and custom user pool attributes.</p>
     #[serde(rename = "AttributeMapping")]
@@ -1963,7 +1963,7 @@ pub struct IdentityProviderType {
 }
 
 /// <p>Initiates the authentication request.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct InitiateAuthRequest {
     /// <p>The Amazon Pinpoint analytics metadata for collecting metrics for <code>InitiateAuth</code> calls.</p>
     #[serde(rename = "AnalyticsMetadata")]
@@ -1990,7 +1990,7 @@ pub struct InitiateAuthRequest {
 }
 
 /// <p>Initiates the authentication response.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct InitiateAuthResponse {
     /// <p>The result of the authentication response. This is only returned if the caller does not need to pass another challenge. If the caller does need to pass another challenge before it gets tokens, <code>ChallengeName</code>, <code>ChallengeParameters</code>, and <code>Session</code> are returned.</p>
     #[serde(rename = "AuthenticationResult")]
@@ -2011,7 +2011,7 @@ pub struct InitiateAuthResponse {
 }
 
 /// <p>Specifies the configuration for AWS Lambda triggers.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct LambdaConfigType {
     /// <p>Creates an authentication challenge.</p>
     #[serde(rename = "CreateAuthChallenge")]
@@ -2056,7 +2056,7 @@ pub struct LambdaConfigType {
 }
 
 /// <p>Represents the request to list the devices.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListDevicesRequest {
     /// <p>The access tokens for the request to list devices.</p>
     #[serde(rename = "AccessToken")]
@@ -2072,7 +2072,7 @@ pub struct ListDevicesRequest {
 }
 
 /// <p>Represents the response to list devices.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListDevicesResponse {
     /// <p>The devices returned in the list devices response.</p>
     #[serde(rename = "Devices")]
@@ -2084,7 +2084,7 @@ pub struct ListDevicesResponse {
     pub pagination_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListGroupsRequest {
     /// <p>The limit of the request to list groups.</p>
     #[serde(rename = "Limit")]
@@ -2099,7 +2099,7 @@ pub struct ListGroupsRequest {
     pub user_pool_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListGroupsResponse {
     /// <p>The group objects for the groups.</p>
     #[serde(rename = "Groups")]
@@ -2111,7 +2111,7 @@ pub struct ListGroupsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListIdentityProvidersRequest {
     /// <p>The maximum number of identity providers to return.</p>
     #[serde(rename = "MaxResults")]
@@ -2126,7 +2126,7 @@ pub struct ListIdentityProvidersRequest {
     pub user_pool_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListIdentityProvidersResponse {
     /// <p>A pagination token.</p>
     #[serde(rename = "NextToken")]
@@ -2137,7 +2137,7 @@ pub struct ListIdentityProvidersResponse {
     pub providers: Vec<ProviderDescription>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListResourceServersRequest {
     /// <p>The maximum number of resource servers to return.</p>
     #[serde(rename = "MaxResults")]
@@ -2152,7 +2152,7 @@ pub struct ListResourceServersRequest {
     pub user_pool_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListResourceServersResponse {
     /// <p>A pagination token.</p>
     #[serde(rename = "NextToken")]
@@ -2164,7 +2164,7 @@ pub struct ListResourceServersResponse {
 }
 
 /// <p>Represents the request to list the user import jobs.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListUserImportJobsRequest {
     /// <p>The maximum number of import jobs you want the request to return.</p>
     #[serde(rename = "MaxResults")]
@@ -2179,7 +2179,7 @@ pub struct ListUserImportJobsRequest {
 }
 
 /// <p>Represents the response from the server to the request to list the user import jobs.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListUserImportJobsResponse {
     /// <p>An identifier that can be used to return the next set of user import jobs in the list.</p>
     #[serde(rename = "PaginationToken")]
@@ -2192,7 +2192,7 @@ pub struct ListUserImportJobsResponse {
 }
 
 /// <p>Represents the request to list the user pool clients.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListUserPoolClientsRequest {
     /// <p>The maximum number of results you want the request to return when listing the user pool clients.</p>
     #[serde(rename = "MaxResults")]
@@ -2208,7 +2208,7 @@ pub struct ListUserPoolClientsRequest {
 }
 
 /// <p>Represents the response from the server that lists user pool clients.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListUserPoolClientsResponse {
     /// <p>An identifier that was returned from the previous call to this operation, which can be used to return the next set of items in the list.</p>
     #[serde(rename = "NextToken")]
@@ -2221,7 +2221,7 @@ pub struct ListUserPoolClientsResponse {
 }
 
 /// <p>Represents the request to list user pools.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListUserPoolsRequest {
     /// <p>The maximum number of results you want the request to return when listing the user pools.</p>
     #[serde(rename = "MaxResults")]
@@ -2233,7 +2233,7 @@ pub struct ListUserPoolsRequest {
 }
 
 /// <p>Represents the response to list user pools.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListUserPoolsResponse {
     /// <p>An identifier that was returned from the previous call to this operation, which can be used to return the next set of items in the list.</p>
     #[serde(rename = "NextToken")]
@@ -2245,7 +2245,7 @@ pub struct ListUserPoolsResponse {
     pub user_pools: Option<Vec<UserPoolDescriptionType>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListUsersInGroupRequest {
     /// <p>The name of the group.</p>
     #[serde(rename = "GroupName")]
@@ -2263,7 +2263,7 @@ pub struct ListUsersInGroupRequest {
     pub user_pool_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListUsersInGroupResponse {
     /// <p>An identifier that was returned from the previous call to this operation, which can be used to return the next set of items in the list.</p>
     #[serde(rename = "NextToken")]
@@ -2276,7 +2276,7 @@ pub struct ListUsersInGroupResponse {
 }
 
 /// <p>Represents the request to list users.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListUsersRequest {
     /// <p>An array of strings, where each string is the name of a user attribute to be returned for each user in the search results. If the array is null, all attributes are returned.</p>
     #[serde(rename = "AttributesToGet")]
@@ -2300,7 +2300,7 @@ pub struct ListUsersRequest {
 }
 
 /// <p>The response from the request to list users.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListUsersResponse {
     /// <p>An identifier that was returned from the previous call to this operation, which can be used to return the next set of items in the list.</p>
     #[serde(rename = "PaginationToken")]
@@ -2313,7 +2313,7 @@ pub struct ListUsersResponse {
 }
 
 /// <p>Specifies the different settings for multi-factor authentication (MFA).</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct MFAOptionType {
     /// <p>The attribute name of the MFA option type.</p>
     #[serde(rename = "AttributeName")]
@@ -2326,7 +2326,7 @@ pub struct MFAOptionType {
 }
 
 /// <p>The message template structure.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct MessageTemplateType {
     /// <p>The message template for email messages.</p>
     #[serde(rename = "EmailMessage")]
@@ -2343,7 +2343,7 @@ pub struct MessageTemplateType {
 }
 
 /// <p>The new device metadata type.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct NewDeviceMetadataType {
     /// <p>The device group key.</p>
     #[serde(rename = "DeviceGroupKey")]
@@ -2356,7 +2356,7 @@ pub struct NewDeviceMetadataType {
 }
 
 /// <p>The notify configuration type.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct NotifyConfigurationType {
     /// <p>Email template used when a detected risk event is blocked.</p>
     #[serde(rename = "BlockEmail")]
@@ -2384,7 +2384,7 @@ pub struct NotifyConfigurationType {
 }
 
 /// <p>The notify email type.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct NotifyEmailType {
     /// <p>The HTML body.</p>
     #[serde(rename = "HtmlBody")]
@@ -2400,7 +2400,7 @@ pub struct NotifyEmailType {
 }
 
 /// <p>The minimum and maximum value of an attribute that is of the number data type.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct NumberAttributeConstraintsType {
     /// <p>The maximum value of an attribute that is of the number data type.</p>
     #[serde(rename = "MaxValue")]
@@ -2413,7 +2413,7 @@ pub struct NumberAttributeConstraintsType {
 }
 
 /// <p>The password policy type.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct PasswordPolicyType {
     /// <p>The minimum length of the password policy that you have set. Cannot be less than 6.</p>
     #[serde(rename = "MinimumLength")]
@@ -2438,7 +2438,7 @@ pub struct PasswordPolicyType {
 }
 
 /// <p>A container for identity provider details.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ProviderDescription {
     /// <p>The date the provider was added to the user pool.</p>
     #[serde(rename = "CreationDate")]
@@ -2459,7 +2459,7 @@ pub struct ProviderDescription {
 }
 
 /// <p>A container for information about an identity provider for a user pool.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ProviderUserIdentifierType {
     /// <p>The name of the provider attribute to link to, for example, <code>NameID</code>.</p>
     #[serde(rename = "ProviderAttributeName")]
@@ -2476,7 +2476,7 @@ pub struct ProviderUserIdentifierType {
 }
 
 /// <p>Represents the request to resend the confirmation code.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ResendConfirmationCodeRequest {
     /// <p>The Amazon Pinpoint analytics metadata for collecting metrics for <code>ResendConfirmationCode</code> calls.</p>
     #[serde(rename = "AnalyticsMetadata")]
@@ -2499,7 +2499,7 @@ pub struct ResendConfirmationCodeRequest {
 }
 
 /// <p>The response from the server when the Amazon Cognito Your User Pools service makes the request to resend a confirmation code.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ResendConfirmationCodeResponse {
     /// <p>The code delivery details returned by the server in response to the request to resend the confirmation code.</p>
     #[serde(rename = "CodeDeliveryDetails")]
@@ -2508,7 +2508,7 @@ pub struct ResendConfirmationCodeResponse {
 }
 
 /// <p>A resource server scope.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ResourceServerScopeType {
     /// <p>A description of the scope.</p>
     #[serde(rename = "ScopeDescription")]
@@ -2519,7 +2519,7 @@ pub struct ResourceServerScopeType {
 }
 
 /// <p>A container for information about a resource server for a user pool.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ResourceServerType {
     /// <p>The identifier for the resource server.</p>
     #[serde(rename = "Identifier")]
@@ -2540,7 +2540,7 @@ pub struct ResourceServerType {
 }
 
 /// <p>The request to respond to an authentication challenge.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RespondToAuthChallengeRequest {
     /// <p>The Amazon Pinpoint analytics metadata for collecting metrics for <code>RespondToAuthChallenge</code> calls.</p>
     #[serde(rename = "AnalyticsMetadata")]
@@ -2567,7 +2567,7 @@ pub struct RespondToAuthChallengeRequest {
 }
 
 /// <p>The response to respond to the authentication challenge.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RespondToAuthChallengeResponse {
     /// <p>The result returned by the server in response to the request to respond to the authentication challenge.</p>
     #[serde(rename = "AuthenticationResult")]
@@ -2588,7 +2588,7 @@ pub struct RespondToAuthChallengeResponse {
 }
 
 /// <p>The risk configuration type.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RiskConfigurationType {
     /// <p>The account takeover risk configuration object including the <code>NotifyConfiguration</code> object and <code>Actions</code> to take in the case of an account takeover.</p>
     #[serde(rename = "AccountTakeoverRiskConfiguration")]
@@ -2618,7 +2618,7 @@ pub struct RiskConfigurationType {
 }
 
 /// <p>The type of the configuration to override the risk decision.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RiskExceptionConfigurationType {
     /// <p>Overrides the risk decision to always block the pre-authentication requests. The IP range is in CIDR notation: a compact representation of an IP address and its associated routing prefix.</p>
     #[serde(rename = "BlockedIPRangeList")]
@@ -2631,7 +2631,7 @@ pub struct RiskExceptionConfigurationType {
 }
 
 /// <p>The SMS multi-factor authentication (MFA) settings type.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SMSMfaSettingsType {
     /// <p>Specifies whether SMS text message MFA is enabled.</p>
     #[serde(rename = "Enabled")]
@@ -2644,7 +2644,7 @@ pub struct SMSMfaSettingsType {
 }
 
 /// <p>Contains information about the schema attribute.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SchemaAttributeType {
     /// <p>The attribute data type.</p>
     #[serde(rename = "AttributeDataType")]
@@ -2676,7 +2676,7 @@ pub struct SchemaAttributeType {
     pub string_attribute_constraints: Option<StringAttributeConstraintsType>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SetRiskConfigurationRequest {
     /// <p>The account takeover risk configuration.</p>
     #[serde(rename = "AccountTakeoverRiskConfiguration")]
@@ -2700,14 +2700,14 @@ pub struct SetRiskConfigurationRequest {
     pub user_pool_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SetRiskConfigurationResponse {
     /// <p>The risk configuration.</p>
     #[serde(rename = "RiskConfiguration")]
     pub risk_configuration: RiskConfigurationType,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SetUICustomizationRequest {
     /// <p>The CSS values in the UI customization.</p>
     #[serde(rename = "CSS")]
@@ -2730,14 +2730,14 @@ pub struct SetUICustomizationRequest {
     pub user_pool_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SetUICustomizationResponse {
     /// <p>The UI customization information.</p>
     #[serde(rename = "UICustomization")]
     pub ui_customization: UICustomizationType,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SetUserMFAPreferenceRequest {
     /// <p>The access token.</p>
     #[serde(rename = "AccessToken")]
@@ -2752,10 +2752,10 @@ pub struct SetUserMFAPreferenceRequest {
     pub software_token_mfa_settings: Option<SoftwareTokenMfaSettingsType>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SetUserMFAPreferenceResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SetUserPoolMfaConfigRequest {
     /// <p>The MFA configuration.</p>
     #[serde(rename = "MfaConfiguration")]
@@ -2774,7 +2774,7 @@ pub struct SetUserPoolMfaConfigRequest {
     pub user_pool_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SetUserPoolMfaConfigResponse {
     /// <p>The MFA configuration.</p>
     #[serde(rename = "MfaConfiguration")]
@@ -2791,7 +2791,7 @@ pub struct SetUserPoolMfaConfigResponse {
 }
 
 /// <p>Represents the request to set user settings.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SetUserSettingsRequest {
     /// <p>The access token for the set user settings request.</p>
     #[serde(rename = "AccessToken")]
@@ -2802,11 +2802,11 @@ pub struct SetUserSettingsRequest {
 }
 
 /// <p>The response from the server for a set user settings request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SetUserSettingsResponse {}
 
 /// <p>Represents the request to register a user.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SignUpRequest {
     /// <p>The Amazon Pinpoint analytics metadata for collecting metrics for <code>SignUp</code> calls.</p>
     #[serde(rename = "AnalyticsMetadata")]
@@ -2840,7 +2840,7 @@ pub struct SignUpRequest {
 }
 
 /// <p>The response from the server for a registration request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SignUpResponse {
     /// <p>The code delivery details returned by the server response to the user registration request.</p>
     #[serde(rename = "CodeDeliveryDetails")]
@@ -2855,7 +2855,7 @@ pub struct SignUpResponse {
 }
 
 /// <p>The SMS configuration type.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SmsConfigurationType {
     /// <p>The external ID.</p>
     #[serde(rename = "ExternalId")]
@@ -2867,7 +2867,7 @@ pub struct SmsConfigurationType {
 }
 
 /// <p>The SMS text message multi-factor authentication (MFA) configuration type.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SmsMfaConfigType {
     /// <p>The SMS authentication message.</p>
     #[serde(rename = "SmsAuthenticationMessage")]
@@ -2880,7 +2880,7 @@ pub struct SmsMfaConfigType {
 }
 
 /// <p>The type used for enabling software token MFA at the user pool level.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SoftwareTokenMfaConfigType {
     /// <p>Specifies whether software token MFA is enabled.</p>
     #[serde(rename = "Enabled")]
@@ -2889,7 +2889,7 @@ pub struct SoftwareTokenMfaConfigType {
 }
 
 /// <p>The type used for enabling software token MFA at the user level.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SoftwareTokenMfaSettingsType {
     /// <p>Specifies whether software token MFA is enabled.</p>
     #[serde(rename = "Enabled")]
@@ -2902,7 +2902,7 @@ pub struct SoftwareTokenMfaSettingsType {
 }
 
 /// <p>Represents the request to start the user import job.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StartUserImportJobRequest {
     /// <p>The job ID for the user import job.</p>
     #[serde(rename = "JobId")]
@@ -2913,7 +2913,7 @@ pub struct StartUserImportJobRequest {
 }
 
 /// <p>Represents the response from the server to the request to start the user import job.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StartUserImportJobResponse {
     /// <p>The job object that represents the user import job.</p>
     #[serde(rename = "UserImportJob")]
@@ -2922,7 +2922,7 @@ pub struct StartUserImportJobResponse {
 }
 
 /// <p>Represents the request to stop the user import job.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StopUserImportJobRequest {
     /// <p>The job ID for the user import job.</p>
     #[serde(rename = "JobId")]
@@ -2933,7 +2933,7 @@ pub struct StopUserImportJobRequest {
 }
 
 /// <p>Represents the response from the server to the request to stop the user import job.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StopUserImportJobResponse {
     /// <p>The job object that represents the user import job.</p>
     #[serde(rename = "UserImportJob")]
@@ -2942,7 +2942,7 @@ pub struct StopUserImportJobResponse {
 }
 
 /// <p>The constraints associated with a string attribute.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct StringAttributeConstraintsType {
     /// <p>The maximum length.</p>
     #[serde(rename = "MaxLength")]
@@ -2955,7 +2955,7 @@ pub struct StringAttributeConstraintsType {
 }
 
 /// <p>A container for the UI customization information for a user pool's built-in app UI.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UICustomizationType {
     /// <p>The CSS values in the UI customization.</p>
     #[serde(rename = "CSS")]
@@ -2987,7 +2987,7 @@ pub struct UICustomizationType {
     pub user_pool_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateAuthEventFeedbackRequest {
     /// <p>The event ID.</p>
     #[serde(rename = "EventId")]
@@ -3006,11 +3006,11 @@ pub struct UpdateAuthEventFeedbackRequest {
     pub username: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateAuthEventFeedbackResponse {}
 
 /// <p>Represents the request to update the device status.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateDeviceStatusRequest {
     /// <p>The access token.</p>
     #[serde(rename = "AccessToken")]
@@ -3025,10 +3025,10 @@ pub struct UpdateDeviceStatusRequest {
 }
 
 /// <p>The response to the request to update the device status.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateDeviceStatusResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateGroupRequest {
     /// <p>A string containing the new description of the group.</p>
     #[serde(rename = "Description")]
@@ -3050,7 +3050,7 @@ pub struct UpdateGroupRequest {
     pub user_pool_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateGroupResponse {
     /// <p>The group object for the group.</p>
     #[serde(rename = "Group")]
@@ -3058,7 +3058,7 @@ pub struct UpdateGroupResponse {
     pub group: Option<GroupType>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateIdentityProviderRequest {
     /// <p>The identity provider attribute mapping to be changed.</p>
     #[serde(rename = "AttributeMapping")]
@@ -3080,14 +3080,14 @@ pub struct UpdateIdentityProviderRequest {
     pub user_pool_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateIdentityProviderResponse {
     /// <p>The identity provider object.</p>
     #[serde(rename = "IdentityProvider")]
     pub identity_provider: IdentityProviderType,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateResourceServerRequest {
     /// <p>The identifier for the resource server.</p>
     #[serde(rename = "Identifier")]
@@ -3104,7 +3104,7 @@ pub struct UpdateResourceServerRequest {
     pub user_pool_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateResourceServerResponse {
     /// <p>The resource server.</p>
     #[serde(rename = "ResourceServer")]
@@ -3112,7 +3112,7 @@ pub struct UpdateResourceServerResponse {
 }
 
 /// <p>Represents the request to update user attributes.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateUserAttributesRequest {
     /// <p>The access token for the request to update user attributes.</p>
     #[serde(rename = "AccessToken")]
@@ -3123,7 +3123,7 @@ pub struct UpdateUserAttributesRequest {
 }
 
 /// <p>Represents the response from the server for the request to update user attributes.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateUserAttributesResponse {
     /// <p>The code delivery details list from the server for the request to update user attributes.</p>
     #[serde(rename = "CodeDeliveryDetailsList")]
@@ -3132,7 +3132,7 @@ pub struct UpdateUserAttributesResponse {
 }
 
 /// <p>Represents the request to update the user pool client.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateUserPoolClientRequest {
     /// <p>Set to <code>code</code> to initiate a code grant flow, which provides an authorization code as the response. This code can be exchanged for access tokens with the token endpoint.</p> <p>Set to <code>token</code> to specify that the client should get the access token (and, optionally, ID token, based on scopes) directly.</p>
     #[serde(rename = "AllowedOAuthFlows")]
@@ -3195,7 +3195,7 @@ pub struct UpdateUserPoolClientRequest {
 }
 
 /// <p>Represents the response from the server to the request to update the user pool client.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateUserPoolClientResponse {
     /// <p>The user pool client value from the response from the server when an update user pool client request is made.</p>
     #[serde(rename = "UserPoolClient")]
@@ -3204,7 +3204,7 @@ pub struct UpdateUserPoolClientResponse {
 }
 
 /// <p>Represents the request to update the user pool.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateUserPoolRequest {
     /// <p>The configuration for <code>AdminCreateUser</code> requests.</p>
     #[serde(rename = "AdminCreateUserConfig")]
@@ -3272,11 +3272,11 @@ pub struct UpdateUserPoolRequest {
 }
 
 /// <p>Represents the response from the server when you make a request to update the user pool.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateUserPoolResponse {}
 
 /// <p>Contextual data such as the user's device fingerprint, IP address, or location used for evaluating the risk of an unexpected event by Amazon Cognito advanced security.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UserContextDataType {
     /// <p>Contextual data such as the user's device fingerprint, IP address, or location used for evaluating the risk of an unexpected event by Amazon Cognito advanced security.</p>
     #[serde(rename = "EncodedData")]
@@ -3285,7 +3285,7 @@ pub struct UserContextDataType {
 }
 
 /// <p>The user import job type.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UserImportJobType {
     /// <p>The role ARN for the Amazon CloudWatch Logging role for the user import job. For more information, see "Creating the CloudWatch Logs IAM Role" in the Amazon Cognito Developer Guide.</p>
     #[serde(rename = "CloudWatchLogsRoleArn")]
@@ -3342,7 +3342,7 @@ pub struct UserImportJobType {
 }
 
 /// <p>The user pool add-ons type.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct UserPoolAddOnsType {
     /// <p>The advanced security mode.</p>
     #[serde(rename = "AdvancedSecurityMode")]
@@ -3350,7 +3350,7 @@ pub struct UserPoolAddOnsType {
 }
 
 /// <p>The description of the user pool client.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UserPoolClientDescription {
     /// <p>The ID of the client associated with the user pool.</p>
     #[serde(rename = "ClientId")]
@@ -3367,7 +3367,7 @@ pub struct UserPoolClientDescription {
 }
 
 /// <p>Contains information about a user pool client.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UserPoolClientType {
     /// <p>Set to <code>code</code> to initiate a code grant flow, which provides an authorization code as the response. This code can be exchanged for access tokens with the token endpoint.</p> <p>Set to <code>token</code> to specify that the client should get the access token (and, optionally, ID token, based on scopes) directly.</p>
     #[serde(rename = "AllowedOAuthFlows")]
@@ -3444,7 +3444,7 @@ pub struct UserPoolClientType {
 }
 
 /// <p>A user pool description.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UserPoolDescriptionType {
     /// <p>The date the user pool description was created.</p>
     #[serde(rename = "CreationDate")]
@@ -3473,7 +3473,7 @@ pub struct UserPoolDescriptionType {
 }
 
 /// <p>The policy associated with a user pool.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct UserPoolPolicyType {
     /// <p>The password policy.</p>
     #[serde(rename = "PasswordPolicy")]
@@ -3482,7 +3482,7 @@ pub struct UserPoolPolicyType {
 }
 
 /// <p>A container for information about the user pool.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UserPoolType {
     /// <p>The configuration for <code>AdminCreateUser</code> requests.</p>
     #[serde(rename = "AdminCreateUserConfig")]
@@ -3595,7 +3595,7 @@ pub struct UserPoolType {
 }
 
 /// <p>The user type.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UserType {
     /// <p>A container with information about the user type attributes.</p>
     #[serde(rename = "Attributes")]
@@ -3628,7 +3628,7 @@ pub struct UserType {
 }
 
 /// <p>The template for verification messages.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct VerificationMessageTemplateType {
     /// <p>The default email option.</p>
     #[serde(rename = "DefaultEmailOption")]
@@ -3656,7 +3656,7 @@ pub struct VerificationMessageTemplateType {
     pub sms_message: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct VerifySoftwareTokenRequest {
     /// <p>The access token.</p>
     #[serde(rename = "AccessToken")]
@@ -3675,7 +3675,7 @@ pub struct VerifySoftwareTokenRequest {
     pub user_code: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct VerifySoftwareTokenResponse {
     /// <p>The session which should be passed both ways in challenge-response calls to the service.</p>
     #[serde(rename = "Session")]
@@ -3688,7 +3688,7 @@ pub struct VerifySoftwareTokenResponse {
 }
 
 /// <p>Represents the request to verify user attributes.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct VerifyUserAttributeRequest {
     /// <p>Represents the access token of the request to verify user attributes.</p>
     #[serde(rename = "AccessToken")]
@@ -3702,7 +3702,7 @@ pub struct VerifyUserAttributeRequest {
 }
 
 /// <p>A container representing the response from the server from the request to verify user attributes.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct VerifyUserAttributeResponse {}
 
 /// Errors returned by AddCustomAttributes

--- a/rusoto/services/cognito-idp/src/generated.rs
+++ b/rusoto/services/cognito-idp/src/generated.rs
@@ -3734,7 +3734,8 @@ impl AddCustomAttributesError {
     pub fn from_body(body: &str) -> AddCustomAttributesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3844,7 +3845,8 @@ impl AdminAddUserToGroupError {
     pub fn from_body(body: &str) -> AdminAddUserToGroupError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3964,7 +3966,8 @@ impl AdminConfirmSignUpError {
     pub fn from_body(body: &str) -> AdminConfirmSignUpError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4114,7 +4117,8 @@ impl AdminCreateUserError {
     pub fn from_body(body: &str) -> AdminCreateUserError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4266,7 +4270,8 @@ impl AdminDeleteUserError {
     pub fn from_body(body: &str) -> AdminDeleteUserError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4374,7 +4379,8 @@ impl AdminDeleteUserAttributesError {
     pub fn from_body(body: &str) -> AdminDeleteUserAttributesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4490,7 +4496,8 @@ impl AdminDisableProviderForUserError {
     pub fn from_body(body: &str) -> AdminDisableProviderForUserError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4610,7 +4617,8 @@ impl AdminDisableUserError {
     pub fn from_body(body: &str) -> AdminDisableUserError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4718,7 +4726,8 @@ impl AdminEnableUserError {
     pub fn from_body(body: &str) -> AdminEnableUserError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4828,7 +4837,8 @@ impl AdminForgetDeviceError {
     pub fn from_body(body: &str) -> AdminForgetDeviceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4944,7 +4954,8 @@ impl AdminGetDeviceError {
     pub fn from_body(body: &str) -> AdminGetDeviceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5054,7 +5065,8 @@ impl AdminGetUserError {
     pub fn from_body(body: &str) -> AdminGetUserError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5180,7 +5192,8 @@ impl AdminInitiateAuthError {
     pub fn from_body(body: &str) -> AdminInitiateAuthError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5334,7 +5347,8 @@ impl AdminLinkProviderForUserError {
     pub fn from_body(body: &str) -> AdminLinkProviderForUserError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5448,7 +5462,8 @@ impl AdminListDevicesError {
     pub fn from_body(body: &str) -> AdminListDevicesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5558,7 +5573,8 @@ impl AdminListGroupsForUserError {
     pub fn from_body(body: &str) -> AdminListGroupsForUserError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5670,7 +5686,8 @@ impl AdminListUserAuthEventsError {
     pub fn from_body(body: &str) -> AdminListUserAuthEventsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5786,7 +5803,8 @@ impl AdminRemoveUserFromGroupError {
     pub fn from_body(body: &str) -> AdminRemoveUserFromGroupError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5910,7 +5928,8 @@ impl AdminResetUserPasswordError {
     pub fn from_body(body: &str) -> AdminResetUserPasswordError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6086,7 +6105,8 @@ impl AdminRespondToAuthChallengeError {
     pub fn from_body(body: &str) -> AdminRespondToAuthChallengeError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6282,7 +6302,8 @@ impl AdminSetUserMFAPreferenceError {
     pub fn from_body(body: &str) -> AdminSetUserMFAPreferenceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6402,7 +6423,8 @@ impl AdminSetUserSettingsError {
     pub fn from_body(body: &str) -> AdminSetUserSettingsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6510,7 +6532,8 @@ impl AdminUpdateAuthEventFeedbackError {
     pub fn from_body(body: &str) -> AdminUpdateAuthEventFeedbackError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6634,7 +6657,8 @@ impl AdminUpdateDeviceStatusError {
     pub fn from_body(body: &str) -> AdminUpdateDeviceStatusError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6758,7 +6782,8 @@ impl AdminUpdateUserAttributesError {
     pub fn from_body(body: &str) -> AdminUpdateUserAttributesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6894,7 +6919,8 @@ impl AdminUserGlobalSignOutError {
     pub fn from_body(body: &str) -> AdminUserGlobalSignOutError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7002,7 +7028,8 @@ impl AssociateSoftwareTokenError {
     pub fn from_body(body: &str) -> AssociateSoftwareTokenError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7118,7 +7145,8 @@ impl ChangePasswordError {
     pub fn from_body(body: &str) -> ChangePasswordError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7254,7 +7282,8 @@ impl ConfirmDeviceError {
     pub fn from_body(body: &str) -> ConfirmDeviceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7406,7 +7435,8 @@ impl ConfirmForgotPasswordError {
     pub fn from_body(body: &str) -> ConfirmForgotPasswordError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7574,7 +7604,8 @@ impl ConfirmSignUpError {
     pub fn from_body(body: &str) -> ConfirmSignUpError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7716,7 +7747,8 @@ impl CreateGroupError {
     pub fn from_body(body: &str) -> CreateGroupError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7830,7 +7862,8 @@ impl CreateIdentityProviderError {
     pub fn from_body(body: &str) -> CreateIdentityProviderError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7944,7 +7977,8 @@ impl CreateResourceServerError {
     pub fn from_body(body: &str) -> CreateResourceServerError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8056,7 +8090,8 @@ impl CreateUserImportJobError {
     pub fn from_body(body: &str) -> CreateUserImportJobError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8176,7 +8211,8 @@ impl CreateUserPoolError {
     pub fn from_body(body: &str) -> CreateUserPoolError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8304,7 +8340,8 @@ impl CreateUserPoolClientError {
     pub fn from_body(body: &str) -> CreateUserPoolClientError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8418,7 +8455,8 @@ impl CreateUserPoolDomainError {
     pub fn from_body(body: &str) -> CreateUserPoolDomainError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8518,7 +8556,8 @@ impl DeleteGroupError {
     pub fn from_body(body: &str) -> DeleteGroupError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8622,7 +8661,8 @@ impl DeleteIdentityProviderError {
     pub fn from_body(body: &str) -> DeleteIdentityProviderError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8732,7 +8772,8 @@ impl DeleteResourceServerError {
     pub fn from_body(body: &str) -> DeleteResourceServerError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8842,7 +8883,8 @@ impl DeleteUserError {
     pub fn from_body(body: &str) -> DeleteUserError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8960,7 +9002,8 @@ impl DeleteUserAttributesError {
     pub fn from_body(body: &str) -> DeleteUserAttributesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9080,7 +9123,8 @@ impl DeleteUserPoolError {
     pub fn from_body(body: &str) -> DeleteUserPoolError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9186,7 +9230,8 @@ impl DeleteUserPoolClientError {
     pub fn from_body(body: &str) -> DeleteUserPoolClientError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9288,7 +9333,8 @@ impl DeleteUserPoolDomainError {
     pub fn from_body(body: &str) -> DeleteUserPoolDomainError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9388,7 +9434,8 @@ impl DescribeIdentityProviderError {
     pub fn from_body(body: &str) -> DescribeIdentityProviderError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9492,7 +9539,8 @@ impl DescribeResourceServerError {
     pub fn from_body(body: &str) -> DescribeResourceServerError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9598,7 +9646,8 @@ impl DescribeRiskConfigurationError {
     pub fn from_body(body: &str) -> DescribeRiskConfigurationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9712,7 +9761,8 @@ impl DescribeUserImportJobError {
     pub fn from_body(body: &str) -> DescribeUserImportJobError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9818,7 +9868,8 @@ impl DescribeUserPoolError {
     pub fn from_body(body: &str) -> DescribeUserPoolError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9924,7 +9975,8 @@ impl DescribeUserPoolClientError {
     pub fn from_body(body: &str) -> DescribeUserPoolClientError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -10026,7 +10078,8 @@ impl DescribeUserPoolDomainError {
     pub fn from_body(body: &str) -> DescribeUserPoolDomainError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -10134,7 +10187,8 @@ impl ForgetDeviceError {
     pub fn from_body(body: &str) -> ForgetDeviceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -10272,7 +10326,8 @@ impl ForgotPasswordError {
     pub fn from_body(body: &str) -> ForgotPasswordError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -10418,7 +10473,8 @@ impl GetCSVHeaderError {
     pub fn from_body(body: &str) -> GetCSVHeaderError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -10528,7 +10584,8 @@ impl GetDeviceError {
     pub fn from_body(body: &str) -> GetDeviceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -10644,7 +10701,8 @@ impl GetGroupError {
     pub fn from_body(body: &str) -> GetGroupError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -10744,7 +10802,8 @@ impl GetIdentityProviderByIdentifierError {
     pub fn from_body(body: &str) -> GetIdentityProviderByIdentifierError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -10852,7 +10911,8 @@ impl GetSigningCertificateError {
     pub fn from_body(body: &str) -> GetSigningCertificateError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -10944,7 +11004,8 @@ impl GetUICustomizationError {
     pub fn from_body(body: &str) -> GetUICustomizationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -11054,7 +11115,8 @@ impl GetUserError {
     pub fn from_body(body: &str) -> GetUserError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -11188,7 +11250,8 @@ impl GetUserAttributeVerificationCodeError {
     pub fn from_body(body: &str) -> GetUserAttributeVerificationCodeError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -11368,7 +11431,8 @@ impl GetUserPoolMfaConfigError {
     pub fn from_body(body: &str) -> GetUserPoolMfaConfigError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -11476,7 +11540,8 @@ impl GlobalSignOutError {
     pub fn from_body(body: &str) -> GlobalSignOutError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -11600,7 +11665,8 @@ impl InitiateAuthError {
     pub fn from_body(body: &str) -> InitiateAuthError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -11738,7 +11804,8 @@ impl ListDevicesError {
     pub fn from_body(body: &str) -> ListDevicesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -11856,7 +11923,8 @@ impl ListGroupsError {
     pub fn from_body(body: &str) -> ListGroupsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -11956,7 +12024,8 @@ impl ListIdentityProvidersError {
     pub fn from_body(body: &str) -> ListIdentityProvidersError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -12060,7 +12129,8 @@ impl ListResourceServersError {
     pub fn from_body(body: &str) -> ListResourceServersError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -12164,7 +12234,8 @@ impl ListUserImportJobsError {
     pub fn from_body(body: &str) -> ListUserImportJobsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -12268,7 +12339,8 @@ impl ListUserPoolClientsError {
     pub fn from_body(body: &str) -> ListUserPoolClientsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -12370,7 +12442,8 @@ impl ListUserPoolsError {
     pub fn from_body(body: &str) -> ListUserPoolsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -12468,7 +12541,8 @@ impl ListUsersError {
     pub fn from_body(body: &str) -> ListUsersError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -12568,7 +12642,8 @@ impl ListUsersInGroupError {
     pub fn from_body(body: &str) -> ListUsersInGroupError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -12688,7 +12763,8 @@ impl ResendConfirmationCodeError {
     pub fn from_body(body: &str) -> ResendConfirmationCodeError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -12870,7 +12946,8 @@ impl RespondToAuthChallengeError {
     pub fn from_body(body: &str) -> RespondToAuthChallengeError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -13054,7 +13131,8 @@ impl SetRiskConfigurationError {
     pub fn from_body(body: &str) -> SetRiskConfigurationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -13174,7 +13252,8 @@ impl SetUICustomizationError {
     pub fn from_body(body: &str) -> SetUICustomizationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -13282,7 +13361,8 @@ impl SetUserMFAPreferenceError {
     pub fn from_body(body: &str) -> SetUserMFAPreferenceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -13400,7 +13480,8 @@ impl SetUserPoolMfaConfigError {
     pub fn from_body(body: &str) -> SetUserPoolMfaConfigError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -13520,7 +13601,8 @@ impl SetUserSettingsError {
     pub fn from_body(body: &str) -> SetUserSettingsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -13648,7 +13730,8 @@ impl SignUpError {
     pub fn from_body(body: &str) -> SignUpError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -13786,7 +13869,8 @@ impl StartUserImportJobError {
     pub fn from_body(body: &str) -> StartUserImportJobError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -13896,7 +13980,8 @@ impl StopUserImportJobError {
     pub fn from_body(body: &str) -> StopUserImportJobError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -14008,7 +14093,8 @@ impl UpdateAuthEventFeedbackError {
     pub fn from_body(body: &str) -> UpdateAuthEventFeedbackError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -14130,7 +14216,8 @@ impl UpdateDeviceStatusError {
     pub fn from_body(body: &str) -> UpdateDeviceStatusError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -14252,7 +14339,8 @@ impl UpdateGroupError {
     pub fn from_body(body: &str) -> UpdateGroupError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -14356,7 +14444,8 @@ impl UpdateIdentityProviderError {
     pub fn from_body(body: &str) -> UpdateIdentityProviderError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -14466,7 +14555,8 @@ impl UpdateResourceServerError {
     pub fn from_body(body: &str) -> UpdateResourceServerError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -14596,7 +14686,8 @@ impl UpdateUserAttributesError {
     pub fn from_body(body: &str) -> UpdateUserAttributesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -14774,7 +14865,8 @@ impl UpdateUserPoolError {
     pub fn from_body(body: &str) -> UpdateUserPoolError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -14910,7 +15002,8 @@ impl UpdateUserPoolClientError {
     pub fn from_body(body: &str) -> UpdateUserPoolClientError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -15042,7 +15135,8 @@ impl VerifySoftwareTokenError {
     pub fn from_body(body: &str) -> VerifySoftwareTokenError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -15192,7 +15286,8 @@ impl VerifyUserAttributeError {
     pub fn from_body(body: &str) -> VerifyUserAttributeError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/cognito-sync/src/generated.rs
+++ b/rusoto/services/cognito-sync/src/generated.rs
@@ -31,7 +31,7 @@ use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 /// <p>The input for the BulkPublish operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct BulkPublishRequest {
     /// <p>A name-spaced GUID (for example, us-east-1:23EC4050-6AEA-7089-A2DD-08002EXAMPLE) created by Amazon Cognito. GUID generation is unique within a region.</p>
     #[serde(rename = "IdentityPoolId")]
@@ -39,7 +39,7 @@ pub struct BulkPublishRequest {
 }
 
 /// <p>The output for the BulkPublish operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BulkPublishResponse {
     /// <p>A name-spaced GUID (for example, us-east-1:23EC4050-6AEA-7089-A2DD-08002EXAMPLE) created by Amazon Cognito. GUID generation is unique within a region.</p>
     #[serde(rename = "IdentityPoolId")]
@@ -48,7 +48,7 @@ pub struct BulkPublishResponse {
 }
 
 /// <p>Configuration options for configure Cognito streams.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CognitoStreams {
     /// <p>The ARN of the role Amazon Cognito can assume in order to publish to the stream. This role must grant access to Amazon Cognito (cognito-sync) to invoke PutRecord on your Cognito stream.</p>
     #[serde(rename = "RoleArn")]
@@ -65,7 +65,7 @@ pub struct CognitoStreams {
 }
 
 /// <p>A collection of data for an identity pool. An identity pool can have multiple datasets. A dataset is per identity and can be general or associated with a particular entity in an application (like a saved game). Datasets are automatically created if they don&#39;t exist. Data is synced by dataset, and a dataset can hold up to 1MB of key-value pairs.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Dataset {
     /// <p>Date on which the dataset was created.</p>
     #[serde(rename = "CreationDate")]
@@ -98,7 +98,7 @@ pub struct Dataset {
 }
 
 /// <p>A request to delete the specific dataset.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteDatasetRequest {
     /// <p>A string of up to 128 characters. Allowed characters are a-z, A-Z, 0-9, &#39;_&#39; (underscore), &#39;-&#39; (dash), and &#39;.&#39; (dot).</p>
     #[serde(rename = "DatasetName")]
@@ -112,7 +112,7 @@ pub struct DeleteDatasetRequest {
 }
 
 /// <p>Response to a successful DeleteDataset request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteDatasetResponse {
     /// <p>A collection of data for an identity pool. An identity pool can have multiple datasets. A dataset is per identity and can be general or associated with a particular entity in an application (like a saved game). Datasets are automatically created if they don&#39;t exist. Data is synced by dataset, and a dataset can hold up to 1MB of key-value pairs.</p>
     #[serde(rename = "Dataset")]
@@ -121,7 +121,7 @@ pub struct DeleteDatasetResponse {
 }
 
 /// <p>A request for meta data about a dataset (creation date, number of records, size) by owner and dataset name.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeDatasetRequest {
     /// <p>A string of up to 128 characters. Allowed characters are a-z, A-Z, 0-9, &#39;_&#39; (underscore), &#39;-&#39; (dash), and &#39;.&#39; (dot).</p>
     #[serde(rename = "DatasetName")]
@@ -135,7 +135,7 @@ pub struct DescribeDatasetRequest {
 }
 
 /// <p>Response to a successful DescribeDataset request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeDatasetResponse {
     /// <p>Meta data for a collection of data for an identity. An identity can have multiple datasets. A dataset can be general or associated with a particular entity in an application (like a saved game). Datasets are automatically created if they don&#39;t exist. Data is synced by dataset, and a dataset can hold up to 1MB of key-value pairs.</p>
     #[serde(rename = "Dataset")]
@@ -144,7 +144,7 @@ pub struct DescribeDatasetResponse {
 }
 
 /// <p>A request for usage information about the identity pool.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeIdentityPoolUsageRequest {
     /// <p>A name-spaced GUID (for example, us-east-1:23EC4050-6AEA-7089-A2DD-08002EXAMPLE) created by Amazon Cognito. GUID generation is unique within a region.</p>
     #[serde(rename = "IdentityPoolId")]
@@ -152,7 +152,7 @@ pub struct DescribeIdentityPoolUsageRequest {
 }
 
 /// <p>Response to a successful DescribeIdentityPoolUsage request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeIdentityPoolUsageResponse {
     /// <p>Information about the usage of the identity pool.</p>
     #[serde(rename = "IdentityPoolUsage")]
@@ -161,7 +161,7 @@ pub struct DescribeIdentityPoolUsageResponse {
 }
 
 /// <p>A request for information about the usage of an identity pool.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeIdentityUsageRequest {
     /// <p>A name-spaced GUID (for example, us-east-1:23EC4050-6AEA-7089-A2DD-08002EXAMPLE) created by Amazon Cognito. GUID generation is unique within a region.</p>
     #[serde(rename = "IdentityId")]
@@ -172,7 +172,7 @@ pub struct DescribeIdentityUsageRequest {
 }
 
 /// <p>The response to a successful DescribeIdentityUsage request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeIdentityUsageResponse {
     /// <p>Usage information for the identity.</p>
     #[serde(rename = "IdentityUsage")]
@@ -181,7 +181,7 @@ pub struct DescribeIdentityUsageResponse {
 }
 
 /// <p>The input for the GetBulkPublishDetails operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetBulkPublishDetailsRequest {
     /// <p>A name-spaced GUID (for example, us-east-1:23EC4050-6AEA-7089-A2DD-08002EXAMPLE) created by Amazon Cognito. GUID generation is unique within a region.</p>
     #[serde(rename = "IdentityPoolId")]
@@ -189,7 +189,7 @@ pub struct GetBulkPublishDetailsRequest {
 }
 
 /// <p>The output for the GetBulkPublishDetails operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetBulkPublishDetailsResponse {
     /// <p>If BulkPublishStatus is SUCCEEDED, the time the last bulk publish operation completed.</p>
     #[serde(rename = "BulkPublishCompleteTime")]
@@ -214,7 +214,7 @@ pub struct GetBulkPublishDetailsResponse {
 }
 
 /// <p>A request for a list of the configured Cognito Events</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetCognitoEventsRequest {
     /// <p>The Cognito Identity Pool ID for the request</p>
     #[serde(rename = "IdentityPoolId")]
@@ -222,7 +222,7 @@ pub struct GetCognitoEventsRequest {
 }
 
 /// <p>The response from the GetCognitoEvents request</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetCognitoEventsResponse {
     /// <p>The Cognito Events returned from the GetCognitoEvents request</p>
     #[serde(rename = "Events")]
@@ -231,7 +231,7 @@ pub struct GetCognitoEventsResponse {
 }
 
 /// <p>The input for the GetIdentityPoolConfiguration operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetIdentityPoolConfigurationRequest {
     /// <p>A name-spaced GUID (for example, us-east-1:23EC4050-6AEA-7089-A2DD-08002EXAMPLE) created by Amazon Cognito. This is the ID of the pool for which to return a configuration.</p>
     #[serde(rename = "IdentityPoolId")]
@@ -239,7 +239,7 @@ pub struct GetIdentityPoolConfigurationRequest {
 }
 
 /// <p>The output for the GetIdentityPoolConfiguration operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetIdentityPoolConfigurationResponse {
     /// <p>Options to apply to this identity pool for Amazon Cognito streams.</p>
     #[serde(rename = "CognitoStreams")]
@@ -256,7 +256,7 @@ pub struct GetIdentityPoolConfigurationResponse {
 }
 
 /// <p>Usage information for the identity pool.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct IdentityPoolUsage {
     /// <p>Data storage information for the identity pool.</p>
     #[serde(rename = "DataStorage")]
@@ -277,7 +277,7 @@ pub struct IdentityPoolUsage {
 }
 
 /// <p>Usage information for the identity.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct IdentityUsage {
     /// <p>Total data storage for this identity.</p>
     #[serde(rename = "DataStorage")]
@@ -302,7 +302,7 @@ pub struct IdentityUsage {
 }
 
 /// <p>Request for a list of datasets for an identity.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListDatasetsRequest {
     /// <p>A name-spaced GUID (for example, us-east-1:23EC4050-6AEA-7089-A2DD-08002EXAMPLE) created by Amazon Cognito. GUID generation is unique within a region.</p>
     #[serde(rename = "IdentityId")]
@@ -321,7 +321,7 @@ pub struct ListDatasetsRequest {
 }
 
 /// <p>Returned for a successful ListDatasets request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListDatasetsResponse {
     /// <p>Number of datasets returned.</p>
     #[serde(rename = "Count")]
@@ -338,7 +338,7 @@ pub struct ListDatasetsResponse {
 }
 
 /// <p>A request for usage information on an identity pool.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListIdentityPoolUsageRequest {
     /// <p>The maximum number of results to be returned.</p>
     #[serde(rename = "MaxResults")]
@@ -351,7 +351,7 @@ pub struct ListIdentityPoolUsageRequest {
 }
 
 /// <p>Returned for a successful ListIdentityPoolUsage request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListIdentityPoolUsageResponse {
     /// <p>Total number of identities for the identity pool.</p>
     #[serde(rename = "Count")]
@@ -372,7 +372,7 @@ pub struct ListIdentityPoolUsageResponse {
 }
 
 /// <p>A request for a list of records.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListRecordsRequest {
     /// <p>A string of up to 128 characters. Allowed characters are a-z, A-Z, 0-9, &#39;_&#39; (underscore), &#39;-&#39; (dash), and &#39;.&#39; (dot).</p>
     #[serde(rename = "DatasetName")]
@@ -402,7 +402,7 @@ pub struct ListRecordsRequest {
 }
 
 /// <p>Returned for a successful ListRecordsRequest.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListRecordsResponse {
     /// <p>Total number of records.</p>
     #[serde(rename = "Count")]
@@ -443,7 +443,7 @@ pub struct ListRecordsResponse {
 }
 
 /// <p>Configuration options to be applied to the identity pool.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct PushSync {
     /// <p>List of SNS platform application ARNs that could be used by clients.</p>
     #[serde(rename = "ApplicationArns")]
@@ -456,7 +456,7 @@ pub struct PushSync {
 }
 
 /// <p>The basic data structure of a dataset.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Record {
     /// <p>The last modified date of the client device.</p>
     #[serde(rename = "DeviceLastModifiedDate")]
@@ -485,7 +485,7 @@ pub struct Record {
 }
 
 /// <p>An update operation for a record.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RecordPatch {
     /// <p>The last modified date of the client device.</p>
     #[serde(rename = "DeviceLastModifiedDate")]
@@ -507,7 +507,7 @@ pub struct RecordPatch {
 }
 
 /// <p>A request to RegisterDevice.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RegisterDeviceRequest {
     /// <p>The unique ID for this identity.</p>
     #[serde(rename = "IdentityId")]
@@ -524,7 +524,7 @@ pub struct RegisterDeviceRequest {
 }
 
 /// <p>Response to a RegisterDevice request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RegisterDeviceResponse {
     /// <p>The unique ID generated for this device by Cognito.</p>
     #[serde(rename = "DeviceId")]
@@ -533,7 +533,7 @@ pub struct RegisterDeviceResponse {
 }
 
 /// <p>A request to configure Cognito Events</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SetCognitoEventsRequest {
     /// <p>The events to configure</p>
     #[serde(rename = "Events")]
@@ -544,7 +544,7 @@ pub struct SetCognitoEventsRequest {
 }
 
 /// <p>The input for the SetIdentityPoolConfiguration operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SetIdentityPoolConfigurationRequest {
     /// <p>Options to apply to this identity pool for Amazon Cognito streams.</p>
     #[serde(rename = "CognitoStreams")]
@@ -560,7 +560,7 @@ pub struct SetIdentityPoolConfigurationRequest {
 }
 
 /// <p>The output for the SetIdentityPoolConfiguration operation</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SetIdentityPoolConfigurationResponse {
     /// <p>Options to apply to this identity pool for Amazon Cognito streams.</p>
     #[serde(rename = "CognitoStreams")]
@@ -577,7 +577,7 @@ pub struct SetIdentityPoolConfigurationResponse {
 }
 
 /// <p>A request to SubscribeToDatasetRequest.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SubscribeToDatasetRequest {
     /// <p>The name of the dataset to subcribe to.</p>
     #[serde(rename = "DatasetName")]
@@ -594,11 +594,11 @@ pub struct SubscribeToDatasetRequest {
 }
 
 /// <p>Response to a SubscribeToDataset request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SubscribeToDatasetResponse {}
 
 /// <p>A request to UnsubscribeFromDataset.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UnsubscribeFromDatasetRequest {
     /// <p>The name of the dataset from which to unsubcribe.</p>
     #[serde(rename = "DatasetName")]
@@ -615,11 +615,11 @@ pub struct UnsubscribeFromDatasetRequest {
 }
 
 /// <p>Response to an UnsubscribeFromDataset request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UnsubscribeFromDatasetResponse {}
 
 /// <p>A request to post updates to records or add and delete records for a dataset and user.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateRecordsRequest {
     /// <p>Intended to supply a device ID that will populate the lastModifiedBy field referenced in other methods. The ClientContext field is not yet implemented.</p>
     #[serde(rename = "ClientContext")]
@@ -648,7 +648,7 @@ pub struct UpdateRecordsRequest {
 }
 
 /// <p>Returned for a successful UpdateRecordsRequest.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateRecordsResponse {
     /// <p>A list of records that have been updated.</p>
     #[serde(rename = "Records")]

--- a/rusoto/services/cognito-sync/src/generated.rs
+++ b/rusoto/services/cognito-sync/src/generated.rs
@@ -685,7 +685,8 @@ impl BulkPublishError {
     pub fn from_body(body: &str) -> BulkPublishError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -793,7 +794,8 @@ impl DeleteDatasetError {
     pub fn from_body(body: &str) -> DeleteDatasetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -899,7 +901,8 @@ impl DescribeDatasetError {
     pub fn from_body(body: &str) -> DescribeDatasetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1001,7 +1004,8 @@ impl DescribeIdentityPoolUsageError {
     pub fn from_body(body: &str) -> DescribeIdentityPoolUsageError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1109,7 +1113,8 @@ impl DescribeIdentityUsageError {
     pub fn from_body(body: &str) -> DescribeIdentityUsageError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1211,7 +1216,8 @@ impl GetBulkPublishDetailsError {
     pub fn from_body(body: &str) -> GetBulkPublishDetailsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1311,7 +1317,8 @@ impl GetCognitoEventsError {
     pub fn from_body(body: &str) -> GetCognitoEventsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1413,7 +1420,8 @@ impl GetIdentityPoolConfigurationError {
     pub fn from_body(body: &str) -> GetIdentityPoolConfigurationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1521,7 +1529,8 @@ impl ListDatasetsError {
     pub fn from_body(body: &str) -> ListDatasetsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1617,7 +1626,8 @@ impl ListIdentityPoolUsageError {
     pub fn from_body(body: &str) -> ListIdentityPoolUsageError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1715,7 +1725,8 @@ impl ListRecordsError {
     pub fn from_body(body: &str) -> ListRecordsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1815,7 +1826,8 @@ impl RegisterDeviceError {
     pub fn from_body(body: &str) -> RegisterDeviceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1921,7 +1933,8 @@ impl SetCognitoEventsError {
     pub fn from_body(body: &str) -> SetCognitoEventsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2025,7 +2038,8 @@ impl SetIdentityPoolConfigurationError {
     pub fn from_body(body: &str) -> SetIdentityPoolConfigurationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2143,7 +2157,8 @@ impl SubscribeToDatasetError {
     pub fn from_body(body: &str) -> SubscribeToDatasetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2253,7 +2268,8 @@ impl UnsubscribeFromDatasetError {
     pub fn from_body(body: &str) -> UnsubscribeFromDatasetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2371,7 +2387,8 @@ impl UpdateRecordsError {
     pub fn from_body(body: &str) -> UpdateRecordsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/config/src/generated.rs
+++ b/rusoto/services/config/src/generated.rs
@@ -31,7 +31,7 @@ use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 /// <p>A collection of accounts and regions.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct AccountAggregationSource {
     /// <p>The 12-digit account ID of the account being aggregated. </p>
     #[serde(rename = "AccountIds")]
@@ -47,7 +47,7 @@ pub struct AccountAggregationSource {
 }
 
 /// <p>Indicates whether an AWS Config rule is compliant based on account ID, region, compliance, and rule name.</p> <p>A rule is compliant if all of the resources that the rule evaluated comply with it. It is noncompliant if any of these resources do not comply.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AggregateComplianceByConfigRule {
     /// <p>The 12-digit account ID of the source account.</p>
     #[serde(rename = "AccountId")]
@@ -68,7 +68,7 @@ pub struct AggregateComplianceByConfigRule {
 }
 
 /// <p>Returns the number of compliant and noncompliant rules for one or more accounts and regions in an aggregator.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AggregateComplianceCount {
     /// <p>The number of compliant and noncompliant AWS Config rules.</p>
     #[serde(rename = "ComplianceSummary")]
@@ -81,7 +81,7 @@ pub struct AggregateComplianceCount {
 }
 
 /// <p>The details of an AWS Config evaluation for an account ID and region in an aggregator. Provides the AWS resource that was evaluated, the compliance of the resource, related time stamps, and supplementary information. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AggregateEvaluationResult {
     /// <p>The 12-digit account ID of the source account.</p>
     #[serde(rename = "AccountId")]
@@ -114,7 +114,7 @@ pub struct AggregateEvaluationResult {
 }
 
 /// <p>The current sync status between the source and the aggregator account.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AggregatedSourceStatus {
     /// <p>The region authorized to collect aggregated data.</p>
     #[serde(rename = "AwsRegion")]
@@ -147,7 +147,7 @@ pub struct AggregatedSourceStatus {
 }
 
 /// <p>An object that represents the authorizations granted to aggregator accounts and regions.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AggregationAuthorization {
     /// <p>The Amazon Resource Name (ARN) of the aggregation object.</p>
     #[serde(rename = "AggregationAuthorizationArn")]
@@ -168,7 +168,7 @@ pub struct AggregationAuthorization {
 }
 
 /// <p>The detailed configuration of a specified resource.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BaseConfigurationItem {
     /// <p>The 12 digit AWS account ID associated with the resource.</p>
     #[serde(rename = "accountId")]
@@ -228,14 +228,14 @@ pub struct BaseConfigurationItem {
     pub version: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct BatchGetResourceConfigRequest {
     /// <p>A list of resource keys to be processed with the current request. Each element in the list consists of the resource type and resource ID.</p>
     #[serde(rename = "resourceKeys")]
     pub resource_keys: Vec<ResourceKey>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BatchGetResourceConfigResponse {
     /// <p>A list that contains the current configuration of one or more resources.</p>
     #[serde(rename = "baseConfigurationItems")]
@@ -248,7 +248,7 @@ pub struct BatchGetResourceConfigResponse {
 }
 
 /// <p>Indicates whether an AWS resource or AWS Config rule is compliant and provides the number of contributors that affect the compliance.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Compliance {
     /// <p>The number of AWS resources or AWS Config rules that cause a result of <code>NON_COMPLIANT</code>, up to a maximum number.</p>
     #[serde(rename = "ComplianceContributorCount")]
@@ -261,7 +261,7 @@ pub struct Compliance {
 }
 
 /// <p>Indicates whether an AWS Config rule is compliant. A rule is compliant if all of the resources that the rule evaluated comply with it. A rule is noncompliant if any of these resources do not comply.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ComplianceByConfigRule {
     /// <p>Indicates whether the AWS Config rule is compliant.</p>
     #[serde(rename = "Compliance")]
@@ -274,7 +274,7 @@ pub struct ComplianceByConfigRule {
 }
 
 /// <p>Indicates whether an AWS resource that is evaluated according to one or more AWS Config rules is compliant. A resource is compliant if it complies with all of the rules that evaluate it. A resource is noncompliant if it does not comply with one or more of these rules.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ComplianceByResource {
     /// <p>Indicates whether the AWS resource complies with all of the AWS Config rules that evaluated it.</p>
     #[serde(rename = "Compliance")]
@@ -291,7 +291,7 @@ pub struct ComplianceByResource {
 }
 
 /// <p>The number of AWS resources or AWS Config rules responsible for the current compliance of the item, up to a maximum number.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ComplianceContributorCount {
     /// <p>Indicates whether the maximum count is reached.</p>
     #[serde(rename = "CapExceeded")]
@@ -304,7 +304,7 @@ pub struct ComplianceContributorCount {
 }
 
 /// <p>The number of AWS Config rules or AWS resources that are compliant and noncompliant.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ComplianceSummary {
     /// <p>The time that AWS Config created the compliance summary.</p>
     #[serde(rename = "ComplianceSummaryTimestamp")]
@@ -321,7 +321,7 @@ pub struct ComplianceSummary {
 }
 
 /// <p>The number of AWS resources of a specific type that are compliant or noncompliant, up to a maximum of 100 for each.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ComplianceSummaryByResourceType {
     /// <p>The number of AWS resources that are compliant or noncompliant, up to a maximum of 100 for each.</p>
     #[serde(rename = "ComplianceSummary")]
@@ -334,7 +334,7 @@ pub struct ComplianceSummaryByResourceType {
 }
 
 /// <p>Provides status of the delivery of the snapshot or the configuration history to the specified Amazon S3 bucket. Also provides the status of notifications about the Amazon S3 delivery to the specified Amazon SNS topic.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ConfigExportDeliveryInfo {
     /// <p>The time of the last attempted delivery.</p>
     #[serde(rename = "lastAttemptTime")]
@@ -363,7 +363,7 @@ pub struct ConfigExportDeliveryInfo {
 }
 
 /// <p>An AWS Config rule represents an AWS Lambda function that you create for a custom rule or a predefined function for an AWS managed rule. The function evaluates configuration items to assess whether your AWS resources comply with your desired configurations. This function can run when AWS Config detects a configuration change to an AWS resource and at a periodic frequency that you choose (for example, every 24 hours).</p> <note> <p>You can use the AWS CLI and AWS SDKs if you want to create a rule that triggers evaluations for your resources when AWS Config delivers the configuration snapshot. For more information, see <a>ConfigSnapshotDeliveryProperties</a>.</p> </note> <p>For more information about developing and using AWS Config rules, see <a href="http://docs.aws.amazon.com/config/latest/developerguide/evaluate-config.html">Evaluating AWS Resource Configurations with AWS Config</a> in the <i>AWS Config Developer Guide</i>.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ConfigRule {
     /// <p>The Amazon Resource Name (ARN) of the AWS Config rule.</p>
     #[serde(rename = "ConfigRuleArn")]
@@ -403,7 +403,7 @@ pub struct ConfigRule {
 }
 
 /// <p>Filters the compliance results based on account ID, region, compliance type, and rule name.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ConfigRuleComplianceFilters {
     /// <p>The 12-digit account ID of the source account. </p>
     #[serde(rename = "AccountId")]
@@ -424,7 +424,7 @@ pub struct ConfigRuleComplianceFilters {
 }
 
 /// <p>Filters the results based on the account IDs and regions.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ConfigRuleComplianceSummaryFilters {
     /// <p>The 12-digit account ID of the source account.</p>
     #[serde(rename = "AccountId")]
@@ -437,7 +437,7 @@ pub struct ConfigRuleComplianceSummaryFilters {
 }
 
 /// <p>Status information for your AWS managed Config rules. The status includes information such as the last time the rule ran, the last time it failed, and the related error for the last failure.</p> <p>This action does not return status information about custom AWS Config rules.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ConfigRuleEvaluationStatus {
     /// <p>The Amazon Resource Name (ARN) of the AWS Config rule.</p>
     #[serde(rename = "ConfigRuleArn")]
@@ -486,7 +486,7 @@ pub struct ConfigRuleEvaluationStatus {
 }
 
 /// <p>Provides options for how often AWS Config delivers configuration snapshots to the Amazon S3 bucket in your delivery channel.</p> <note> <p>If you want to create a rule that triggers evaluations for your resources when AWS Config delivers the configuration snapshot, see the following:</p> </note> <p>The frequency for a rule that triggers evaluations for your resources when AWS Config delivers the configuration snapshot is set by one of two values, depending on which is less frequent:</p> <ul> <li> <p>The value for the <code>deliveryFrequency</code> parameter within the delivery channel configuration, which sets how often AWS Config delivers configuration snapshots. This value also sets how often AWS Config invokes evaluations for AWS Config rules.</p> </li> <li> <p>The value for the <code>MaximumExecutionFrequency</code> parameter, which sets the maximum frequency with which AWS Config invokes evaluations for the rule. For more information, see <a>ConfigRule</a>.</p> </li> </ul> <p>If the <code>deliveryFrequency</code> value is less frequent than the <code>MaximumExecutionFrequency</code> value for a rule, AWS Config invokes the rule only as often as the <code>deliveryFrequency</code> value.</p> <ol> <li> <p>For example, you want your rule to run evaluations when AWS Config delivers the configuration snapshot.</p> </li> <li> <p>You specify the <code>MaximumExecutionFrequency</code> value for <code>Six_Hours</code>. </p> </li> <li> <p>You then specify the delivery channel <code>deliveryFrequency</code> value for <code>TwentyFour_Hours</code>.</p> </li> <li> <p>Because the value for <code>deliveryFrequency</code> is less frequent than <code>MaximumExecutionFrequency</code>, AWS Config invokes evaluations for the rule every 24 hours. </p> </li> </ol> <p>You should set the <code>MaximumExecutionFrequency</code> value to be at least as frequent as the <code>deliveryFrequency</code> value. You can view the <code>deliveryFrequency</code> value by using the <code>DescribeDeliveryChannnels</code> action.</p> <p>To update the <code>deliveryFrequency</code> with which AWS Config delivers your configuration snapshots, use the <code>PutDeliveryChannel</code> action.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ConfigSnapshotDeliveryProperties {
     /// <p>The frequency with which AWS Config delivers configuration snapshots.</p>
     #[serde(rename = "deliveryFrequency")]
@@ -495,7 +495,7 @@ pub struct ConfigSnapshotDeliveryProperties {
 }
 
 /// <p>A list that contains the status of the delivery of the configuration stream notification to the Amazon SNS topic.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ConfigStreamDeliveryInfo {
     /// <p>The error code from the last attempted delivery.</p>
     #[serde(rename = "lastErrorCode")]
@@ -516,7 +516,7 @@ pub struct ConfigStreamDeliveryInfo {
 }
 
 /// <p>The details about the configuration aggregator, including information about source accounts, regions, and metadata of the aggregator. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ConfigurationAggregator {
     /// <p>Provides a list of source accounts and regions to be aggregated.</p>
     #[serde(rename = "AccountAggregationSources")]
@@ -545,7 +545,7 @@ pub struct ConfigurationAggregator {
 }
 
 /// <p>A list that contains detailed configurations of a specified resource.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ConfigurationItem {
     /// <p>The 12-digit AWS account ID associated with the resource.</p>
     #[serde(rename = "accountId")]
@@ -622,7 +622,7 @@ pub struct ConfigurationItem {
 }
 
 /// <p>An object that represents the recording of configuration changes of an AWS resource.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ConfigurationRecorder {
     /// <p>The name of the recorder. By default, AWS Config automatically assigns the name "default" when creating the configuration recorder. You cannot change the assigned name.</p>
     #[serde(rename = "name")]
@@ -639,7 +639,7 @@ pub struct ConfigurationRecorder {
 }
 
 /// <p>The current status of the configuration recorder.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ConfigurationRecorderStatus {
     /// <p>The error code indicating that the recording failed.</p>
     #[serde(rename = "lastErrorCode")]
@@ -675,7 +675,7 @@ pub struct ConfigurationRecorderStatus {
     pub recording: Option<bool>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteAggregationAuthorizationRequest {
     /// <p>The 12-digit account ID of the account authorized to aggregate data.</p>
     #[serde(rename = "AuthorizedAccountId")]
@@ -686,14 +686,14 @@ pub struct DeleteAggregationAuthorizationRequest {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteConfigRuleRequest {
     /// <p>The name of the AWS Config rule that you want to delete.</p>
     #[serde(rename = "ConfigRuleName")]
     pub config_rule_name: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteConfigurationAggregatorRequest {
     /// <p>The name of the configuration aggregator.</p>
     #[serde(rename = "ConfigurationAggregatorName")]
@@ -701,7 +701,7 @@ pub struct DeleteConfigurationAggregatorRequest {
 }
 
 /// <p>The request object for the <code>DeleteConfigurationRecorder</code> action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteConfigurationRecorderRequest {
     /// <p>The name of the configuration recorder to be deleted. You can retrieve the name of your configuration recorder by using the <code>DescribeConfigurationRecorders</code> action.</p>
     #[serde(rename = "ConfigurationRecorderName")]
@@ -709,7 +709,7 @@ pub struct DeleteConfigurationRecorderRequest {
 }
 
 /// <p>The input for the <a>DeleteDeliveryChannel</a> action. The action accepts the following data, in JSON format. </p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteDeliveryChannelRequest {
     /// <p>The name of the delivery channel to delete.</p>
     #[serde(rename = "DeliveryChannelName")]
@@ -717,7 +717,7 @@ pub struct DeleteDeliveryChannelRequest {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteEvaluationResultsRequest {
     /// <p>The name of the AWS Config rule for which you want to delete the evaluation results.</p>
     #[serde(rename = "ConfigRuleName")]
@@ -725,10 +725,10 @@ pub struct DeleteEvaluationResultsRequest {
 }
 
 /// <p>The output when you delete the evaluation results for the specified AWS Config rule.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteEvaluationResultsResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeletePendingAggregationRequestRequest {
     /// <p>The 12-digit account ID of the account requesting to aggregate data.</p>
     #[serde(rename = "RequesterAccountId")]
@@ -739,7 +739,7 @@ pub struct DeletePendingAggregationRequestRequest {
 }
 
 /// <p>The input for the <a>DeliverConfigSnapshot</a> action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeliverConfigSnapshotRequest {
     /// <p>The name of the delivery channel through which the snapshot is delivered.</p>
     #[serde(rename = "deliveryChannelName")]
@@ -747,7 +747,7 @@ pub struct DeliverConfigSnapshotRequest {
 }
 
 /// <p>The output for the <a>DeliverConfigSnapshot</a> action, in JSON format.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeliverConfigSnapshotResponse {
     /// <p>The ID of the snapshot that is being created.</p>
     #[serde(rename = "configSnapshotId")]
@@ -756,7 +756,7 @@ pub struct DeliverConfigSnapshotResponse {
 }
 
 /// <p>The channel through which AWS Config delivers notifications and updated configuration states.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct DeliveryChannel {
     /// <p>The options for how often AWS Config delivers configuration snapshots to the Amazon S3 bucket.</p>
     #[serde(rename = "configSnapshotDeliveryProperties")]
@@ -781,7 +781,7 @@ pub struct DeliveryChannel {
 }
 
 /// <p>The status of a specified delivery channel.</p> <p>Valid values: <code>Success</code> | <code>Failure</code> </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeliveryChannelStatus {
     /// <p>A list that contains the status of the delivery of the configuration history to the specified Amazon S3 bucket.</p>
     #[serde(rename = "configHistoryDeliveryInfo")]
@@ -801,7 +801,7 @@ pub struct DeliveryChannelStatus {
     pub name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeAggregateComplianceByConfigRulesRequest {
     /// <p>The name of the configuration aggregator.</p>
     #[serde(rename = "ConfigurationAggregatorName")]
@@ -820,7 +820,7 @@ pub struct DescribeAggregateComplianceByConfigRulesRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeAggregateComplianceByConfigRulesResponse {
     /// <p>Returns a list of AggregateComplianceByConfigRule object.</p>
     #[serde(rename = "AggregateComplianceByConfigRules")]
@@ -832,7 +832,7 @@ pub struct DescribeAggregateComplianceByConfigRulesResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeAggregationAuthorizationsRequest {
     /// <p>The maximum number of AggregationAuthorizations returned on each page. The default is maximum. If you specify 0, AWS Config uses the default.</p>
     #[serde(rename = "Limit")]
@@ -844,7 +844,7 @@ pub struct DescribeAggregationAuthorizationsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeAggregationAuthorizationsResponse {
     /// <p>Returns a list of authorizations granted to various aggregator accounts and regions.</p>
     #[serde(rename = "AggregationAuthorizations")]
@@ -857,7 +857,7 @@ pub struct DescribeAggregationAuthorizationsResponse {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeComplianceByConfigRuleRequest {
     /// <p>Filters the results by compliance.</p> <p>The allowed values are <code>COMPLIANT</code>, <code>NON_COMPLIANT</code>, and <code>INSUFFICIENT_DATA</code>.</p>
     #[serde(rename = "ComplianceTypes")]
@@ -874,7 +874,7 @@ pub struct DescribeComplianceByConfigRuleRequest {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeComplianceByConfigRuleResponse {
     /// <p>Indicates whether each of the specified AWS Config rules is compliant.</p>
     #[serde(rename = "ComplianceByConfigRules")]
@@ -887,7 +887,7 @@ pub struct DescribeComplianceByConfigRuleResponse {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeComplianceByResourceRequest {
     /// <p>Filters the results by compliance.</p> <p>The allowed values are <code>COMPLIANT</code> and <code>NON_COMPLIANT</code>.</p>
     #[serde(rename = "ComplianceTypes")]
@@ -912,7 +912,7 @@ pub struct DescribeComplianceByResourceRequest {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeComplianceByResourceResponse {
     /// <p>Indicates whether the specified AWS resource complies with all of the AWS Config rules that evaluate it.</p>
     #[serde(rename = "ComplianceByResources")]
@@ -925,7 +925,7 @@ pub struct DescribeComplianceByResourceResponse {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeConfigRuleEvaluationStatusRequest {
     /// <p>The name of the AWS managed Config rules for which you want status information. If you do not specify any names, AWS Config returns status information for all AWS managed Config rules that you use.</p>
     #[serde(rename = "ConfigRuleNames")]
@@ -942,7 +942,7 @@ pub struct DescribeConfigRuleEvaluationStatusRequest {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeConfigRuleEvaluationStatusResponse {
     /// <p>Status information about your AWS managed Config rules.</p>
     #[serde(rename = "ConfigRulesEvaluationStatus")]
@@ -955,7 +955,7 @@ pub struct DescribeConfigRuleEvaluationStatusResponse {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeConfigRulesRequest {
     /// <p>The names of the AWS Config rules for which you want details. If you do not specify any names, AWS Config returns details for all your rules.</p>
     #[serde(rename = "ConfigRuleNames")]
@@ -968,7 +968,7 @@ pub struct DescribeConfigRulesRequest {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeConfigRulesResponse {
     /// <p>The details about your AWS Config rules.</p>
     #[serde(rename = "ConfigRules")]
@@ -980,7 +980,7 @@ pub struct DescribeConfigRulesResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeConfigurationAggregatorSourcesStatusRequest {
     /// <p>The name of the configuration aggregator.</p>
     #[serde(rename = "ConfigurationAggregatorName")]
@@ -999,7 +999,7 @@ pub struct DescribeConfigurationAggregatorSourcesStatusRequest {
     pub update_status: Option<Vec<String>>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeConfigurationAggregatorSourcesStatusResponse {
     /// <p>Retuns an AggregatedSourceStatus object. </p>
     #[serde(rename = "AggregatedSourceStatusList")]
@@ -1011,7 +1011,7 @@ pub struct DescribeConfigurationAggregatorSourcesStatusResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeConfigurationAggregatorsRequest {
     /// <p>The name of the configuration aggregators.</p>
     #[serde(rename = "ConfigurationAggregatorNames")]
@@ -1027,7 +1027,7 @@ pub struct DescribeConfigurationAggregatorsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeConfigurationAggregatorsResponse {
     /// <p>Returns a ConfigurationAggregators object.</p>
     #[serde(rename = "ConfigurationAggregators")]
@@ -1040,7 +1040,7 @@ pub struct DescribeConfigurationAggregatorsResponse {
 }
 
 /// <p>The input for the <a>DescribeConfigurationRecorderStatus</a> action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeConfigurationRecorderStatusRequest {
     /// <p>The name(s) of the configuration recorder. If the name is not specified, the action returns the current status of all the configuration recorders associated with the account.</p>
     #[serde(rename = "ConfigurationRecorderNames")]
@@ -1049,7 +1049,7 @@ pub struct DescribeConfigurationRecorderStatusRequest {
 }
 
 /// <p>The output for the <a>DescribeConfigurationRecorderStatus</a> action, in JSON format.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeConfigurationRecorderStatusResponse {
     /// <p>A list that contains status of the specified recorders.</p>
     #[serde(rename = "ConfigurationRecordersStatus")]
@@ -1058,7 +1058,7 @@ pub struct DescribeConfigurationRecorderStatusResponse {
 }
 
 /// <p>The input for the <a>DescribeConfigurationRecorders</a> action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeConfigurationRecordersRequest {
     /// <p>A list of configuration recorder names.</p>
     #[serde(rename = "ConfigurationRecorderNames")]
@@ -1067,7 +1067,7 @@ pub struct DescribeConfigurationRecordersRequest {
 }
 
 /// <p>The output for the <a>DescribeConfigurationRecorders</a> action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeConfigurationRecordersResponse {
     /// <p>A list that contains the descriptions of the specified configuration recorders.</p>
     #[serde(rename = "ConfigurationRecorders")]
@@ -1076,7 +1076,7 @@ pub struct DescribeConfigurationRecordersResponse {
 }
 
 /// <p>The input for the <a>DeliveryChannelStatus</a> action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeDeliveryChannelStatusRequest {
     /// <p>A list of delivery channel names.</p>
     #[serde(rename = "DeliveryChannelNames")]
@@ -1085,7 +1085,7 @@ pub struct DescribeDeliveryChannelStatusRequest {
 }
 
 /// <p>The output for the <a>DescribeDeliveryChannelStatus</a> action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeDeliveryChannelStatusResponse {
     /// <p>A list that contains the status of a specified delivery channel.</p>
     #[serde(rename = "DeliveryChannelsStatus")]
@@ -1094,7 +1094,7 @@ pub struct DescribeDeliveryChannelStatusResponse {
 }
 
 /// <p>The input for the <a>DescribeDeliveryChannels</a> action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeDeliveryChannelsRequest {
     /// <p>A list of delivery channel names.</p>
     #[serde(rename = "DeliveryChannelNames")]
@@ -1103,7 +1103,7 @@ pub struct DescribeDeliveryChannelsRequest {
 }
 
 /// <p>The output for the <a>DescribeDeliveryChannels</a> action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeDeliveryChannelsResponse {
     /// <p>A list that contains the descriptions of the specified delivery channel.</p>
     #[serde(rename = "DeliveryChannels")]
@@ -1111,7 +1111,7 @@ pub struct DescribeDeliveryChannelsResponse {
     pub delivery_channels: Option<Vec<DeliveryChannel>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribePendingAggregationRequestsRequest {
     /// <p>The maximum number of evaluation results returned on each page. The default is maximum. If you specify 0, AWS Config uses the default.</p>
     #[serde(rename = "Limit")]
@@ -1123,7 +1123,7 @@ pub struct DescribePendingAggregationRequestsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribePendingAggregationRequestsResponse {
     /// <p>The nextToken string returned on a previous page that you use to get the next page of results in a paginated response.</p>
     #[serde(rename = "NextToken")]
@@ -1136,7 +1136,7 @@ pub struct DescribePendingAggregationRequestsResponse {
 }
 
 /// <p>Identifies an AWS resource and indicates whether it complies with the AWS Config rule that it was evaluated against.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Evaluation {
     /// <p>Supplementary information about how the evaluation determined the compliance.</p>
     #[serde(rename = "Annotation")]
@@ -1157,7 +1157,7 @@ pub struct Evaluation {
 }
 
 /// <p>The details of an AWS Config evaluation. Provides the AWS resource that was evaluated, the compliance of the resource, related time stamps, and supplementary information.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct EvaluationResult {
     /// <p>Supplementary information about how the evaluation determined the compliance.</p>
     #[serde(rename = "Annotation")]
@@ -1186,7 +1186,7 @@ pub struct EvaluationResult {
 }
 
 /// <p>Uniquely identifies an evaluation result.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct EvaluationResultIdentifier {
     /// <p>Identifies an AWS Config rule used to evaluate an AWS resource, and provides the type and ID of the evaluated resource.</p>
     #[serde(rename = "EvaluationResultQualifier")]
@@ -1199,7 +1199,7 @@ pub struct EvaluationResultIdentifier {
 }
 
 /// <p>Identifies an AWS Config rule that evaluated an AWS resource, and provides the type and ID of the resource that the rule evaluated.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct EvaluationResultQualifier {
     /// <p>The name of the AWS Config rule that was used in the evaluation.</p>
     #[serde(rename = "ConfigRuleName")]
@@ -1215,7 +1215,7 @@ pub struct EvaluationResultQualifier {
     pub resource_type: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetAggregateComplianceDetailsByConfigRuleRequest {
     /// <p>The 12-digit account ID of the source account.</p>
     #[serde(rename = "AccountId")]
@@ -1243,7 +1243,7 @@ pub struct GetAggregateComplianceDetailsByConfigRuleRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetAggregateComplianceDetailsByConfigRuleResponse {
     /// <p>Returns an AggregateEvaluationResults object.</p>
     #[serde(rename = "AggregateEvaluationResults")]
@@ -1255,7 +1255,7 @@ pub struct GetAggregateComplianceDetailsByConfigRuleResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetAggregateConfigRuleComplianceSummaryRequest {
     /// <p>The name of the configuration aggregator.</p>
     #[serde(rename = "ConfigurationAggregatorName")]
@@ -1278,7 +1278,7 @@ pub struct GetAggregateConfigRuleComplianceSummaryRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetAggregateConfigRuleComplianceSummaryResponse {
     /// <p>Returns a list of AggregateComplianceCounts object.</p>
     #[serde(rename = "AggregateComplianceCounts")]
@@ -1295,7 +1295,7 @@ pub struct GetAggregateConfigRuleComplianceSummaryResponse {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetComplianceDetailsByConfigRuleRequest {
     /// <p>Filters the results by compliance.</p> <p>The allowed values are <code>COMPLIANT</code>, <code>NON_COMPLIANT</code>, and <code>NOT_APPLICABLE</code>.</p>
     #[serde(rename = "ComplianceTypes")]
@@ -1315,7 +1315,7 @@ pub struct GetComplianceDetailsByConfigRuleRequest {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetComplianceDetailsByConfigRuleResponse {
     /// <p>Indicates whether the AWS resource complies with the specified AWS Config rule.</p>
     #[serde(rename = "EvaluationResults")]
@@ -1328,7 +1328,7 @@ pub struct GetComplianceDetailsByConfigRuleResponse {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetComplianceDetailsByResourceRequest {
     /// <p>Filters the results by compliance.</p> <p>The allowed values are <code>COMPLIANT</code>, <code>NON_COMPLIANT</code>, and <code>NOT_APPLICABLE</code>.</p>
     #[serde(rename = "ComplianceTypes")]
@@ -1347,7 +1347,7 @@ pub struct GetComplianceDetailsByResourceRequest {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetComplianceDetailsByResourceResponse {
     /// <p>Indicates whether the specified AWS resource complies each AWS Config rule.</p>
     #[serde(rename = "EvaluationResults")]
@@ -1360,7 +1360,7 @@ pub struct GetComplianceDetailsByResourceResponse {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetComplianceSummaryByConfigRuleResponse {
     /// <p>The number of AWS Config rules that are compliant and the number that are noncompliant, up to a maximum of 25 for each.</p>
     #[serde(rename = "ComplianceSummary")]
@@ -1369,7 +1369,7 @@ pub struct GetComplianceSummaryByConfigRuleResponse {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetComplianceSummaryByResourceTypeRequest {
     /// <p>Specify one or more resource types to get the number of resources that are compliant and the number that are noncompliant for each resource type.</p> <p>For this request, you can specify an AWS resource type such as <code>AWS::EC2::Instance</code>. You can specify that the resource type is an AWS account by specifying <code>AWS::::Account</code>.</p>
     #[serde(rename = "ResourceTypes")]
@@ -1378,7 +1378,7 @@ pub struct GetComplianceSummaryByResourceTypeRequest {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetComplianceSummaryByResourceTypeResponse {
     /// <p>The number of resources that are compliant and the number that are noncompliant. If one or more resource types were provided with the request, the numbers are returned for each resource type. The maximum number returned is 100.</p>
     #[serde(rename = "ComplianceSummariesByResourceType")]
@@ -1386,7 +1386,7 @@ pub struct GetComplianceSummaryByResourceTypeResponse {
     pub compliance_summaries_by_resource_type: Option<Vec<ComplianceSummaryByResourceType>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetDiscoveredResourceCountsRequest {
     /// <p>The maximum number of <a>ResourceCount</a> objects returned on each page. The default is 100. You cannot specify a number greater than 100. If you specify 0, AWS Config uses the default.</p>
     #[serde(rename = "limit")]
@@ -1402,7 +1402,7 @@ pub struct GetDiscoveredResourceCountsRequest {
     pub resource_types: Option<Vec<String>>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetDiscoveredResourceCountsResponse {
     /// <p>The string that you use in a subsequent request to get the next page of results in a paginated response.</p>
     #[serde(rename = "nextToken")]
@@ -1419,7 +1419,7 @@ pub struct GetDiscoveredResourceCountsResponse {
 }
 
 /// <p>The input for the <a>GetResourceConfigHistory</a> action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetResourceConfigHistoryRequest {
     /// <p>The chronological order for configuration items listed. By default, the results are listed in reverse chronological order.</p>
     #[serde(rename = "chronologicalOrder")]
@@ -1450,7 +1450,7 @@ pub struct GetResourceConfigHistoryRequest {
 }
 
 /// <p>The output for the <a>GetResourceConfigHistory</a> action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetResourceConfigHistoryResponse {
     /// <p>A list that contains the configuration history of one or more resources.</p>
     #[serde(rename = "configurationItems")]
@@ -1463,7 +1463,7 @@ pub struct GetResourceConfigHistoryResponse {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListDiscoveredResourcesRequest {
     /// <p>Specifies whether AWS Config includes deleted resources in the results. By default, deleted resources are not included.</p>
     #[serde(rename = "includeDeletedResources")]
@@ -1491,7 +1491,7 @@ pub struct ListDiscoveredResourcesRequest {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListDiscoveredResourcesResponse {
     /// <p>The string that you use in a subsequent request to get the next page of results in a paginated response.</p>
     #[serde(rename = "nextToken")]
@@ -1504,7 +1504,7 @@ pub struct ListDiscoveredResourcesResponse {
 }
 
 /// <p>This object contains regions to setup the aggregator and an IAM role to retrieve organization details.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct OrganizationAggregationSource {
     /// <p>If true, aggreagate existing AWS Config regions and future regions.</p>
     #[serde(rename = "AllAwsRegions")]
@@ -1520,7 +1520,7 @@ pub struct OrganizationAggregationSource {
 }
 
 /// <p>An object that represents the account ID and region of an aggregator account that is requesting authorization but is not yet authorized.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PendingAggregationRequest {
     /// <p>The 12-digit account ID of the account requesting to aggregate data.</p>
     #[serde(rename = "RequesterAccountId")]
@@ -1532,7 +1532,7 @@ pub struct PendingAggregationRequest {
     pub requester_aws_region: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PutAggregationAuthorizationRequest {
     /// <p>The 12-digit account ID of the account authorized to aggregate data.</p>
     #[serde(rename = "AuthorizedAccountId")]
@@ -1542,7 +1542,7 @@ pub struct PutAggregationAuthorizationRequest {
     pub authorized_aws_region: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PutAggregationAuthorizationResponse {
     /// <p>Returns an AggregationAuthorization object. </p>
     #[serde(rename = "AggregationAuthorization")]
@@ -1550,14 +1550,14 @@ pub struct PutAggregationAuthorizationResponse {
     pub aggregation_authorization: Option<AggregationAuthorization>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PutConfigRuleRequest {
     /// <p>The rule that you want to add to your account.</p>
     #[serde(rename = "ConfigRule")]
     pub config_rule: ConfigRule,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PutConfigurationAggregatorRequest {
     /// <p>A list of AccountAggregationSource object. </p>
     #[serde(rename = "AccountAggregationSources")]
@@ -1572,7 +1572,7 @@ pub struct PutConfigurationAggregatorRequest {
     pub organization_aggregation_source: Option<OrganizationAggregationSource>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PutConfigurationAggregatorResponse {
     /// <p>Returns a ConfigurationAggregator object.</p>
     #[serde(rename = "ConfigurationAggregator")]
@@ -1581,7 +1581,7 @@ pub struct PutConfigurationAggregatorResponse {
 }
 
 /// <p>The input for the <a>PutConfigurationRecorder</a> action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PutConfigurationRecorderRequest {
     /// <p>The configuration recorder object that records each configuration change made to the resources.</p>
     #[serde(rename = "ConfigurationRecorder")]
@@ -1589,7 +1589,7 @@ pub struct PutConfigurationRecorderRequest {
 }
 
 /// <p>The input for the <a>PutDeliveryChannel</a> action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PutDeliveryChannelRequest {
     /// <p>The configuration delivery channel object that delivers the configuration information to an Amazon S3 bucket and to an Amazon SNS topic.</p>
     #[serde(rename = "DeliveryChannel")]
@@ -1597,7 +1597,7 @@ pub struct PutDeliveryChannelRequest {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PutEvaluationsRequest {
     /// <p>The assessments that the AWS Lambda function performs. Each evaluation identifies an AWS resource and indicates whether it complies with the AWS Config rule that invokes the AWS Lambda function.</p>
     #[serde(rename = "Evaluations")]
@@ -1613,7 +1613,7 @@ pub struct PutEvaluationsRequest {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PutEvaluationsResponse {
     /// <p>Requests that failed because of a client or server error.</p>
     #[serde(rename = "FailedEvaluations")]
@@ -1622,7 +1622,7 @@ pub struct PutEvaluationsResponse {
 }
 
 /// <p>Specifies the types of AWS resource for which AWS Config records configuration changes.</p> <p>In the recording group, you specify whether all supported types or specific types of resources are recorded.</p> <p>By default, AWS Config records configuration changes for all supported types of regional resources that AWS Config discovers in the region in which it is running. Regional resources are tied to a region and can be used only in that region. Examples of regional resources are EC2 instances and EBS volumes.</p> <p>You can also have AWS Config record configuration changes for supported types of global resources (for example, IAM resources). Global resources are not tied to an individual region and can be used in all regions.</p> <important> <p>The configuration details for any global resource are the same in all regions. If you customize AWS Config in multiple regions to record global resources, it will create multiple configuration items each time a global resource changes: one configuration item for each region. These configuration items will contain identical data. To prevent duplicate configuration items, you should consider customizing AWS Config in only one region to record global resources, unless you want the configuration items to be available in multiple regions.</p> </important> <p>If you don't want AWS Config to record all resources, you can specify which types of resources it will record with the <code>resourceTypes</code> parameter.</p> <p>For a list of supported resource types, see <a href="http://docs.aws.amazon.com/config/latest/developerguide/resource-config-reference.html#supported-resources">Supported Resource Types</a>.</p> <p>For more information, see <a href="http://docs.aws.amazon.com/config/latest/developerguide/select-resources.html">Selecting Which Resources AWS Config Records</a>.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RecordingGroup {
     /// <p>Specifies whether AWS Config records configuration changes for every supported type of regional resource.</p> <p>If you set this option to <code>true</code>, when AWS Config adds support for a new type of regional resource, it starts recording resources of that type automatically.</p> <p>If you set this option to <code>true</code>, you cannot enumerate a list of <code>resourceTypes</code>.</p>
     #[serde(rename = "allSupported")]
@@ -1639,7 +1639,7 @@ pub struct RecordingGroup {
 }
 
 /// <p>The relationship of the related resource to the main resource.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Relationship {
     /// <p>The type of relationship with the related resource.</p>
     #[serde(rename = "relationshipName")]
@@ -1660,7 +1660,7 @@ pub struct Relationship {
 }
 
 /// <p>An object that contains the resource type and the number of resources.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ResourceCount {
     /// <p>The number of resources.</p>
     #[serde(rename = "count")]
@@ -1673,7 +1673,7 @@ pub struct ResourceCount {
 }
 
 /// <p>The details that identify a resource that is discovered by AWS Config, including the resource type, ID, and (if available) the custom resource name.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ResourceIdentifier {
     /// <p>The time that the resource was deleted.</p>
     #[serde(rename = "resourceDeletionTime")]
@@ -1694,7 +1694,7 @@ pub struct ResourceIdentifier {
 }
 
 /// <p>The details that identify a resource within AWS Config, including the resource type and resource ID.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ResourceKey {
     /// <p>The ID of the resource (for example., sg-xxxxxx). </p>
     #[serde(rename = "resourceId")]
@@ -1705,7 +1705,7 @@ pub struct ResourceKey {
 }
 
 /// <p>Defines which resources trigger an evaluation for an AWS Config rule. The scope can include one or more resource types, a combination of a tag key and value, or a combination of one resource type and one resource ID. Specify a scope to constrain which resources trigger an evaluation for a rule. Otherwise, evaluations for the rule are triggered when any resource in your recording group changes in configuration.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Scope {
     /// <p>The ID of the only AWS resource that you want to trigger an evaluation for the rule. If you specify a resource ID, you must specify one resource type for <code>ComplianceResourceTypes</code>.</p>
     #[serde(rename = "ComplianceResourceId")]
@@ -1726,7 +1726,7 @@ pub struct Scope {
 }
 
 /// <p>Provides the AWS Config rule owner (AWS or customer), the rule identifier, and the events that trigger the evaluation of your AWS resources.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Source {
     /// <p>Indicates whether AWS or the customer owns and manages the AWS Config rule.</p>
     #[serde(rename = "Owner")]
@@ -1741,7 +1741,7 @@ pub struct Source {
 }
 
 /// <p>Provides the source and the message types that trigger AWS Config to evaluate your AWS resources against a rule. It also provides the frequency with which you want AWS Config to run evaluations for the rule if the trigger type is periodic. You can specify the parameter values for <code>SourceDetail</code> only for custom rules. </p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SourceDetail {
     /// <p>The source of the event, such as an AWS service, that triggers AWS Config to evaluate your AWS resources.</p>
     #[serde(rename = "EventSource")]
@@ -1758,7 +1758,7 @@ pub struct SourceDetail {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StartConfigRulesEvaluationRequest {
     /// <p>The list of names of AWS Config rules that you want to run evaluations for.</p>
     #[serde(rename = "ConfigRuleNames")]
@@ -1767,11 +1767,11 @@ pub struct StartConfigRulesEvaluationRequest {
 }
 
 /// <p>The output when you start the evaluation for the specified AWS Config rule.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StartConfigRulesEvaluationResponse {}
 
 /// <p>The input for the <a>StartConfigurationRecorder</a> action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StartConfigurationRecorderRequest {
     /// <p>The name of the recorder object that records each configuration change made to the resources.</p>
     #[serde(rename = "ConfigurationRecorderName")]
@@ -1779,7 +1779,7 @@ pub struct StartConfigurationRecorderRequest {
 }
 
 /// <p>The input for the <a>StopConfigurationRecorder</a> action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StopConfigurationRecorderRequest {
     /// <p>The name of the recorder object that records each configuration change made to the resources.</p>
     #[serde(rename = "ConfigurationRecorderName")]

--- a/rusoto/services/config/src/generated.rs
+++ b/rusoto/services/config/src/generated.rs
@@ -1805,7 +1805,8 @@ impl BatchGetResourceConfigError {
     pub fn from_body(body: &str) -> BatchGetResourceConfigError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1887,7 +1888,8 @@ impl DeleteAggregationAuthorizationError {
     pub fn from_body(body: &str) -> DeleteAggregationAuthorizationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1971,7 +1973,8 @@ impl DeleteConfigRuleError {
     pub fn from_body(body: &str) -> DeleteConfigRuleError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2053,7 +2056,8 @@ impl DeleteConfigurationAggregatorError {
     pub fn from_body(body: &str) -> DeleteConfigurationAggregatorError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2135,7 +2139,8 @@ impl DeleteConfigurationRecorderError {
     pub fn from_body(body: &str) -> DeleteConfigurationRecorderError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2219,7 +2224,8 @@ impl DeleteDeliveryChannelError {
     pub fn from_body(body: &str) -> DeleteDeliveryChannelError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2309,7 +2315,8 @@ impl DeleteEvaluationResultsError {
     pub fn from_body(body: &str) -> DeleteEvaluationResultsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2393,7 +2400,8 @@ impl DeletePendingAggregationRequestError {
     pub fn from_body(body: &str) -> DeletePendingAggregationRequestError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2479,7 +2487,8 @@ impl DeliverConfigSnapshotError {
     pub fn from_body(body: &str) -> DeliverConfigSnapshotError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2577,7 +2586,8 @@ impl DescribeAggregateComplianceByConfigRulesError {
     pub fn from_body(body: &str) -> DescribeAggregateComplianceByConfigRulesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2681,7 +2691,8 @@ impl DescribeAggregationAuthorizationsError {
     pub fn from_body(body: &str) -> DescribeAggregationAuthorizationsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2779,7 +2790,8 @@ impl DescribeComplianceByConfigRuleError {
     pub fn from_body(body: &str) -> DescribeComplianceByConfigRuleError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2875,7 +2887,8 @@ impl DescribeComplianceByResourceError {
     pub fn from_body(body: &str) -> DescribeComplianceByResourceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2967,7 +2980,8 @@ impl DescribeConfigRuleEvaluationStatusError {
     pub fn from_body(body: &str) -> DescribeConfigRuleEvaluationStatusError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3063,7 +3077,8 @@ impl DescribeConfigRulesError {
     pub fn from_body(body: &str) -> DescribeConfigRulesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3153,7 +3168,8 @@ impl DescribeConfigurationAggregatorSourcesStatusError {
     pub fn from_body(body: &str) -> DescribeConfigurationAggregatorSourcesStatusError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3251,7 +3267,8 @@ impl DescribeConfigurationAggregatorsError {
     pub fn from_body(body: &str) -> DescribeConfigurationAggregatorsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3351,7 +3368,8 @@ impl DescribeConfigurationRecorderStatusError {
     pub fn from_body(body: &str) -> DescribeConfigurationRecorderStatusError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3435,7 +3453,8 @@ impl DescribeConfigurationRecordersError {
     pub fn from_body(body: &str) -> DescribeConfigurationRecordersError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3517,7 +3536,8 @@ impl DescribeDeliveryChannelStatusError {
     pub fn from_body(body: &str) -> DescribeDeliveryChannelStatusError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3599,7 +3619,8 @@ impl DescribeDeliveryChannelsError {
     pub fn from_body(body: &str) -> DescribeDeliveryChannelsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3685,7 +3706,8 @@ impl DescribePendingAggregationRequestsError {
     pub fn from_body(body: &str) -> DescribePendingAggregationRequestsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3783,7 +3805,8 @@ impl GetAggregateComplianceDetailsByConfigRuleError {
     pub fn from_body(body: &str) -> GetAggregateComplianceDetailsByConfigRuleError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3871,7 +3894,8 @@ impl GetAggregateConfigRuleComplianceSummaryError {
     pub fn from_body(body: &str) -> GetAggregateConfigRuleComplianceSummaryError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3973,7 +3997,8 @@ impl GetComplianceDetailsByConfigRuleError {
     pub fn from_body(body: &str) -> GetComplianceDetailsByConfigRuleError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4067,7 +4092,8 @@ impl GetComplianceDetailsByResourceError {
     pub fn from_body(body: &str) -> GetComplianceDetailsByResourceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4147,7 +4173,8 @@ impl GetComplianceSummaryByConfigRuleError {
     pub fn from_body(body: &str) -> GetComplianceSummaryByConfigRuleError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4223,7 +4250,8 @@ impl GetComplianceSummaryByResourceTypeError {
     pub fn from_body(body: &str) -> GetComplianceSummaryByResourceTypeError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4307,7 +4335,8 @@ impl GetDiscoveredResourceCountsError {
     pub fn from_body(body: &str) -> GetDiscoveredResourceCountsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4401,7 +4430,8 @@ impl GetResourceConfigHistoryError {
     pub fn from_body(body: &str) -> GetResourceConfigHistoryError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4505,7 +4535,8 @@ impl ListDiscoveredResourcesError {
     pub fn from_body(body: &str) -> ListDiscoveredResourcesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4595,7 +4626,8 @@ impl PutAggregationAuthorizationError {
     pub fn from_body(body: &str) -> PutAggregationAuthorizationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4685,7 +4717,8 @@ impl PutConfigRuleError {
     pub fn from_body(body: &str) -> PutConfigRuleError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4793,7 +4826,8 @@ impl PutConfigurationAggregatorError {
     pub fn from_body(body: &str) -> PutConfigurationAggregatorError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4907,7 +4941,8 @@ impl PutConfigurationRecorderError {
     pub fn from_body(body: &str) -> PutConfigurationRecorderError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5019,7 +5054,8 @@ impl PutDeliveryChannelError {
     pub fn from_body(body: &str) -> PutDeliveryChannelError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5135,7 +5171,8 @@ impl PutEvaluationsError {
     pub fn from_body(body: &str) -> PutEvaluationsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5227,7 +5264,8 @@ impl StartConfigRulesEvaluationError {
     pub fn from_body(body: &str) -> StartConfigRulesEvaluationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5325,7 +5363,8 @@ impl StartConfigurationRecorderError {
     pub fn from_body(body: &str) -> StartConfigurationRecorderError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5413,7 +5452,8 @@ impl StopConfigurationRecorderError {
     pub fn from_body(body: &str) -> StopConfigurationRecorderError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/cur/src/generated.rs
+++ b/rusoto/services/cur/src/generated.rs
@@ -31,7 +31,7 @@ use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 /// <p>Request of DeleteReportDefinition</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteReportDefinitionRequest {
     #[serde(rename = "ReportName")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -39,7 +39,7 @@ pub struct DeleteReportDefinitionRequest {
 }
 
 /// <p>Response of DeleteReportDefinition</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteReportDefinitionResponse {
     #[serde(rename = "ResponseMessage")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -47,7 +47,7 @@ pub struct DeleteReportDefinitionResponse {
 }
 
 /// <p>Request of DescribeReportDefinitions</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeReportDefinitionsRequest {
     #[serde(rename = "MaxResults")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -58,7 +58,7 @@ pub struct DescribeReportDefinitionsRequest {
 }
 
 /// <p>Response of DescribeReportDefinitions</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeReportDefinitionsResponse {
     #[serde(rename = "NextToken")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -69,18 +69,18 @@ pub struct DescribeReportDefinitionsResponse {
 }
 
 /// <p>Request of PutReportDefinition</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PutReportDefinitionRequest {
     #[serde(rename = "ReportDefinition")]
     pub report_definition: ReportDefinition,
 }
 
 /// <p>Response of PutReportDefinition</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PutReportDefinitionResponse {}
 
 /// <p>The definition of AWS Cost and Usage Report. Customer can specify the report name, time unit, report format, compression format, S3 bucket and additional artifacts and schema elements in the definition.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ReportDefinition {
     #[serde(rename = "AdditionalArtifacts")]
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/rusoto/services/cur/src/generated.rs
+++ b/rusoto/services/cur/src/generated.rs
@@ -122,7 +122,8 @@ impl DeleteReportDefinitionError {
     pub fn from_body(body: &str) -> DeleteReportDefinitionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -202,7 +203,8 @@ impl DescribeReportDefinitionsError {
     pub fn from_body(body: &str) -> DescribeReportDefinitionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -286,7 +288,8 @@ impl PutReportDefinitionError {
     pub fn from_body(body: &str) -> PutReportDefinitionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/datapipeline/src/generated.rs
+++ b/rusoto/services/datapipeline/src/generated.rs
@@ -31,7 +31,7 @@ use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 /// <p>Contains the parameters for ActivatePipeline.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ActivatePipelineInput {
     /// <p>A list of parameter values to pass to the pipeline at activation.</p>
     #[serde(rename = "parameterValues")]
@@ -47,11 +47,11 @@ pub struct ActivatePipelineInput {
 }
 
 /// <p>Contains the output of ActivatePipeline.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ActivatePipelineOutput {}
 
 /// <p>Contains the parameters for AddTags.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AddTagsInput {
     /// <p>The ID of the pipeline.</p>
     #[serde(rename = "pipelineId")]
@@ -62,11 +62,11 @@ pub struct AddTagsInput {
 }
 
 /// <p>Contains the output of AddTags.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AddTagsOutput {}
 
 /// <p>Contains the parameters for CreatePipeline.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreatePipelineInput {
     /// <p>The description for the pipeline.</p>
     #[serde(rename = "description")]
@@ -85,7 +85,7 @@ pub struct CreatePipelineInput {
 }
 
 /// <p>Contains the output of CreatePipeline.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreatePipelineOutput {
     /// <p>The ID that AWS Data Pipeline assigns the newly created pipeline. For example, <code>df-06372391ZG65EXAMPLE</code>.</p>
     #[serde(rename = "pipelineId")]
@@ -93,7 +93,7 @@ pub struct CreatePipelineOutput {
 }
 
 /// <p>Contains the parameters for DeactivatePipeline.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeactivatePipelineInput {
     /// <p>Indicates whether to cancel any running objects. The default is true, which sets the state of any running objects to <code>CANCELED</code>. If this value is false, the pipeline is deactivated after all running objects finish.</p>
     #[serde(rename = "cancelActive")]
@@ -105,11 +105,11 @@ pub struct DeactivatePipelineInput {
 }
 
 /// <p>Contains the output of DeactivatePipeline.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeactivatePipelineOutput {}
 
 /// <p>Contains the parameters for DeletePipeline.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeletePipelineInput {
     /// <p>The ID of the pipeline.</p>
     #[serde(rename = "pipelineId")]
@@ -117,7 +117,7 @@ pub struct DeletePipelineInput {
 }
 
 /// <p>Contains the parameters for DescribeObjects.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeObjectsInput {
     /// <p>Indicates whether any expressions in the object should be evaluated when the object descriptions are returned.</p>
     #[serde(rename = "evaluateExpressions")]
@@ -136,7 +136,7 @@ pub struct DescribeObjectsInput {
 }
 
 /// <p>Contains the output of DescribeObjects.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeObjectsOutput {
     /// <p>Indicates whether there are more results to return.</p>
     #[serde(rename = "hasMoreResults")]
@@ -152,7 +152,7 @@ pub struct DescribeObjectsOutput {
 }
 
 /// <p>Contains the parameters for DescribePipelines.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribePipelinesInput {
     /// <p>The IDs of the pipelines to describe. You can pass as many as 25 identifiers in a single call. To obtain pipeline IDs, call <a>ListPipelines</a>.</p>
     #[serde(rename = "pipelineIds")]
@@ -160,7 +160,7 @@ pub struct DescribePipelinesInput {
 }
 
 /// <p>Contains the output of DescribePipelines.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribePipelinesOutput {
     /// <p>An array of descriptions for the specified pipelines.</p>
     #[serde(rename = "pipelineDescriptionList")]
@@ -168,7 +168,7 @@ pub struct DescribePipelinesOutput {
 }
 
 /// <p>Contains the parameters for EvaluateExpression.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct EvaluateExpressionInput {
     /// <p>The expression to evaluate.</p>
     #[serde(rename = "expression")]
@@ -182,7 +182,7 @@ pub struct EvaluateExpressionInput {
 }
 
 /// <p>Contains the output of EvaluateExpression.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct EvaluateExpressionOutput {
     /// <p>The evaluated expression.</p>
     #[serde(rename = "evaluatedExpression")]
@@ -190,7 +190,7 @@ pub struct EvaluateExpressionOutput {
 }
 
 /// <p>A key-value pair that describes a property of a pipeline object. The value is specified as either a string value (<code>StringValue</code>) or a reference to another object (<code>RefValue</code>) but not as both.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Field {
     /// <p>The field identifier.</p>
     #[serde(rename = "key")]
@@ -206,7 +206,7 @@ pub struct Field {
 }
 
 /// <p>Contains the parameters for GetPipelineDefinition.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetPipelineDefinitionInput {
     /// <p>The ID of the pipeline.</p>
     #[serde(rename = "pipelineId")]
@@ -218,7 +218,7 @@ pub struct GetPipelineDefinitionInput {
 }
 
 /// <p>Contains the output of GetPipelineDefinition.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetPipelineDefinitionOutput {
     /// <p>The parameter objects used in the pipeline definition.</p>
     #[serde(rename = "parameterObjects")]
@@ -235,7 +235,7 @@ pub struct GetPipelineDefinitionOutput {
 }
 
 /// <p><p>Identity information for the EC2 instance that is hosting the task runner. You can get this value by calling a metadata URI from the EC2 instance. For more information, see <a href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AESDG-chapter-instancedata.html">Instance Metadata</a> in the <i>Amazon Elastic Compute Cloud User Guide.</i> Passing in this value proves that your task runner is running on an EC2 instance, and ensures the proper AWS Data Pipeline service charges are applied to your pipeline.</p></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct InstanceIdentity {
     /// <p>A description of an EC2 instance that is generated when the instance is launched and exposed to the instance via the instance metadata service in the form of a JSON representation of an object.</p>
     #[serde(rename = "document")]
@@ -248,7 +248,7 @@ pub struct InstanceIdentity {
 }
 
 /// <p>Contains the parameters for ListPipelines.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListPipelinesInput {
     /// <p>The starting point for the results to be returned. For the first call, this value should be empty. As long as there are more results, continue to call <code>ListPipelines</code> with the marker value from the previous call to retrieve the next set of results.</p>
     #[serde(rename = "marker")]
@@ -257,7 +257,7 @@ pub struct ListPipelinesInput {
 }
 
 /// <p>Contains the output of ListPipelines.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListPipelinesOutput {
     /// <p>Indicates whether there are more results that can be obtained by a subsequent call.</p>
     #[serde(rename = "hasMoreResults")]
@@ -273,7 +273,7 @@ pub struct ListPipelinesOutput {
 }
 
 /// <p>Contains a logical operation for comparing the value of a field with a specified value.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct Operator {
     /// <p> The logical operation to be performed: equal (<code>EQ</code>), equal reference (<code>REF_EQ</code>), less than or equal (<code>LE</code>), greater than or equal (<code>GE</code>), or between (<code>BETWEEN</code>). Equal reference (<code>REF_EQ</code>) can be used only with reference fields. The other comparison types can be used only with String fields. The comparison types you can use apply only to certain object fields, as detailed below. </p> <p> The comparison operators EQ and REF_EQ act on the following fields: </p> <ul> <li>name</li> <li>@sphere</li> <li>parent</li> <li>@componentParent</li> <li>@instanceParent</li> <li>@status</li> <li>@scheduledStartTime</li> <li>@scheduledEndTime</li> <li>@actualStartTime</li> <li>@actualEndTime</li> </ul> <p> The comparison operators <code>GE</code>, <code>LE</code>, and <code>BETWEEN</code> act on the following fields: </p> <ul> <li>@scheduledStartTime</li> <li>@scheduledEndTime</li> <li>@actualStartTime</li> <li>@actualEndTime</li> </ul> <p>Note that fields beginning with the at sign (@) are read-only and set by the web service. When you name fields, you should choose names containing only alpha-numeric values, as symbols may be reserved by AWS Data Pipeline. User-defined fields that you add to a pipeline should prefix their name with the string "my".</p>
     #[serde(rename = "type")]
@@ -286,7 +286,7 @@ pub struct Operator {
 }
 
 /// <p>The attributes allowed or specified with a parameter object.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ParameterAttribute {
     /// <p>The field identifier.</p>
     #[serde(rename = "key")]
@@ -297,7 +297,7 @@ pub struct ParameterAttribute {
 }
 
 /// <p>Contains information about a parameter object.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ParameterObject {
     /// <p>The attributes of the parameter object.</p>
     #[serde(rename = "attributes")]
@@ -308,7 +308,7 @@ pub struct ParameterObject {
 }
 
 /// <p>A value or list of parameter values. </p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ParameterValue {
     /// <p>The ID of the parameter value.</p>
     #[serde(rename = "id")]
@@ -319,7 +319,7 @@ pub struct ParameterValue {
 }
 
 /// <p>Contains pipeline metadata.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PipelineDescription {
     /// <p>Description of the pipeline.</p>
     #[serde(rename = "description")]
@@ -341,7 +341,7 @@ pub struct PipelineDescription {
 }
 
 /// <p>Contains the name and identifier of a pipeline.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PipelineIdName {
     /// <p>The ID of the pipeline that was assigned by AWS Data Pipeline. This is a string of the form <code>df-297EG78HU43EEXAMPLE</code>.</p>
     #[serde(rename = "id")]
@@ -354,7 +354,7 @@ pub struct PipelineIdName {
 }
 
 /// <p>Contains information about a pipeline object. This can be a logical, physical, or physical attempt pipeline object. The complete set of components of a pipeline defines the pipeline.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct PipelineObject {
     /// <p>Key-value pairs that define the properties of the object.</p>
     #[serde(rename = "fields")]
@@ -368,7 +368,7 @@ pub struct PipelineObject {
 }
 
 /// <p>Contains the parameters for PollForTask.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PollForTaskInput {
     /// <p>The public DNS name of the calling task runner.</p>
     #[serde(rename = "hostname")]
@@ -384,7 +384,7 @@ pub struct PollForTaskInput {
 }
 
 /// <p>Contains the output of PollForTask.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PollForTaskOutput {
     /// <p>The information needed to complete the task that is being assigned to the task runner. One of the fields returned in this object is <code>taskId</code>, which contains an identifier for the task being assigned. The calling task runner uses <code>taskId</code> in subsequent calls to <a>ReportTaskProgress</a> and <a>SetTaskStatus</a>.</p>
     #[serde(rename = "taskObject")]
@@ -393,7 +393,7 @@ pub struct PollForTaskOutput {
 }
 
 /// <p>Contains the parameters for PutPipelineDefinition.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PutPipelineDefinitionInput {
     /// <p>The parameter objects used with the pipeline.</p>
     #[serde(rename = "parameterObjects")]
@@ -412,7 +412,7 @@ pub struct PutPipelineDefinitionInput {
 }
 
 /// <p>Contains the output of PutPipelineDefinition.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PutPipelineDefinitionOutput {
     /// <p>Indicates whether there were validation errors, and the pipeline definition is stored but cannot be activated until you correct the pipeline and call <code>PutPipelineDefinition</code> to commit the corrected pipeline.</p>
     #[serde(rename = "errored")]
@@ -428,7 +428,7 @@ pub struct PutPipelineDefinitionOutput {
 }
 
 /// <p>Defines the query to run against an object.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct Query {
     /// <p>List of selectors that define the query. An object must satisfy all of the selectors to match the query.</p>
     #[serde(rename = "selectors")]
@@ -437,7 +437,7 @@ pub struct Query {
 }
 
 /// <p>Contains the parameters for QueryObjects.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct QueryObjectsInput {
     /// <p>The maximum number of object names that <code>QueryObjects</code> will return in a single call. The default value is 100. </p>
     #[serde(rename = "limit")]
@@ -460,7 +460,7 @@ pub struct QueryObjectsInput {
 }
 
 /// <p>Contains the output of QueryObjects.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct QueryObjectsOutput {
     /// <p>Indicates whether there are more results that can be obtained by a subsequent call.</p>
     #[serde(rename = "hasMoreResults")]
@@ -477,7 +477,7 @@ pub struct QueryObjectsOutput {
 }
 
 /// <p>Contains the parameters for RemoveTags.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RemoveTagsInput {
     /// <p>The ID of the pipeline.</p>
     #[serde(rename = "pipelineId")]
@@ -488,11 +488,11 @@ pub struct RemoveTagsInput {
 }
 
 /// <p>Contains the output of RemoveTags.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RemoveTagsOutput {}
 
 /// <p>Contains the parameters for ReportTaskProgress.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ReportTaskProgressInput {
     /// <p>Key-value pairs that define the properties of the ReportTaskProgressInput object.</p>
     #[serde(rename = "fields")]
@@ -504,7 +504,7 @@ pub struct ReportTaskProgressInput {
 }
 
 /// <p>Contains the output of ReportTaskProgress.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ReportTaskProgressOutput {
     /// <p>If true, the calling task runner should cancel processing of the task. The task runner does not need to call <a>SetTaskStatus</a> for canceled tasks.</p>
     #[serde(rename = "canceled")]
@@ -512,7 +512,7 @@ pub struct ReportTaskProgressOutput {
 }
 
 /// <p>Contains the parameters for ReportTaskRunnerHeartbeat.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ReportTaskRunnerHeartbeatInput {
     /// <p>The public DNS name of the task runner.</p>
     #[serde(rename = "hostname")]
@@ -528,7 +528,7 @@ pub struct ReportTaskRunnerHeartbeatInput {
 }
 
 /// <p>Contains the output of ReportTaskRunnerHeartbeat.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ReportTaskRunnerHeartbeatOutput {
     /// <p>Indicates whether the calling task runner should terminate.</p>
     #[serde(rename = "terminate")]
@@ -536,7 +536,7 @@ pub struct ReportTaskRunnerHeartbeatOutput {
 }
 
 /// <p>A comparision that is used to determine whether a query should return this object.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct Selector {
     /// <p>The name of the field that the operator will be applied to. The field name is the "key" portion of the field definition in the pipeline definition syntax that is used by the AWS Data Pipeline API. If the field is not set on the object, the condition fails.</p>
     #[serde(rename = "fieldName")]
@@ -548,7 +548,7 @@ pub struct Selector {
 }
 
 /// <p>Contains the parameters for SetStatus.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SetStatusInput {
     /// <p>The IDs of the objects. The corresponding objects can be either physical or components, but not a mix of both types.</p>
     #[serde(rename = "objectIds")]
@@ -562,7 +562,7 @@ pub struct SetStatusInput {
 }
 
 /// <p>Contains the parameters for SetTaskStatus.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SetTaskStatusInput {
     /// <p>If an error occurred during the task, this value specifies the error code. This value is set on the physical attempt object. It is used to display error information to the user. It should not start with string "Service_" which is reserved by the system.</p>
     #[serde(rename = "errorId")]
@@ -585,11 +585,11 @@ pub struct SetTaskStatusInput {
 }
 
 /// <p>Contains the output of SetTaskStatus.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SetTaskStatusOutput {}
 
 /// <p>Tags are key/value pairs defined by a user and associated with a pipeline to control access. AWS Data Pipeline allows you to associate ten tags per pipeline. For more information, see <a href="http://docs.aws.amazon.com/datapipeline/latest/DeveloperGuide/dp-control-access.html">Controlling User Access to Pipelines</a> in the <i>AWS Data Pipeline Developer Guide</i>.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Tag {
     /// <p>The key name of a tag defined by a user. For more information, see <a href="http://docs.aws.amazon.com/datapipeline/latest/DeveloperGuide/dp-control-access.html">Controlling User Access to Pipelines</a> in the <i>AWS Data Pipeline Developer Guide</i>.</p>
     #[serde(rename = "key")]
@@ -600,7 +600,7 @@ pub struct Tag {
 }
 
 /// <p>Contains information about a pipeline task that is assigned to a task runner.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct TaskObject {
     /// <p>The ID of the pipeline task attempt object. AWS Data Pipeline uses this value to track how many times a task is attempted.</p>
     #[serde(rename = "attemptId")]
@@ -621,7 +621,7 @@ pub struct TaskObject {
 }
 
 /// <p>Contains the parameters for ValidatePipelineDefinition.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ValidatePipelineDefinitionInput {
     /// <p>The parameter objects used with the pipeline.</p>
     #[serde(rename = "parameterObjects")]
@@ -640,7 +640,7 @@ pub struct ValidatePipelineDefinitionInput {
 }
 
 /// <p>Contains the output of ValidatePipelineDefinition.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ValidatePipelineDefinitionOutput {
     /// <p>Indicates whether there were validation errors.</p>
     #[serde(rename = "errored")]
@@ -656,7 +656,7 @@ pub struct ValidatePipelineDefinitionOutput {
 }
 
 /// <p>Defines a validation error. Validation errors prevent pipeline activation. The set of validation errors that can be returned are defined by AWS Data Pipeline.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ValidationError {
     /// <p>A description of the validation error.</p>
     #[serde(rename = "errors")]
@@ -669,7 +669,7 @@ pub struct ValidationError {
 }
 
 /// <p>Defines a validation warning. Validation warnings do not prevent pipeline activation. The set of validation warnings that can be returned are defined by AWS Data Pipeline.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ValidationWarning {
     /// <p>The identifier of the object that contains the validation warning.</p>
     #[serde(rename = "id")]

--- a/rusoto/services/datapipeline/src/generated.rs
+++ b/rusoto/services/datapipeline/src/generated.rs
@@ -706,7 +706,8 @@ impl ActivatePipelineError {
     pub fn from_body(body: &str) -> ActivatePipelineError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -802,7 +803,8 @@ impl AddTagsError {
     pub fn from_body(body: &str) -> AddTagsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -892,7 +894,8 @@ impl CreatePipelineError {
     pub fn from_body(body: &str) -> CreatePipelineError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -980,7 +983,8 @@ impl DeactivatePipelineError {
     pub fn from_body(body: &str) -> DeactivatePipelineError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1076,7 +1080,8 @@ impl DeletePipelineError {
     pub fn from_body(body: &str) -> DeletePipelineError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1168,7 +1173,8 @@ impl DescribeObjectsError {
     pub fn from_body(body: &str) -> DescribeObjectsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1264,7 +1270,8 @@ impl DescribePipelinesError {
     pub fn from_body(body: &str) -> DescribePipelinesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1364,7 +1371,8 @@ impl EvaluateExpressionError {
     pub fn from_body(body: &str) -> EvaluateExpressionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1466,7 +1474,8 @@ impl GetPipelineDefinitionError {
     pub fn from_body(body: &str) -> GetPipelineDefinitionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1560,7 +1569,8 @@ impl ListPipelinesError {
     pub fn from_body(body: &str) -> ListPipelinesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1646,7 +1656,8 @@ impl PollForTaskError {
     pub fn from_body(body: &str) -> PollForTaskError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1738,7 +1749,8 @@ impl PutPipelineDefinitionError {
     pub fn from_body(body: &str) -> PutPipelineDefinitionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1836,7 +1848,8 @@ impl QueryObjectsError {
     pub fn from_body(body: &str) -> QueryObjectsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1932,7 +1945,8 @@ impl RemoveTagsError {
     pub fn from_body(body: &str) -> RemoveTagsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2028,7 +2042,8 @@ impl ReportTaskProgressError {
     pub fn from_body(body: &str) -> ReportTaskProgressError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2126,7 +2141,8 @@ impl ReportTaskRunnerHeartbeatError {
     pub fn from_body(body: &str) -> ReportTaskRunnerHeartbeatError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2216,7 +2232,8 @@ impl SetStatusError {
     pub fn from_body(body: &str) -> SetStatusError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2312,7 +2329,8 @@ impl SetTaskStatusError {
     pub fn from_body(body: &str) -> SetTaskStatusError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2412,7 +2430,8 @@ impl ValidatePipelineDefinitionError {
     pub fn from_body(body: &str) -> ValidatePipelineDefinitionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/dax/src/generated.rs
+++ b/rusoto/services/dax/src/generated.rs
@@ -31,7 +31,7 @@ use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 /// <p>Contains all of the attributes of a specific DAX cluster.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Cluster {
     /// <p>The number of nodes in the cluster that are active (i.e., capable of serving requests).</p>
     #[serde(rename = "ActiveNodes")]
@@ -99,7 +99,7 @@ pub struct Cluster {
     pub total_nodes: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateClusterRequest {
     /// <p>The Availability Zones (AZs) in which the cluster nodes will be created. All nodes belonging to the cluster are placed in these Availability Zones. Use this parameter if you want to distribute the nodes across multiple AZs.</p>
     #[serde(rename = "AvailabilityZones")]
@@ -147,7 +147,7 @@ pub struct CreateClusterRequest {
     pub tags: Option<Vec<Tag>>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateClusterResponse {
     /// <p>A description of the DAX cluster that you have created.</p>
     #[serde(rename = "Cluster")]
@@ -155,7 +155,7 @@ pub struct CreateClusterResponse {
     pub cluster: Option<Cluster>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateParameterGroupRequest {
     /// <p>A description of the parameter group.</p>
     #[serde(rename = "Description")]
@@ -166,7 +166,7 @@ pub struct CreateParameterGroupRequest {
     pub parameter_group_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateParameterGroupResponse {
     /// <p>Represents the output of a <i>CreateParameterGroup</i> action.</p>
     #[serde(rename = "ParameterGroup")]
@@ -174,7 +174,7 @@ pub struct CreateParameterGroupResponse {
     pub parameter_group: Option<ParameterGroup>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateSubnetGroupRequest {
     /// <p>A description for the subnet group</p>
     #[serde(rename = "Description")]
@@ -188,7 +188,7 @@ pub struct CreateSubnetGroupRequest {
     pub subnet_ids: Vec<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateSubnetGroupResponse {
     /// <p>Represents the output of a <i>CreateSubnetGroup</i> operation.</p>
     #[serde(rename = "SubnetGroup")]
@@ -196,7 +196,7 @@ pub struct CreateSubnetGroupResponse {
     pub subnet_group: Option<SubnetGroup>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DecreaseReplicationFactorRequest {
     /// <p>The Availability Zone(s) from which to remove nodes.</p>
     #[serde(rename = "AvailabilityZones")]
@@ -214,7 +214,7 @@ pub struct DecreaseReplicationFactorRequest {
     pub node_ids_to_remove: Option<Vec<String>>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DecreaseReplicationFactorResponse {
     /// <p>A description of the DAX cluster, after you have decreased its replication factor.</p>
     #[serde(rename = "Cluster")]
@@ -222,14 +222,14 @@ pub struct DecreaseReplicationFactorResponse {
     pub cluster: Option<Cluster>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteClusterRequest {
     /// <p>The name of the cluster to be deleted.</p>
     #[serde(rename = "ClusterName")]
     pub cluster_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteClusterResponse {
     /// <p>A description of the DAX cluster that is being deleted.</p>
     #[serde(rename = "Cluster")]
@@ -237,14 +237,14 @@ pub struct DeleteClusterResponse {
     pub cluster: Option<Cluster>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteParameterGroupRequest {
     /// <p>The name of the parameter group to delete.</p>
     #[serde(rename = "ParameterGroupName")]
     pub parameter_group_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteParameterGroupResponse {
     /// <p>A user-specified message for this action (i.e., a reason for deleting the parameter group).</p>
     #[serde(rename = "DeletionMessage")]
@@ -252,14 +252,14 @@ pub struct DeleteParameterGroupResponse {
     pub deletion_message: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteSubnetGroupRequest {
     /// <p>The name of the subnet group to delete.</p>
     #[serde(rename = "SubnetGroupName")]
     pub subnet_group_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteSubnetGroupResponse {
     /// <p>A user-specified message for this action (i.e., a reason for deleting the subnet group).</p>
     #[serde(rename = "DeletionMessage")]
@@ -267,7 +267,7 @@ pub struct DeleteSubnetGroupResponse {
     pub deletion_message: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeClustersRequest {
     /// <p>The names of the DAX clusters being described.</p>
     #[serde(rename = "ClusterNames")]
@@ -283,7 +283,7 @@ pub struct DescribeClustersRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeClustersResponse {
     /// <p>The descriptions of your DAX clusters, in response to a <i>DescribeClusters</i> request.</p>
     #[serde(rename = "Clusters")]
@@ -295,7 +295,7 @@ pub struct DescribeClustersResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeDefaultParametersRequest {
     /// <p>The maximum number of results to include in the response. If more results exist than the specified <code>MaxResults</code> value, a token is included in the response so that the remaining results can be retrieved.</p> <p>The value for <code>MaxResults</code> must be between 20 and 100.</p>
     #[serde(rename = "MaxResults")]
@@ -307,7 +307,7 @@ pub struct DescribeDefaultParametersRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeDefaultParametersResponse {
     /// <p>Provides an identifier to allow retrieval of paginated results.</p>
     #[serde(rename = "NextToken")]
@@ -319,7 +319,7 @@ pub struct DescribeDefaultParametersResponse {
     pub parameters: Option<Vec<Parameter>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeEventsRequest {
     /// <p>The number of minutes' worth of events to retrieve.</p>
     #[serde(rename = "Duration")]
@@ -351,7 +351,7 @@ pub struct DescribeEventsRequest {
     pub start_time: Option<f64>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeEventsResponse {
     /// <p>An array of events. Each element in the array represents one event.</p>
     #[serde(rename = "Events")]
@@ -363,7 +363,7 @@ pub struct DescribeEventsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeParameterGroupsRequest {
     /// <p>The maximum number of results to include in the response. If more results exist than the specified <code>MaxResults</code> value, a token is included in the response so that the remaining results can be retrieved.</p> <p>The value for <code>MaxResults</code> must be between 20 and 100.</p>
     #[serde(rename = "MaxResults")]
@@ -379,7 +379,7 @@ pub struct DescribeParameterGroupsRequest {
     pub parameter_group_names: Option<Vec<String>>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeParameterGroupsResponse {
     /// <p>Provides an identifier to allow retrieval of paginated results.</p>
     #[serde(rename = "NextToken")]
@@ -391,7 +391,7 @@ pub struct DescribeParameterGroupsResponse {
     pub parameter_groups: Option<Vec<ParameterGroup>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeParametersRequest {
     /// <p>The maximum number of results to include in the response. If more results exist than the specified <code>MaxResults</code> value, a token is included in the response so that the remaining results can be retrieved.</p> <p>The value for <code>MaxResults</code> must be between 20 and 100.</p>
     #[serde(rename = "MaxResults")]
@@ -410,7 +410,7 @@ pub struct DescribeParametersRequest {
     pub source: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeParametersResponse {
     /// <p>Provides an identifier to allow retrieval of paginated results.</p>
     #[serde(rename = "NextToken")]
@@ -422,7 +422,7 @@ pub struct DescribeParametersResponse {
     pub parameters: Option<Vec<Parameter>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeSubnetGroupsRequest {
     /// <p>The maximum number of results to include in the response. If more results exist than the specified <code>MaxResults</code> value, a token is included in the response so that the remaining results can be retrieved.</p> <p>The value for <code>MaxResults</code> must be between 20 and 100.</p>
     #[serde(rename = "MaxResults")]
@@ -438,7 +438,7 @@ pub struct DescribeSubnetGroupsRequest {
     pub subnet_group_names: Option<Vec<String>>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeSubnetGroupsResponse {
     /// <p>Provides an identifier to allow retrieval of paginated results.</p>
     #[serde(rename = "NextToken")]
@@ -451,7 +451,7 @@ pub struct DescribeSubnetGroupsResponse {
 }
 
 /// <p>Represents the information required for client programs to connect to the configuration endpoint for a DAX cluster, or to an individual node within the cluster.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Endpoint {
     /// <p>The DNS hostname of the endpoint.</p>
     #[serde(rename = "Address")]
@@ -464,7 +464,7 @@ pub struct Endpoint {
 }
 
 /// <p>Represents a single occurrence of something interesting within the system. Some examples of events are creating a DAX cluster, adding or removing a node, or rebooting a node.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Event {
     /// <p>The date and time when the event occurred.</p>
     #[serde(rename = "Date")]
@@ -484,7 +484,7 @@ pub struct Event {
     pub source_type: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct IncreaseReplicationFactorRequest {
     /// <p>The Availability Zones (AZs) in which the cluster nodes will be created. All nodes belonging to the cluster are placed in these Availability Zones. Use this parameter if you want to distribute the nodes across multiple AZs.</p>
     #[serde(rename = "AvailabilityZones")]
@@ -498,7 +498,7 @@ pub struct IncreaseReplicationFactorRequest {
     pub new_replication_factor: i64,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct IncreaseReplicationFactorResponse {
     /// <p>A description of the DAX cluster. with its new replication factor.</p>
     #[serde(rename = "Cluster")]
@@ -506,7 +506,7 @@ pub struct IncreaseReplicationFactorResponse {
     pub cluster: Option<Cluster>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListTagsRequest {
     /// <p>An optional token returned from a prior request. Use this token for pagination of results from this action. If this parameter is specified, the response includes only results beyond the token.</p>
     #[serde(rename = "NextToken")]
@@ -517,7 +517,7 @@ pub struct ListTagsRequest {
     pub resource_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListTagsResponse {
     /// <p>If this value is present, there are additional results to be displayed. To retrieve them, call <code>ListTags</code> again, with <code>NextToken</code> set to this value.</p>
     #[serde(rename = "NextToken")]
@@ -530,7 +530,7 @@ pub struct ListTagsResponse {
 }
 
 /// <p>Represents an individual node within a DAX cluster.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Node {
     /// <p>The Availability Zone (AZ) in which the node has been deployed.</p>
     #[serde(rename = "AvailabilityZone")]
@@ -559,7 +559,7 @@ pub struct Node {
 }
 
 /// <p>Represents a parameter value that is applicable to a particular node type.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct NodeTypeSpecificValue {
     /// <p>A node type to which the parameter value applies.</p>
     #[serde(rename = "NodeType")]
@@ -572,7 +572,7 @@ pub struct NodeTypeSpecificValue {
 }
 
 /// <p>Describes a notification topic and its status. Notification topics are used for publishing DAX events to subscribers using Amazon Simple Notification Service (SNS).</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct NotificationConfiguration {
     /// <p>The Amazon Resource Name (ARN) that identifies the topic. </p>
     #[serde(rename = "TopicArn")]
@@ -585,7 +585,7 @@ pub struct NotificationConfiguration {
 }
 
 /// <p>Describes an individual setting that controls some aspect of DAX behavior.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Parameter {
     /// <p>A range of values within which the parameter can be set.</p>
     #[serde(rename = "AllowedValues")]
@@ -630,7 +630,7 @@ pub struct Parameter {
 }
 
 /// <p>A named set of parameters that are applied to all of the nodes in a DAX cluster.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ParameterGroup {
     /// <p>A description of the parameter group.</p>
     #[serde(rename = "Description")]
@@ -643,7 +643,7 @@ pub struct ParameterGroup {
 }
 
 /// <p>The status of a parameter group.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ParameterGroupStatus {
     /// <p>The node IDs of one or more nodes to be rebooted.</p>
     #[serde(rename = "NodeIdsToReboot")]
@@ -660,7 +660,7 @@ pub struct ParameterGroupStatus {
 }
 
 /// <p>An individual DAX parameter.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ParameterNameValue {
     /// <p>The name of the parameter.</p>
     #[serde(rename = "ParameterName")]
@@ -672,7 +672,7 @@ pub struct ParameterNameValue {
     pub parameter_value: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RebootNodeRequest {
     /// <p>The name of the DAX cluster containing the node to be rebooted.</p>
     #[serde(rename = "ClusterName")]
@@ -682,7 +682,7 @@ pub struct RebootNodeRequest {
     pub node_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RebootNodeResponse {
     /// <p>A description of the DAX cluster after a node has been rebooted.</p>
     #[serde(rename = "Cluster")]
@@ -691,7 +691,7 @@ pub struct RebootNodeResponse {
 }
 
 /// <p>An individual VPC security group and its status.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SecurityGroupMembership {
     /// <p>The unique ID for this security group.</p>
     #[serde(rename = "SecurityGroupIdentifier")]
@@ -704,7 +704,7 @@ pub struct SecurityGroupMembership {
 }
 
 /// <p>Represents the subnet associated with a DAX cluster. This parameter refers to subnets defined in Amazon Virtual Private Cloud (Amazon VPC) and used with DAX.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Subnet {
     /// <p>The Availability Zone (AZ) for subnet subnet.</p>
     #[serde(rename = "SubnetAvailabilityZone")]
@@ -717,7 +717,7 @@ pub struct Subnet {
 }
 
 /// <p><p>Represents the output of one of the following actions:</p> <ul> <li> <p> <i>CreateSubnetGroup</i> </p> </li> <li> <p> <i>ModifySubnetGroup</i> </p> </li> </ul></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SubnetGroup {
     /// <p>The description of the subnet group.</p>
     #[serde(rename = "Description")]
@@ -738,7 +738,7 @@ pub struct SubnetGroup {
 }
 
 /// <p>A description of a tag. Every tag is a key-value pair. You can add up to 50 tags to a single DAX cluster.</p> <p>AWS-assigned tag names and values are automatically assigned the <code>aws:</code> prefix, which the user cannot assign. AWS-assigned tag names do not count towards the tag limit of 50. User-assigned tag names have the prefix <code>user:</code>.</p> <p>You cannot backdate the application of a tag.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Tag {
     /// <p>The key for the tag. Tag keys are case sensitive. Every DAX cluster can only have one tag with the same key. If you try to add an existing tag (same key), the existing tag value will be updated to the new value.</p>
     #[serde(rename = "Key")]
@@ -750,7 +750,7 @@ pub struct Tag {
     pub value: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct TagResourceRequest {
     /// <p>The name of the DAX resource to which tags should be added.</p>
     #[serde(rename = "ResourceName")]
@@ -760,7 +760,7 @@ pub struct TagResourceRequest {
     pub tags: Vec<Tag>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct TagResourceResponse {
     /// <p>The list of tags that are associated with the DAX resource.</p>
     #[serde(rename = "Tags")]
@@ -768,7 +768,7 @@ pub struct TagResourceResponse {
     pub tags: Option<Vec<Tag>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UntagResourceRequest {
     /// <p>The name of the DAX resource from which the tags should be removed.</p>
     #[serde(rename = "ResourceName")]
@@ -778,7 +778,7 @@ pub struct UntagResourceRequest {
     pub tag_keys: Vec<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UntagResourceResponse {
     /// <p>The tag keys that have been removed from the cluster.</p>
     #[serde(rename = "Tags")]
@@ -786,7 +786,7 @@ pub struct UntagResourceResponse {
     pub tags: Option<Vec<Tag>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateClusterRequest {
     /// <p>The name of the DAX cluster to be modified.</p>
     #[serde(rename = "ClusterName")]
@@ -817,7 +817,7 @@ pub struct UpdateClusterRequest {
     pub security_group_ids: Option<Vec<String>>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateClusterResponse {
     /// <p>A description of the DAX cluster, after it has been modified.</p>
     #[serde(rename = "Cluster")]
@@ -825,7 +825,7 @@ pub struct UpdateClusterResponse {
     pub cluster: Option<Cluster>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateParameterGroupRequest {
     /// <p>The name of the parameter group.</p>
     #[serde(rename = "ParameterGroupName")]
@@ -835,7 +835,7 @@ pub struct UpdateParameterGroupRequest {
     pub parameter_name_values: Vec<ParameterNameValue>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateParameterGroupResponse {
     /// <p>The parameter group that has been modified.</p>
     #[serde(rename = "ParameterGroup")]
@@ -843,7 +843,7 @@ pub struct UpdateParameterGroupResponse {
     pub parameter_group: Option<ParameterGroup>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateSubnetGroupRequest {
     /// <p>A description of the subnet group.</p>
     #[serde(rename = "Description")]
@@ -858,7 +858,7 @@ pub struct UpdateSubnetGroupRequest {
     pub subnet_ids: Option<Vec<String>>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateSubnetGroupResponse {
     /// <p>The subnet group that has been modified.</p>
     #[serde(rename = "SubnetGroup")]

--- a/rusoto/services/dax/src/generated.rs
+++ b/rusoto/services/dax/src/generated.rs
@@ -909,7 +909,8 @@ impl CreateClusterError {
     pub fn from_body(body: &str) -> CreateClusterError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1053,7 +1054,8 @@ impl CreateParameterGroupError {
     pub fn from_body(body: &str) -> CreateParameterGroupError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1165,7 +1167,8 @@ impl CreateSubnetGroupError {
     pub fn from_body(body: &str) -> CreateSubnetGroupError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1269,7 +1272,8 @@ impl DecreaseReplicationFactorError {
     pub fn from_body(body: &str) -> DecreaseReplicationFactorError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1377,7 +1381,8 @@ impl DeleteClusterError {
     pub fn from_body(body: &str) -> DeleteClusterError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1473,7 +1478,8 @@ impl DeleteParameterGroupError {
     pub fn from_body(body: &str) -> DeleteParameterGroupError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1575,7 +1581,8 @@ impl DeleteSubnetGroupError {
     pub fn from_body(body: &str) -> DeleteSubnetGroupError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1663,7 +1670,8 @@ impl DescribeClustersError {
     pub fn from_body(body: &str) -> DescribeClustersError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1753,7 +1761,8 @@ impl DescribeDefaultParametersError {
     pub fn from_body(body: &str) -> DescribeDefaultParametersError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1843,7 +1852,8 @@ impl DescribeEventsError {
     pub fn from_body(body: &str) -> DescribeEventsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1931,7 +1941,8 @@ impl DescribeParameterGroupsError {
     pub fn from_body(body: &str) -> DescribeParameterGroupsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2029,7 +2040,8 @@ impl DescribeParametersError {
     pub fn from_body(body: &str) -> DescribeParametersError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2121,7 +2133,8 @@ impl DescribeSubnetGroupsError {
     pub fn from_body(body: &str) -> DescribeSubnetGroupsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2217,7 +2230,8 @@ impl IncreaseReplicationFactorError {
     pub fn from_body(body: &str) -> IncreaseReplicationFactorError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2347,7 +2361,8 @@ impl ListTagsError {
     pub fn from_body(body: &str) -> ListTagsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2447,7 +2462,8 @@ impl RebootNodeError {
     pub fn from_body(body: &str) -> RebootNodeError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2549,7 +2565,8 @@ impl TagResourceError {
     pub fn from_body(body: &str) -> TagResourceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2657,7 +2674,8 @@ impl UntagResourceError {
     pub fn from_body(body: &str) -> UntagResourceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2765,7 +2783,8 @@ impl UpdateClusterError {
     pub fn from_body(body: &str) -> UpdateClusterError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2871,7 +2890,8 @@ impl UpdateParameterGroupError {
     pub fn from_body(body: &str) -> UpdateParameterGroupError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2977,7 +2997,8 @@ impl UpdateSubnetGroupError {
     pub fn from_body(body: &str) -> UpdateSubnetGroupError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/devicefarm/src/generated.rs
+++ b/rusoto/services/devicefarm/src/generated.rs
@@ -31,7 +31,7 @@ use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 /// <p>A container for account-level settings within AWS Device Farm.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AccountSettings {
     /// <p>The AWS account number specified in the <code>AccountSettings</code> container.</p>
     #[serde(rename = "awsAccountNumber")]
@@ -68,7 +68,7 @@ pub struct AccountSettings {
 }
 
 /// <p>Represents the output of a test. Examples of artifacts include logs and screenshots.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Artifact {
     /// <p>The artifact's ARN.</p>
     #[serde(rename = "arn")]
@@ -93,7 +93,7 @@ pub struct Artifact {
 }
 
 /// <p>Represents the amount of CPU that an app is using on a physical device.</p> <p>Note that this does not represent system-wide CPU usage.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CPU {
     /// <p>The CPU's architecture, for example x86 or ARM.</p>
     #[serde(rename = "architecture")]
@@ -110,7 +110,7 @@ pub struct CPU {
 }
 
 /// <p>Represents entity counters.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Counters {
     /// <p>The number of errored entities.</p>
     #[serde(rename = "errored")]
@@ -143,7 +143,7 @@ pub struct Counters {
 }
 
 /// <p>Represents a request to the create device pool operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateDevicePoolRequest {
     /// <p>The device pool's description.</p>
     #[serde(rename = "description")]
@@ -161,7 +161,7 @@ pub struct CreateDevicePoolRequest {
 }
 
 /// <p>Represents the result of a create device pool request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateDevicePoolResult {
     /// <p>The newly created device pool.</p>
     #[serde(rename = "devicePool")]
@@ -169,7 +169,7 @@ pub struct CreateDevicePoolResult {
     pub device_pool: Option<DevicePool>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateInstanceProfileRequest {
     /// <p>The description of your instance profile.</p>
     #[serde(rename = "description")]
@@ -192,7 +192,7 @@ pub struct CreateInstanceProfileRequest {
     pub reboot_after_use: Option<bool>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateInstanceProfileResult {
     /// <p>An object containing information about your instance profile.</p>
     #[serde(rename = "instanceProfile")]
@@ -200,7 +200,7 @@ pub struct CreateInstanceProfileResult {
     pub instance_profile: Option<InstanceProfile>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateNetworkProfileRequest {
     /// <p>The description of the network profile.</p>
     #[serde(rename = "description")]
@@ -250,7 +250,7 @@ pub struct CreateNetworkProfileRequest {
     pub uplink_loss_percent: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateNetworkProfileResult {
     /// <p>The network profile that is returned by the create network profile request.</p>
     #[serde(rename = "networkProfile")]
@@ -259,7 +259,7 @@ pub struct CreateNetworkProfileResult {
 }
 
 /// <p>Represents a request to the create project operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateProjectRequest {
     /// <p>Sets the execution timeout value (in minutes) for a project. All test runs in this project will use the specified execution timeout value unless overridden when scheduling a run.</p>
     #[serde(rename = "defaultJobTimeoutMinutes")]
@@ -271,7 +271,7 @@ pub struct CreateProjectRequest {
 }
 
 /// <p>Represents the result of a create project request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateProjectResult {
     /// <p>The newly created project.</p>
     #[serde(rename = "project")]
@@ -280,7 +280,7 @@ pub struct CreateProjectResult {
 }
 
 /// <p>Configuration settings for a remote access session, including billing method.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateRemoteAccessSessionConfiguration {
     /// <p>The billing method for the remote access session.</p>
     #[serde(rename = "billingMethod")]
@@ -289,7 +289,7 @@ pub struct CreateRemoteAccessSessionConfiguration {
 }
 
 /// <p>Creates and submits a request to start a remote access session.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateRemoteAccessSessionRequest {
     /// <p>Unique identifier for the client. If you want access to multiple devices on the same client, you should pass the same <code>clientId</code> value in each call to <code>CreateRemoteAccessSession</code>. This is required only if <code>remoteDebugEnabled</code> is set to <code>true</code>.</p>
     #[serde(rename = "clientId")]
@@ -340,7 +340,7 @@ pub struct CreateRemoteAccessSessionRequest {
 }
 
 /// <p>Represents the server response from a request to create a remote access session.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateRemoteAccessSessionResult {
     /// <p>A container that describes the remote access session when the request to create a remote access session is sent.</p>
     #[serde(rename = "remoteAccessSession")]
@@ -349,7 +349,7 @@ pub struct CreateRemoteAccessSessionResult {
 }
 
 /// <p>Represents a request to the create upload operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateUploadRequest {
     /// <p>The upload's content type (for example, "application/octet-stream").</p>
     #[serde(rename = "contentType")]
@@ -367,7 +367,7 @@ pub struct CreateUploadRequest {
 }
 
 /// <p>Represents the result of a create upload request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateUploadResult {
     /// <p>The newly created upload.</p>
     #[serde(rename = "upload")]
@@ -376,7 +376,7 @@ pub struct CreateUploadResult {
 }
 
 /// <p>A JSON object specifying the paths where the artifacts generated by the customer's tests, on the device or in the test environment, will be pulled from.</p> <p>Specify <code>deviceHostPaths</code> and optionally specify either <code>iosPaths</code> or <code>androidPaths</code>.</p> <p>For web app tests, you can specify both <code>iosPaths</code> and <code>androidPaths</code>.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CustomerArtifactPaths {
     /// <p>Comma-separated list of paths on the Android device where the artifacts generated by the customer's tests will be pulled from.</p>
     #[serde(rename = "androidPaths")]
@@ -393,7 +393,7 @@ pub struct CustomerArtifactPaths {
 }
 
 /// <p>Represents a request to the delete device pool operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteDevicePoolRequest {
     /// <p>Represents the Amazon Resource Name (ARN) of the Device Farm device pool you wish to delete.</p>
     #[serde(rename = "arn")]
@@ -401,31 +401,31 @@ pub struct DeleteDevicePoolRequest {
 }
 
 /// <p>Represents the result of a delete device pool request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteDevicePoolResult {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteInstanceProfileRequest {
     /// <p>The Amazon Resource Name (ARN) of the instance profile you are requesting to delete.</p>
     #[serde(rename = "arn")]
     pub arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteInstanceProfileResult {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteNetworkProfileRequest {
     /// <p>The Amazon Resource Name (ARN) of the network profile you want to delete.</p>
     #[serde(rename = "arn")]
     pub arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteNetworkProfileResult {}
 
 /// <p>Represents a request to the delete project operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteProjectRequest {
     /// <p>Represents the Amazon Resource Name (ARN) of the Device Farm project you wish to delete.</p>
     #[serde(rename = "arn")]
@@ -433,11 +433,11 @@ pub struct DeleteProjectRequest {
 }
 
 /// <p>Represents the result of a delete project request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteProjectResult {}
 
 /// <p>Represents the request to delete the specified remote access session.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteRemoteAccessSessionRequest {
     /// <p>The Amazon Resource Name (ARN) of the sesssion for which you want to delete remote access.</p>
     #[serde(rename = "arn")]
@@ -445,11 +445,11 @@ pub struct DeleteRemoteAccessSessionRequest {
 }
 
 /// <p>The response from the server when a request is made to delete the remote access session.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteRemoteAccessSessionResult {}
 
 /// <p>Represents a request to the delete run operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteRunRequest {
     /// <p>The Amazon Resource Name (ARN) for the run you wish to delete.</p>
     #[serde(rename = "arn")]
@@ -457,11 +457,11 @@ pub struct DeleteRunRequest {
 }
 
 /// <p>Represents the result of a delete run request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteRunResult {}
 
 /// <p>Represents a request to the delete upload operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteUploadRequest {
     /// <p>Represents the Amazon Resource Name (ARN) of the Device Farm upload you wish to delete.</p>
     #[serde(rename = "arn")]
@@ -469,11 +469,11 @@ pub struct DeleteUploadRequest {
 }
 
 /// <p>Represents the result of a delete upload request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteUploadResult {}
 
 /// <p>Represents a device type that an app is tested against.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Device {
     /// <p>The device's ARN.</p>
     #[serde(rename = "arn")]
@@ -558,7 +558,7 @@ pub struct Device {
 }
 
 /// <p>Represents the device instance.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeviceInstance {
     /// <p>The Amazon Resource Name (ARN) of the device instance.</p>
     #[serde(rename = "arn")]
@@ -587,7 +587,7 @@ pub struct DeviceInstance {
 }
 
 /// <p>Represents the total (metered or unmetered) minutes used by the resource to run tests. Contains the sum of minutes consumed by all children.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeviceMinutes {
     /// <p>When specified, represents only the sum of metered minutes used by the resource to run tests.</p>
     #[serde(rename = "metered")]
@@ -604,7 +604,7 @@ pub struct DeviceMinutes {
 }
 
 /// <p>Represents a collection of device types.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DevicePool {
     /// <p>The device pool's ARN.</p>
     #[serde(rename = "arn")]
@@ -629,7 +629,7 @@ pub struct DevicePool {
 }
 
 /// <p>Represents a device pool compatibility result.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DevicePoolCompatibilityResult {
     /// <p>Whether the result was compatible with the device pool.</p>
     #[serde(rename = "compatible")]
@@ -646,7 +646,7 @@ pub struct DevicePoolCompatibilityResult {
 }
 
 /// <p>Represents configuration information about a test run, such as the execution timeout (in minutes).</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ExecutionConfiguration {
     /// <p>True if account cleanup is enabled at the beginning of the test; otherwise, false.</p>
     #[serde(rename = "accountsCleanup")]
@@ -667,11 +667,11 @@ pub struct ExecutionConfiguration {
 }
 
 /// <p>Represents the request sent to retrieve the account settings.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetAccountSettingsRequest {}
 
 /// <p>Represents the account settings return values from the <code>GetAccountSettings</code> request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetAccountSettingsResult {
     /// <p>The account settings.</p>
     #[serde(rename = "accountSettings")]
@@ -679,14 +679,14 @@ pub struct GetAccountSettingsResult {
     pub account_settings: Option<AccountSettings>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetDeviceInstanceRequest {
     /// <p>The Amazon Resource Name (ARN) of the instance you're requesting information about.</p>
     #[serde(rename = "arn")]
     pub arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetDeviceInstanceResult {
     /// <p>An object containing information about your device instance.</p>
     #[serde(rename = "deviceInstance")]
@@ -695,7 +695,7 @@ pub struct GetDeviceInstanceResult {
 }
 
 /// <p>Represents a request to the get device pool compatibility operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetDevicePoolCompatibilityRequest {
     /// <p>The ARN of the app that is associated with the specified device pool.</p>
     #[serde(rename = "appArn")]
@@ -715,7 +715,7 @@ pub struct GetDevicePoolCompatibilityRequest {
 }
 
 /// <p>Represents the result of describe device pool compatibility request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetDevicePoolCompatibilityResult {
     /// <p>Information about compatible devices.</p>
     #[serde(rename = "compatibleDevices")]
@@ -728,7 +728,7 @@ pub struct GetDevicePoolCompatibilityResult {
 }
 
 /// <p>Represents a request to the get device pool operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetDevicePoolRequest {
     /// <p>The device pool's ARN.</p>
     #[serde(rename = "arn")]
@@ -736,7 +736,7 @@ pub struct GetDevicePoolRequest {
 }
 
 /// <p>Represents the result of a get device pool request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetDevicePoolResult {
     /// <p>An object containing information about the requested device pool.</p>
     #[serde(rename = "devicePool")]
@@ -745,7 +745,7 @@ pub struct GetDevicePoolResult {
 }
 
 /// <p>Represents a request to the get device request.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetDeviceRequest {
     /// <p>The device type's ARN.</p>
     #[serde(rename = "arn")]
@@ -753,7 +753,7 @@ pub struct GetDeviceRequest {
 }
 
 /// <p>Represents the result of a get device request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetDeviceResult {
     /// <p>An object containing information about the requested device.</p>
     #[serde(rename = "device")]
@@ -761,14 +761,14 @@ pub struct GetDeviceResult {
     pub device: Option<Device>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetInstanceProfileRequest {
     /// <p>The Amazon Resource Name (ARN) of your instance profile.</p>
     #[serde(rename = "arn")]
     pub arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetInstanceProfileResult {
     /// <p>An object containing information about your instance profile.</p>
     #[serde(rename = "instanceProfile")]
@@ -777,7 +777,7 @@ pub struct GetInstanceProfileResult {
 }
 
 /// <p>Represents a request to the get job operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetJobRequest {
     /// <p>The job's ARN.</p>
     #[serde(rename = "arn")]
@@ -785,7 +785,7 @@ pub struct GetJobRequest {
 }
 
 /// <p>Represents the result of a get job request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetJobResult {
     /// <p>An object containing information about the requested job.</p>
     #[serde(rename = "job")]
@@ -793,14 +793,14 @@ pub struct GetJobResult {
     pub job: Option<Job>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetNetworkProfileRequest {
     /// <p>The Amazon Resource Name (ARN) of the network profile you want to return information about.</p>
     #[serde(rename = "arn")]
     pub arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetNetworkProfileResult {
     /// <p>The network profile.</p>
     #[serde(rename = "networkProfile")]
@@ -809,7 +809,7 @@ pub struct GetNetworkProfileResult {
 }
 
 /// <p>Represents the request to retrieve the offering status for the specified customer or account.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetOfferingStatusRequest {
     /// <p>An identifier that was returned from the previous call to this operation, which can be used to return the next set of items in the list.</p>
     #[serde(rename = "nextToken")]
@@ -818,7 +818,7 @@ pub struct GetOfferingStatusRequest {
 }
 
 /// <p>Returns the status result for a device offering.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetOfferingStatusResult {
     /// <p>When specified, gets the offering status for the current period.</p>
     #[serde(rename = "current")]
@@ -835,7 +835,7 @@ pub struct GetOfferingStatusResult {
 }
 
 /// <p>Represents a request to the get project operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetProjectRequest {
     /// <p>The project's ARN.</p>
     #[serde(rename = "arn")]
@@ -843,7 +843,7 @@ pub struct GetProjectRequest {
 }
 
 /// <p>Represents the result of a get project request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetProjectResult {
     /// <p>The project you wish to get information about.</p>
     #[serde(rename = "project")]
@@ -852,7 +852,7 @@ pub struct GetProjectResult {
 }
 
 /// <p>Represents the request to get information about the specified remote access session.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetRemoteAccessSessionRequest {
     /// <p>The Amazon Resource Name (ARN) of the remote access session about which you want to get session information.</p>
     #[serde(rename = "arn")]
@@ -860,7 +860,7 @@ pub struct GetRemoteAccessSessionRequest {
 }
 
 /// <p>Represents the response from the server that lists detailed information about the remote access session.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetRemoteAccessSessionResult {
     /// <p>A container that lists detailed information about the remote access session.</p>
     #[serde(rename = "remoteAccessSession")]
@@ -869,7 +869,7 @@ pub struct GetRemoteAccessSessionResult {
 }
 
 /// <p>Represents a request to the get run operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetRunRequest {
     /// <p>The run's ARN.</p>
     #[serde(rename = "arn")]
@@ -877,7 +877,7 @@ pub struct GetRunRequest {
 }
 
 /// <p>Represents the result of a get run request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetRunResult {
     /// <p>The run you wish to get results from.</p>
     #[serde(rename = "run")]
@@ -886,7 +886,7 @@ pub struct GetRunResult {
 }
 
 /// <p>Represents a request to the get suite operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetSuiteRequest {
     /// <p>The suite's ARN.</p>
     #[serde(rename = "arn")]
@@ -894,7 +894,7 @@ pub struct GetSuiteRequest {
 }
 
 /// <p>Represents the result of a get suite request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetSuiteResult {
     /// <p>A collection of one or more tests.</p>
     #[serde(rename = "suite")]
@@ -903,7 +903,7 @@ pub struct GetSuiteResult {
 }
 
 /// <p>Represents a request to the get test operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetTestRequest {
     /// <p>The test's ARN.</p>
     #[serde(rename = "arn")]
@@ -911,7 +911,7 @@ pub struct GetTestRequest {
 }
 
 /// <p>Represents the result of a get test request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetTestResult {
     /// <p>A test condition that is evaluated.</p>
     #[serde(rename = "test")]
@@ -920,7 +920,7 @@ pub struct GetTestResult {
 }
 
 /// <p>Represents a request to the get upload operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetUploadRequest {
     /// <p>The upload's ARN.</p>
     #[serde(rename = "arn")]
@@ -928,7 +928,7 @@ pub struct GetUploadRequest {
 }
 
 /// <p>Represents the result of a get upload request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetUploadResult {
     /// <p>An app or a set of one or more tests to upload or that have been uploaded.</p>
     #[serde(rename = "upload")]
@@ -937,7 +937,7 @@ pub struct GetUploadResult {
 }
 
 /// <p>Represents information about incompatibility.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct IncompatibilityMessage {
     /// <p>A message about the incompatibility.</p>
     #[serde(rename = "message")]
@@ -950,7 +950,7 @@ pub struct IncompatibilityMessage {
 }
 
 /// <p>Represents the request to install an Android application (in .apk format) or an iOS application (in .ipa format) as part of a remote access session.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct InstallToRemoteAccessSessionRequest {
     /// <p>The Amazon Resource Name (ARN) of the app about which you are requesting information.</p>
     #[serde(rename = "appArn")]
@@ -961,7 +961,7 @@ pub struct InstallToRemoteAccessSessionRequest {
 }
 
 /// <p>Represents the response from the server after AWS Device Farm makes a request to install to a remote access session.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct InstallToRemoteAccessSessionResult {
     /// <p>An app to upload or that has been uploaded.</p>
     #[serde(rename = "appUpload")]
@@ -970,7 +970,7 @@ pub struct InstallToRemoteAccessSessionResult {
 }
 
 /// <p>Represents the instance profile.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct InstanceProfile {
     /// <p>The Amazon Resource Name (ARN) of the instance profile.</p>
     #[serde(rename = "arn")]
@@ -999,7 +999,7 @@ pub struct InstanceProfile {
 }
 
 /// <p>Represents a device.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Job {
     /// <p>The job's ARN.</p>
     #[serde(rename = "arn")]
@@ -1056,7 +1056,7 @@ pub struct Job {
 }
 
 /// <p>Represents a request to the list artifacts operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListArtifactsRequest {
     /// <p>The Run, Job, Suite, or Test ARN.</p>
     #[serde(rename = "arn")]
@@ -1071,7 +1071,7 @@ pub struct ListArtifactsRequest {
 }
 
 /// <p>Represents the result of a list artifacts operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListArtifactsResult {
     /// <p>Information about the artifacts.</p>
     #[serde(rename = "artifacts")]
@@ -1083,7 +1083,7 @@ pub struct ListArtifactsResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListDeviceInstancesRequest {
     /// <p>An integer specifying the maximum number of items you want to return in the API response.</p>
     #[serde(rename = "maxResults")]
@@ -1095,7 +1095,7 @@ pub struct ListDeviceInstancesRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListDeviceInstancesResult {
     /// <p>An object containing information about your device instances.</p>
     #[serde(rename = "deviceInstances")]
@@ -1108,7 +1108,7 @@ pub struct ListDeviceInstancesResult {
 }
 
 /// <p>Represents the result of a list device pools request.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListDevicePoolsRequest {
     /// <p>The project ARN.</p>
     #[serde(rename = "arn")]
@@ -1124,7 +1124,7 @@ pub struct ListDevicePoolsRequest {
 }
 
 /// <p>Represents the result of a list device pools request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListDevicePoolsResult {
     /// <p>Information about the device pools.</p>
     #[serde(rename = "devicePools")]
@@ -1137,7 +1137,7 @@ pub struct ListDevicePoolsResult {
 }
 
 /// <p>Represents the result of a list devices request.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListDevicesRequest {
     /// <p>The Amazon Resource Name (ARN) of the project.</p>
     #[serde(rename = "arn")]
@@ -1150,7 +1150,7 @@ pub struct ListDevicesRequest {
 }
 
 /// <p>Represents the result of a list devices operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListDevicesResult {
     /// <p>Information about the devices.</p>
     #[serde(rename = "devices")]
@@ -1162,7 +1162,7 @@ pub struct ListDevicesResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListInstanceProfilesRequest {
     /// <p>An integer specifying the maximum number of items you want to return in the API response.</p>
     #[serde(rename = "maxResults")]
@@ -1174,7 +1174,7 @@ pub struct ListInstanceProfilesRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListInstanceProfilesResult {
     /// <p>An object containing information about your instance profiles.</p>
     #[serde(rename = "instanceProfiles")]
@@ -1187,7 +1187,7 @@ pub struct ListInstanceProfilesResult {
 }
 
 /// <p>Represents a request to the list jobs operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListJobsRequest {
     /// <p>The run's Amazon Resource Name (ARN).</p>
     #[serde(rename = "arn")]
@@ -1199,7 +1199,7 @@ pub struct ListJobsRequest {
 }
 
 /// <p>Represents the result of a list jobs request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListJobsResult {
     /// <p>Information about the jobs.</p>
     #[serde(rename = "jobs")]
@@ -1211,7 +1211,7 @@ pub struct ListJobsResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListNetworkProfilesRequest {
     /// <p>The Amazon Resource Name (ARN) of the project for which you want to list network profiles.</p>
     #[serde(rename = "arn")]
@@ -1226,7 +1226,7 @@ pub struct ListNetworkProfilesRequest {
     pub type_: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListNetworkProfilesResult {
     /// <p>A list of the available network profiles.</p>
     #[serde(rename = "networkProfiles")]
@@ -1238,7 +1238,7 @@ pub struct ListNetworkProfilesResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListOfferingPromotionsRequest {
     /// <p>An identifier that was returned from the previous call to this operation, which can be used to return the next set of items in the list.</p>
     #[serde(rename = "nextToken")]
@@ -1246,7 +1246,7 @@ pub struct ListOfferingPromotionsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListOfferingPromotionsResult {
     /// <p>An identifier to be used in the next call to this operation, to return the next set of items in the list.</p>
     #[serde(rename = "nextToken")]
@@ -1259,7 +1259,7 @@ pub struct ListOfferingPromotionsResult {
 }
 
 /// <p>Represents the request to list the offering transaction history.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListOfferingTransactionsRequest {
     /// <p>An identifier that was returned from the previous call to this operation, which can be used to return the next set of items in the list.</p>
     #[serde(rename = "nextToken")]
@@ -1268,7 +1268,7 @@ pub struct ListOfferingTransactionsRequest {
 }
 
 /// <p>Returns the transaction log of the specified offerings.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListOfferingTransactionsResult {
     /// <p>An identifier that was returned from the previous call to this operation, which can be used to return the next set of items in the list.</p>
     #[serde(rename = "nextToken")]
@@ -1281,7 +1281,7 @@ pub struct ListOfferingTransactionsResult {
 }
 
 /// <p>Represents the request to list all offerings.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListOfferingsRequest {
     /// <p>An identifier that was returned from the previous call to this operation, which can be used to return the next set of items in the list.</p>
     #[serde(rename = "nextToken")]
@@ -1290,7 +1290,7 @@ pub struct ListOfferingsRequest {
 }
 
 /// <p>Represents the return values of the list of offerings.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListOfferingsResult {
     /// <p>An identifier that was returned from the previous call to this operation, which can be used to return the next set of items in the list.</p>
     #[serde(rename = "nextToken")]
@@ -1303,7 +1303,7 @@ pub struct ListOfferingsResult {
 }
 
 /// <p>Represents a request to the list projects operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListProjectsRequest {
     /// <p>Optional. If no Amazon Resource Name (ARN) is specified, then AWS Device Farm returns a list of all projects for the AWS account. You can also specify a project ARN.</p>
     #[serde(rename = "arn")]
@@ -1316,7 +1316,7 @@ pub struct ListProjectsRequest {
 }
 
 /// <p>Represents the result of a list projects request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListProjectsResult {
     /// <p>If the number of items that are returned is significantly large, this is an identifier that is also returned, which can be used in a subsequent call to this operation to return the next set of items in the list.</p>
     #[serde(rename = "nextToken")]
@@ -1329,7 +1329,7 @@ pub struct ListProjectsResult {
 }
 
 /// <p>Represents the request to return information about the remote access session.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListRemoteAccessSessionsRequest {
     /// <p>The Amazon Resource Name (ARN) of the remote access session about which you are requesting information.</p>
     #[serde(rename = "arn")]
@@ -1341,7 +1341,7 @@ pub struct ListRemoteAccessSessionsRequest {
 }
 
 /// <p>Represents the response from the server after AWS Device Farm makes a request to return information about the remote access session.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListRemoteAccessSessionsResult {
     /// <p>An identifier that was returned from the previous call to this operation, which can be used to return the next set of items in the list.</p>
     #[serde(rename = "nextToken")]
@@ -1354,7 +1354,7 @@ pub struct ListRemoteAccessSessionsResult {
 }
 
 /// <p>Represents a request to the list runs operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListRunsRequest {
     /// <p>The Amazon Resource Name (ARN) of the project for which you want to list runs.</p>
     #[serde(rename = "arn")]
@@ -1366,7 +1366,7 @@ pub struct ListRunsRequest {
 }
 
 /// <p>Represents the result of a list runs request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListRunsResult {
     /// <p>If the number of items that are returned is significantly large, this is an identifier that is also returned, which can be used in a subsequent call to this operation to return the next set of items in the list.</p>
     #[serde(rename = "nextToken")]
@@ -1379,7 +1379,7 @@ pub struct ListRunsResult {
 }
 
 /// <p>Represents a request to the list samples operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListSamplesRequest {
     /// <p>The Amazon Resource Name (ARN) of the project for which you want to list samples.</p>
     #[serde(rename = "arn")]
@@ -1391,7 +1391,7 @@ pub struct ListSamplesRequest {
 }
 
 /// <p>Represents the result of a list samples request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListSamplesResult {
     /// <p>If the number of items that are returned is significantly large, this is an identifier that is also returned, which can be used in a subsequent call to this operation to return the next set of items in the list.</p>
     #[serde(rename = "nextToken")]
@@ -1404,7 +1404,7 @@ pub struct ListSamplesResult {
 }
 
 /// <p>Represents a request to the list suites operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListSuitesRequest {
     /// <p>The job's Amazon Resource Name (ARN).</p>
     #[serde(rename = "arn")]
@@ -1416,7 +1416,7 @@ pub struct ListSuitesRequest {
 }
 
 /// <p>Represents the result of a list suites request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListSuitesResult {
     /// <p>If the number of items that are returned is significantly large, this is an identifier that is also returned, which can be used in a subsequent call to this operation to return the next set of items in the list.</p>
     #[serde(rename = "nextToken")]
@@ -1429,7 +1429,7 @@ pub struct ListSuitesResult {
 }
 
 /// <p>Represents a request to the list tests operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListTestsRequest {
     /// <p>The test suite's Amazon Resource Name (ARN).</p>
     #[serde(rename = "arn")]
@@ -1441,7 +1441,7 @@ pub struct ListTestsRequest {
 }
 
 /// <p>Represents the result of a list tests request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListTestsResult {
     /// <p>If the number of items that are returned is significantly large, this is an identifier that is also returned, which can be used in a subsequent call to this operation to return the next set of items in the list.</p>
     #[serde(rename = "nextToken")]
@@ -1454,7 +1454,7 @@ pub struct ListTestsResult {
 }
 
 /// <p>Represents a request to the list unique problems operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListUniqueProblemsRequest {
     /// <p>The unique problems' ARNs.</p>
     #[serde(rename = "arn")]
@@ -1466,7 +1466,7 @@ pub struct ListUniqueProblemsRequest {
 }
 
 /// <p>Represents the result of a list unique problems request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListUniqueProblemsResult {
     /// <p>If the number of items that are returned is significantly large, this is an identifier that is also returned, which can be used in a subsequent call to this operation to return the next set of items in the list.</p>
     #[serde(rename = "nextToken")]
@@ -1479,7 +1479,7 @@ pub struct ListUniqueProblemsResult {
 }
 
 /// <p>Represents a request to the list uploads operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListUploadsRequest {
     /// <p>The Amazon Resource Name (ARN) of the project for which you want to list uploads.</p>
     #[serde(rename = "arn")]
@@ -1491,7 +1491,7 @@ pub struct ListUploadsRequest {
 }
 
 /// <p>Represents the result of a list uploads request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListUploadsResult {
     /// <p>If the number of items that are returned is significantly large, this is an identifier that is also returned, which can be used in a subsequent call to this operation to return the next set of items in the list.</p>
     #[serde(rename = "nextToken")]
@@ -1504,7 +1504,7 @@ pub struct ListUploadsResult {
 }
 
 /// <p>Represents a latitude and longitude pair, expressed in geographic coordinate system degrees (for example 47.6204, -122.3491).</p> <p>Elevation is currently not supported.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Location {
     /// <p>The latitude.</p>
     #[serde(rename = "latitude")]
@@ -1515,7 +1515,7 @@ pub struct Location {
 }
 
 /// <p>A number representing the monetary amount for an offering or transaction.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct MonetaryAmount {
     /// <p>The numerical amount of an offering or transaction.</p>
     #[serde(rename = "amount")]
@@ -1528,7 +1528,7 @@ pub struct MonetaryAmount {
 }
 
 /// <p>An array of settings that describes characteristics of a network profile.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct NetworkProfile {
     /// <p>The Amazon Resource Name (ARN) of the network profile.</p>
     #[serde(rename = "arn")]
@@ -1581,7 +1581,7 @@ pub struct NetworkProfile {
 }
 
 /// <p>Represents the metadata of a device offering.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Offering {
     /// <p>A string describing the offering.</p>
     #[serde(rename = "description")]
@@ -1606,7 +1606,7 @@ pub struct Offering {
 }
 
 /// <p>Represents information about an offering promotion.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct OfferingPromotion {
     /// <p>A string describing the offering promotion.</p>
     #[serde(rename = "description")]
@@ -1619,7 +1619,7 @@ pub struct OfferingPromotion {
 }
 
 /// <p>The status of the offering.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct OfferingStatus {
     /// <p>The date on which the offering is effective.</p>
     #[serde(rename = "effectiveOn")]
@@ -1640,7 +1640,7 @@ pub struct OfferingStatus {
 }
 
 /// <p>Represents the metadata of an offering transaction.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct OfferingTransaction {
     /// <p>The cost of an offering transaction.</p>
     #[serde(rename = "cost")]
@@ -1665,7 +1665,7 @@ pub struct OfferingTransaction {
 }
 
 /// <p>Represents a specific warning or failure.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Problem {
     /// <p>Information about the associated device.</p>
     #[serde(rename = "device")]
@@ -1698,7 +1698,7 @@ pub struct Problem {
 }
 
 /// <p>Information about a problem detail.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ProblemDetail {
     /// <p>The problem detail's ARN.</p>
     #[serde(rename = "arn")]
@@ -1711,7 +1711,7 @@ pub struct ProblemDetail {
 }
 
 /// <p>Represents an operating-system neutral workspace for running and managing tests.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Project {
     /// <p>The project's ARN.</p>
     #[serde(rename = "arn")]
@@ -1732,7 +1732,7 @@ pub struct Project {
 }
 
 /// <p>Represents a request for a purchase offering.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PurchaseOfferingRequest {
     /// <p>The ID of the offering.</p>
     #[serde(rename = "offeringId")]
@@ -1749,7 +1749,7 @@ pub struct PurchaseOfferingRequest {
 }
 
 /// <p>The result of the purchase offering (e.g., success or failure).</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PurchaseOfferingResult {
     /// <p>Represents the offering transaction for the purchase result.</p>
     #[serde(rename = "offeringTransaction")]
@@ -1758,7 +1758,7 @@ pub struct PurchaseOfferingResult {
 }
 
 /// <p>Represents the set of radios and their states on a device. Examples of radios include Wi-Fi, GPS, Bluetooth, and NFC.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Radios {
     /// <p>True if Bluetooth is enabled at the beginning of the test; otherwise, false.</p>
     #[serde(rename = "bluetooth")]
@@ -1779,7 +1779,7 @@ pub struct Radios {
 }
 
 /// <p>Specifies whether charges for devices will be recurring.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RecurringCharge {
     /// <p>The cost of the recurring charge.</p>
     #[serde(rename = "cost")]
@@ -1792,7 +1792,7 @@ pub struct RecurringCharge {
 }
 
 /// <p>Represents information about the remote access session.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RemoteAccessSession {
     /// <p>The Amazon Resource Name (ARN) of the remote access session.</p>
     #[serde(rename = "arn")]
@@ -1881,7 +1881,7 @@ pub struct RemoteAccessSession {
 }
 
 /// <p>A request representing an offering renewal.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RenewOfferingRequest {
     /// <p>The ID of a request to renew an offering.</p>
     #[serde(rename = "offeringId")]
@@ -1894,7 +1894,7 @@ pub struct RenewOfferingRequest {
 }
 
 /// <p>The result of a renewal offering.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RenewOfferingResult {
     /// <p>Represents the status of the offering transaction for the renewal.</p>
     #[serde(rename = "offeringTransaction")]
@@ -1903,7 +1903,7 @@ pub struct RenewOfferingResult {
 }
 
 /// <p>Represents the screen resolution of a device in height and width, expressed in pixels.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Resolution {
     /// <p>The screen resolution's height, expressed in pixels.</p>
     #[serde(rename = "height")]
@@ -1916,7 +1916,7 @@ pub struct Resolution {
 }
 
 /// <p>Represents a condition for a device pool.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Rule {
     /// <p><p>The rule&#39;s stringified attribute. For example, specify the value as <code>&quot;&quot;abc&quot;&quot;</code>.</p> <p>Allowed values include:</p> <ul> <li> <p>ARN: The ARN.</p> </li> <li> <p>FORM<em>FACTOR: The form factor (for example, phone or tablet).</p> </li> <li> <p>MANUFACTURER: The manufacturer.</p> </li> <li> <p>PLATFORM: The platform (for example, Android or iOS).</p> </li> <li> <p>REMOTE</em>ACCESS<em>ENABLED: Whether the device is enabled for remote access.</p> </li> <li> <p>APPIUM</em>VERSION: The Appium version for the test.</p> </li> <li> <p>INSTANCE<em>ARN: The Amazon Resource Name (ARN) of the device instance.</p> </li> <li> <p>INSTANCE</em>LABELS: The label of the device instance.</p> </li> </ul></p>
     #[serde(rename = "attribute")]
@@ -1933,7 +1933,7 @@ pub struct Rule {
 }
 
 /// <p>Represents a test run on a set of devices with a given app package, test parameters, etc.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Run {
     /// <p>An app to upload or that has been uploaded.</p>
     #[serde(rename = "appUpload")]
@@ -2054,7 +2054,7 @@ pub struct Run {
 }
 
 /// <p>Represents a sample of performance data.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Sample {
     /// <p>The sample's ARN.</p>
     #[serde(rename = "arn")]
@@ -2071,7 +2071,7 @@ pub struct Sample {
 }
 
 /// <p>Represents the settings for a run. Includes things like location, radio states, auxiliary apps, and network profiles.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ScheduleRunConfiguration {
     /// <p>A list of auxiliary apps for the run.</p>
     #[serde(rename = "auxiliaryApps")]
@@ -2108,7 +2108,7 @@ pub struct ScheduleRunConfiguration {
 }
 
 /// <p>Represents a request to the schedule run operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ScheduleRunRequest {
     /// <p>The ARN of the app to schedule a run.</p>
     #[serde(rename = "appArn")]
@@ -2138,7 +2138,7 @@ pub struct ScheduleRunRequest {
 }
 
 /// <p>Represents the result of a schedule run request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ScheduleRunResult {
     /// <p>Information about the scheduled run.</p>
     #[serde(rename = "run")]
@@ -2147,7 +2147,7 @@ pub struct ScheduleRunResult {
 }
 
 /// <p>Represents additional test settings.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ScheduleRunTest {
     /// <p>The test's filter.</p>
     #[serde(rename = "filter")]
@@ -2167,7 +2167,7 @@ pub struct ScheduleRunTest {
 }
 
 /// <p>Represents the request to stop the remote access session.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StopRemoteAccessSessionRequest {
     /// <p>The Amazon Resource Name (ARN) of the remote access session you wish to stop.</p>
     #[serde(rename = "arn")]
@@ -2175,7 +2175,7 @@ pub struct StopRemoteAccessSessionRequest {
 }
 
 /// <p>Represents the response from the server that describes the remote access session when AWS Device Farm stops the session.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StopRemoteAccessSessionResult {
     /// <p>A container representing the metadata from the service about the remote access session you are stopping.</p>
     #[serde(rename = "remoteAccessSession")]
@@ -2184,7 +2184,7 @@ pub struct StopRemoteAccessSessionResult {
 }
 
 /// <p>Represents the request to stop a specific run.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StopRunRequest {
     /// <p>Represents the Amazon Resource Name (ARN) of the Device Farm run you wish to stop.</p>
     #[serde(rename = "arn")]
@@ -2192,7 +2192,7 @@ pub struct StopRunRequest {
 }
 
 /// <p>Represents the results of your stop run attempt.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StopRunResult {
     /// <p>The run that was stopped.</p>
     #[serde(rename = "run")]
@@ -2201,7 +2201,7 @@ pub struct StopRunResult {
 }
 
 /// <p>Represents a collection of one or more tests.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Suite {
     /// <p>The suite's ARN.</p>
     #[serde(rename = "arn")]
@@ -2250,7 +2250,7 @@ pub struct Suite {
 }
 
 /// <p>Represents a condition that is evaluated.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Test {
     /// <p>The test's ARN.</p>
     #[serde(rename = "arn")]
@@ -2299,7 +2299,7 @@ pub struct Test {
 }
 
 /// <p>Represents information about free trial device minutes for an AWS account.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct TrialMinutes {
     /// <p>The number of free trial minutes remaining in the account.</p>
     #[serde(rename = "remaining")]
@@ -2312,7 +2312,7 @@ pub struct TrialMinutes {
 }
 
 /// <p>A collection of one or more problems, grouped by their result.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UniqueProblem {
     /// <p>A message about the unique problems' result.</p>
     #[serde(rename = "message")]
@@ -2324,7 +2324,7 @@ pub struct UniqueProblem {
     pub problems: Option<Vec<Problem>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateDeviceInstanceRequest {
     /// <p>The Amazon Resource Name (ARN) of the device instance.</p>
     #[serde(rename = "arn")]
@@ -2339,7 +2339,7 @@ pub struct UpdateDeviceInstanceRequest {
     pub profile_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateDeviceInstanceResult {
     /// <p>An object containing information about your device instance.</p>
     #[serde(rename = "deviceInstance")]
@@ -2348,7 +2348,7 @@ pub struct UpdateDeviceInstanceResult {
 }
 
 /// <p>Represents a request to the update device pool operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateDevicePoolRequest {
     /// <p>The Amazon Resourc Name (ARN) of the Device Farm device pool you wish to update.</p>
     #[serde(rename = "arn")]
@@ -2368,7 +2368,7 @@ pub struct UpdateDevicePoolRequest {
 }
 
 /// <p>Represents the result of an update device pool request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateDevicePoolResult {
     /// <p>The device pool you just updated.</p>
     #[serde(rename = "devicePool")]
@@ -2376,7 +2376,7 @@ pub struct UpdateDevicePoolResult {
     pub device_pool: Option<DevicePool>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateInstanceProfileRequest {
     /// <p>The Amazon Resource Name (ARN) of the instance profile.</p>
     #[serde(rename = "arn")]
@@ -2403,7 +2403,7 @@ pub struct UpdateInstanceProfileRequest {
     pub reboot_after_use: Option<bool>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateInstanceProfileResult {
     /// <p>An object containing information about your instance profile.</p>
     #[serde(rename = "instanceProfile")]
@@ -2411,7 +2411,7 @@ pub struct UpdateInstanceProfileResult {
     pub instance_profile: Option<InstanceProfile>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateNetworkProfileRequest {
     /// <p>The Amazon Resource Name (ARN) of the project for which you want to update network profile settings.</p>
     #[serde(rename = "arn")]
@@ -2462,7 +2462,7 @@ pub struct UpdateNetworkProfileRequest {
     pub uplink_loss_percent: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateNetworkProfileResult {
     /// <p>A list of the available network profiles.</p>
     #[serde(rename = "networkProfile")]
@@ -2471,7 +2471,7 @@ pub struct UpdateNetworkProfileResult {
 }
 
 /// <p>Represents a request to the update project operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateProjectRequest {
     /// <p>The Amazon Resource Name (ARN) of the project whose name you wish to update.</p>
     #[serde(rename = "arn")]
@@ -2487,7 +2487,7 @@ pub struct UpdateProjectRequest {
 }
 
 /// <p>Represents the result of an update project request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateProjectResult {
     /// <p>The project you wish to update.</p>
     #[serde(rename = "project")]
@@ -2496,7 +2496,7 @@ pub struct UpdateProjectResult {
 }
 
 /// <p>An app or a set of one or more tests to upload or that have been uploaded.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Upload {
     /// <p>The upload's ARN.</p>
     #[serde(rename = "arn")]

--- a/rusoto/services/devicefarm/src/generated.rs
+++ b/rusoto/services/devicefarm/src/generated.rs
@@ -2561,7 +2561,8 @@ impl CreateDevicePoolError {
     pub fn from_body(body: &str) -> CreateDevicePoolError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2657,7 +2658,8 @@ impl CreateInstanceProfileError {
     pub fn from_body(body: &str) -> CreateInstanceProfileError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2755,7 +2757,8 @@ impl CreateNetworkProfileError {
     pub fn from_body(body: &str) -> CreateNetworkProfileError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2853,7 +2856,8 @@ impl CreateProjectError {
     pub fn from_body(body: &str) -> CreateProjectError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2949,7 +2953,8 @@ impl CreateRemoteAccessSessionError {
     pub fn from_body(body: &str) -> CreateRemoteAccessSessionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3047,7 +3052,8 @@ impl CreateUploadError {
     pub fn from_body(body: &str) -> CreateUploadError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3139,7 +3145,8 @@ impl DeleteDevicePoolError {
     pub fn from_body(body: &str) -> DeleteDevicePoolError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3235,7 +3242,8 @@ impl DeleteInstanceProfileError {
     pub fn from_body(body: &str) -> DeleteInstanceProfileError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3333,7 +3341,8 @@ impl DeleteNetworkProfileError {
     pub fn from_body(body: &str) -> DeleteNetworkProfileError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3431,7 +3440,8 @@ impl DeleteProjectError {
     pub fn from_body(body: &str) -> DeleteProjectError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3527,7 +3537,8 @@ impl DeleteRemoteAccessSessionError {
     pub fn from_body(body: &str) -> DeleteRemoteAccessSessionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3625,7 +3636,8 @@ impl DeleteRunError {
     pub fn from_body(body: &str) -> DeleteRunError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3715,7 +3727,8 @@ impl DeleteUploadError {
     pub fn from_body(body: &str) -> DeleteUploadError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3807,7 +3820,8 @@ impl GetAccountSettingsError {
     pub fn from_body(body: &str) -> GetAccountSettingsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3905,7 +3919,8 @@ impl GetDeviceError {
     pub fn from_body(body: &str) -> GetDeviceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3995,7 +4010,8 @@ impl GetDeviceInstanceError {
     pub fn from_body(body: &str) -> GetDeviceInstanceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4093,7 +4109,8 @@ impl GetDevicePoolError {
     pub fn from_body(body: &str) -> GetDevicePoolError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4189,7 +4206,8 @@ impl GetDevicePoolCompatibilityError {
     pub fn from_body(body: &str) -> GetDevicePoolCompatibilityError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4287,7 +4305,8 @@ impl GetInstanceProfileError {
     pub fn from_body(body: &str) -> GetInstanceProfileError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4385,7 +4404,8 @@ impl GetJobError {
     pub fn from_body(body: &str) -> GetJobError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4475,7 +4495,8 @@ impl GetNetworkProfileError {
     pub fn from_body(body: &str) -> GetNetworkProfileError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4575,7 +4596,8 @@ impl GetOfferingStatusError {
     pub fn from_body(body: &str) -> GetOfferingStatusError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4677,7 +4699,8 @@ impl GetProjectError {
     pub fn from_body(body: &str) -> GetProjectError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4767,7 +4790,8 @@ impl GetRemoteAccessSessionError {
     pub fn from_body(body: &str) -> GetRemoteAccessSessionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4865,7 +4889,8 @@ impl GetRunError {
     pub fn from_body(body: &str) -> GetRunError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4955,7 +4980,8 @@ impl GetSuiteError {
     pub fn from_body(body: &str) -> GetSuiteError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5045,7 +5071,8 @@ impl GetTestError {
     pub fn from_body(body: &str) -> GetTestError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5135,7 +5162,8 @@ impl GetUploadError {
     pub fn from_body(body: &str) -> GetUploadError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5225,7 +5253,8 @@ impl InstallToRemoteAccessSessionError {
     pub fn from_body(body: &str) -> InstallToRemoteAccessSessionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5323,7 +5352,8 @@ impl ListArtifactsError {
     pub fn from_body(body: &str) -> ListArtifactsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5419,7 +5449,8 @@ impl ListDeviceInstancesError {
     pub fn from_body(body: &str) -> ListDeviceInstancesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5517,7 +5548,8 @@ impl ListDevicePoolsError {
     pub fn from_body(body: &str) -> ListDevicePoolsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5613,7 +5645,8 @@ impl ListDevicesError {
     pub fn from_body(body: &str) -> ListDevicesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5705,7 +5738,8 @@ impl ListInstanceProfilesError {
     pub fn from_body(body: &str) -> ListInstanceProfilesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5803,7 +5837,8 @@ impl ListJobsError {
     pub fn from_body(body: &str) -> ListJobsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5893,7 +5928,8 @@ impl ListNetworkProfilesError {
     pub fn from_body(body: &str) -> ListNetworkProfilesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5993,7 +6029,8 @@ impl ListOfferingPromotionsError {
     pub fn from_body(body: &str) -> ListOfferingPromotionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6097,7 +6134,8 @@ impl ListOfferingTransactionsError {
     pub fn from_body(body: &str) -> ListOfferingTransactionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6201,7 +6239,8 @@ impl ListOfferingsError {
     pub fn from_body(body: &str) -> ListOfferingsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6301,7 +6340,8 @@ impl ListProjectsError {
     pub fn from_body(body: &str) -> ListProjectsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6393,7 +6433,8 @@ impl ListRemoteAccessSessionsError {
     pub fn from_body(body: &str) -> ListRemoteAccessSessionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6491,7 +6532,8 @@ impl ListRunsError {
     pub fn from_body(body: &str) -> ListRunsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6581,7 +6623,8 @@ impl ListSamplesError {
     pub fn from_body(body: &str) -> ListSamplesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6673,7 +6716,8 @@ impl ListSuitesError {
     pub fn from_body(body: &str) -> ListSuitesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6763,7 +6807,8 @@ impl ListTestsError {
     pub fn from_body(body: &str) -> ListTestsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6853,7 +6898,8 @@ impl ListUniqueProblemsError {
     pub fn from_body(body: &str) -> ListUniqueProblemsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6951,7 +6997,8 @@ impl ListUploadsError {
     pub fn from_body(body: &str) -> ListUploadsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7045,7 +7092,8 @@ impl PurchaseOfferingError {
     pub fn from_body(body: &str) -> PurchaseOfferingError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7147,7 +7195,8 @@ impl RenewOfferingError {
     pub fn from_body(body: &str) -> RenewOfferingError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7249,7 +7298,8 @@ impl ScheduleRunError {
     pub fn from_body(body: &str) -> ScheduleRunError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7345,7 +7395,8 @@ impl StopRemoteAccessSessionError {
     pub fn from_body(body: &str) -> StopRemoteAccessSessionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7443,7 +7494,8 @@ impl StopRunError {
     pub fn from_body(body: &str) -> StopRunError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7533,7 +7585,8 @@ impl UpdateDeviceInstanceError {
     pub fn from_body(body: &str) -> UpdateDeviceInstanceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7631,7 +7684,8 @@ impl UpdateDevicePoolError {
     pub fn from_body(body: &str) -> UpdateDevicePoolError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7727,7 +7781,8 @@ impl UpdateInstanceProfileError {
     pub fn from_body(body: &str) -> UpdateInstanceProfileError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7825,7 +7880,8 @@ impl UpdateNetworkProfileError {
     pub fn from_body(body: &str) -> UpdateNetworkProfileError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7923,7 +7979,8 @@ impl UpdateProjectError {
     pub fn from_body(body: &str) -> UpdateProjectError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/directconnect/src/generated.rs
+++ b/rusoto/services/directconnect/src/generated.rs
@@ -1269,7 +1269,8 @@ impl AllocateConnectionOnInterconnectError {
     pub fn from_body(body: &str) -> AllocateConnectionOnInterconnectError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1359,7 +1360,8 @@ impl AllocateHostedConnectionError {
     pub fn from_body(body: &str) -> AllocateHostedConnectionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1449,7 +1451,8 @@ impl AllocatePrivateVirtualInterfaceError {
     pub fn from_body(body: &str) -> AllocatePrivateVirtualInterfaceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1539,7 +1542,8 @@ impl AllocatePublicVirtualInterfaceError {
     pub fn from_body(body: &str) -> AllocatePublicVirtualInterfaceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1629,7 +1633,8 @@ impl AssociateConnectionWithLagError {
     pub fn from_body(body: &str) -> AssociateConnectionWithLagError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1719,7 +1724,8 @@ impl AssociateHostedConnectionError {
     pub fn from_body(body: &str) -> AssociateHostedConnectionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1809,7 +1815,8 @@ impl AssociateVirtualInterfaceError {
     pub fn from_body(body: &str) -> AssociateVirtualInterfaceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1899,7 +1906,8 @@ impl ConfirmConnectionError {
     pub fn from_body(body: &str) -> ConfirmConnectionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1985,7 +1993,8 @@ impl ConfirmPrivateVirtualInterfaceError {
     pub fn from_body(body: &str) -> ConfirmPrivateVirtualInterfaceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2075,7 +2084,8 @@ impl ConfirmPublicVirtualInterfaceError {
     pub fn from_body(body: &str) -> ConfirmPublicVirtualInterfaceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2165,7 +2175,8 @@ impl CreateBGPPeerError {
     pub fn from_body(body: &str) -> CreateBGPPeerError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2249,7 +2260,8 @@ impl CreateConnectionError {
     pub fn from_body(body: &str) -> CreateConnectionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2333,7 +2345,8 @@ impl CreateDirectConnectGatewayError {
     pub fn from_body(body: &str) -> CreateDirectConnectGatewayError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2423,7 +2436,8 @@ impl CreateDirectConnectGatewayAssociationError {
     pub fn from_body(body: &str) -> CreateDirectConnectGatewayAssociationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2515,7 +2529,8 @@ impl CreateInterconnectError {
     pub fn from_body(body: &str) -> CreateInterconnectError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2601,7 +2616,8 @@ impl CreateLagError {
     pub fn from_body(body: &str) -> CreateLagError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2683,7 +2699,8 @@ impl CreatePrivateVirtualInterfaceError {
     pub fn from_body(body: &str) -> CreatePrivateVirtualInterfaceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2773,7 +2790,8 @@ impl CreatePublicVirtualInterfaceError {
     pub fn from_body(body: &str) -> CreatePublicVirtualInterfaceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2863,7 +2881,8 @@ impl DeleteBGPPeerError {
     pub fn from_body(body: &str) -> DeleteBGPPeerError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2947,7 +2966,8 @@ impl DeleteConnectionError {
     pub fn from_body(body: &str) -> DeleteConnectionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3031,7 +3051,8 @@ impl DeleteDirectConnectGatewayError {
     pub fn from_body(body: &str) -> DeleteDirectConnectGatewayError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3121,7 +3142,8 @@ impl DeleteDirectConnectGatewayAssociationError {
     pub fn from_body(body: &str) -> DeleteDirectConnectGatewayAssociationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3213,7 +3235,8 @@ impl DeleteInterconnectError {
     pub fn from_body(body: &str) -> DeleteInterconnectError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3299,7 +3322,8 @@ impl DeleteLagError {
     pub fn from_body(body: &str) -> DeleteLagError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3381,7 +3405,8 @@ impl DeleteVirtualInterfaceError {
     pub fn from_body(body: &str) -> DeleteVirtualInterfaceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3471,7 +3496,8 @@ impl DescribeConnectionLoaError {
     pub fn from_body(body: &str) -> DescribeConnectionLoaError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3557,7 +3583,8 @@ impl DescribeConnectionsError {
     pub fn from_body(body: &str) -> DescribeConnectionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3643,7 +3670,8 @@ impl DescribeConnectionsOnInterconnectError {
     pub fn from_body(body: &str) -> DescribeConnectionsOnInterconnectError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3733,7 +3761,8 @@ impl DescribeDirectConnectGatewayAssociationsError {
     pub fn from_body(body: &str) -> DescribeDirectConnectGatewayAssociationsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3827,7 +3856,8 @@ impl DescribeDirectConnectGatewayAttachmentsError {
     pub fn from_body(body: &str) -> DescribeDirectConnectGatewayAttachmentsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3919,7 +3949,8 @@ impl DescribeDirectConnectGatewaysError {
     pub fn from_body(body: &str) -> DescribeDirectConnectGatewaysError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4009,7 +4040,8 @@ impl DescribeHostedConnectionsError {
     pub fn from_body(body: &str) -> DescribeHostedConnectionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4099,7 +4131,8 @@ impl DescribeInterconnectLoaError {
     pub fn from_body(body: &str) -> DescribeInterconnectLoaError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4189,7 +4222,8 @@ impl DescribeInterconnectsError {
     pub fn from_body(body: &str) -> DescribeInterconnectsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4275,7 +4309,8 @@ impl DescribeLagsError {
     pub fn from_body(body: &str) -> DescribeLagsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4359,7 +4394,8 @@ impl DescribeLoaError {
     pub fn from_body(body: &str) -> DescribeLoaError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4443,7 +4479,8 @@ impl DescribeLocationsError {
     pub fn from_body(body: &str) -> DescribeLocationsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4529,7 +4566,8 @@ impl DescribeTagsError {
     pub fn from_body(body: &str) -> DescribeTagsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4613,7 +4651,8 @@ impl DescribeVirtualGatewaysError {
     pub fn from_body(body: &str) -> DescribeVirtualGatewaysError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4703,7 +4742,8 @@ impl DescribeVirtualInterfacesError {
     pub fn from_body(body: &str) -> DescribeVirtualInterfacesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4793,7 +4833,8 @@ impl DisassociateConnectionFromLagError {
     pub fn from_body(body: &str) -> DisassociateConnectionFromLagError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4887,7 +4928,8 @@ impl TagResourceError {
     pub fn from_body(body: &str) -> TagResourceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4979,7 +5021,8 @@ impl UntagResourceError {
     pub fn from_body(body: &str) -> UntagResourceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5063,7 +5106,8 @@ impl UpdateLagError {
     pub fn from_body(body: &str) -> UpdateLagError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/directconnect/src/generated.rs
+++ b/rusoto/services/directconnect/src/generated.rs
@@ -31,7 +31,7 @@ use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 /// <p>Container for the parameters to the AllocateConnectionOnInterconnect operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AllocateConnectionOnInterconnectRequest {
     /// <p>Bandwidth of the connection.</p> <p>Example: "<i>500Mbps</i>"</p> <p>Default: None</p> <p>Values: 50Mbps, 100Mbps, 200Mbps, 300Mbps, 400Mbps, or 500Mbps</p>
     #[serde(rename = "bandwidth")]
@@ -51,7 +51,7 @@ pub struct AllocateConnectionOnInterconnectRequest {
 }
 
 /// <p>Container for the parameters to theHostedConnection operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AllocateHostedConnectionRequest {
     /// <p>The bandwidth of the connection.</p> <p>Example: <code>500Mbps</code> </p> <p>Default: None</p> <p>Values: 50Mbps, 100Mbps, 200Mbps, 300Mbps, 400Mbps, or 500Mbps</p>
     #[serde(rename = "bandwidth")]
@@ -71,7 +71,7 @@ pub struct AllocateHostedConnectionRequest {
 }
 
 /// <p>Container for the parameters to the AllocatePrivateVirtualInterface operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AllocatePrivateVirtualInterfaceRequest {
     /// <p>The connection ID on which the private virtual interface is provisioned.</p> <p>Default: None</p>
     #[serde(rename = "connectionId")]
@@ -85,7 +85,7 @@ pub struct AllocatePrivateVirtualInterfaceRequest {
 }
 
 /// <p>Container for the parameters to the AllocatePublicVirtualInterface operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AllocatePublicVirtualInterfaceRequest {
     /// <p>The connection ID on which the public virtual interface is provisioned.</p> <p>Default: None</p>
     #[serde(rename = "connectionId")]
@@ -99,7 +99,7 @@ pub struct AllocatePublicVirtualInterfaceRequest {
 }
 
 /// <p>Container for the parameters to the AssociateConnectionWithLag operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AssociateConnectionWithLagRequest {
     /// <p>The ID of the connection.</p> <p>Example: dxcon-abc123</p> <p>Default: None</p>
     #[serde(rename = "connectionId")]
@@ -110,7 +110,7 @@ pub struct AssociateConnectionWithLagRequest {
 }
 
 /// <p>Container for the parameters to the AssociateHostedConnection operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AssociateHostedConnectionRequest {
     /// <p>The ID of the hosted connection.</p> <p>Example: dxcon-abc123</p> <p>Default: None</p>
     #[serde(rename = "connectionId")]
@@ -121,7 +121,7 @@ pub struct AssociateHostedConnectionRequest {
 }
 
 /// <p>Container for the parameters to the AssociateVirtualInterface operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AssociateVirtualInterfaceRequest {
     /// <p>The ID of the LAG or connection with which to associate the virtual interface.</p> <p>Example: dxlag-abc123 or dxcon-abc123</p> <p>Default: None</p>
     #[serde(rename = "connectionId")]
@@ -132,7 +132,7 @@ pub struct AssociateVirtualInterfaceRequest {
 }
 
 /// <p>A structure containing information about a BGP peer.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BGPPeer {
     #[serde(rename = "addressFamily")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -158,14 +158,14 @@ pub struct BGPPeer {
 }
 
 /// <p>Container for the parameters to the ConfirmConnection operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ConfirmConnectionRequest {
     #[serde(rename = "connectionId")]
     pub connection_id: String,
 }
 
 /// <p>The response received when ConfirmConnection is called.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ConfirmConnectionResponse {
     #[serde(rename = "connectionState")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -173,7 +173,7 @@ pub struct ConfirmConnectionResponse {
 }
 
 /// <p>Container for the parameters to the ConfirmPrivateVirtualInterface operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ConfirmPrivateVirtualInterfaceRequest {
     /// <p>ID of the direct connect gateway that will be attached to the virtual interface.</p> <p> A direct connect gateway can be managed via the AWS Direct Connect console or the <a>CreateDirectConnectGateway</a> action.</p> <p>Default: None</p>
     #[serde(rename = "directConnectGatewayId")]
@@ -188,7 +188,7 @@ pub struct ConfirmPrivateVirtualInterfaceRequest {
 }
 
 /// <p>The response received when ConfirmPrivateVirtualInterface is called.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ConfirmPrivateVirtualInterfaceResponse {
     #[serde(rename = "virtualInterfaceState")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -196,14 +196,14 @@ pub struct ConfirmPrivateVirtualInterfaceResponse {
 }
 
 /// <p>Container for the parameters to the ConfirmPublicVirtualInterface operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ConfirmPublicVirtualInterfaceRequest {
     #[serde(rename = "virtualInterfaceId")]
     pub virtual_interface_id: String,
 }
 
 /// <p>The response received when ConfirmPublicVirtualInterface is called.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ConfirmPublicVirtualInterfaceResponse {
     #[serde(rename = "virtualInterfaceState")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -211,7 +211,7 @@ pub struct ConfirmPublicVirtualInterfaceResponse {
 }
 
 /// <p>A connection represents the physical network connection between the AWS Direct Connect location and the customer.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Connection {
     /// <p>The Direct Connection endpoint which the physical connection terminates on.</p>
     #[serde(rename = "awsDevice")]
@@ -257,7 +257,7 @@ pub struct Connection {
 }
 
 /// <p>A structure containing a list of connections.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Connections {
     /// <p>A list of connections.</p>
     #[serde(rename = "connections")]
@@ -266,7 +266,7 @@ pub struct Connections {
 }
 
 /// <p>Container for the parameters to the CreateBGPPeer operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateBGPPeerRequest {
     /// <p>Detailed information for the BGP peer to be created.</p> <p>Default: None</p>
     #[serde(rename = "newBGPPeer")]
@@ -279,7 +279,7 @@ pub struct CreateBGPPeerRequest {
 }
 
 /// <p>The response received when CreateBGPPeer is called.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateBGPPeerResponse {
     #[serde(rename = "virtualInterface")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -287,7 +287,7 @@ pub struct CreateBGPPeerResponse {
 }
 
 /// <p>Container for the parameters to the CreateConnection operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateConnectionRequest {
     #[serde(rename = "bandwidth")]
     pub bandwidth: String,
@@ -301,7 +301,7 @@ pub struct CreateConnectionRequest {
 }
 
 /// <p>Container for the parameters to the CreateDirectConnectGatewayAssociation operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateDirectConnectGatewayAssociationRequest {
     /// <p>The ID of the direct connect gateway.</p> <p>Example: "abcd1234-dcba-5678-be23-cdef9876ab45"</p> <p>Default: None</p>
     #[serde(rename = "directConnectGatewayId")]
@@ -312,7 +312,7 @@ pub struct CreateDirectConnectGatewayAssociationRequest {
 }
 
 /// <p>Container for the response from the CreateDirectConnectGatewayAssociation API call</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateDirectConnectGatewayAssociationResult {
     /// <p>The direct connect gateway association to be created.</p>
     #[serde(rename = "directConnectGatewayAssociation")]
@@ -321,7 +321,7 @@ pub struct CreateDirectConnectGatewayAssociationResult {
 }
 
 /// <p>Container for the parameters to the CreateDirectConnectGateway operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateDirectConnectGatewayRequest {
     /// <p>The autonomous system number (ASN) for Border Gateway Protocol (BGP) to be configured on the Amazon side of the connection. The ASN must be in the private range of 64,512 to 65,534 or 4,200,000,000 to 4,294,967,294 </p> <p>Example: 65200</p> <p>Default: 64512</p>
     #[serde(rename = "amazonSideAsn")]
@@ -333,7 +333,7 @@ pub struct CreateDirectConnectGatewayRequest {
 }
 
 /// <p>Container for the response from the CreateDirectConnectGateway API call</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateDirectConnectGatewayResult {
     /// <p>The direct connect gateway to be created.</p>
     #[serde(rename = "directConnectGateway")]
@@ -342,7 +342,7 @@ pub struct CreateDirectConnectGatewayResult {
 }
 
 /// <p>Container for the parameters to the CreateInterconnect operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateInterconnectRequest {
     /// <p>The port bandwidth</p> <p>Example: 1Gbps</p> <p>Default: None</p> <p>Available values: 1Gbps,10Gbps</p>
     #[serde(rename = "bandwidth")]
@@ -359,7 +359,7 @@ pub struct CreateInterconnectRequest {
 }
 
 /// <p>Container for the parameters to the CreateLag operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateLagRequest {
     /// <p>The ID of an existing connection to migrate to the LAG.</p> <p>Default: None</p>
     #[serde(rename = "connectionId")]
@@ -380,7 +380,7 @@ pub struct CreateLagRequest {
 }
 
 /// <p>Container for the parameters to the CreatePrivateVirtualInterface operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreatePrivateVirtualInterfaceRequest {
     #[serde(rename = "connectionId")]
     pub connection_id: String,
@@ -390,7 +390,7 @@ pub struct CreatePrivateVirtualInterfaceRequest {
 }
 
 /// <p>Container for the parameters to the CreatePublicVirtualInterface operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreatePublicVirtualInterfaceRequest {
     #[serde(rename = "connectionId")]
     pub connection_id: String,
@@ -400,7 +400,7 @@ pub struct CreatePublicVirtualInterfaceRequest {
 }
 
 /// <p>Container for the parameters to the DeleteBGPPeer operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteBGPPeerRequest {
     #[serde(rename = "asn")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -415,7 +415,7 @@ pub struct DeleteBGPPeerRequest {
 }
 
 /// <p>The response received when DeleteBGPPeer is called.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteBGPPeerResponse {
     #[serde(rename = "virtualInterface")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -423,14 +423,14 @@ pub struct DeleteBGPPeerResponse {
 }
 
 /// <p>Container for the parameters to the DeleteConnection operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteConnectionRequest {
     #[serde(rename = "connectionId")]
     pub connection_id: String,
 }
 
 /// <p>Container for the parameters to the DeleteDirectConnectGatewayAssociation operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteDirectConnectGatewayAssociationRequest {
     /// <p>The ID of the direct connect gateway.</p> <p>Example: "abcd1234-dcba-5678-be23-cdef9876ab45"</p> <p>Default: None</p>
     #[serde(rename = "directConnectGatewayId")]
@@ -441,7 +441,7 @@ pub struct DeleteDirectConnectGatewayAssociationRequest {
 }
 
 /// <p>Container for the response from the DeleteDirectConnectGatewayAssociation API call</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteDirectConnectGatewayAssociationResult {
     /// <p>The direct connect gateway association to be deleted.</p>
     #[serde(rename = "directConnectGatewayAssociation")]
@@ -450,7 +450,7 @@ pub struct DeleteDirectConnectGatewayAssociationResult {
 }
 
 /// <p>Container for the parameters to the DeleteDirectConnectGateway operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteDirectConnectGatewayRequest {
     /// <p>The ID of the direct connect gateway.</p> <p>Example: "abcd1234-dcba-5678-be23-cdef9876ab45"</p> <p>Default: None</p>
     #[serde(rename = "directConnectGatewayId")]
@@ -458,7 +458,7 @@ pub struct DeleteDirectConnectGatewayRequest {
 }
 
 /// <p>Container for the response from the DeleteDirectConnectGateway API call</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteDirectConnectGatewayResult {
     /// <p>The direct connect gateway to be deleted.</p>
     #[serde(rename = "directConnectGateway")]
@@ -467,14 +467,14 @@ pub struct DeleteDirectConnectGatewayResult {
 }
 
 /// <p>Container for the parameters to the DeleteInterconnect operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteInterconnectRequest {
     #[serde(rename = "interconnectId")]
     pub interconnect_id: String,
 }
 
 /// <p>The response received when DeleteInterconnect is called.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteInterconnectResponse {
     #[serde(rename = "interconnectState")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -482,7 +482,7 @@ pub struct DeleteInterconnectResponse {
 }
 
 /// <p>Container for the parameters to the DeleteLag operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteLagRequest {
     /// <p>The ID of the LAG to delete.</p> <p>Example: dxlag-abc123</p> <p>Default: None</p>
     #[serde(rename = "lagId")]
@@ -490,14 +490,14 @@ pub struct DeleteLagRequest {
 }
 
 /// <p>Container for the parameters to the DeleteVirtualInterface operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteVirtualInterfaceRequest {
     #[serde(rename = "virtualInterfaceId")]
     pub virtual_interface_id: String,
 }
 
 /// <p>The response received when DeleteVirtualInterface is called.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteVirtualInterfaceResponse {
     #[serde(rename = "virtualInterfaceState")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -505,7 +505,7 @@ pub struct DeleteVirtualInterfaceResponse {
 }
 
 /// <p>Container for the parameters to the DescribeConnectionLoa operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeConnectionLoaRequest {
     #[serde(rename = "connectionId")]
     pub connection_id: String,
@@ -519,7 +519,7 @@ pub struct DescribeConnectionLoaRequest {
 }
 
 /// <p>The response received when DescribeConnectionLoa is called.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeConnectionLoaResponse {
     #[serde(rename = "loa")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -527,7 +527,7 @@ pub struct DescribeConnectionLoaResponse {
 }
 
 /// <p>Container for the parameters to the DescribeConnectionsOnInterconnect operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeConnectionsOnInterconnectRequest {
     /// <p>ID of the interconnect on which a list of connection is provisioned.</p> <p>Example: dxcon-abc123</p> <p>Default: None</p>
     #[serde(rename = "interconnectId")]
@@ -535,7 +535,7 @@ pub struct DescribeConnectionsOnInterconnectRequest {
 }
 
 /// <p>Container for the parameters to the DescribeConnections operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeConnectionsRequest {
     #[serde(rename = "connectionId")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -543,7 +543,7 @@ pub struct DescribeConnectionsRequest {
 }
 
 /// <p>Container for the parameters to the DescribeDirectConnectGatewayAssociations operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeDirectConnectGatewayAssociationsRequest {
     /// <p>The ID of the direct connect gateway.</p> <p>Example: "abcd1234-dcba-5678-be23-cdef9876ab45"</p> <p>Default: None</p>
     #[serde(rename = "directConnectGatewayId")]
@@ -564,7 +564,7 @@ pub struct DescribeDirectConnectGatewayAssociationsRequest {
 }
 
 /// <p>Container for the response from the DescribeDirectConnectGatewayAssociations API call</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeDirectConnectGatewayAssociationsResult {
     /// <p>Information about the direct connect gateway associations.</p>
     #[serde(rename = "directConnectGatewayAssociations")]
@@ -576,7 +576,7 @@ pub struct DescribeDirectConnectGatewayAssociationsResult {
 }
 
 /// <p>Container for the parameters to the DescribeDirectConnectGatewayAttachments operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeDirectConnectGatewayAttachmentsRequest {
     /// <p>The ID of the direct connect gateway.</p> <p>Example: "abcd1234-dcba-5678-be23-cdef9876ab45"</p> <p>Default: None</p>
     #[serde(rename = "directConnectGatewayId")]
@@ -597,7 +597,7 @@ pub struct DescribeDirectConnectGatewayAttachmentsRequest {
 }
 
 /// <p>Container for the response from the DescribeDirectConnectGatewayAttachments API call</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeDirectConnectGatewayAttachmentsResult {
     /// <p>Information about the direct connect gateway attachments.</p>
     #[serde(rename = "directConnectGatewayAttachments")]
@@ -609,7 +609,7 @@ pub struct DescribeDirectConnectGatewayAttachmentsResult {
 }
 
 /// <p>Container for the parameters to the DescribeDirectConnectGateways operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeDirectConnectGatewaysRequest {
     /// <p>The ID of the direct connect gateway.</p> <p>Example: "abcd1234-dcba-5678-be23-cdef9876ab45"</p> <p>Default: None</p>
     #[serde(rename = "directConnectGatewayId")]
@@ -626,7 +626,7 @@ pub struct DescribeDirectConnectGatewaysRequest {
 }
 
 /// <p>Container for the response from the DescribeDirectConnectGateways API call</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeDirectConnectGatewaysResult {
     /// <p>Information about the direct connect gateways.</p>
     #[serde(rename = "directConnectGateways")]
@@ -638,7 +638,7 @@ pub struct DescribeDirectConnectGatewaysResult {
 }
 
 /// <p>Container for the parameters to the DescribeHostedConnections operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeHostedConnectionsRequest {
     /// <p>The ID of the interconnect or LAG on which the hosted connections are provisioned.</p> <p>Example: dxcon-abc123 or dxlag-abc123</p> <p>Default: None</p>
     #[serde(rename = "connectionId")]
@@ -646,7 +646,7 @@ pub struct DescribeHostedConnectionsRequest {
 }
 
 /// <p>Container for the parameters to the DescribeInterconnectLoa operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeInterconnectLoaRequest {
     #[serde(rename = "interconnectId")]
     pub interconnect_id: String,
@@ -660,7 +660,7 @@ pub struct DescribeInterconnectLoaRequest {
 }
 
 /// <p>The response received when DescribeInterconnectLoa is called.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeInterconnectLoaResponse {
     #[serde(rename = "loa")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -668,7 +668,7 @@ pub struct DescribeInterconnectLoaResponse {
 }
 
 /// <p>Container for the parameters to the DescribeInterconnects operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeInterconnectsRequest {
     #[serde(rename = "interconnectId")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -676,7 +676,7 @@ pub struct DescribeInterconnectsRequest {
 }
 
 /// <p>Container for the parameters to the DescribeLags operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeLagsRequest {
     /// <p>The ID of the LAG.</p> <p>Example: dxlag-abc123</p> <p>Default: None</p>
     #[serde(rename = "lagId")]
@@ -685,7 +685,7 @@ pub struct DescribeLagsRequest {
 }
 
 /// <p>Container for the parameters to the DescribeLoa operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeLoaRequest {
     /// <p>The ID of a connection, LAG, or interconnect for which to get the LOA-CFA information.</p> <p>Example: dxcon-abc123 or dxlag-abc123</p> <p>Default: None</p>
     #[serde(rename = "connectionId")]
@@ -701,7 +701,7 @@ pub struct DescribeLoaRequest {
 }
 
 /// <p>Container for the parameters to the DescribeTags operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeTagsRequest {
     /// <p>The Amazon Resource Names (ARNs) of the Direct Connect resources.</p>
     #[serde(rename = "resourceArns")]
@@ -709,7 +709,7 @@ pub struct DescribeTagsRequest {
 }
 
 /// <p>The response received when DescribeTags is called.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeTagsResponse {
     /// <p>Information about the tags.</p>
     #[serde(rename = "resourceTags")]
@@ -718,7 +718,7 @@ pub struct DescribeTagsResponse {
 }
 
 /// <p>Container for the parameters to the DescribeVirtualInterfaces operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeVirtualInterfacesRequest {
     #[serde(rename = "connectionId")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -729,7 +729,7 @@ pub struct DescribeVirtualInterfacesRequest {
 }
 
 /// <p>A direct connect gateway is an intermediate object that enables you to connect virtual interfaces and virtual private gateways.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DirectConnectGateway {
     /// <p>The autonomous system number (ASN) for the Amazon side of the connection.</p>
     #[serde(rename = "amazonSideAsn")]
@@ -754,7 +754,7 @@ pub struct DirectConnectGateway {
 }
 
 /// <p>The association between a direct connect gateway and virtual private gateway.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DirectConnectGatewayAssociation {
     #[serde(rename = "associationState")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -778,7 +778,7 @@ pub struct DirectConnectGatewayAssociation {
 }
 
 /// <p>The association between a direct connect gateway and virtual interface.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DirectConnectGatewayAttachment {
     #[serde(rename = "attachmentState")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -802,7 +802,7 @@ pub struct DirectConnectGatewayAttachment {
 }
 
 /// <p>Container for the parameters to the DisassociateConnectionFromLag operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DisassociateConnectionFromLagRequest {
     /// <p>The ID of the connection to disassociate from the LAG.</p> <p>Example: dxcon-abc123</p> <p>Default: None</p>
     #[serde(rename = "connectionId")]
@@ -813,7 +813,7 @@ pub struct DisassociateConnectionFromLagRequest {
 }
 
 /// <p>An interconnect is a connection that can host other connections.</p> <p>Like a standard AWS Direct Connect connection, an interconnect represents the physical connection between an AWS Direct Connect partner's network and a specific Direct Connect location. An AWS Direct Connect partner who owns an interconnect can provision hosted connections on the interconnect for their end customers, thereby providing the end customers with connectivity to AWS services.</p> <p>The resources of the interconnect, including bandwidth and VLAN numbers, are shared by all of the hosted connections on the interconnect, and the owner of the interconnect determines how these resources are assigned.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Interconnect {
     /// <p>The Direct Connection endpoint which the physical connection terminates on.</p>
     #[serde(rename = "awsDevice")]
@@ -847,7 +847,7 @@ pub struct Interconnect {
 }
 
 /// <p>A structure containing a list of interconnects.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Interconnects {
     /// <p>A list of interconnects.</p>
     #[serde(rename = "interconnects")]
@@ -856,7 +856,7 @@ pub struct Interconnects {
 }
 
 /// <p>Describes a link aggregation group (LAG). A LAG is a connection that uses the Link Aggregation Control Protocol (LACP) to logically aggregate a bundle of physical connections. Like an interconnect, it can host other connections. All connections in a LAG must terminate on the same physical AWS Direct Connect endpoint, and must be the same bandwidth.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Lag {
     /// <p><p>Indicates whether the LAG can host other connections.</p> <note> <p>This is intended for use by AWS Direct Connect partners only.</p> </note></p>
     #[serde(rename = "allowsHostedConnections")]
@@ -905,7 +905,7 @@ pub struct Lag {
 }
 
 /// <p>A structure containing a list of LAGs.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Lags {
     /// <p>A list of LAGs.</p>
     #[serde(rename = "lags")]
@@ -914,7 +914,7 @@ pub struct Lags {
 }
 
 /// <p>A structure containing the Letter of Authorization - Connecting Facility Assignment (LOA-CFA) for a connection.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Loa {
     #[serde(rename = "loaContent")]
     #[serde(
@@ -929,7 +929,7 @@ pub struct Loa {
 }
 
 /// <p>An AWS Direct Connect location where connections and interconnects can be requested.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Location {
     /// <p>The code used to indicate the AWS Direct Connect location.</p>
     #[serde(rename = "locationCode")]
@@ -942,7 +942,7 @@ pub struct Location {
 }
 
 /// <p>A location is a network facility where AWS Direct Connect routers are available to be connected. Generally, these are colocation hubs where many network providers have equipment, and where cross connects can be delivered. Locations include a name and facility code, and must be provided when creating a connection.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Locations {
     /// <p>A list of colocation hubs where network providers have equipment. Most regions have multiple locations available.</p>
     #[serde(rename = "locations")]
@@ -951,7 +951,7 @@ pub struct Locations {
 }
 
 /// <p>A structure containing information about a new BGP peer.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct NewBGPPeer {
     #[serde(rename = "addressFamily")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -971,7 +971,7 @@ pub struct NewBGPPeer {
 }
 
 /// <p>A structure containing information about a new private virtual interface.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct NewPrivateVirtualInterface {
     #[serde(rename = "addressFamily")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1000,7 +1000,7 @@ pub struct NewPrivateVirtualInterface {
 }
 
 /// <p>A structure containing information about a private virtual interface that will be provisioned on a connection.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct NewPrivateVirtualInterfaceAllocation {
     #[serde(rename = "addressFamily")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1023,7 +1023,7 @@ pub struct NewPrivateVirtualInterfaceAllocation {
 }
 
 /// <p>A structure containing information about a new public virtual interface.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct NewPublicVirtualInterface {
     #[serde(rename = "addressFamily")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1049,7 +1049,7 @@ pub struct NewPublicVirtualInterface {
 }
 
 /// <p>A structure containing information about a public virtual interface that will be provisioned on a connection.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct NewPublicVirtualInterfaceAllocation {
     #[serde(rename = "addressFamily")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1075,7 +1075,7 @@ pub struct NewPublicVirtualInterfaceAllocation {
 }
 
 /// <p>The tags associated with a Direct Connect resource.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ResourceTag {
     /// <p>The Amazon Resource Name (ARN) of the Direct Connect resource.</p>
     #[serde(rename = "resourceArn")]
@@ -1088,7 +1088,7 @@ pub struct ResourceTag {
 }
 
 /// <p>A route filter prefix that the customer can advertise through Border Gateway Protocol (BGP) over a public virtual interface.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RouteFilterPrefix {
     /// <p>CIDR notation for the advertised route. Multiple routes are separated by commas.</p> <p>IPv6 CIDRs must be at least a /64 or shorter</p> <p>Example: 10.10.10.0/24,10.10.11.0/24,2001:db8::/64</p>
     #[serde(rename = "cidr")]
@@ -1097,7 +1097,7 @@ pub struct RouteFilterPrefix {
 }
 
 /// <p>Information about a tag.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Tag {
     /// <p>The key of the tag.</p>
     #[serde(rename = "key")]
@@ -1109,7 +1109,7 @@ pub struct Tag {
 }
 
 /// <p>Container for the parameters to the TagResource operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct TagResourceRequest {
     /// <p>The Amazon Resource Name (ARN) of the Direct Connect resource.</p> <p>Example: arn:aws:directconnect:us-east-1:123456789012:dxcon/dxcon-fg5678gh</p>
     #[serde(rename = "resourceArn")]
@@ -1120,11 +1120,11 @@ pub struct TagResourceRequest {
 }
 
 /// <p>The response received when TagResource is called.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct TagResourceResponse {}
 
 /// <p>Container for the parameters to the UntagResource operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UntagResourceRequest {
     /// <p>The Amazon Resource Name (ARN) of the Direct Connect resource.</p>
     #[serde(rename = "resourceArn")]
@@ -1135,11 +1135,11 @@ pub struct UntagResourceRequest {
 }
 
 /// <p>The response received when UntagResource is called.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UntagResourceResponse {}
 
 /// <p>Container for the parameters to the UpdateLag operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateLagRequest {
     /// <p>The ID of the LAG to update.</p> <p>Example: dxlag-abc123</p> <p>Default: None</p>
     #[serde(rename = "lagId")]
@@ -1155,7 +1155,7 @@ pub struct UpdateLagRequest {
 }
 
 /// <p>You can create one or more AWS Direct Connect private virtual interfaces linking to your virtual private gateway.</p> <p>Virtual private gateways can be managed using the Amazon Virtual Private Cloud (Amazon VPC) console or the <a href="http://docs.aws.amazon.com/AWSEC2/latest/APIReference/ApiReference-query-CreateVpnGateway.html">Amazon EC2 CreateVpnGateway action</a>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct VirtualGateway {
     #[serde(rename = "virtualGatewayId")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1166,7 +1166,7 @@ pub struct VirtualGateway {
 }
 
 /// <p>A structure containing a list of virtual private gateways.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct VirtualGateways {
     /// <p>A list of virtual private gateways.</p>
     #[serde(rename = "virtualGateways")]
@@ -1175,7 +1175,7 @@ pub struct VirtualGateways {
 }
 
 /// <p>A virtual interface (VLAN) transmits the traffic between the AWS Direct Connect location and the customer.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct VirtualInterface {
     #[serde(rename = "addressFamily")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1240,7 +1240,7 @@ pub struct VirtualInterface {
 }
 
 /// <p>A structure containing a list of virtual interfaces.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct VirtualInterfaces {
     /// <p>A list of virtual interfaces.</p>
     #[serde(rename = "virtualInterfaces")]

--- a/rusoto/services/discovery/src/generated.rs
+++ b/rusoto/services/discovery/src/generated.rs
@@ -729,7 +729,8 @@ impl AssociateConfigurationItemsToApplicationError {
     pub fn from_body(body: &str) -> AssociateConfigurationItemsToApplicationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -841,7 +842,8 @@ impl CreateApplicationError {
     pub fn from_body(body: &str) -> CreateApplicationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -941,7 +943,8 @@ impl CreateTagsError {
     pub fn from_body(body: &str) -> CreateTagsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1039,7 +1042,8 @@ impl DeleteApplicationsError {
     pub fn from_body(body: &str) -> DeleteApplicationsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1139,7 +1143,8 @@ impl DeleteTagsError {
     pub fn from_body(body: &str) -> DeleteTagsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1237,7 +1242,8 @@ impl DescribeAgentsError {
     pub fn from_body(body: &str) -> DescribeAgentsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1333,7 +1339,8 @@ impl DescribeConfigurationsError {
     pub fn from_body(body: &str) -> DescribeConfigurationsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1437,7 +1444,8 @@ impl DescribeExportConfigurationsError {
     pub fn from_body(body: &str) -> DescribeExportConfigurationsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1549,7 +1557,8 @@ impl DescribeExportTasksError {
     pub fn from_body(body: &str) -> DescribeExportTasksError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1649,7 +1658,8 @@ impl DescribeTagsError {
     pub fn from_body(body: &str) -> DescribeTagsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1749,7 +1759,8 @@ impl DisassociateConfigurationItemsFromApplicationError {
     pub fn from_body(body: &str) -> DisassociateConfigurationItemsFromApplicationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1875,7 +1886,8 @@ impl ExportConfigurationsError {
     pub fn from_body(body: &str) -> ExportConfigurationsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1981,7 +1993,8 @@ impl GetDiscoverySummaryError {
     pub fn from_body(body: &str) -> GetDiscoverySummaryError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2081,7 +2094,8 @@ impl ListConfigurationsError {
     pub fn from_body(body: &str) -> ListConfigurationsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2183,7 +2197,8 @@ impl ListServerNeighborsError {
     pub fn from_body(body: &str) -> ListServerNeighborsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2281,7 +2296,8 @@ impl StartDataCollectionByAgentIdsError {
     pub fn from_body(body: &str) -> StartDataCollectionByAgentIdsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2389,7 +2405,8 @@ impl StartExportTaskError {
     pub fn from_body(body: &str) -> StartExportTaskError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2489,7 +2506,8 @@ impl StopDataCollectionByAgentIdsError {
     pub fn from_body(body: &str) -> StopDataCollectionByAgentIdsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2595,7 +2613,8 @@ impl UpdateApplicationError {
     pub fn from_body(body: &str) -> UpdateApplicationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/discovery/src/generated.rs
+++ b/rusoto/services/discovery/src/generated.rs
@@ -31,7 +31,7 @@ use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 /// <p>Information about agents or connectors that were instructed to start collecting data. Information includes the agent/connector ID, a description of the operation, and whether the agent/connector configuration was updated.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AgentConfigurationStatus {
     /// <p>The agent/connector ID.</p>
     #[serde(rename = "agentId")]
@@ -48,7 +48,7 @@ pub struct AgentConfigurationStatus {
 }
 
 /// <p>Information about agents or connectors associated with the user’s AWS account. Information includes agent or connector IDs, IP addresses, media access control (MAC) addresses, agent or connector health, hostname where the agent or connector resides, and agent version for each agent.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AgentInfo {
     /// <p>The agent or connector ID.</p>
     #[serde(rename = "agentId")]
@@ -93,7 +93,7 @@ pub struct AgentInfo {
 }
 
 /// <p>Network details about the host where the agent/connector resides.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AgentNetworkInfo {
     /// <p>The IP address for the host where the agent/connector resides.</p>
     #[serde(rename = "ipAddress")]
@@ -105,7 +105,7 @@ pub struct AgentNetworkInfo {
     pub mac_address: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AssociateConfigurationItemsToApplicationRequest {
     /// <p>The configuration ID of an application with which items are to be associated.</p>
     #[serde(rename = "applicationConfigurationId")]
@@ -115,11 +115,11 @@ pub struct AssociateConfigurationItemsToApplicationRequest {
     pub configuration_ids: Vec<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AssociateConfigurationItemsToApplicationResponse {}
 
 /// <p>Tags for a configuration item. Tags are metadata that help you categorize IT assets.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ConfigurationTag {
     /// <p>The configuration ID for the item to tag. You can specify a list of keys and values.</p>
     #[serde(rename = "configurationId")]
@@ -143,7 +143,7 @@ pub struct ConfigurationTag {
     pub value: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateApplicationRequest {
     /// <p>Description of the application to be created.</p>
     #[serde(rename = "description")]
@@ -154,7 +154,7 @@ pub struct CreateApplicationRequest {
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateApplicationResponse {
     /// <p>Configuration ID of an application to be created.</p>
     #[serde(rename = "configurationId")]
@@ -162,7 +162,7 @@ pub struct CreateApplicationResponse {
     pub configuration_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateTagsRequest {
     /// <p>A list of configuration items that you want to tag.</p>
     #[serde(rename = "configurationIds")]
@@ -172,11 +172,11 @@ pub struct CreateTagsRequest {
     pub tags: Vec<Tag>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateTagsResponse {}
 
 /// <p>Inventory data for installed discovery agents.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CustomerAgentInfo {
     /// <p>Number of active discovery agents.</p>
     #[serde(rename = "activeAgents")]
@@ -202,7 +202,7 @@ pub struct CustomerAgentInfo {
 }
 
 /// <p>Inventory data for installed discovery connectors.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CustomerConnectorInfo {
     /// <p>Number of active discovery connectors.</p>
     #[serde(rename = "activeConnectors")]
@@ -227,17 +227,17 @@ pub struct CustomerConnectorInfo {
     pub unknown_connectors: i64,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteApplicationsRequest {
     /// <p>Configuration ID of an application to be deleted.</p>
     #[serde(rename = "configurationIds")]
     pub configuration_ids: Vec<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteApplicationsResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteTagsRequest {
     /// <p>A list of configuration items with tags that you want to delete.</p>
     #[serde(rename = "configurationIds")]
@@ -248,10 +248,10 @@ pub struct DeleteTagsRequest {
     pub tags: Option<Vec<Tag>>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteTagsResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeAgentsRequest {
     /// <p>The agent or the Connector IDs for which you want information. If you specify no IDs, the system returns information about all agents/Connectors associated with your AWS user account.</p>
     #[serde(rename = "agentIds")]
@@ -271,7 +271,7 @@ pub struct DescribeAgentsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeAgentsResponse {
     /// <p>Lists agents or the Connector by ID or lists all agents/Connectors associated with your user account if you did not specify an agent/Connector ID. The output includes agent/Connector IDs, IP addresses, media access control (MAC) addresses, agent/Connector health, host name where the agent/Connector resides, and the version number of each agent/Connector.</p>
     #[serde(rename = "agentsInfo")]
@@ -283,14 +283,14 @@ pub struct DescribeAgentsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeConfigurationsRequest {
     /// <p>One or more configuration IDs.</p>
     #[serde(rename = "configurationIds")]
     pub configuration_ids: Vec<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeConfigurationsResponse {
     /// <p>A key in the response map. The value is an array of data.</p>
     #[serde(rename = "configurations")]
@@ -298,7 +298,7 @@ pub struct DescribeConfigurationsResponse {
     pub configurations: Option<Vec<::std::collections::HashMap<String, String>>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeExportConfigurationsRequest {
     /// <p>A unique identifier that you can use to query the export status.</p>
     #[serde(rename = "exportIds")]
@@ -314,7 +314,7 @@ pub struct DescribeExportConfigurationsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeExportConfigurationsResponse {
     /// <p>Returns export details. When the status is complete, the response includes a URL for an Amazon S3 bucket where you can view the data in a CSV file.</p>
     #[serde(rename = "exportsInfo")]
@@ -326,7 +326,7 @@ pub struct DescribeExportConfigurationsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeExportTasksRequest {
     /// <p>One or more unique identifiers used to query the status of an export request.</p>
     #[serde(rename = "exportIds")]
@@ -346,7 +346,7 @@ pub struct DescribeExportTasksRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeExportTasksResponse {
     /// <p>Contains one or more sets of export request details. When the status of a request is <code>SUCCEEDED</code>, the response includes a URL for an Amazon S3 bucket where you can view the data in a CSV file.</p>
     #[serde(rename = "exportsInfo")]
@@ -358,7 +358,7 @@ pub struct DescribeExportTasksResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeTagsRequest {
     /// <p>You can filter the list using a <i>key</i>-<i>value</i> format. You can separate these items by using logical operators. Allowed filters include <code>tagKey</code>, <code>tagValue</code>, and <code>configurationId</code>. </p>
     #[serde(rename = "filters")]
@@ -374,7 +374,7 @@ pub struct DescribeTagsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeTagsResponse {
     /// <p>The call returns a token. Use this token to get the next set of results.</p>
     #[serde(rename = "nextToken")]
@@ -386,7 +386,7 @@ pub struct DescribeTagsResponse {
     pub tags: Option<Vec<ConfigurationTag>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DisassociateConfigurationItemsFromApplicationRequest {
     /// <p>Configuration ID of an application from which each item is disassociated.</p>
     #[serde(rename = "applicationConfigurationId")]
@@ -396,10 +396,10 @@ pub struct DisassociateConfigurationItemsFromApplicationRequest {
     pub configuration_ids: Vec<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DisassociateConfigurationItemsFromApplicationResponse {}
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ExportConfigurationsResponse {
     /// <p>A unique identifier that you can use to query the export status.</p>
     #[serde(rename = "exportId")]
@@ -408,7 +408,7 @@ pub struct ExportConfigurationsResponse {
 }
 
 /// <p>Used to select which agent's data is to be exported. A single agent ID may be selected for export using the <a href="http://docs.aws.amazon.com/application-discovery/latest/APIReference/API_StartExportTask.html">StartExportTask</a> action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ExportFilter {
     /// <p>Supported condition: <code>EQUALS</code> </p>
     #[serde(rename = "condition")]
@@ -422,7 +422,7 @@ pub struct ExportFilter {
 }
 
 /// <p>Information regarding the export status of discovered data. The value is an array of objects.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ExportInfo {
     /// <p>A URL for an Amazon S3 bucket where you can review the exported data. The URL is displayed only if the export succeeded.</p>
     #[serde(rename = "configurationsDownloadUrl")]
@@ -455,7 +455,7 @@ pub struct ExportInfo {
 }
 
 /// <p>A filter that can use conditional operators.</p> <p>For more information about filters, see <a href="http://docs.aws.amazon.com/application-discovery/latest/APIReference/discovery-api-queries.html">Querying Discovered Configuration Items</a>. </p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct Filter {
     /// <p>A conditional operator. The following operators are valid: EQUALS, NOT_EQUALS, CONTAINS, NOT_CONTAINS. If you specify multiple filters, the system utilizes all filters as though concatenated by <i>AND</i>. If you specify multiple values for a particular filter, the system differentiates the values using <i>OR</i>. Calling either <i>DescribeConfigurations</i> or <i>ListConfigurations</i> returns attributes of matching configuration items.</p>
     #[serde(rename = "condition")]
@@ -468,10 +468,10 @@ pub struct Filter {
     pub values: Vec<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetDiscoverySummaryRequest {}
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetDiscoverySummaryResponse {
     /// <p>Details about discovered agents, including agent status and health.</p>
     #[serde(rename = "agentSummary")]
@@ -499,7 +499,7 @@ pub struct GetDiscoverySummaryResponse {
     pub servers_mappedto_tags: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListConfigurationsRequest {
     /// <p>A valid configuration identified by Application Discovery Service. </p>
     #[serde(rename = "configurationType")]
@@ -522,7 +522,7 @@ pub struct ListConfigurationsRequest {
     pub order_by: Option<Vec<OrderByElement>>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListConfigurationsResponse {
     /// <p>Returns configuration details, including the configuration ID, attribute names, and attribute values.</p>
     #[serde(rename = "configurations")]
@@ -534,7 +534,7 @@ pub struct ListConfigurationsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListServerNeighborsRequest {
     /// <p>Configuration ID of the server for which neighbors are being listed.</p>
     #[serde(rename = "configurationId")]
@@ -557,7 +557,7 @@ pub struct ListServerNeighborsRequest {
     pub port_information_needed: Option<bool>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListServerNeighborsResponse {
     /// <p>Count of distinct servers that are one hop away from the given server.</p>
     #[serde(rename = "knownDependencyCount")]
@@ -573,7 +573,7 @@ pub struct ListServerNeighborsResponse {
 }
 
 /// <p>Details about neighboring servers.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct NeighborConnectionDetail {
     /// <p>The number of open network connections with the neighboring server.</p>
     #[serde(rename = "connectionsCount")]
@@ -595,7 +595,7 @@ pub struct NeighborConnectionDetail {
 }
 
 /// <p>A field and direction for ordered output.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct OrderByElement {
     /// <p>The field on which to order.</p>
     #[serde(rename = "fieldName")]
@@ -606,14 +606,14 @@ pub struct OrderByElement {
     pub sort_order: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StartDataCollectionByAgentIdsRequest {
     /// <p>The IDs of the agents or connectors from which to start collecting data. If you send a request to an agent/connector ID that you do not have permission to contact, according to your AWS account, the service does not throw an exception. Instead, it returns the error in the <i>Description</i> field. If you send a request to multiple agents/connectors and you do not have permission to contact some of those agents/connectors, the system does not throw an exception. Instead, the system shows <code>Failed</code> in the <i>Description</i> field.</p>
     #[serde(rename = "agentIds")]
     pub agent_ids: Vec<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StartDataCollectionByAgentIdsResponse {
     /// <p>Information about agents or the connector that were instructed to start collecting data. Information includes the agent/connector ID, a description of the operation performed, and whether the agent/connector configuration was updated.</p>
     #[serde(rename = "agentsConfigurationStatus")]
@@ -621,7 +621,7 @@ pub struct StartDataCollectionByAgentIdsResponse {
     pub agents_configuration_status: Option<Vec<AgentConfigurationStatus>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StartExportTaskRequest {
     /// <p>The end timestamp for exported data from the single Application Discovery Agent selected in the filters. If no value is specified, exported data includes the most recent data collected by the agent.</p>
     #[serde(rename = "endTime")]
@@ -641,7 +641,7 @@ pub struct StartExportTaskRequest {
     pub start_time: Option<f64>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StartExportTaskResponse {
     /// <p>A unique identifier used to query the status of an export request.</p>
     #[serde(rename = "exportId")]
@@ -649,14 +649,14 @@ pub struct StartExportTaskResponse {
     pub export_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StopDataCollectionByAgentIdsRequest {
     /// <p>The IDs of the agents or connectors from which to stop collecting data.</p>
     #[serde(rename = "agentIds")]
     pub agent_ids: Vec<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StopDataCollectionByAgentIdsResponse {
     /// <p>Information about the agents or connector that were instructed to stop collecting data. Information includes the agent/connector ID, a description of the operation performed, and whether the agent/connector configuration was updated.</p>
     #[serde(rename = "agentsConfigurationStatus")]
@@ -665,7 +665,7 @@ pub struct StopDataCollectionByAgentIdsResponse {
 }
 
 /// <p>Metadata that help you categorize IT assets.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct Tag {
     /// <p>The type of tag on which to filter.</p>
     #[serde(rename = "key")]
@@ -676,7 +676,7 @@ pub struct Tag {
 }
 
 /// <p>The tag filter. Valid names are: <code>tagKey</code>, <code>tagValue</code>, <code>configurationId</code>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct TagFilter {
     /// <p>A name of the tag filter.</p>
     #[serde(rename = "name")]
@@ -686,7 +686,7 @@ pub struct TagFilter {
     pub values: Vec<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateApplicationRequest {
     /// <p>Configuration ID of the application to be updated.</p>
     #[serde(rename = "configurationId")]
@@ -701,7 +701,7 @@ pub struct UpdateApplicationRequest {
     pub name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateApplicationResponse {}
 
 /// Errors returned by AssociateConfigurationItemsToApplication

--- a/rusoto/services/dms/src/generated.rs
+++ b/rusoto/services/dms/src/generated.rs
@@ -2156,7 +2156,8 @@ impl AddTagsToResourceError {
     pub fn from_body(body: &str) -> AddTagsToResourceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2246,7 +2247,8 @@ impl CreateEndpointError {
     pub fn from_body(body: &str) -> CreateEndpointError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2352,7 +2354,8 @@ impl CreateEventSubscriptionError {
     pub fn from_body(body: &str) -> CreateEventSubscriptionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2472,7 +2475,8 @@ impl CreateReplicationInstanceError {
     pub fn from_body(body: &str) -> CreateReplicationInstanceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2616,7 +2620,8 @@ impl CreateReplicationSubnetGroupError {
     pub fn from_body(body: &str) -> CreateReplicationSubnetGroupError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2714,7 +2719,8 @@ impl CreateReplicationTaskError {
     pub fn from_body(body: &str) -> CreateReplicationTaskError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2824,7 +2830,8 @@ impl DeleteCertificateError {
     pub fn from_body(body: &str) -> DeleteCertificateError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2912,7 +2919,8 @@ impl DeleteEndpointError {
     pub fn from_body(body: &str) -> DeleteEndpointError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2996,7 +3004,8 @@ impl DeleteEventSubscriptionError {
     pub fn from_body(body: &str) -> DeleteEventSubscriptionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3084,7 +3093,8 @@ impl DeleteReplicationInstanceError {
     pub fn from_body(body: &str) -> DeleteReplicationInstanceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3174,7 +3184,8 @@ impl DeleteReplicationSubnetGroupError {
     pub fn from_body(body: &str) -> DeleteReplicationSubnetGroupError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3264,7 +3275,8 @@ impl DeleteReplicationTaskError {
     pub fn from_body(body: &str) -> DeleteReplicationTaskError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3348,7 +3360,8 @@ impl DescribeAccountAttributesError {
     pub fn from_body(body: &str) -> DescribeAccountAttributesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3424,7 +3437,8 @@ impl DescribeCertificatesError {
     pub fn from_body(body: &str) -> DescribeCertificatesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3504,7 +3518,8 @@ impl DescribeConnectionsError {
     pub fn from_body(body: &str) -> DescribeConnectionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3582,7 +3597,8 @@ impl DescribeEndpointTypesError {
     pub fn from_body(body: &str) -> DescribeEndpointTypesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3658,7 +3674,8 @@ impl DescribeEndpointsError {
     pub fn from_body(body: &str) -> DescribeEndpointsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3736,7 +3753,8 @@ impl DescribeEventCategoriesError {
     pub fn from_body(body: &str) -> DescribeEventCategoriesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3812,7 +3830,8 @@ impl DescribeEventSubscriptionsError {
     pub fn from_body(body: &str) -> DescribeEventSubscriptionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3892,7 +3911,8 @@ impl DescribeEventsError {
     pub fn from_body(body: &str) -> DescribeEventsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3964,7 +3984,8 @@ impl DescribeOrderableReplicationInstancesError {
     pub fn from_body(body: &str) -> DescribeOrderableReplicationInstancesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4044,7 +4065,8 @@ impl DescribeRefreshSchemasStatusError {
     pub fn from_body(body: &str) -> DescribeRefreshSchemasStatusError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4134,7 +4156,8 @@ impl DescribeReplicationInstanceTaskLogsError {
     pub fn from_body(body: &str) -> DescribeReplicationInstanceTaskLogsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4222,7 +4245,8 @@ impl DescribeReplicationInstancesError {
     pub fn from_body(body: &str) -> DescribeReplicationInstancesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4304,7 +4328,8 @@ impl DescribeReplicationSubnetGroupsError {
     pub fn from_body(body: &str) -> DescribeReplicationSubnetGroupsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4386,7 +4411,8 @@ impl DescribeReplicationTaskAssessmentResultsError {
     pub fn from_body(body: &str) -> DescribeReplicationTaskAssessmentResultsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4474,7 +4500,8 @@ impl DescribeReplicationTasksError {
     pub fn from_body(body: &str) -> DescribeReplicationTasksError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4558,7 +4585,8 @@ impl DescribeSchemasError {
     pub fn from_body(body: &str) -> DescribeSchemasError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4642,7 +4670,8 @@ impl DescribeTableStatisticsError {
     pub fn from_body(body: &str) -> DescribeTableStatisticsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4732,7 +4761,8 @@ impl ImportCertificateError {
     pub fn from_body(body: &str) -> ImportCertificateError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4824,7 +4854,8 @@ impl ListTagsForResourceError {
     pub fn from_body(body: &str) -> ListTagsForResourceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4912,7 +4943,8 @@ impl ModifyEndpointError {
     pub fn from_body(body: &str) -> ModifyEndpointError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5012,7 +5044,8 @@ impl ModifyEventSubscriptionError {
     pub fn from_body(body: &str) -> ModifyEventSubscriptionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5118,7 +5151,8 @@ impl ModifyReplicationInstanceError {
     pub fn from_body(body: &str) -> ModifyReplicationInstanceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5240,7 +5274,8 @@ impl ModifyReplicationSubnetGroupError {
     pub fn from_body(body: &str) -> ModifyReplicationSubnetGroupError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5334,7 +5369,8 @@ impl ModifyReplicationTaskError {
     pub fn from_body(body: &str) -> ModifyReplicationTaskError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5434,7 +5470,8 @@ impl RebootReplicationInstanceError {
     pub fn from_body(body: &str) -> RebootReplicationInstanceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5528,7 +5565,8 @@ impl RefreshSchemasError {
     pub fn from_body(body: &str) -> RefreshSchemasError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5620,7 +5658,8 @@ impl ReloadTablesError {
     pub fn from_body(body: &str) -> ReloadTablesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5702,7 +5741,8 @@ impl RemoveTagsFromResourceError {
     pub fn from_body(body: &str) -> RemoveTagsFromResourceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5784,7 +5824,8 @@ impl StartReplicationTaskError {
     pub fn from_body(body: &str) -> StartReplicationTaskError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5872,7 +5913,8 @@ impl StartReplicationTaskAssessmentError {
     pub fn from_body(body: &str) -> StartReplicationTaskAssessmentError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5962,7 +6004,8 @@ impl StopReplicationTaskError {
     pub fn from_body(body: &str) -> StopReplicationTaskError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6054,7 +6097,8 @@ impl TestConnectionError {
     pub fn from_body(body: &str) -> TestConnectionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/dms/src/generated.rs
+++ b/rusoto/services/dms/src/generated.rs
@@ -31,7 +31,7 @@ use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 /// <p>Describes a quota for an AWS account, for example, the number of replication instances allowed.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AccountQuota {
     /// <p>The name of the AWS DMS quota for this AWS account.</p>
     #[serde(rename = "AccountQuotaName")]
@@ -48,7 +48,7 @@ pub struct AccountQuota {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AddTagsToResourceMessage {
     /// <p>The Amazon Resource Name (ARN) of the AWS DMS resource the tag is to be added to. AWS DMS resources include a replication instance, endpoint, and a replication task.</p>
     #[serde(rename = "ResourceArn")]
@@ -59,11 +59,11 @@ pub struct AddTagsToResourceMessage {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AddTagsToResourceResponse {}
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AvailabilityZone {
     /// <p>The name of the availability zone.</p>
     #[serde(rename = "Name")]
@@ -72,7 +72,7 @@ pub struct AvailabilityZone {
 }
 
 /// <p>The SSL certificate that can be used to encrypt connections between the endpoints and the replication instance.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Certificate {
     /// <p>The Amazon Resource Name (ARN) for the certificate.</p>
     #[serde(rename = "CertificateArn")]
@@ -121,7 +121,7 @@ pub struct Certificate {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Connection {
     /// <p>The Amazon Resource Name (ARN) string that uniquely identifies the endpoint.</p>
     #[serde(rename = "EndpointArn")]
@@ -150,7 +150,7 @@ pub struct Connection {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateEndpointMessage {
     /// <p>The Amazon Resource Name (ARN) for the certificate.</p>
     #[serde(rename = "CertificateArn")]
@@ -216,7 +216,7 @@ pub struct CreateEndpointMessage {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateEndpointResponse {
     /// <p>The endpoint that was created.</p>
     #[serde(rename = "Endpoint")]
@@ -225,7 +225,7 @@ pub struct CreateEndpointResponse {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateEventSubscriptionMessage {
     /// <p> A Boolean value; set to <b>true</b> to activate the subscription, or set to <b>false</b> to create the subscription but not activate it. </p>
     #[serde(rename = "Enabled")]
@@ -256,7 +256,7 @@ pub struct CreateEventSubscriptionMessage {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateEventSubscriptionResponse {
     /// <p>The event subscription that was created.</p>
     #[serde(rename = "EventSubscription")]
@@ -265,7 +265,7 @@ pub struct CreateEventSubscriptionResponse {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateReplicationInstanceMessage {
     /// <p>The amount of storage (in gigabytes) to be initially allocated for the replication instance.</p>
     #[serde(rename = "AllocatedStorage")]
@@ -320,7 +320,7 @@ pub struct CreateReplicationInstanceMessage {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateReplicationInstanceResponse {
     /// <p>The replication instance that was created.</p>
     #[serde(rename = "ReplicationInstance")]
@@ -329,7 +329,7 @@ pub struct CreateReplicationInstanceResponse {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateReplicationSubnetGroupMessage {
     /// <p>The description for the subnet group.</p>
     #[serde(rename = "ReplicationSubnetGroupDescription")]
@@ -347,7 +347,7 @@ pub struct CreateReplicationSubnetGroupMessage {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateReplicationSubnetGroupResponse {
     /// <p>The replication subnet group that was created.</p>
     #[serde(rename = "ReplicationSubnetGroup")]
@@ -356,7 +356,7 @@ pub struct CreateReplicationSubnetGroupResponse {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateReplicationTaskMessage {
     /// <p>The start time for the Change Data Capture (CDC) operation.</p>
     #[serde(rename = "CdcStartTime")]
@@ -391,7 +391,7 @@ pub struct CreateReplicationTaskMessage {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateReplicationTaskResponse {
     /// <p>The replication task that was created.</p>
     #[serde(rename = "ReplicationTask")]
@@ -399,14 +399,14 @@ pub struct CreateReplicationTaskResponse {
     pub replication_task: Option<ReplicationTask>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteCertificateMessage {
     /// <p>The Amazon Resource Name (ARN) of the deleted certificate.</p>
     #[serde(rename = "CertificateArn")]
     pub certificate_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteCertificateResponse {
     /// <p>The Secure Sockets Layer (SSL) certificate.</p>
     #[serde(rename = "Certificate")]
@@ -415,7 +415,7 @@ pub struct DeleteCertificateResponse {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteEndpointMessage {
     /// <p>The Amazon Resource Name (ARN) string that uniquely identifies the endpoint.</p>
     #[serde(rename = "EndpointArn")]
@@ -423,7 +423,7 @@ pub struct DeleteEndpointMessage {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteEndpointResponse {
     /// <p>The endpoint that was deleted.</p>
     #[serde(rename = "Endpoint")]
@@ -432,7 +432,7 @@ pub struct DeleteEndpointResponse {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteEventSubscriptionMessage {
     /// <p>The name of the DMS event notification subscription to be deleted.</p>
     #[serde(rename = "SubscriptionName")]
@@ -440,7 +440,7 @@ pub struct DeleteEventSubscriptionMessage {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteEventSubscriptionResponse {
     /// <p>The event subscription that was deleted.</p>
     #[serde(rename = "EventSubscription")]
@@ -449,7 +449,7 @@ pub struct DeleteEventSubscriptionResponse {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteReplicationInstanceMessage {
     /// <p>The Amazon Resource Name (ARN) of the replication instance to be deleted.</p>
     #[serde(rename = "ReplicationInstanceArn")]
@@ -457,7 +457,7 @@ pub struct DeleteReplicationInstanceMessage {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteReplicationInstanceResponse {
     /// <p>The replication instance that was deleted.</p>
     #[serde(rename = "ReplicationInstance")]
@@ -466,7 +466,7 @@ pub struct DeleteReplicationInstanceResponse {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteReplicationSubnetGroupMessage {
     /// <p>The subnet group name of the replication instance.</p>
     #[serde(rename = "ReplicationSubnetGroupIdentifier")]
@@ -474,11 +474,11 @@ pub struct DeleteReplicationSubnetGroupMessage {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteReplicationSubnetGroupResponse {}
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteReplicationTaskMessage {
     /// <p>The Amazon Resource Name (ARN) of the replication task to be deleted.</p>
     #[serde(rename = "ReplicationTaskArn")]
@@ -486,7 +486,7 @@ pub struct DeleteReplicationTaskMessage {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteReplicationTaskResponse {
     /// <p>The deleted replication task.</p>
     #[serde(rename = "ReplicationTask")]
@@ -495,11 +495,11 @@ pub struct DeleteReplicationTaskResponse {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeAccountAttributesMessage {}
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeAccountAttributesResponse {
     /// <p>Account quota information.</p>
     #[serde(rename = "AccountQuotas")]
@@ -507,7 +507,7 @@ pub struct DescribeAccountAttributesResponse {
     pub account_quotas: Option<Vec<AccountQuota>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeCertificatesMessage {
     /// <p>Filters applied to the certificate described in the form of key-value pairs.</p>
     #[serde(rename = "Filters")]
@@ -523,7 +523,7 @@ pub struct DescribeCertificatesMessage {
     pub max_records: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeCertificatesResponse {
     /// <p>The Secure Sockets Layer (SSL) certificates associated with the replication instance.</p>
     #[serde(rename = "Certificates")]
@@ -536,7 +536,7 @@ pub struct DescribeCertificatesResponse {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeConnectionsMessage {
     /// <p>The filters applied to the connection.</p> <p>Valid filter names: endpoint-arn | replication-instance-arn</p>
     #[serde(rename = "Filters")]
@@ -553,7 +553,7 @@ pub struct DescribeConnectionsMessage {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeConnectionsResponse {
     /// <p>A description of the connections.</p>
     #[serde(rename = "Connections")]
@@ -566,7 +566,7 @@ pub struct DescribeConnectionsResponse {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeEndpointTypesMessage {
     /// <p>Filters applied to the describe action.</p> <p>Valid filter names: engine-name | endpoint-type</p>
     #[serde(rename = "Filters")]
@@ -583,7 +583,7 @@ pub struct DescribeEndpointTypesMessage {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeEndpointTypesResponse {
     /// <p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>
     #[serde(rename = "Marker")]
@@ -596,7 +596,7 @@ pub struct DescribeEndpointTypesResponse {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeEndpointsMessage {
     /// <p>Filters applied to the describe action.</p> <p>Valid filter names: endpoint-arn | endpoint-type | endpoint-id | engine-name</p>
     #[serde(rename = "Filters")]
@@ -613,7 +613,7 @@ pub struct DescribeEndpointsMessage {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeEndpointsResponse {
     /// <p>Endpoint description.</p>
     #[serde(rename = "Endpoints")]
@@ -626,7 +626,7 @@ pub struct DescribeEndpointsResponse {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeEventCategoriesMessage {
     /// <p>Filters applied to the action.</p>
     #[serde(rename = "Filters")]
@@ -639,7 +639,7 @@ pub struct DescribeEventCategoriesMessage {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeEventCategoriesResponse {
     /// <p>A list of event categories.</p>
     #[serde(rename = "EventCategoryGroupList")]
@@ -648,7 +648,7 @@ pub struct DescribeEventCategoriesResponse {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeEventSubscriptionsMessage {
     /// <p>Filters applied to the action.</p>
     #[serde(rename = "Filters")]
@@ -669,7 +669,7 @@ pub struct DescribeEventSubscriptionsMessage {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeEventSubscriptionsResponse {
     /// <p>A list of event subscriptions.</p>
     #[serde(rename = "EventSubscriptionsList")]
@@ -682,7 +682,7 @@ pub struct DescribeEventSubscriptionsResponse {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeEventsMessage {
     /// <p>The duration of the events to be listed.</p>
     #[serde(rename = "Duration")]
@@ -723,7 +723,7 @@ pub struct DescribeEventsMessage {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeEventsResponse {
     /// <p>The events described.</p>
     #[serde(rename = "Events")]
@@ -736,7 +736,7 @@ pub struct DescribeEventsResponse {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeOrderableReplicationInstancesMessage {
     /// <p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>
     #[serde(rename = "Marker")]
@@ -749,7 +749,7 @@ pub struct DescribeOrderableReplicationInstancesMessage {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeOrderableReplicationInstancesResponse {
     /// <p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>
     #[serde(rename = "Marker")]
@@ -762,7 +762,7 @@ pub struct DescribeOrderableReplicationInstancesResponse {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeRefreshSchemasStatusMessage {
     /// <p>The Amazon Resource Name (ARN) string that uniquely identifies the endpoint.</p>
     #[serde(rename = "EndpointArn")]
@@ -770,7 +770,7 @@ pub struct DescribeRefreshSchemasStatusMessage {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeRefreshSchemasStatusResponse {
     /// <p>The status of the schema.</p>
     #[serde(rename = "RefreshSchemasStatus")]
@@ -778,7 +778,7 @@ pub struct DescribeRefreshSchemasStatusResponse {
     pub refresh_schemas_status: Option<RefreshSchemasStatus>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeReplicationInstanceTaskLogsMessage {
     /// <p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>.</p>
     #[serde(rename = "Marker")]
@@ -793,7 +793,7 @@ pub struct DescribeReplicationInstanceTaskLogsMessage {
     pub replication_instance_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeReplicationInstanceTaskLogsResponse {
     /// <p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>.</p>
     #[serde(rename = "Marker")]
@@ -810,7 +810,7 @@ pub struct DescribeReplicationInstanceTaskLogsResponse {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeReplicationInstancesMessage {
     /// <p>Filters applied to the describe action.</p> <p>Valid filter names: replication-instance-arn | replication-instance-id | replication-instance-class | engine-version</p>
     #[serde(rename = "Filters")]
@@ -827,7 +827,7 @@ pub struct DescribeReplicationInstancesMessage {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeReplicationInstancesResponse {
     /// <p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>
     #[serde(rename = "Marker")]
@@ -840,7 +840,7 @@ pub struct DescribeReplicationInstancesResponse {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeReplicationSubnetGroupsMessage {
     /// <p>Filters applied to the describe action.</p>
     #[serde(rename = "Filters")]
@@ -857,7 +857,7 @@ pub struct DescribeReplicationSubnetGroupsMessage {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeReplicationSubnetGroupsResponse {
     /// <p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>
     #[serde(rename = "Marker")]
@@ -870,7 +870,7 @@ pub struct DescribeReplicationSubnetGroupsResponse {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeReplicationTaskAssessmentResultsMessage {
     /// <p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>
     #[serde(rename = "Marker")]
@@ -887,7 +887,7 @@ pub struct DescribeReplicationTaskAssessmentResultsMessage {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeReplicationTaskAssessmentResultsResponse {
     /// <p>- The Amazon S3 bucket where the task assessment report is located. </p>
     #[serde(rename = "BucketName")]
@@ -904,7 +904,7 @@ pub struct DescribeReplicationTaskAssessmentResultsResponse {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeReplicationTasksMessage {
     /// <p>Filters applied to the describe action.</p> <p>Valid filter names: replication-task-arn | replication-task-id | migration-type | endpoint-arn | replication-instance-arn</p>
     #[serde(rename = "Filters")]
@@ -921,7 +921,7 @@ pub struct DescribeReplicationTasksMessage {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeReplicationTasksResponse {
     /// <p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>
     #[serde(rename = "Marker")]
@@ -934,7 +934,7 @@ pub struct DescribeReplicationTasksResponse {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeSchemasMessage {
     /// <p>The Amazon Resource Name (ARN) string that uniquely identifies the endpoint.</p>
     #[serde(rename = "EndpointArn")]
@@ -950,7 +950,7 @@ pub struct DescribeSchemasMessage {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeSchemasResponse {
     /// <p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>
     #[serde(rename = "Marker")]
@@ -963,7 +963,7 @@ pub struct DescribeSchemasResponse {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeTableStatisticsMessage {
     /// <p>Filters applied to the describe table statistics action.</p> <p>Valid filter names: schema-name | table-name | table-state</p> <p>A combination of filters creates an AND condition where each record matches all specified filters.</p>
     #[serde(rename = "Filters")]
@@ -983,7 +983,7 @@ pub struct DescribeTableStatisticsMessage {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeTableStatisticsResponse {
     /// <p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>
     #[serde(rename = "Marker")]
@@ -1000,7 +1000,7 @@ pub struct DescribeTableStatisticsResponse {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct DynamoDbSettings {
     /// <p> The Amazon Resource Name (ARN) used by the service access IAM role. </p>
     #[serde(rename = "ServiceAccessRoleArn")]
@@ -1008,7 +1008,7 @@ pub struct DynamoDbSettings {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Endpoint {
     /// <p>The Amazon Resource Name (ARN) used for SSL connection to the endpoint.</p>
     #[serde(rename = "CertificateArn")]
@@ -1081,7 +1081,7 @@ pub struct Endpoint {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Event {
     /// <p>The date of the event.</p>
     #[serde(rename = "Date")]
@@ -1106,7 +1106,7 @@ pub struct Event {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct EventCategoryGroup {
     /// <p> A list of event categories for a <code>SourceType</code> that you want to subscribe to. </p>
     #[serde(rename = "EventCategories")]
@@ -1119,7 +1119,7 @@ pub struct EventCategoryGroup {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct EventSubscription {
     /// <p>The AWS DMS event notification subscription Id.</p>
     #[serde(rename = "CustSubscriptionId")]
@@ -1160,7 +1160,7 @@ pub struct EventSubscription {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct Filter {
     /// <p>The name of the filter.</p>
     #[serde(rename = "Name")]
@@ -1170,7 +1170,7 @@ pub struct Filter {
     pub values: Vec<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ImportCertificateMessage {
     /// <p>The customer-assigned name of the certificate. Valid characters are A-z and 0-9.</p>
     #[serde(rename = "CertificateIdentifier")]
@@ -1193,7 +1193,7 @@ pub struct ImportCertificateMessage {
     pub tags: Option<Vec<Tag>>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ImportCertificateResponse {
     /// <p>The certificate to be uploaded.</p>
     #[serde(rename = "Certificate")]
@@ -1202,7 +1202,7 @@ pub struct ImportCertificateResponse {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListTagsForResourceMessage {
     /// <p>The Amazon Resource Name (ARN) string that uniquely identifies the AWS DMS resource.</p>
     #[serde(rename = "ResourceArn")]
@@ -1210,7 +1210,7 @@ pub struct ListTagsForResourceMessage {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListTagsForResourceResponse {
     /// <p>A list of tags for the resource.</p>
     #[serde(rename = "TagList")]
@@ -1219,7 +1219,7 @@ pub struct ListTagsForResourceResponse {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ModifyEndpointMessage {
     /// <p>The Amazon Resource Name (ARN) of the certificate used for SSL connection.</p>
     #[serde(rename = "CertificateArn")]
@@ -1283,7 +1283,7 @@ pub struct ModifyEndpointMessage {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ModifyEndpointResponse {
     /// <p>The modified endpoint.</p>
     #[serde(rename = "Endpoint")]
@@ -1292,7 +1292,7 @@ pub struct ModifyEndpointResponse {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ModifyEventSubscriptionMessage {
     /// <p> A Boolean value; set to <b>true</b> to activate the subscription. </p>
     #[serde(rename = "Enabled")]
@@ -1316,7 +1316,7 @@ pub struct ModifyEventSubscriptionMessage {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ModifyEventSubscriptionResponse {
     /// <p>The modified event subscription.</p>
     #[serde(rename = "EventSubscription")]
@@ -1325,7 +1325,7 @@ pub struct ModifyEventSubscriptionResponse {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ModifyReplicationInstanceMessage {
     /// <p>The amount of storage (in gigabytes) to be allocated for the replication instance.</p>
     #[serde(rename = "AllocatedStorage")]
@@ -1373,7 +1373,7 @@ pub struct ModifyReplicationInstanceMessage {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ModifyReplicationInstanceResponse {
     /// <p>The modified replication instance.</p>
     #[serde(rename = "ReplicationInstance")]
@@ -1382,7 +1382,7 @@ pub struct ModifyReplicationInstanceResponse {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ModifyReplicationSubnetGroupMessage {
     /// <p>The description of the replication instance subnet group.</p>
     #[serde(rename = "ReplicationSubnetGroupDescription")]
@@ -1397,7 +1397,7 @@ pub struct ModifyReplicationSubnetGroupMessage {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ModifyReplicationSubnetGroupResponse {
     /// <p>The modified replication subnet group.</p>
     #[serde(rename = "ReplicationSubnetGroup")]
@@ -1406,7 +1406,7 @@ pub struct ModifyReplicationSubnetGroupResponse {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ModifyReplicationTaskMessage {
     /// <p>The start time for the Change Data Capture (CDC) operation.</p>
     #[serde(rename = "CdcStartTime")]
@@ -1434,7 +1434,7 @@ pub struct ModifyReplicationTaskMessage {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ModifyReplicationTaskResponse {
     /// <p>The replication task that was modified.</p>
     #[serde(rename = "ReplicationTask")]
@@ -1443,7 +1443,7 @@ pub struct ModifyReplicationTaskResponse {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct MongoDbSettings {
     /// <p> The authentication mechanism you use to access the MongoDB source endpoint.</p> <p>Valid values: DEFAULT, MONGODB_CR, SCRAM_SHA_1 </p> <p>DEFAULT – For MongoDB version 2.x, use MONGODB_CR. For MongoDB version 3.x, use SCRAM_SHA_1. This attribute is not used when authType=No.</p>
     #[serde(rename = "AuthMechanism")]
@@ -1492,7 +1492,7 @@ pub struct MongoDbSettings {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct OrderableReplicationInstance {
     /// <p>The default amount of storage (in gigabytes) that is allocated for the replication instance.</p>
     #[serde(rename = "DefaultAllocatedStorage")]
@@ -1524,7 +1524,7 @@ pub struct OrderableReplicationInstance {
     pub storage_type: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RebootReplicationInstanceMessage {
     /// <p>If this parameter is <code>true</code>, the reboot is conducted through a Multi-AZ failover. (If the instance isn't configured for Multi-AZ, then you can't specify <code>true</code>.)</p>
     #[serde(rename = "ForceFailover")]
@@ -1535,7 +1535,7 @@ pub struct RebootReplicationInstanceMessage {
     pub replication_instance_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RebootReplicationInstanceResponse {
     /// <p>The replication instance that is being rebooted. </p>
     #[serde(rename = "ReplicationInstance")]
@@ -1544,7 +1544,7 @@ pub struct RebootReplicationInstanceResponse {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RefreshSchemasMessage {
     /// <p>The Amazon Resource Name (ARN) string that uniquely identifies the endpoint.</p>
     #[serde(rename = "EndpointArn")]
@@ -1555,7 +1555,7 @@ pub struct RefreshSchemasMessage {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RefreshSchemasResponse {
     /// <p>The status of the refreshed schema.</p>
     #[serde(rename = "RefreshSchemasStatus")]
@@ -1564,7 +1564,7 @@ pub struct RefreshSchemasResponse {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RefreshSchemasStatus {
     /// <p>The Amazon Resource Name (ARN) string that uniquely identifies the endpoint.</p>
     #[serde(rename = "EndpointArn")]
@@ -1588,7 +1588,7 @@ pub struct RefreshSchemasStatus {
     pub status: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ReloadTablesMessage {
     /// <p>The Amazon Resource Name (ARN) of the replication instance. </p>
     #[serde(rename = "ReplicationTaskArn")]
@@ -1598,7 +1598,7 @@ pub struct ReloadTablesMessage {
     pub tables_to_reload: Vec<TableToReload>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ReloadTablesResponse {
     /// <p>The Amazon Resource Name (ARN) of the replication task. </p>
     #[serde(rename = "ReplicationTaskArn")]
@@ -1607,7 +1607,7 @@ pub struct ReloadTablesResponse {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RemoveTagsFromResourceMessage {
     /// <p>&gt;The Amazon Resource Name (ARN) of the AWS DMS resource the tag is to be removed from.</p>
     #[serde(rename = "ResourceArn")]
@@ -1618,11 +1618,11 @@ pub struct RemoveTagsFromResourceMessage {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RemoveTagsFromResourceResponse {}
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ReplicationInstance {
     /// <p>The amount of storage (in gigabytes) that is allocated for the replication instance.</p>
     #[serde(rename = "AllocatedStorage")]
@@ -1703,7 +1703,7 @@ pub struct ReplicationInstance {
 }
 
 /// <p>Contains metadata for a replication instance task log.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ReplicationInstanceTaskLog {
     /// <p>The size, in bytes, of the replication task log.</p>
     #[serde(rename = "ReplicationInstanceTaskLogSize")]
@@ -1720,7 +1720,7 @@ pub struct ReplicationInstanceTaskLog {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ReplicationPendingModifiedValues {
     /// <p>The amount of storage (in gigabytes) that is allocated for the replication instance.</p>
     #[serde(rename = "AllocatedStorage")]
@@ -1741,7 +1741,7 @@ pub struct ReplicationPendingModifiedValues {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ReplicationSubnetGroup {
     /// <p>The description of the replication subnet group.</p>
     #[serde(rename = "ReplicationSubnetGroupDescription")]
@@ -1766,7 +1766,7 @@ pub struct ReplicationSubnetGroup {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ReplicationTask {
     /// <p>The last error (failure) message generated for the replication instance.</p>
     #[serde(rename = "LastFailureMessage")]
@@ -1827,7 +1827,7 @@ pub struct ReplicationTask {
 }
 
 /// <p> The task assessment report in JSON format. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ReplicationTaskAssessmentResult {
     /// <p> The task assessment results in JSON format. </p>
     #[serde(rename = "AssessmentResults")]
@@ -1860,7 +1860,7 @@ pub struct ReplicationTaskAssessmentResult {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ReplicationTaskStats {
     /// <p>The elapsed time of the task, in milliseconds.</p>
     #[serde(rename = "ElapsedTimeMillis")]
@@ -1889,7 +1889,7 @@ pub struct ReplicationTaskStats {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct S3Settings {
     /// <p> An optional parameter to set a folder name in the S3 bucket. If provided, tables are created in the path &lt;bucketFolder&gt;/&lt;schema_name&gt;/&lt;table_name&gt;/. If this parameter is not specified, then the path used is &lt;schema_name&gt;/&lt;table_name&gt;/. </p>
     #[serde(rename = "BucketFolder")]
@@ -1922,7 +1922,7 @@ pub struct S3Settings {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StartReplicationTaskAssessmentMessage {
     /// <p> The Amazon Resource Name (ARN) of the replication task. </p>
     #[serde(rename = "ReplicationTaskArn")]
@@ -1930,7 +1930,7 @@ pub struct StartReplicationTaskAssessmentMessage {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StartReplicationTaskAssessmentResponse {
     /// <p> The assessed replication task. </p>
     #[serde(rename = "ReplicationTask")]
@@ -1939,7 +1939,7 @@ pub struct StartReplicationTaskAssessmentResponse {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StartReplicationTaskMessage {
     /// <p>The start time for the Change Data Capture (CDC) operation.</p>
     #[serde(rename = "CdcStartTime")]
@@ -1954,7 +1954,7 @@ pub struct StartReplicationTaskMessage {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StartReplicationTaskResponse {
     /// <p>The replication task started.</p>
     #[serde(rename = "ReplicationTask")]
@@ -1963,7 +1963,7 @@ pub struct StartReplicationTaskResponse {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StopReplicationTaskMessage {
     /// <p>The Amazon Resource Name(ARN) of the replication task to be stopped.</p>
     #[serde(rename = "ReplicationTaskArn")]
@@ -1971,7 +1971,7 @@ pub struct StopReplicationTaskMessage {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StopReplicationTaskResponse {
     /// <p>The replication task stopped.</p>
     #[serde(rename = "ReplicationTask")]
@@ -1980,7 +1980,7 @@ pub struct StopReplicationTaskResponse {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Subnet {
     /// <p>The Availability Zone of the subnet.</p>
     #[serde(rename = "SubnetAvailabilityZone")]
@@ -1997,7 +1997,7 @@ pub struct Subnet {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SupportedEndpointType {
     /// <p>The type of endpoint.</p>
     #[serde(rename = "EndpointType")]
@@ -2014,7 +2014,7 @@ pub struct SupportedEndpointType {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct TableStatistics {
     /// <p>The Data Definition Language (DDL) used to build and modify the structure of your tables.</p>
     #[serde(rename = "Ddls")]
@@ -2079,7 +2079,7 @@ pub struct TableStatistics {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct TableToReload {
     /// <p>The schema name of the table to be reloaded.</p>
     #[serde(rename = "SchemaName")]
@@ -2092,7 +2092,7 @@ pub struct TableToReload {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Tag {
     /// <p>A key is the required name of the tag. The string value can be from 1 to 128 Unicode characters in length and cannot be prefixed with "aws:" or "dms:". The string can only contain only the set of Unicode letters, digits, white-space, '_', '.', '/', '=', '+', '-' (Java regex: "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-]*)$").</p>
     #[serde(rename = "Key")]
@@ -2105,7 +2105,7 @@ pub struct Tag {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct TestConnectionMessage {
     /// <p>The Amazon Resource Name (ARN) string that uniquely identifies the endpoint.</p>
     #[serde(rename = "EndpointArn")]
@@ -2116,7 +2116,7 @@ pub struct TestConnectionMessage {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct TestConnectionResponse {
     /// <p>The connection tested.</p>
     #[serde(rename = "Connection")]
@@ -2125,7 +2125,7 @@ pub struct TestConnectionResponse {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct VpcSecurityGroupMembership {
     /// <p>The status of the VPC security group.</p>
     #[serde(rename = "Status")]

--- a/rusoto/services/ds/src/generated.rs
+++ b/rusoto/services/ds/src/generated.rs
@@ -1446,7 +1446,8 @@ impl AddIpRoutesError {
     pub fn from_body(body: &str) -> AddIpRoutesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1552,7 +1553,8 @@ impl AddTagsToResourceError {
     pub fn from_body(body: &str) -> AddTagsToResourceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1652,7 +1654,8 @@ impl CancelSchemaExtensionError {
     pub fn from_body(body: &str) -> CancelSchemaExtensionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1746,7 +1749,8 @@ impl ConnectDirectoryError {
     pub fn from_body(body: &str) -> ConnectDirectoryError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1842,7 +1846,8 @@ impl CreateAliasError {
     pub fn from_body(body: &str) -> CreateAliasError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1946,7 +1951,8 @@ impl CreateComputerError {
     pub fn from_body(body: &str) -> CreateComputerError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2060,7 +2066,8 @@ impl CreateConditionalForwarderError {
     pub fn from_body(body: &str) -> CreateConditionalForwarderError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2180,7 +2187,8 @@ impl CreateDirectoryError {
     pub fn from_body(body: &str) -> CreateDirectoryError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2276,7 +2284,8 @@ impl CreateMicrosoftADError {
     pub fn from_body(body: &str) -> CreateMicrosoftADError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2380,7 +2389,8 @@ impl CreateSnapshotError {
     pub fn from_body(body: &str) -> CreateSnapshotError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2480,7 +2490,8 @@ impl CreateTrustError {
     pub fn from_body(body: &str) -> CreateTrustError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2584,7 +2595,8 @@ impl DeleteConditionalForwarderError {
     pub fn from_body(body: &str) -> DeleteConditionalForwarderError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2696,7 +2708,8 @@ impl DeleteDirectoryError {
     pub fn from_body(body: &str) -> DeleteDirectoryError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2786,7 +2799,8 @@ impl DeleteSnapshotError {
     pub fn from_body(body: &str) -> DeleteSnapshotError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2880,7 +2894,8 @@ impl DeleteTrustError {
     pub fn from_body(body: &str) -> DeleteTrustError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2976,7 +2991,8 @@ impl DeregisterEventTopicError {
     pub fn from_body(body: &str) -> DeregisterEventTopicError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3078,7 +3094,8 @@ impl DescribeConditionalForwardersError {
     pub fn from_body(body: &str) -> DescribeConditionalForwardersError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3194,7 +3211,8 @@ impl DescribeDirectoriesError {
     pub fn from_body(body: &str) -> DescribeDirectoriesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3300,7 +3318,8 @@ impl DescribeDomainControllersError {
     pub fn from_body(body: &str) -> DescribeDomainControllersError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3414,7 +3433,8 @@ impl DescribeEventTopicsError {
     pub fn from_body(body: &str) -> DescribeEventTopicsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3514,7 +3534,8 @@ impl DescribeSnapshotsError {
     pub fn from_body(body: &str) -> DescribeSnapshotsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3620,7 +3641,8 @@ impl DescribeTrustsError {
     pub fn from_body(body: &str) -> DescribeTrustsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3718,7 +3740,8 @@ impl DisableRadiusError {
     pub fn from_body(body: &str) -> DisableRadiusError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3808,7 +3831,8 @@ impl DisableSsoError {
     pub fn from_body(body: &str) -> DisableSsoError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3904,7 +3928,8 @@ impl EnableRadiusError {
     pub fn from_body(body: &str) -> EnableRadiusError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4002,7 +4027,8 @@ impl EnableSsoError {
     pub fn from_body(body: &str) -> EnableSsoError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4094,7 +4120,8 @@ impl GetDirectoryLimitsError {
     pub fn from_body(body: &str) -> GetDirectoryLimitsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4186,7 +4213,8 @@ impl GetSnapshotLimitsError {
     pub fn from_body(body: &str) -> GetSnapshotLimitsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4282,7 +4310,8 @@ impl ListIpRoutesError {
     pub fn from_body(body: &str) -> ListIpRoutesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4378,7 +4407,8 @@ impl ListSchemaExtensionsError {
     pub fn from_body(body: &str) -> ListSchemaExtensionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4478,7 +4508,8 @@ impl ListTagsForResourceError {
     pub fn from_body(body: &str) -> ListTagsForResourceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4580,7 +4611,8 @@ impl RegisterEventTopicError {
     pub fn from_body(body: &str) -> RegisterEventTopicError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4680,7 +4712,8 @@ impl RemoveIpRoutesError {
     pub fn from_body(body: &str) -> RemoveIpRoutesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4776,7 +4809,8 @@ impl RemoveTagsFromResourceError {
     pub fn from_body(body: &str) -> RemoveTagsFromResourceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4874,7 +4908,8 @@ impl RestoreFromSnapshotError {
     pub fn from_body(body: &str) -> RestoreFromSnapshotError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4976,7 +5011,8 @@ impl StartSchemaExtensionError {
     pub fn from_body(body: &str) -> StartSchemaExtensionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5088,7 +5124,8 @@ impl UpdateConditionalForwarderError {
     pub fn from_body(body: &str) -> UpdateConditionalForwarderError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5208,7 +5245,8 @@ impl UpdateNumberOfDomainControllersError {
     pub fn from_body(body: &str) -> UpdateNumberOfDomainControllersError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5328,7 +5366,8 @@ impl UpdateRadiusError {
     pub fn from_body(body: &str) -> UpdateRadiusError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5422,7 +5461,8 @@ impl VerifyTrustError {
     pub fn from_body(body: &str) -> VerifyTrustError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/ds/src/generated.rs
+++ b/rusoto/services/ds/src/generated.rs
@@ -30,7 +30,7 @@ use rusoto_core::signature::SignedRequest;
 use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AddIpRoutesRequest {
     /// <p>Identifier (ID) of the directory to which to add the address block.</p>
     #[serde(rename = "DirectoryId")]
@@ -44,10 +44,10 @@ pub struct AddIpRoutesRequest {
     pub update_security_group_for_directory_controllers: Option<bool>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AddIpRoutesResult {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AddTagsToResourceRequest {
     /// <p>Identifier (ID) for the directory to which to add the tag.</p>
     #[serde(rename = "ResourceId")]
@@ -57,11 +57,11 @@ pub struct AddTagsToResourceRequest {
     pub tags: Vec<Tag>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AddTagsToResourceResult {}
 
 /// <p>Represents a named directory attribute.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Attribute {
     /// <p>The name of the attribute.</p>
     #[serde(rename = "Name")]
@@ -73,7 +73,7 @@ pub struct Attribute {
     pub value: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CancelSchemaExtensionRequest {
     /// <p>The identifier of the directory whose schema extension will be canceled.</p>
     #[serde(rename = "DirectoryId")]
@@ -83,11 +83,11 @@ pub struct CancelSchemaExtensionRequest {
     pub schema_extension_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CancelSchemaExtensionResult {}
 
 /// <p>Contains information about a computer account in a directory.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Computer {
     /// <p>An array of <a>Attribute</a> objects containing the LDAP attributes that belong to the computer account.</p>
     #[serde(rename = "ComputerAttributes")]
@@ -104,7 +104,7 @@ pub struct Computer {
 }
 
 /// <p>Points to a remote domain with which you are setting up a trust relationship. Conditional forwarders are required in order to set up a trust relationship with another domain.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ConditionalForwarder {
     /// <p>The IP addresses of the remote DNS server associated with RemoteDomainName. This is the IP address of the DNS server that your conditional forwarder points to.</p>
     #[serde(rename = "DnsIpAddrs")]
@@ -121,7 +121,7 @@ pub struct ConditionalForwarder {
 }
 
 /// <p>Contains the inputs for the <a>ConnectDirectory</a> operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ConnectDirectoryRequest {
     /// <p>A <a>DirectoryConnectSettings</a> object that contains additional information for the operation.</p>
     #[serde(rename = "ConnectSettings")]
@@ -146,7 +146,7 @@ pub struct ConnectDirectoryRequest {
 }
 
 /// <p>Contains the results of the <a>ConnectDirectory</a> operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ConnectDirectoryResult {
     /// <p>The identifier of the new directory.</p>
     #[serde(rename = "DirectoryId")]
@@ -155,7 +155,7 @@ pub struct ConnectDirectoryResult {
 }
 
 /// <p>Contains the inputs for the <a>CreateAlias</a> operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateAliasRequest {
     /// <p>The requested alias.</p> <p>The alias must be unique amongst all aliases in AWS. This operation throws an <code>EntityAlreadyExistsException</code> error if the alias already exists.</p>
     #[serde(rename = "Alias")]
@@ -166,7 +166,7 @@ pub struct CreateAliasRequest {
 }
 
 /// <p>Contains the results of the <a>CreateAlias</a> operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateAliasResult {
     /// <p>The alias for the directory.</p>
     #[serde(rename = "Alias")]
@@ -179,7 +179,7 @@ pub struct CreateAliasResult {
 }
 
 /// <p>Contains the inputs for the <a>CreateComputer</a> operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateComputerRequest {
     /// <p>An array of <a>Attribute</a> objects that contain any LDAP attributes to apply to the computer account.</p>
     #[serde(rename = "ComputerAttributes")]
@@ -201,7 +201,7 @@ pub struct CreateComputerRequest {
 }
 
 /// <p>Contains the results for the <a>CreateComputer</a> operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateComputerResult {
     /// <p>A <a>Computer</a> object that represents the computer account.</p>
     #[serde(rename = "Computer")]
@@ -210,7 +210,7 @@ pub struct CreateComputerResult {
 }
 
 /// <p>Initiates the creation of a conditional forwarder for your AWS Directory Service for Microsoft Active Directory. Conditional forwarders are required in order to set up a trust relationship with another domain.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateConditionalForwarderRequest {
     /// <p>The directory ID of the AWS directory for which you are creating the conditional forwarder.</p>
     #[serde(rename = "DirectoryId")]
@@ -224,11 +224,11 @@ pub struct CreateConditionalForwarderRequest {
 }
 
 /// <p>The result of a CreateConditinalForwarder request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateConditionalForwarderResult {}
 
 /// <p>Contains the inputs for the <a>CreateDirectory</a> operation. </p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateDirectoryRequest {
     /// <p>A textual description for the directory.</p>
     #[serde(rename = "Description")]
@@ -254,7 +254,7 @@ pub struct CreateDirectoryRequest {
 }
 
 /// <p>Contains the results of the <a>CreateDirectory</a> operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateDirectoryResult {
     /// <p>The identifier of the directory that was created.</p>
     #[serde(rename = "DirectoryId")]
@@ -263,7 +263,7 @@ pub struct CreateDirectoryResult {
 }
 
 /// <p>Creates a Microsoft AD in the AWS cloud.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateMicrosoftADRequest {
     /// <p>A textual description for the directory. This label will appear on the AWS console <code>Directory Details</code> page after the directory is created.</p>
     #[serde(rename = "Description")]
@@ -289,7 +289,7 @@ pub struct CreateMicrosoftADRequest {
 }
 
 /// <p>Result of a CreateMicrosoftAD request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateMicrosoftADResult {
     /// <p>The identifier of the directory that was created.</p>
     #[serde(rename = "DirectoryId")]
@@ -298,7 +298,7 @@ pub struct CreateMicrosoftADResult {
 }
 
 /// <p>Contains the inputs for the <a>CreateSnapshot</a> operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateSnapshotRequest {
     /// <p>The identifier of the directory of which to take a snapshot.</p>
     #[serde(rename = "DirectoryId")]
@@ -310,7 +310,7 @@ pub struct CreateSnapshotRequest {
 }
 
 /// <p>Contains the results of the <a>CreateSnapshot</a> operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateSnapshotResult {
     /// <p>The identifier of the snapshot that was created.</p>
     #[serde(rename = "SnapshotId")]
@@ -319,7 +319,7 @@ pub struct CreateSnapshotResult {
 }
 
 /// <p>AWS Directory Service for Microsoft Active Directory allows you to configure trust relationships. For example, you can establish a trust between your Microsoft AD in the AWS cloud, and your existing on-premises Microsoft Active Directory. This would allow you to provide users and groups access to resources in either domain, with a single set of credentials.</p> <p>This action initiates the creation of the AWS side of a trust relationship between a Microsoft AD in the AWS cloud and an external domain.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateTrustRequest {
     /// <p>The IP addresses of the remote DNS server associated with RemoteDomainName.</p>
     #[serde(rename = "ConditionalForwarderIpAddrs")]
@@ -344,7 +344,7 @@ pub struct CreateTrustRequest {
 }
 
 /// <p>The result of a CreateTrust request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateTrustResult {
     /// <p>A unique identifier for the trust relationship that was created.</p>
     #[serde(rename = "TrustId")]
@@ -353,7 +353,7 @@ pub struct CreateTrustResult {
 }
 
 /// <p>Deletes a conditional forwarder.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteConditionalForwarderRequest {
     /// <p>The directory ID for which you are deleting the conditional forwarder.</p>
     #[serde(rename = "DirectoryId")]
@@ -364,11 +364,11 @@ pub struct DeleteConditionalForwarderRequest {
 }
 
 /// <p>The result of a DeleteConditionalForwarder request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteConditionalForwarderResult {}
 
 /// <p>Contains the inputs for the <a>DeleteDirectory</a> operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteDirectoryRequest {
     /// <p>The identifier of the directory to delete.</p>
     #[serde(rename = "DirectoryId")]
@@ -376,7 +376,7 @@ pub struct DeleteDirectoryRequest {
 }
 
 /// <p>Contains the results of the <a>DeleteDirectory</a> operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteDirectoryResult {
     /// <p>The directory identifier.</p>
     #[serde(rename = "DirectoryId")]
@@ -385,7 +385,7 @@ pub struct DeleteDirectoryResult {
 }
 
 /// <p>Contains the inputs for the <a>DeleteSnapshot</a> operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteSnapshotRequest {
     /// <p>The identifier of the directory snapshot to be deleted.</p>
     #[serde(rename = "SnapshotId")]
@@ -393,7 +393,7 @@ pub struct DeleteSnapshotRequest {
 }
 
 /// <p>Contains the results of the <a>DeleteSnapshot</a> operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteSnapshotResult {
     /// <p>The identifier of the directory snapshot that was deleted.</p>
     #[serde(rename = "SnapshotId")]
@@ -402,7 +402,7 @@ pub struct DeleteSnapshotResult {
 }
 
 /// <p>Deletes the local side of an existing trust relationship between the Microsoft AD in the AWS cloud and the external domain.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteTrustRequest {
     /// <p>Delete a conditional forwarder as part of a DeleteTrustRequest.</p>
     #[serde(rename = "DeleteAssociatedConditionalForwarder")]
@@ -414,7 +414,7 @@ pub struct DeleteTrustRequest {
 }
 
 /// <p>The result of a DeleteTrust request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteTrustResult {
     /// <p>The Trust ID of the trust relationship that was deleted.</p>
     #[serde(rename = "TrustId")]
@@ -423,7 +423,7 @@ pub struct DeleteTrustResult {
 }
 
 /// <p>Removes the specified directory as a publisher to the specified SNS topic.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeregisterEventTopicRequest {
     /// <p>The Directory ID to remove as a publisher. This directory will no longer send messages to the specified SNS topic.</p>
     #[serde(rename = "DirectoryId")]
@@ -434,11 +434,11 @@ pub struct DeregisterEventTopicRequest {
 }
 
 /// <p>The result of a DeregisterEventTopic request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeregisterEventTopicResult {}
 
 /// <p>Describes a conditional forwarder.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeConditionalForwardersRequest {
     /// <p>The directory ID for which to get the list of associated conditional forwarders.</p>
     #[serde(rename = "DirectoryId")]
@@ -450,7 +450,7 @@ pub struct DescribeConditionalForwardersRequest {
 }
 
 /// <p>The result of a DescribeConditionalForwarder request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeConditionalForwardersResult {
     /// <p>The list of conditional forwarders that have been created.</p>
     #[serde(rename = "ConditionalForwarders")]
@@ -459,7 +459,7 @@ pub struct DescribeConditionalForwardersResult {
 }
 
 /// <p>Contains the inputs for the <a>DescribeDirectories</a> operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeDirectoriesRequest {
     /// <p>A list of identifiers of the directories for which to obtain the information. If this member is null, all directories that belong to the current account are returned.</p> <p>An empty list results in an <code>InvalidParameterException</code> being thrown.</p>
     #[serde(rename = "DirectoryIds")]
@@ -476,7 +476,7 @@ pub struct DescribeDirectoriesRequest {
 }
 
 /// <p>Contains the results of the <a>DescribeDirectories</a> operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeDirectoriesResult {
     /// <p>The list of <a>DirectoryDescription</a> objects that were retrieved.</p> <p>It is possible that this list contains less than the number of items specified in the <i>Limit</i> member of the request. This occurs if there are less than the requested number of items left to retrieve, or if the limitations of the operation have been exceeded.</p>
     #[serde(rename = "DirectoryDescriptions")]
@@ -488,7 +488,7 @@ pub struct DescribeDirectoriesResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeDomainControllersRequest {
     /// <p>Identifier of the directory for which to retrieve the domain controller information.</p>
     #[serde(rename = "DirectoryId")]
@@ -507,7 +507,7 @@ pub struct DescribeDomainControllersRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeDomainControllersResult {
     /// <p>List of the <a>DomainController</a> objects that were retrieved.</p>
     #[serde(rename = "DomainControllers")]
@@ -520,7 +520,7 @@ pub struct DescribeDomainControllersResult {
 }
 
 /// <p>Describes event topics.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeEventTopicsRequest {
     /// <p>The Directory ID for which to get the list of associated SNS topics. If this member is null, associations for all Directory IDs are returned.</p>
     #[serde(rename = "DirectoryId")]
@@ -533,7 +533,7 @@ pub struct DescribeEventTopicsRequest {
 }
 
 /// <p>The result of a DescribeEventTopic request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeEventTopicsResult {
     /// <p>A list of SNS topic names that receive status messages from the specified Directory ID.</p>
     #[serde(rename = "EventTopics")]
@@ -542,7 +542,7 @@ pub struct DescribeEventTopicsResult {
 }
 
 /// <p>Contains the inputs for the <a>DescribeSnapshots</a> operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeSnapshotsRequest {
     /// <p>The identifier of the directory for which to retrieve snapshot information.</p>
     #[serde(rename = "DirectoryId")]
@@ -563,7 +563,7 @@ pub struct DescribeSnapshotsRequest {
 }
 
 /// <p>Contains the results of the <a>DescribeSnapshots</a> operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeSnapshotsResult {
     /// <p>If not null, more results are available. Pass this value in the <i>NextToken</i> member of a subsequent call to <a>DescribeSnapshots</a>.</p>
     #[serde(rename = "NextToken")]
@@ -576,7 +576,7 @@ pub struct DescribeSnapshotsResult {
 }
 
 /// <p>Describes the trust relationships for a particular Microsoft AD in the AWS cloud. If no input parameters are are provided, such as directory ID or trust ID, this request describes all the trust relationships.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeTrustsRequest {
     /// <p>The Directory ID of the AWS directory that is a part of the requested trust relationship.</p>
     #[serde(rename = "DirectoryId")]
@@ -597,7 +597,7 @@ pub struct DescribeTrustsRequest {
 }
 
 /// <p>The result of a DescribeTrust request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeTrustsResult {
     /// <p>If not null, more results are available. Pass this value for the <i>NextToken</i> parameter in a subsequent call to <a>DescribeTrusts</a> to retrieve the next set of items.</p>
     #[serde(rename = "NextToken")]
@@ -610,7 +610,7 @@ pub struct DescribeTrustsResult {
 }
 
 /// <p>Contains information for the <a>ConnectDirectory</a> operation when an AD Connector directory is being created.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DirectoryConnectSettings {
     /// <p>A list of one or more IP addresses of DNS servers or domain controllers in the on-premises directory.</p>
     #[serde(rename = "CustomerDnsIps")]
@@ -627,7 +627,7 @@ pub struct DirectoryConnectSettings {
 }
 
 /// <p>Contains information about an AD Connector directory.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DirectoryConnectSettingsDescription {
     /// <p>A list of the Availability Zones that the directory is in.</p>
     #[serde(rename = "AvailabilityZones")]
@@ -656,7 +656,7 @@ pub struct DirectoryConnectSettingsDescription {
 }
 
 /// <p>Contains information about an AWS Directory Service directory.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DirectoryDescription {
     /// <p>The access URL for the directory, such as <code>http://&lt;alias&gt;.awsapps.com</code>. If no alias has been created for the directory, <code>&lt;alias&gt;</code> is the directory identifier, such as <code>d-XXXXXXXXXX</code>.</p>
     #[serde(rename = "AccessUrl")]
@@ -741,7 +741,7 @@ pub struct DirectoryDescription {
 }
 
 /// <p>Contains directory limit information for a region.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DirectoryLimits {
     /// <p>The current number of cloud directories in the region.</p>
     #[serde(rename = "CloudOnlyDirectoriesCurrentCount")]
@@ -782,7 +782,7 @@ pub struct DirectoryLimits {
 }
 
 /// <p>Contains VPC information for the <a>CreateDirectory</a> or <a>CreateMicrosoftAD</a> operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DirectoryVpcSettings {
     /// <p>The identifiers of the subnets for the directory servers. The two subnets must be in different Availability Zones. AWS Directory Service creates a directory server and a DNS server in each of these subnets.</p>
     #[serde(rename = "SubnetIds")]
@@ -793,7 +793,7 @@ pub struct DirectoryVpcSettings {
 }
 
 /// <p>Contains information about the directory.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DirectoryVpcSettingsDescription {
     /// <p>The list of Availability Zones that the directory is in.</p>
     #[serde(rename = "AvailabilityZones")]
@@ -814,7 +814,7 @@ pub struct DirectoryVpcSettingsDescription {
 }
 
 /// <p>Contains the inputs for the <a>DisableRadius</a> operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DisableRadiusRequest {
     /// <p>The identifier of the directory for which to disable MFA.</p>
     #[serde(rename = "DirectoryId")]
@@ -822,11 +822,11 @@ pub struct DisableRadiusRequest {
 }
 
 /// <p>Contains the results of the <a>DisableRadius</a> operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DisableRadiusResult {}
 
 /// <p>Contains the inputs for the <a>DisableSso</a> operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DisableSsoRequest {
     /// <p>The identifier of the directory for which to disable single-sign on.</p>
     #[serde(rename = "DirectoryId")]
@@ -842,11 +842,11 @@ pub struct DisableSsoRequest {
 }
 
 /// <p>Contains the results of the <a>DisableSso</a> operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DisableSsoResult {}
 
 /// <p>Contains information about the domain controllers for a specified directory.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DomainController {
     /// <p>The Availability Zone where the domain controller is located.</p>
     #[serde(rename = "AvailabilityZone")]
@@ -891,7 +891,7 @@ pub struct DomainController {
 }
 
 /// <p>Contains the inputs for the <a>EnableRadius</a> operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct EnableRadiusRequest {
     /// <p>The identifier of the directory for which to enable MFA.</p>
     #[serde(rename = "DirectoryId")]
@@ -902,11 +902,11 @@ pub struct EnableRadiusRequest {
 }
 
 /// <p>Contains the results of the <a>EnableRadius</a> operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct EnableRadiusResult {}
 
 /// <p>Contains the inputs for the <a>EnableSso</a> operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct EnableSsoRequest {
     /// <p>The identifier of the directory for which to enable single-sign on.</p>
     #[serde(rename = "DirectoryId")]
@@ -922,11 +922,11 @@ pub struct EnableSsoRequest {
 }
 
 /// <p>Contains the results of the <a>EnableSso</a> operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct EnableSsoResult {}
 
 /// <p>Information about SNS topic and AWS Directory Service directory associations.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct EventTopic {
     /// <p>The date and time of when you associated your directory with the SNS topic.</p>
     #[serde(rename = "CreatedDateTime")]
@@ -951,11 +951,11 @@ pub struct EventTopic {
 }
 
 /// <p>Contains the inputs for the <a>GetDirectoryLimits</a> operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetDirectoryLimitsRequest {}
 
 /// <p>Contains the results of the <a>GetDirectoryLimits</a> operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetDirectoryLimitsResult {
     /// <p>A <a>DirectoryLimits</a> object that contains the directory limits for the current region.</p>
     #[serde(rename = "DirectoryLimits")]
@@ -964,7 +964,7 @@ pub struct GetDirectoryLimitsResult {
 }
 
 /// <p>Contains the inputs for the <a>GetSnapshotLimits</a> operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetSnapshotLimitsRequest {
     /// <p>Contains the identifier of the directory to obtain the limits for.</p>
     #[serde(rename = "DirectoryId")]
@@ -972,7 +972,7 @@ pub struct GetSnapshotLimitsRequest {
 }
 
 /// <p>Contains the results of the <a>GetSnapshotLimits</a> operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetSnapshotLimitsResult {
     /// <p>A <a>SnapshotLimits</a> object that contains the manual snapshot limits for the specified directory.</p>
     #[serde(rename = "SnapshotLimits")]
@@ -981,7 +981,7 @@ pub struct GetSnapshotLimitsResult {
 }
 
 /// <p>IP address block. This is often the address block of the DNS server used for your on-premises domain. </p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct IpRoute {
     /// <p>IP address block using CIDR format, for example 10.0.0.0/24. This is often the address block of the DNS server used for your on-premises domain. For a single IP address use a CIDR address block with /32. For example 10.0.0.0/32.</p>
     #[serde(rename = "CidrIp")]
@@ -994,7 +994,7 @@ pub struct IpRoute {
 }
 
 /// <p>Information about one or more IP address blocks.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct IpRouteInfo {
     /// <p>The date and time the address block was added to the directory.</p>
     #[serde(rename = "AddedDateTime")]
@@ -1022,7 +1022,7 @@ pub struct IpRouteInfo {
     pub ip_route_status_reason: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListIpRoutesRequest {
     /// <p>Identifier (ID) of the directory for which you want to retrieve the IP addresses.</p>
     #[serde(rename = "DirectoryId")]
@@ -1037,7 +1037,7 @@ pub struct ListIpRoutesRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListIpRoutesResult {
     /// <p>A list of <a>IpRoute</a>s.</p>
     #[serde(rename = "IpRoutesInfo")]
@@ -1049,7 +1049,7 @@ pub struct ListIpRoutesResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListSchemaExtensionsRequest {
     /// <p>The identifier of the directory from which to retrieve the schema extension information.</p>
     #[serde(rename = "DirectoryId")]
@@ -1064,7 +1064,7 @@ pub struct ListSchemaExtensionsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListSchemaExtensionsResult {
     /// <p>If not null, more results are available. Pass this value for the <code>NextToken</code> parameter in a subsequent call to <code>ListSchemaExtensions</code> to retrieve the next set of items.</p>
     #[serde(rename = "NextToken")]
@@ -1076,7 +1076,7 @@ pub struct ListSchemaExtensionsResult {
     pub schema_extensions_info: Option<Vec<SchemaExtensionInfo>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListTagsForResourceRequest {
     /// <p>Reserved for future use.</p>
     #[serde(rename = "Limit")]
@@ -1091,7 +1091,7 @@ pub struct ListTagsForResourceRequest {
     pub resource_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListTagsForResourceResult {
     /// <p>Reserved for future use.</p>
     #[serde(rename = "NextToken")]
@@ -1104,7 +1104,7 @@ pub struct ListTagsForResourceResult {
 }
 
 /// <p>Contains information about a Remote Authentication Dial In User Service (RADIUS) server.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RadiusSettings {
     /// <p>The protocol specified for your RADIUS endpoints.</p>
     #[serde(rename = "AuthenticationProtocol")]
@@ -1141,7 +1141,7 @@ pub struct RadiusSettings {
 }
 
 /// <p>Registers a new event topic.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RegisterEventTopicRequest {
     /// <p>The Directory ID that will publish status messages to the SNS topic.</p>
     #[serde(rename = "DirectoryId")]
@@ -1152,10 +1152,10 @@ pub struct RegisterEventTopicRequest {
 }
 
 /// <p>The result of a RegisterEventTopic request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RegisterEventTopicResult {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RemoveIpRoutesRequest {
     /// <p>IP address blocks that you want to remove.</p>
     #[serde(rename = "CidrIps")]
@@ -1165,10 +1165,10 @@ pub struct RemoveIpRoutesRequest {
     pub directory_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RemoveIpRoutesResult {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RemoveTagsFromResourceRequest {
     /// <p>Identifier (ID) of the directory from which to remove the tag.</p>
     #[serde(rename = "ResourceId")]
@@ -1178,11 +1178,11 @@ pub struct RemoveTagsFromResourceRequest {
     pub tag_keys: Vec<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RemoveTagsFromResourceResult {}
 
 /// <p>An object representing the inputs for the <a>RestoreFromSnapshot</a> operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RestoreFromSnapshotRequest {
     /// <p>The identifier of the snapshot to restore from.</p>
     #[serde(rename = "SnapshotId")]
@@ -1190,11 +1190,11 @@ pub struct RestoreFromSnapshotRequest {
 }
 
 /// <p>Contains the results of the <a>RestoreFromSnapshot</a> operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RestoreFromSnapshotResult {}
 
 /// <p>Information about a schema extension.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SchemaExtensionInfo {
     /// <p>A description of the schema extension.</p>
     #[serde(rename = "Description")]
@@ -1227,7 +1227,7 @@ pub struct SchemaExtensionInfo {
 }
 
 /// <p>Describes a directory snapshot.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Snapshot {
     /// <p>The directory identifier.</p>
     #[serde(rename = "DirectoryId")]
@@ -1256,7 +1256,7 @@ pub struct Snapshot {
 }
 
 /// <p>Contains manual snapshot limit information for a directory.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SnapshotLimits {
     /// <p>The current number of manual snapshots of the directory.</p>
     #[serde(rename = "ManualSnapshotsCurrentCount")]
@@ -1272,7 +1272,7 @@ pub struct SnapshotLimits {
     pub manual_snapshots_limit_reached: Option<bool>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StartSchemaExtensionRequest {
     /// <p>If true, creates a snapshot of the directory before applying the schema extension.</p>
     #[serde(rename = "CreateSnapshotBeforeSchemaExtension")]
@@ -1288,7 +1288,7 @@ pub struct StartSchemaExtensionRequest {
     pub ldif_content: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StartSchemaExtensionResult {
     /// <p>The identifier of the schema extension that will be applied.</p>
     #[serde(rename = "SchemaExtensionId")]
@@ -1297,7 +1297,7 @@ pub struct StartSchemaExtensionResult {
 }
 
 /// <p>Metadata assigned to a directory consisting of a key-value pair.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Tag {
     /// <p>Required name of the tag. The string value can be Unicode characters and cannot be prefixed with "aws:". The string can contain only the set of Unicode letters, digits, white-space, '_', '.', '/', '=', '+', '-' (Java regex: "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-]*)$").</p>
     #[serde(rename = "Key")]
@@ -1308,7 +1308,7 @@ pub struct Tag {
 }
 
 /// <p>Describes a trust relationship between an Microsoft AD in the AWS cloud and an external domain.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Trust {
     /// <p>The date and time that the trust relationship was created.</p>
     #[serde(rename = "CreatedDateTime")]
@@ -1353,7 +1353,7 @@ pub struct Trust {
 }
 
 /// <p>Updates a conditional forwarder.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateConditionalForwarderRequest {
     /// <p>The directory ID of the AWS directory for which to update the conditional forwarder.</p>
     #[serde(rename = "DirectoryId")]
@@ -1367,10 +1367,10 @@ pub struct UpdateConditionalForwarderRequest {
 }
 
 /// <p>The result of an UpdateConditionalForwarder request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateConditionalForwarderResult {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateNumberOfDomainControllersRequest {
     /// <p>The number of domain controllers desired in the directory.</p>
     #[serde(rename = "DesiredNumber")]
@@ -1380,11 +1380,11 @@ pub struct UpdateNumberOfDomainControllersRequest {
     pub directory_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateNumberOfDomainControllersResult {}
 
 /// <p>Contains the inputs for the <a>UpdateRadius</a> operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateRadiusRequest {
     /// <p>The identifier of the directory for which to update the RADIUS server information.</p>
     #[serde(rename = "DirectoryId")]
@@ -1395,11 +1395,11 @@ pub struct UpdateRadiusRequest {
 }
 
 /// <p>Contains the results of the <a>UpdateRadius</a> operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateRadiusResult {}
 
 /// <p>Initiates the verification of an existing trust relationship between a Microsoft AD in the AWS cloud and an external domain.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct VerifyTrustRequest {
     /// <p>The unique Trust ID of the trust relationship to verify.</p>
     #[serde(rename = "TrustId")]
@@ -1407,7 +1407,7 @@ pub struct VerifyTrustRequest {
 }
 
 /// <p>Result of a VerifyTrust request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct VerifyTrustResult {
     /// <p>The unique Trust ID of the trust relationship that was verified.</p>
     #[serde(rename = "TrustId")]

--- a/rusoto/services/dynamodb/src/generated.rs
+++ b/rusoto/services/dynamodb/src/generated.rs
@@ -31,7 +31,7 @@ use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 /// <p>Represents an attribute for describing the key schema for the table and indexes.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct AttributeDefinition {
     /// <p>A name for the attribute.</p>
     #[serde(rename = "AttributeName")]
@@ -42,7 +42,7 @@ pub struct AttributeDefinition {
 }
 
 /// <p>Represents the data for an attribute.</p> <p>Each attribute value is described as a name-value pair. The name is the data type, and the value is the data itself.</p> <p>For more information, see <a href="http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes">Data Types</a> in the <i>Amazon DynamoDB Developer Guide</i>.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct AttributeValue {
     /// <p>An attribute of type Binary. For example:</p> <p> <code>"B": "dGhpcyB0ZXh0IGlzIGJhc2U2NC1lbmNvZGVk"</code> </p>
     #[serde(rename = "B")]
@@ -91,7 +91,7 @@ pub struct AttributeValue {
 }
 
 /// <p>For the <code>UpdateItem</code> operation, represents the attributes to be modified, the action to perform on each, and the new value for each.</p> <note> <p>You cannot use <code>UpdateItem</code> to update any primary key attributes. Instead, you will need to delete the item, and then use <code>PutItem</code> to create a new item with new attributes.</p> </note> <p>Attribute values cannot be null; string and binary type attributes must have lengths greater than zero; and set type attributes must not be empty. Requests with empty values will be rejected with a <code>ValidationException</code> exception.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AttributeValueUpdate {
     /// <p><p>Specifies how to perform the update. Valid values are <code>PUT</code> (default), <code>DELETE</code>, and <code>ADD</code>. The behavior depends on whether the specified primary key already exists in the table.</p> <p> <b>If an item with the specified <i>Key</i> is found in the table:</b> </p> <ul> <li> <p> <code>PUT</code> - Adds the specified attribute to the item. If the attribute already exists, it is replaced by the new value. </p> </li> <li> <p> <code>DELETE</code> - If no value is specified, the attribute and its value are removed from the item. The data type of the specified value must match the existing value&#39;s data type.</p> <p>If a <i>set</i> of values is specified, then those values are subtracted from the old set. For example, if the attribute value was the set <code>[a,b,c]</code> and the <code>DELETE</code> action specified <code>[a,c]</code>, then the final attribute value would be <code>[b]</code>. Specifying an empty set is an error.</p> </li> <li> <p> <code>ADD</code> - If the attribute does not already exist, then the attribute and its values are added to the item. If the attribute does exist, then the behavior of <code>ADD</code> depends on the data type of the attribute:</p> <ul> <li> <p>If the existing attribute is a number, and if <code>Value</code> is also a number, then the <code>Value</code> is mathematically added to the existing attribute. If <code>Value</code> is a negative number, then it is subtracted from the existing attribute.</p> <note> <p> If you use <code>ADD</code> to increment or decrement a number value for an item that doesn&#39;t exist before the update, DynamoDB uses 0 as the initial value.</p> <p>In addition, if you use <code>ADD</code> to update an existing item, and intend to increment or decrement an attribute value which does not yet exist, DynamoDB uses <code>0</code> as the initial value. For example, suppose that the item you want to update does not yet have an attribute named <i>itemcount</i>, but you decide to <code>ADD</code> the number <code>3</code> to this attribute anyway, even though it currently does not exist. DynamoDB will create the <i>itemcount</i> attribute, set its initial value to <code>0</code>, and finally add <code>3</code> to it. The result will be a new <i>itemcount</i> attribute in the item, with a value of <code>3</code>.</p> </note> </li> <li> <p>If the existing data type is a set, and if the <code>Value</code> is also a set, then the <code>Value</code> is added to the existing set. (This is a <i>set</i> operation, not mathematical addition.) For example, if the attribute value was the set <code>[1,2]</code>, and the <code>ADD</code> action specified <code>[3]</code>, then the final attribute value would be <code>[1,2,3]</code>. An error occurs if an Add action is specified for a set attribute and the attribute type specified does not match the existing set type. </p> <p>Both sets must have the same primitive data type. For example, if the existing data type is a set of strings, the <code>Value</code> must also be a set of strings. The same holds true for number sets and binary sets.</p> </li> </ul> <p>This action is only valid for an existing attribute whose data type is number or is a set. Do not use <code>ADD</code> for any other data types.</p> </li> </ul> <p> <b>If no item with the specified <i>Key</i> is found:</b> </p> <ul> <li> <p> <code>PUT</code> - DynamoDB creates a new item with the specified primary key, and then adds the attribute. </p> </li> <li> <p> <code>DELETE</code> - Nothing happens; there is no attribute to delete.</p> </li> <li> <p> <code>ADD</code> - DynamoDB creates an item with the supplied primary key and number (or set of numbers) for the attribute value. The only data types allowed are number and number set; no other data types can be specified.</p> </li> </ul></p>
     #[serde(rename = "Action")]
@@ -104,7 +104,7 @@ pub struct AttributeValueUpdate {
 }
 
 /// <p>Contains the description of the backup created for the table.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BackupDescription {
     /// <p>Contains the details of the backup created for the table. </p>
     #[serde(rename = "BackupDetails")]
@@ -121,7 +121,7 @@ pub struct BackupDescription {
 }
 
 /// <p>Contains the details of the backup created for the table.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BackupDetails {
     /// <p>ARN associated with the backup.</p>
     #[serde(rename = "BackupArn")]
@@ -142,7 +142,7 @@ pub struct BackupDetails {
 }
 
 /// <p>Contains details for the backup.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BackupSummary {
     /// <p>ARN associated with the backup.</p>
     #[serde(rename = "BackupArn")]
@@ -179,7 +179,7 @@ pub struct BackupSummary {
 }
 
 /// <p>Represents the input of a <code>BatchGetItem</code> operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct BatchGetItemInput {
     /// <p><p>A map of one or more table names and, for each table, a map that describes one or more items to retrieve from that table. Each table name can be used only once per <code>BatchGetItem</code> request.</p> <p>Each element in the map of items to retrieve consists of the following:</p> <ul> <li> <p> <code>ConsistentRead</code> - If <code>true</code>, a strongly consistent read is used; if <code>false</code> (the default), an eventually consistent read is used.</p> </li> <li> <p> <code>ExpressionAttributeNames</code> - One or more substitution tokens for attribute names in the <code>ProjectionExpression</code> parameter. The following are some use cases for using <code>ExpressionAttributeNames</code>:</p> <ul> <li> <p>To access an attribute whose name conflicts with a DynamoDB reserved word.</p> </li> <li> <p>To create a placeholder for repeating occurrences of an attribute name in an expression.</p> </li> <li> <p>To prevent special characters in an attribute name from being misinterpreted in an expression.</p> </li> </ul> <p>Use the <b>#</b> character in an expression to dereference an attribute name. For example, consider the following attribute name:</p> <ul> <li> <p> <code>Percentile</code> </p> </li> </ul> <p>The name of this attribute conflicts with a reserved word, so it cannot be used directly in an expression. (For the complete list of reserved words, see <a href="http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html">Reserved Words</a> in the <i>Amazon DynamoDB Developer Guide</i>). To work around this, you could specify the following for <code>ExpressionAttributeNames</code>:</p> <ul> <li> <p> <code>{&quot;#P&quot;:&quot;Percentile&quot;}</code> </p> </li> </ul> <p>You could then use this substitution in an expression, as in this example:</p> <ul> <li> <p> <code>#P = :val</code> </p> </li> </ul> <note> <p>Tokens that begin with the <b>:</b> character are <i>expression attribute values</i>, which are placeholders for the actual value at runtime.</p> </note> <p>For more information on expression attribute names, see <a href="http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.AccessingItemAttributes.html">Accessing Item Attributes</a> in the <i>Amazon DynamoDB Developer Guide</i>.</p> </li> <li> <p> <code>Keys</code> - An array of primary key attribute values that define specific items in the table. For each primary key, you must provide <i>all</i> of the key attributes. For example, with a simple primary key, you only need to provide the partition key value. For a composite key, you must provide <i>both</i> the partition key value and the sort key value.</p> </li> <li> <p> <code>ProjectionExpression</code> - A string that identifies one or more attributes to retrieve from the table. These attributes can include scalars, sets, or elements of a JSON document. The attributes in the expression must be separated by commas.</p> <p>If no attribute names are specified, then all attributes will be returned. If any of the requested attributes are not found, they will not appear in the result.</p> <p>For more information, see <a href="http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.AccessingItemAttributes.html">Accessing Item Attributes</a> in the <i>Amazon DynamoDB Developer Guide</i>.</p> </li> <li> <p> <code>AttributesToGet</code> - This is a legacy parameter. Use <code>ProjectionExpression</code> instead. For more information, see <a href="http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/LegacyConditionalParameters.AttributesToGet.html">AttributesToGet</a> in the <i>Amazon DynamoDB Developer Guide</i>. </p> </li> </ul></p>
     #[serde(rename = "RequestItems")]
@@ -190,7 +190,7 @@ pub struct BatchGetItemInput {
 }
 
 /// <p>Represents the output of a <code>BatchGetItem</code> operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BatchGetItemOutput {
     /// <p><p>The read capacity units consumed by the entire <code>BatchGetItem</code> operation.</p> <p>Each element consists of:</p> <ul> <li> <p> <code>TableName</code> - The table that consumed the provisioned throughput.</p> </li> <li> <p> <code>CapacityUnits</code> - The total number of capacity units consumed.</p> </li> </ul></p>
     #[serde(rename = "ConsumedCapacity")]
@@ -212,7 +212,7 @@ pub struct BatchGetItemOutput {
 }
 
 /// <p>Represents the input of a <code>BatchWriteItem</code> operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct BatchWriteItemInput {
     /// <p><p>A map of one or more table names and, for each table, a list of operations to be performed (<code>DeleteRequest</code> or <code>PutRequest</code>). Each element in the map consists of the following:</p> <ul> <li> <p> <code>DeleteRequest</code> - Perform a <code>DeleteItem</code> operation on the specified item. The item to be deleted is identified by a <code>Key</code> subelement:</p> <ul> <li> <p> <code>Key</code> - A map of primary key attribute values that uniquely identify the item. Each entry in this map consists of an attribute name and an attribute value. For each primary key, you must provide <i>all</i> of the key attributes. For example, with a simple primary key, you only need to provide a value for the partition key. For a composite primary key, you must provide values for <i>both</i> the partition key and the sort key.</p> </li> </ul> </li> <li> <p> <code>PutRequest</code> - Perform a <code>PutItem</code> operation on the specified item. The item to be put is identified by an <code>Item</code> subelement:</p> <ul> <li> <p> <code>Item</code> - A map of attributes and their values. Each entry in this map consists of an attribute name and an attribute value. Attribute values must not be null; string and binary type attributes must have lengths greater than zero; and set type attributes must not be empty. Requests that contain empty values will be rejected with a <code>ValidationException</code> exception.</p> <p>If you specify any attributes that are part of an index key, then the data types for those attributes must match those of the schema in the table&#39;s attribute definition.</p> </li> </ul> </li> </ul></p>
     #[serde(rename = "RequestItems")]
@@ -227,7 +227,7 @@ pub struct BatchWriteItemInput {
 }
 
 /// <p>Represents the output of a <code>BatchWriteItem</code> operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BatchWriteItemOutput {
     /// <p><p>The capacity units consumed by the entire <code>BatchWriteItem</code> operation.</p> <p>Each element consists of:</p> <ul> <li> <p> <code>TableName</code> - The table that consumed the provisioned throughput.</p> </li> <li> <p> <code>CapacityUnits</code> - The total number of capacity units consumed.</p> </li> </ul></p>
     #[serde(rename = "ConsumedCapacity")]
@@ -245,7 +245,7 @@ pub struct BatchWriteItemOutput {
 }
 
 /// <p>Represents the amount of provisioned throughput capacity consumed on a table or an index.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Capacity {
     /// <p>The total number of capacity units consumed on a table or an index.</p>
     #[serde(rename = "CapacityUnits")]
@@ -254,7 +254,7 @@ pub struct Capacity {
 }
 
 /// <p><p>Represents the selection criteria for a <code>Query</code> or <code>Scan</code> operation:</p> <ul> <li> <p>For a <code>Query</code> operation, <code>Condition</code> is used for specifying the <code>KeyConditions</code> to use when querying a table or an index. For <code>KeyConditions</code>, only the following comparison operators are supported:</p> <p> <code>EQ | LE | LT | GE | GT | BEGINS_WITH | BETWEEN</code> </p> <p> <code>Condition</code> is also used in a <code>QueryFilter</code>, which evaluates the query results and returns only the desired values.</p> </li> <li> <p>For a <code>Scan</code> operation, <code>Condition</code> is used in a <code>ScanFilter</code>, which evaluates the scan results and returns only the desired values.</p> </li> </ul></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct Condition {
     /// <p>One or more values to evaluate against the supplied attribute. The number of values in the list depends on the <code>ComparisonOperator</code> being used.</p> <p>For type Number, value comparisons are numeric.</p> <p>String value comparisons for greater than, equals, or less than are based on ASCII character code values. For example, <code>a</code> is greater than <code>A</code>, and <code>a</code> is greater than <code>B</code>. For a list of code values, see <a href="http://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters">http://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters</a>.</p> <p>For Binary, DynamoDB treats each byte of the binary data as unsigned when it compares binary values.</p>
     #[serde(rename = "AttributeValueList")]
@@ -266,7 +266,7 @@ pub struct Condition {
 }
 
 /// <p>The capacity units consumed by an operation. The data returned includes the total provisioned throughput consumed, along with statistics for the table and any indexes involved in the operation. <code>ConsumedCapacity</code> is only returned if the request asked for it. For more information, see <a href="http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ProvisionedThroughputIntro.html">Provisioned Throughput</a> in the <i>Amazon DynamoDB Developer Guide</i>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ConsumedCapacity {
     /// <p>The total number of capacity units consumed by the operation.</p>
     #[serde(rename = "CapacityUnits")]
@@ -291,7 +291,7 @@ pub struct ConsumedCapacity {
 }
 
 /// <p>Represents the continuous backups and point in time recovery settings on the table.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ContinuousBackupsDescription {
     /// <p> <code>ContinuousBackupsStatus</code> can be one of the following states : ENABLED, DISABLED</p>
     #[serde(rename = "ContinuousBackupsStatus")]
@@ -302,7 +302,7 @@ pub struct ContinuousBackupsDescription {
     pub point_in_time_recovery_description: Option<PointInTimeRecoveryDescription>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateBackupInput {
     /// <p>Specified name for the backup.</p>
     #[serde(rename = "BackupName")]
@@ -312,7 +312,7 @@ pub struct CreateBackupInput {
     pub table_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateBackupOutput {
     /// <p>Contains the details of the backup created for the table.</p>
     #[serde(rename = "BackupDetails")]
@@ -321,7 +321,7 @@ pub struct CreateBackupOutput {
 }
 
 /// <p>Represents a new global secondary index to be added to an existing table.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateGlobalSecondaryIndexAction {
     /// <p>The name of the global secondary index to be created.</p>
     #[serde(rename = "IndexName")]
@@ -337,7 +337,7 @@ pub struct CreateGlobalSecondaryIndexAction {
     pub provisioned_throughput: ProvisionedThroughput,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateGlobalTableInput {
     /// <p>The global table name.</p>
     #[serde(rename = "GlobalTableName")]
@@ -347,7 +347,7 @@ pub struct CreateGlobalTableInput {
     pub replication_group: Vec<Replica>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateGlobalTableOutput {
     /// <p>Contains the details of the global table.</p>
     #[serde(rename = "GlobalTableDescription")]
@@ -356,7 +356,7 @@ pub struct CreateGlobalTableOutput {
 }
 
 /// <p>Represents a replica to be added.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateReplicaAction {
     /// <p>The region of the replica to be added.</p>
     #[serde(rename = "RegionName")]
@@ -364,7 +364,7 @@ pub struct CreateReplicaAction {
 }
 
 /// <p>Represents the input of a <code>CreateTable</code> operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateTableInput {
     /// <p>An array of attributes that describe the key schema for the table and indexes.</p>
     #[serde(rename = "AttributeDefinitions")]
@@ -397,7 +397,7 @@ pub struct CreateTableInput {
 }
 
 /// <p>Represents the output of a <code>CreateTable</code> operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateTableOutput {
     /// <p>Represents the properties of the table.</p>
     #[serde(rename = "TableDescription")]
@@ -405,14 +405,14 @@ pub struct CreateTableOutput {
     pub table_description: Option<TableDescription>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteBackupInput {
     /// <p>The ARN associated with the backup.</p>
     #[serde(rename = "BackupArn")]
     pub backup_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteBackupOutput {
     /// <p>Contains the description of the backup created for the table.</p>
     #[serde(rename = "BackupDescription")]
@@ -421,7 +421,7 @@ pub struct DeleteBackupOutput {
 }
 
 /// <p>Represents a global secondary index to be deleted from an existing table.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteGlobalSecondaryIndexAction {
     /// <p>The name of the global secondary index to be deleted.</p>
     #[serde(rename = "IndexName")]
@@ -429,7 +429,7 @@ pub struct DeleteGlobalSecondaryIndexAction {
 }
 
 /// <p>Represents the input of a <code>DeleteItem</code> operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteItemInput {
     /// <p>A condition that must be satisfied in order for a conditional <code>DeleteItem</code> to succeed.</p> <p>An expression can contain any of the following:</p> <ul> <li> <p>Functions: <code>attribute_exists | attribute_not_exists | attribute_type | contains | begins_with | size</code> </p> <p>These function names are case-sensitive.</p> </li> <li> <p>Comparison operators: <code>= | &lt;&gt; | &lt; | &gt; | &lt;= | &gt;= | BETWEEN | IN </code> </p> </li> <li> <p> Logical operators: <code>AND | OR | NOT</code> </p> </li> </ul> <p>For more information on condition expressions, see <a href="http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.SpecifyingConditions.html">Specifying Conditions</a> in the <i>Amazon DynamoDB Developer Guide</i>.</p>
     #[serde(rename = "ConditionExpression")]
@@ -471,7 +471,7 @@ pub struct DeleteItemInput {
 }
 
 /// <p>Represents the output of a <code>DeleteItem</code> operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteItemOutput {
     /// <p>A map of attribute names to <code>AttributeValue</code> objects, representing the item as it appeared before the <code>DeleteItem</code> operation. This map appears in the response only if <code>ReturnValues</code> was specified as <code>ALL_OLD</code> in the request.</p>
     #[serde(rename = "Attributes")]
@@ -488,7 +488,7 @@ pub struct DeleteItemOutput {
 }
 
 /// <p>Represents a replica to be removed.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteReplicaAction {
     /// <p>The region of the replica to be removed.</p>
     #[serde(rename = "RegionName")]
@@ -496,7 +496,7 @@ pub struct DeleteReplicaAction {
 }
 
 /// <p>Represents a request to perform a <code>DeleteItem</code> operation on an item.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct DeleteRequest {
     /// <p>A map of attribute name to attribute values, representing the primary key of the item to delete. All of the table's primary key attributes must be specified, and their data types must match those of the table's key schema.</p>
     #[serde(rename = "Key")]
@@ -504,7 +504,7 @@ pub struct DeleteRequest {
 }
 
 /// <p>Represents the input of a <code>DeleteTable</code> operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteTableInput {
     /// <p>The name of the table to delete.</p>
     #[serde(rename = "TableName")]
@@ -512,7 +512,7 @@ pub struct DeleteTableInput {
 }
 
 /// <p>Represents the output of a <code>DeleteTable</code> operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteTableOutput {
     /// <p>Represents the properties of a table.</p>
     #[serde(rename = "TableDescription")]
@@ -520,14 +520,14 @@ pub struct DeleteTableOutput {
     pub table_description: Option<TableDescription>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeBackupInput {
     /// <p>The ARN associated with the backup.</p>
     #[serde(rename = "BackupArn")]
     pub backup_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeBackupOutput {
     /// <p>Contains the description of the backup created for the table.</p>
     #[serde(rename = "BackupDescription")]
@@ -535,14 +535,14 @@ pub struct DescribeBackupOutput {
     pub backup_description: Option<BackupDescription>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeContinuousBackupsInput {
     /// <p>Name of the table for which the customer wants to check the continuous backups and point in time recovery settings.</p>
     #[serde(rename = "TableName")]
     pub table_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeContinuousBackupsOutput {
     /// <p> <code>ContinuousBackupsDescription</code> can be one of the following : ENABLED, DISABLED. </p>
     #[serde(rename = "ContinuousBackupsDescription")]
@@ -550,14 +550,14 @@ pub struct DescribeContinuousBackupsOutput {
     pub continuous_backups_description: Option<ContinuousBackupsDescription>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeGlobalTableInput {
     /// <p>The name of the global table.</p>
     #[serde(rename = "GlobalTableName")]
     pub global_table_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeGlobalTableOutput {
     /// <p>Contains the details of the global table.</p>
     #[serde(rename = "GlobalTableDescription")]
@@ -566,11 +566,11 @@ pub struct DescribeGlobalTableOutput {
 }
 
 /// <p>Represents the input of a <code>DescribeLimits</code> operation. Has no content.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeLimitsInput {}
 
 /// <p>Represents the output of a <code>DescribeLimits</code> operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeLimitsOutput {
     /// <p>The maximum total read capacity units that your account allows you to provision across all of your tables in this region.</p>
     #[serde(rename = "AccountMaxReadCapacityUnits")]
@@ -591,7 +591,7 @@ pub struct DescribeLimitsOutput {
 }
 
 /// <p>Represents the input of a <code>DescribeTable</code> operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeTableInput {
     /// <p>The name of the table to describe.</p>
     #[serde(rename = "TableName")]
@@ -599,7 +599,7 @@ pub struct DescribeTableInput {
 }
 
 /// <p>Represents the output of a <code>DescribeTable</code> operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeTableOutput {
     /// <p>The properties of the table.</p>
     #[serde(rename = "Table")]
@@ -607,14 +607,14 @@ pub struct DescribeTableOutput {
     pub table: Option<TableDescription>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeTimeToLiveInput {
     /// <p>The name of the table to be described.</p>
     #[serde(rename = "TableName")]
     pub table_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeTimeToLiveOutput {
     /// <p><p/></p>
     #[serde(rename = "TimeToLiveDescription")]
@@ -623,7 +623,7 @@ pub struct DescribeTimeToLiveOutput {
 }
 
 /// <p>Represents a condition to be compared with an attribute value. This condition can be used with <code>DeleteItem</code>, <code>PutItem</code> or <code>UpdateItem</code> operations; if the comparison evaluates to true, the operation succeeds; if not, the operation fails. You can use <code>ExpectedAttributeValue</code> in one of two different ways:</p> <ul> <li> <p>Use <code>AttributeValueList</code> to specify one or more values to compare against an attribute. Use <code>ComparisonOperator</code> to specify how you want to perform the comparison. If the comparison evaluates to true, then the conditional operation succeeds.</p> </li> <li> <p>Use <code>Value</code> to specify a value that DynamoDB will compare against an attribute. If the values match, then <code>ExpectedAttributeValue</code> evaluates to true and the conditional operation succeeds. Optionally, you can also set <code>Exists</code> to false, indicating that you <i>do not</i> expect to find the attribute value in the table. In this case, the conditional operation succeeds only if the comparison evaluates to false.</p> </li> </ul> <p> <code>Value</code> and <code>Exists</code> are incompatible with <code>AttributeValueList</code> and <code>ComparisonOperator</code>. Note that if you use both sets of parameters at once, DynamoDB will return a <code>ValidationException</code> exception.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ExpectedAttributeValue {
     /// <p>One or more values to evaluate against the supplied attribute. The number of values in the list depends on the <code>ComparisonOperator</code> being used.</p> <p>For type Number, value comparisons are numeric.</p> <p>String value comparisons for greater than, equals, or less than are based on ASCII character code values. For example, <code>a</code> is greater than <code>A</code>, and <code>a</code> is greater than <code>B</code>. For a list of code values, see <a href="http://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters">http://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters</a>.</p> <p>For Binary, DynamoDB treats each byte of the binary data as unsigned when it compares binary values.</p> <p>For information on specifying data types in JSON, see <a href="http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DataFormat.html">JSON Data Format</a> in the <i>Amazon DynamoDB Developer Guide</i>.</p>
     #[serde(rename = "AttributeValueList")]
@@ -644,7 +644,7 @@ pub struct ExpectedAttributeValue {
 }
 
 /// <p>Represents the input of a <code>GetItem</code> operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetItemInput {
     /// <p>This is a legacy parameter. Use <code>ProjectionExpression</code> instead. For more information, see <a href="http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/LegacyConditionalParameters.AttributesToGet.html">AttributesToGet</a> in the <i>Amazon DynamoDB Developer Guide</i>.</p>
     #[serde(rename = "AttributesToGet")]
@@ -674,7 +674,7 @@ pub struct GetItemInput {
 }
 
 /// <p>Represents the output of a <code>GetItem</code> operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetItemOutput {
     /// <p>The capacity units consumed by the <code>GetItem</code> operation. The data returned includes the total provisioned throughput consumed, along with statistics for the table and any indexes involved in the operation. <code>ConsumedCapacity</code> is only returned if the <code>ReturnConsumedCapacity</code> parameter was specified. For more information, see <a href="http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ProvisionedThroughputIntro.html">Provisioned Throughput</a> in the <i>Amazon DynamoDB Developer Guide</i>.</p>
     #[serde(rename = "ConsumedCapacity")]
@@ -687,7 +687,7 @@ pub struct GetItemOutput {
 }
 
 /// <p>Represents the properties of a global secondary index.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GlobalSecondaryIndex {
     /// <p>The name of the global secondary index. The name must be unique among all other indexes on this table.</p>
     #[serde(rename = "IndexName")]
@@ -704,7 +704,7 @@ pub struct GlobalSecondaryIndex {
 }
 
 /// <p>Represents the properties of a global secondary index.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GlobalSecondaryIndexDescription {
     /// <p><p>Indicates whether the index is currently backfilling. <i>Backfilling</i> is the process of reading items from the table and determining whether they can be added to the index. (Not all items will qualify: For example, a partition key cannot have any duplicate values.) If an item can be added to the index, DynamoDB will do so. After all items have been processed, the backfilling operation is complete and <code>Backfilling</code> is false.</p> <note> <p>For indexes that were created during a <code>CreateTable</code> operation, the <code>Backfilling</code> attribute does not appear in the <code>DescribeTable</code> output.</p> </note></p>
     #[serde(rename = "Backfilling")]
@@ -745,7 +745,7 @@ pub struct GlobalSecondaryIndexDescription {
 }
 
 /// <p>Represents the properties of a global secondary index for the table when the backup was created.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GlobalSecondaryIndexInfo {
     /// <p>The name of the global secondary index.</p>
     #[serde(rename = "IndexName")]
@@ -766,7 +766,7 @@ pub struct GlobalSecondaryIndexInfo {
 }
 
 /// <p><p>Represents one of the following:</p> <ul> <li> <p>A new global secondary index to be added to an existing table.</p> </li> <li> <p>New provisioned throughput parameters for an existing global secondary index.</p> </li> <li> <p>An existing global secondary index to be removed from an existing table.</p> </li> </ul></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GlobalSecondaryIndexUpdate {
     /// <p><p>The parameters required for creating a global secondary index on an existing table:</p> <ul> <li> <p> <code>IndexName </code> </p> </li> <li> <p> <code>KeySchema </code> </p> </li> <li> <p> <code>AttributeDefinitions </code> </p> </li> <li> <p> <code>Projection </code> </p> </li> <li> <p> <code>ProvisionedThroughput </code> </p> </li> </ul></p>
     #[serde(rename = "Create")]
@@ -783,7 +783,7 @@ pub struct GlobalSecondaryIndexUpdate {
 }
 
 /// <p>Represents the properties of a global table.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GlobalTable {
     /// <p>The global table name.</p>
     #[serde(rename = "GlobalTableName")]
@@ -796,7 +796,7 @@ pub struct GlobalTable {
 }
 
 /// <p>Contains details about the global table.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GlobalTableDescription {
     /// <p>The creation time of the global table.</p>
     #[serde(rename = "CreationDateTime")]
@@ -821,7 +821,7 @@ pub struct GlobalTableDescription {
 }
 
 /// <p>Information about item collections, if any, that were affected by the operation. <code>ItemCollectionMetrics</code> is only returned if the request asked for it. If the table does not have any local secondary indexes, this information is not returned in the response.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ItemCollectionMetrics {
     /// <p>The partition key value of the item collection. This value is the same as the partition key value of the item.</p>
     #[serde(rename = "ItemCollectionKey")]
@@ -834,7 +834,7 @@ pub struct ItemCollectionMetrics {
 }
 
 /// <p>Represents <i>a single element</i> of a key schema. A key schema specifies the attributes that make up the primary key of a table, or the key attributes of an index.</p> <p>A <code>KeySchemaElement</code> represents exactly one attribute of the primary key. For example, a simple primary key would be represented by one <code>KeySchemaElement</code> (for the partition key). A composite primary key would require one <code>KeySchemaElement</code> for the partition key, and another <code>KeySchemaElement</code> for the sort key.</p> <p>A <code>KeySchemaElement</code> must be a scalar, top-level attribute (not a nested attribute). The data type must be one of String, Number, or Binary. The attribute cannot be nested within a List or a Map.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct KeySchemaElement {
     /// <p>The name of a key attribute.</p>
     #[serde(rename = "AttributeName")]
@@ -845,7 +845,7 @@ pub struct KeySchemaElement {
 }
 
 /// <p>Represents a set of primary keys and, for each key, the attributes to retrieve from the table.</p> <p>For each primary key, you must provide <i>all</i> of the key attributes. For example, with a simple primary key, you only need to provide the partition key. For a composite primary key, you must provide <i>both</i> the partition key and the sort key.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct KeysAndAttributes {
     /// <p>This is a legacy parameter. Use <code>ProjectionExpression</code> instead. For more information, see <a href="http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/LegacyConditionalParameters.html">Legacy Conditional Parameters</a> in the <i>Amazon DynamoDB Developer Guide</i>.</p>
     #[serde(rename = "AttributesToGet")]
@@ -868,7 +868,7 @@ pub struct KeysAndAttributes {
     pub projection_expression: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListBackupsInput {
     /// <p> <code>LastEvaluatedBackupARN</code> returned by the previous ListBackups call. </p>
     #[serde(rename = "ExclusiveStartBackupArn")]
@@ -892,7 +892,7 @@ pub struct ListBackupsInput {
     pub time_range_upper_bound: Option<f64>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListBackupsOutput {
     /// <p>List of <code>BackupSummary</code> objects.</p>
     #[serde(rename = "BackupSummaries")]
@@ -904,7 +904,7 @@ pub struct ListBackupsOutput {
     pub last_evaluated_backup_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListGlobalTablesInput {
     /// <p>The first global table name that this operation will evaluate.</p>
     #[serde(rename = "ExclusiveStartGlobalTableName")]
@@ -920,7 +920,7 @@ pub struct ListGlobalTablesInput {
     pub region_name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListGlobalTablesOutput {
     /// <p>List of global table names.</p>
     #[serde(rename = "GlobalTables")]
@@ -933,7 +933,7 @@ pub struct ListGlobalTablesOutput {
 }
 
 /// <p>Represents the input of a <code>ListTables</code> operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListTablesInput {
     /// <p>The first table name that this operation will evaluate. Use the value that was returned for <code>LastEvaluatedTableName</code> in a previous operation, so that you can obtain the next page of results.</p>
     #[serde(rename = "ExclusiveStartTableName")]
@@ -946,7 +946,7 @@ pub struct ListTablesInput {
 }
 
 /// <p>Represents the output of a <code>ListTables</code> operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListTablesOutput {
     /// <p>The name of the last table in the current page of results. Use this value as the <code>ExclusiveStartTableName</code> in a new request to obtain the next page of results, until all the table names are returned.</p> <p>If you do not receive a <code>LastEvaluatedTableName</code> value in the response, this means that there are no more table names to be retrieved.</p>
     #[serde(rename = "LastEvaluatedTableName")]
@@ -958,7 +958,7 @@ pub struct ListTablesOutput {
     pub table_names: Option<Vec<String>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListTagsOfResourceInput {
     /// <p>An optional string that, if supplied, must be copied from the output of a previous call to ListTagOfResource. When provided in this manner, this API fetches the next page of results.</p>
     #[serde(rename = "NextToken")]
@@ -969,7 +969,7 @@ pub struct ListTagsOfResourceInput {
     pub resource_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListTagsOfResourceOutput {
     /// <p>If this value is returned, there are additional results to be displayed. To retrieve them, call ListTagsOfResource again, with NextToken set to this value.</p>
     #[serde(rename = "NextToken")]
@@ -982,7 +982,7 @@ pub struct ListTagsOfResourceOutput {
 }
 
 /// <p>Represents the properties of a local secondary index.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct LocalSecondaryIndex {
     /// <p>The name of the local secondary index. The name must be unique among all other indexes on this table.</p>
     #[serde(rename = "IndexName")]
@@ -996,7 +996,7 @@ pub struct LocalSecondaryIndex {
 }
 
 /// <p>Represents the properties of a local secondary index.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct LocalSecondaryIndexDescription {
     /// <p>The Amazon Resource Name (ARN) that uniquely identifies the index.</p>
     #[serde(rename = "IndexArn")]
@@ -1025,7 +1025,7 @@ pub struct LocalSecondaryIndexDescription {
 }
 
 /// <p>Represents the properties of a local secondary index for the table when the backup was created.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct LocalSecondaryIndexInfo {
     /// <p>Represents the name of the local secondary index.</p>
     #[serde(rename = "IndexName")]
@@ -1042,7 +1042,7 @@ pub struct LocalSecondaryIndexInfo {
 }
 
 /// <p>The description of the point in time settings applied to the table.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PointInTimeRecoveryDescription {
     /// <p>Specifies the earliest point in time you can restore your table to. It is equal to the maximum of point in time recovery enabled time and <code>CurrentTime</code> - <code>PointInTimeRecoveryPeriod</code>.</p>
     #[serde(rename = "EarliestRestorableDateTime")]
@@ -1059,7 +1059,7 @@ pub struct PointInTimeRecoveryDescription {
 }
 
 /// <p>Represents the settings used to enable point in time recovery.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PointInTimeRecoverySpecification {
     /// <p>Indicates whether point in time recovery is enabled (true) or disabled (false) on the table.</p>
     #[serde(rename = "PointInTimeRecoveryEnabled")]
@@ -1067,7 +1067,7 @@ pub struct PointInTimeRecoverySpecification {
 }
 
 /// <p>Represents attributes that are copied (projected) from the table into an index. These are in addition to the primary key attributes and index key attributes, which are automatically projected.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Projection {
     /// <p>Represents the non-key attribute names which will be projected into the index.</p> <p>For local secondary indexes, the total count of <code>NonKeyAttributes</code> summed across all of the local secondary indexes, must not exceed 20. If you project the same attribute into two different indexes, this counts as two distinct attributes when determining the total.</p>
     #[serde(rename = "NonKeyAttributes")]
@@ -1080,7 +1080,7 @@ pub struct Projection {
 }
 
 /// <p>Represents the provisioned throughput settings for a specified table or index. The settings can be modified using the <code>UpdateTable</code> operation.</p> <p>For current minimum and maximum provisioned throughput values, see <a href="http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Limits.html">Limits</a> in the <i>Amazon DynamoDB Developer Guide</i>.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ProvisionedThroughput {
     /// <p>The maximum number of strongly consistent reads consumed per second before DynamoDB returns a <code>ThrottlingException</code>. For more information, see <a href="http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/WorkingWithTables.html#ProvisionedThroughput">Specifying Read and Write Requirements</a> in the <i>Amazon DynamoDB Developer Guide</i>.</p>
     #[serde(rename = "ReadCapacityUnits")]
@@ -1091,7 +1091,7 @@ pub struct ProvisionedThroughput {
 }
 
 /// <p>Represents the provisioned throughput settings for the table, consisting of read and write capacity units, along with data about increases and decreases.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ProvisionedThroughputDescription {
     /// <p>The date and time of the last provisioned throughput decrease for this table.</p>
     #[serde(rename = "LastDecreaseDateTime")]
@@ -1116,7 +1116,7 @@ pub struct ProvisionedThroughputDescription {
 }
 
 /// <p>Represents the input of a <code>PutItem</code> operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PutItemInput {
     /// <p>A condition that must be satisfied in order for a conditional <code>PutItem</code> operation to succeed.</p> <p>An expression can contain any of the following:</p> <ul> <li> <p>Functions: <code>attribute_exists | attribute_not_exists | attribute_type | contains | begins_with | size</code> </p> <p>These function names are case-sensitive.</p> </li> <li> <p>Comparison operators: <code>= | &lt;&gt; | &lt; | &gt; | &lt;= | &gt;= | BETWEEN | IN </code> </p> </li> <li> <p> Logical operators: <code>AND | OR | NOT</code> </p> </li> </ul> <p>For more information on condition expressions, see <a href="http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.SpecifyingConditions.html">Specifying Conditions</a> in the <i>Amazon DynamoDB Developer Guide</i>.</p>
     #[serde(rename = "ConditionExpression")]
@@ -1158,7 +1158,7 @@ pub struct PutItemInput {
 }
 
 /// <p>Represents the output of a <code>PutItem</code> operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PutItemOutput {
     /// <p>The attribute values as they appeared before the <code>PutItem</code> operation, but only if <code>ReturnValues</code> is specified as <code>ALL_OLD</code> in the request. Each element consists of an attribute name and an attribute value.</p>
     #[serde(rename = "Attributes")]
@@ -1175,7 +1175,7 @@ pub struct PutItemOutput {
 }
 
 /// <p>Represents a request to perform a <code>PutItem</code> operation on an item.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct PutRequest {
     /// <p>A map of attribute name to attribute values, representing the primary key of an item to be processed by <code>PutItem</code>. All of the table's primary key attributes must be specified, and their data types must match those of the table's key schema. If any attributes are present in the item which are part of an index key schema for the table, their types must match the index key schema.</p>
     #[serde(rename = "Item")]
@@ -1183,7 +1183,7 @@ pub struct PutRequest {
 }
 
 /// <p>Represents the input of a <code>Query</code> operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct QueryInput {
     /// <p>This is a legacy parameter. Use <code>ProjectionExpression</code> instead. For more information, see <a href="http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/LegacyConditionalParameters.AttributesToGet.html">AttributesToGet</a> in the <i>Amazon DynamoDB Developer Guide</i>.</p>
     #[serde(rename = "AttributesToGet")]
@@ -1254,7 +1254,7 @@ pub struct QueryInput {
 }
 
 /// <p>Represents the output of a <code>Query</code> operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct QueryOutput {
     /// <p>The capacity units consumed by the <code>Query</code> operation. The data returned includes the total provisioned throughput consumed, along with statistics for the table and any indexes involved in the operation. <code>ConsumedCapacity</code> is only returned if the <code>ReturnConsumedCapacity</code> parameter was specified For more information, see <a href="http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ProvisionedThroughputIntro.html">Provisioned Throughput</a> in the <i>Amazon DynamoDB Developer Guide</i>.</p>
     #[serde(rename = "ConsumedCapacity")]
@@ -1279,7 +1279,7 @@ pub struct QueryOutput {
 }
 
 /// <p>Represents the properties of a replica.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Replica {
     /// <p>The region where the replica needs to be created.</p>
     #[serde(rename = "RegionName")]
@@ -1288,7 +1288,7 @@ pub struct Replica {
 }
 
 /// <p>Contains the details of the replica.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ReplicaDescription {
     /// <p>The name of the region.</p>
     #[serde(rename = "RegionName")]
@@ -1297,7 +1297,7 @@ pub struct ReplicaDescription {
 }
 
 /// <p><p>Represents one of the following:</p> <ul> <li> <p>A new replica to be added to an existing global table.</p> </li> <li> <p>New parameters for an existing replica.</p> </li> <li> <p>An existing replica to be removed from an existing global table.</p> </li> </ul></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ReplicaUpdate {
     /// <p>The parameters required for creating a replica on an existing global table.</p>
     #[serde(rename = "Create")]
@@ -1310,7 +1310,7 @@ pub struct ReplicaUpdate {
 }
 
 /// <p>Contains details for the restore.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RestoreSummary {
     /// <p>Point in time or source backup time.</p>
     #[serde(rename = "RestoreDateTime")]
@@ -1328,7 +1328,7 @@ pub struct RestoreSummary {
     pub source_table_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RestoreTableFromBackupInput {
     /// <p>The ARN associated with the backup.</p>
     #[serde(rename = "BackupArn")]
@@ -1338,7 +1338,7 @@ pub struct RestoreTableFromBackupInput {
     pub target_table_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RestoreTableFromBackupOutput {
     /// <p>The description of the table created from an existing backup.</p>
     #[serde(rename = "TableDescription")]
@@ -1346,7 +1346,7 @@ pub struct RestoreTableFromBackupOutput {
     pub table_description: Option<TableDescription>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RestoreTableToPointInTimeInput {
     /// <p>Time in the past to restore the table to.</p>
     #[serde(rename = "RestoreDateTime")]
@@ -1364,7 +1364,7 @@ pub struct RestoreTableToPointInTimeInput {
     pub use_latest_restorable_time: Option<bool>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RestoreTableToPointInTimeOutput {
     /// <p>Represents the properties of a table.</p>
     #[serde(rename = "TableDescription")]
@@ -1373,7 +1373,7 @@ pub struct RestoreTableToPointInTimeOutput {
 }
 
 /// <p>The description of the server-side encryption status on the specified table.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SSEDescription {
     /// <p><p>The current state of server-side encryption:</p> <ul> <li> <p> <code>ENABLING</code> - Server-side encryption is being enabled.</p> </li> <li> <p> <code>ENABLED</code> - Server-side encryption is enabled.</p> </li> <li> <p> <code>DISABLING</code> - Server-side encryption is being disabled.</p> </li> <li> <p> <code>DISABLED</code> - Server-side encryption is disabled.</p> </li> </ul></p>
     #[serde(rename = "Status")]
@@ -1382,7 +1382,7 @@ pub struct SSEDescription {
 }
 
 /// <p>Represents the settings used to enable server-side encryption.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SSESpecification {
     /// <p>Indicates whether server-side encryption is enabled (true) or disabled (false) on the table.</p>
     #[serde(rename = "Enabled")]
@@ -1390,7 +1390,7 @@ pub struct SSESpecification {
 }
 
 /// <p>Represents the input of a <code>Scan</code> operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ScanInput {
     /// <p>This is a legacy parameter. Use <code>ProjectionExpression</code> instead. For more information, see <a href="http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/LegacyConditionalParameters.AttributesToGet.html">AttributesToGet</a> in the <i>Amazon DynamoDB Developer Guide</i>.</p>
     #[serde(rename = "AttributesToGet")]
@@ -1457,7 +1457,7 @@ pub struct ScanInput {
 }
 
 /// <p>Represents the output of a <code>Scan</code> operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ScanOutput {
     /// <p>The capacity units consumed by the <code>Scan</code> operation. The data returned includes the total provisioned throughput consumed, along with statistics for the table and any indexes involved in the operation. <code>ConsumedCapacity</code> is only returned if the <code>ReturnConsumedCapacity</code> parameter was specified. For more information, see <a href="http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ProvisionedThroughputIntro.html">Provisioned Throughput</a> in the <i>Amazon DynamoDB Developer Guide</i>.</p>
     #[serde(rename = "ConsumedCapacity")]
@@ -1482,7 +1482,7 @@ pub struct ScanOutput {
 }
 
 /// <p>Contains the details of the table when the backup was created. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SourceTableDetails {
     /// <p>Number of items in the table. Please note this is an approximate value. </p>
     #[serde(rename = "ItemCount")]
@@ -1514,7 +1514,7 @@ pub struct SourceTableDetails {
 }
 
 /// <p>Contains the details of the features enabled on the table when the backup was created. For example, LSIs, GSIs, streams, TTL. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SourceTableFeatureDetails {
     /// <p>Represents the GSI properties for the table when the backup was created. It includes the IndexName, KeySchema, Projection and ProvisionedThroughput for the GSIs on the table at the time of backup. </p>
     #[serde(rename = "GlobalSecondaryIndexes")]
@@ -1539,7 +1539,7 @@ pub struct SourceTableFeatureDetails {
 }
 
 /// <p>Represents the DynamoDB Streams configuration for a table in DynamoDB.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct StreamSpecification {
     /// <p>Indicates whether DynamoDB Streams is enabled (true) or disabled (false) on the table.</p>
     #[serde(rename = "StreamEnabled")]
@@ -1552,7 +1552,7 @@ pub struct StreamSpecification {
 }
 
 /// <p>Represents the properties of a table.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct TableDescription {
     /// <p><p>An array of <code>AttributeDefinition</code> objects. Each of these objects describes one attribute in the table and index key schema.</p> <p>Each <code>AttributeDefinition</code> object in this array is composed of:</p> <ul> <li> <p> <code>AttributeName</code> - The name of the attribute.</p> </li> <li> <p> <code>AttributeType</code> - The data type for the attribute.</p> </li> </ul></p>
     #[serde(rename = "AttributeDefinitions")]
@@ -1625,7 +1625,7 @@ pub struct TableDescription {
 }
 
 /// <p>Describes a tag. A tag is a key-value pair. You can add up to 50 tags to a single DynamoDB table. </p> <p> AWS-assigned tag names and values are automatically assigned the aws: prefix, which the user cannot assign. AWS-assigned tag names do not count towards the tag limit of 50. User-assigned tag names have the prefix user: in the Cost Allocation Report. You cannot backdate the application of a tag. </p> <p>For an overview on tagging DynamoDB resources, see <a href="http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Tagging.html">Tagging for DynamoDB</a> in the <i>Amazon DynamoDB Developer Guide</i>.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Tag {
     /// <p>The key of the tag.Tag keys are case sensitive. Each DynamoDB table can only have up to one tag with the same key. If you try to add an existing tag (same key), the existing tag value will be updated to the new value. </p>
     #[serde(rename = "Key")]
@@ -1635,7 +1635,7 @@ pub struct Tag {
     pub value: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct TagResourceInput {
     /// <p>Identifies the Amazon DynamoDB resource to which tags should be added. This value is an Amazon Resource Name (ARN).</p>
     #[serde(rename = "ResourceArn")]
@@ -1646,7 +1646,7 @@ pub struct TagResourceInput {
 }
 
 /// <p>The description of the Time to Live (TTL) status on the specified table. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct TimeToLiveDescription {
     /// <p> The name of the Time to Live attribute for items in the table.</p>
     #[serde(rename = "AttributeName")]
@@ -1659,7 +1659,7 @@ pub struct TimeToLiveDescription {
 }
 
 /// <p>Represents the settings used to enable or disable Time to Live for the specified table.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TimeToLiveSpecification {
     /// <p>The name of the Time to Live attribute used to store the expiration time for items in the table.</p>
     #[serde(rename = "AttributeName")]
@@ -1669,7 +1669,7 @@ pub struct TimeToLiveSpecification {
     pub enabled: bool,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UntagResourceInput {
     /// <p>The Amazon DyanamoDB resource the tags will be removed from. This value is an Amazon Resource Name (ARN).</p>
     #[serde(rename = "ResourceArn")]
@@ -1679,7 +1679,7 @@ pub struct UntagResourceInput {
     pub tag_keys: Vec<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateContinuousBackupsInput {
     /// <p>Represents the settings used to enable point in time recovery.</p>
     #[serde(rename = "PointInTimeRecoverySpecification")]
@@ -1689,7 +1689,7 @@ pub struct UpdateContinuousBackupsInput {
     pub table_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateContinuousBackupsOutput {
     /// <p>Represents the continuous backups and point in time recovery settings on the table.</p>
     #[serde(rename = "ContinuousBackupsDescription")]
@@ -1698,7 +1698,7 @@ pub struct UpdateContinuousBackupsOutput {
 }
 
 /// <p>Represents the new provisioned throughput settings to be applied to a global secondary index.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateGlobalSecondaryIndexAction {
     /// <p>The name of the global secondary index to be updated.</p>
     #[serde(rename = "IndexName")]
@@ -1708,7 +1708,7 @@ pub struct UpdateGlobalSecondaryIndexAction {
     pub provisioned_throughput: ProvisionedThroughput,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateGlobalTableInput {
     /// <p>The global table name.</p>
     #[serde(rename = "GlobalTableName")]
@@ -1718,7 +1718,7 @@ pub struct UpdateGlobalTableInput {
     pub replica_updates: Vec<ReplicaUpdate>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateGlobalTableOutput {
     /// <p>Contains the details of the global table.</p>
     #[serde(rename = "GlobalTableDescription")]
@@ -1727,7 +1727,7 @@ pub struct UpdateGlobalTableOutput {
 }
 
 /// <p>Represents the input of an <code>UpdateItem</code> operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateItemInput {
     /// <p>This is a legacy parameter. Use <code>UpdateExpression</code> instead. For more information, see <a href="http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/LegacyConditionalParameters.AttributeUpdates.html">AttributeUpdates</a> in the <i>Amazon DynamoDB Developer Guide</i>.</p>
     #[serde(rename = "AttributeUpdates")]
@@ -1777,7 +1777,7 @@ pub struct UpdateItemInput {
 }
 
 /// <p>Represents the output of an <code>UpdateItem</code> operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateItemOutput {
     /// <p>A map of attribute values as they appear before or after the <code>UpdateItem</code> operation, as determined by the <code>ReturnValues</code> parameter.</p> <p>The <code>Attributes</code> map is only present if <code>ReturnValues</code> was specified as something other than <code>NONE</code> in the request. Each element represents one attribute.</p>
     #[serde(rename = "Attributes")]
@@ -1794,7 +1794,7 @@ pub struct UpdateItemOutput {
 }
 
 /// <p>Represents the input of an <code>UpdateTable</code> operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateTableInput {
     /// <p>An array of attributes that describe the key schema for the table and indexes. If you are adding a new global secondary index to the table, <code>AttributeDefinitions</code> must include the key element(s) of the new index.</p>
     #[serde(rename = "AttributeDefinitions")]
@@ -1818,7 +1818,7 @@ pub struct UpdateTableInput {
 }
 
 /// <p>Represents the output of an <code>UpdateTable</code> operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateTableOutput {
     /// <p>Represents the properties of the table.</p>
     #[serde(rename = "TableDescription")]
@@ -1827,7 +1827,7 @@ pub struct UpdateTableOutput {
 }
 
 /// <p>Represents the input of an <code>UpdateTimeToLive</code> operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateTimeToLiveInput {
     /// <p>The name of the table to be configured.</p>
     #[serde(rename = "TableName")]
@@ -1837,7 +1837,7 @@ pub struct UpdateTimeToLiveInput {
     pub time_to_live_specification: TimeToLiveSpecification,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateTimeToLiveOutput {
     /// <p>Represents the output of an <code>UpdateTimeToLive</code> operation.</p>
     #[serde(rename = "TimeToLiveSpecification")]
@@ -1846,7 +1846,7 @@ pub struct UpdateTimeToLiveOutput {
 }
 
 /// <p>Represents an operation to perform - either <code>DeleteItem</code> or <code>PutItem</code>. You can only request one of these operations, not both, in a single <code>WriteRequest</code>. If you do need to perform both of these operations, you will need to provide two separate <code>WriteRequest</code> objects.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct WriteRequest {
     /// <p>A request to perform a <code>DeleteItem</code> operation.</p>
     #[serde(rename = "DeleteRequest")]

--- a/rusoto/services/dynamodb/src/generated.rs
+++ b/rusoto/services/dynamodb/src/generated.rs
@@ -1881,7 +1881,8 @@ impl BatchGetItemError {
     pub fn from_body(body: &str) -> BatchGetItemError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1975,7 +1976,8 @@ impl BatchWriteItemError {
     pub fn from_body(body: &str) -> BatchWriteItemError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2079,7 +2081,8 @@ impl CreateBackupError {
     pub fn from_body(body: &str) -> CreateBackupError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2183,7 +2186,8 @@ impl CreateGlobalTableError {
     pub fn from_body(body: &str) -> CreateGlobalTableError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2281,7 +2285,8 @@ impl CreateTableError {
     pub fn from_body(body: &str) -> CreateTableError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2373,7 +2378,8 @@ impl DeleteBackupError {
     pub fn from_body(body: &str) -> DeleteBackupError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2471,7 +2477,8 @@ impl DeleteItemError {
     pub fn from_body(body: &str) -> DeleteItemError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2571,7 +2578,8 @@ impl DeleteTableError {
     pub fn from_body(body: &str) -> DeleteTableError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2663,7 +2671,8 @@ impl DescribeBackupError {
     pub fn from_body(body: &str) -> DescribeBackupError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2747,7 +2756,8 @@ impl DescribeContinuousBackupsError {
     pub fn from_body(body: &str) -> DescribeContinuousBackupsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2833,7 +2843,8 @@ impl DescribeGlobalTableError {
     pub fn from_body(body: &str) -> DescribeGlobalTableError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2917,7 +2928,8 @@ impl DescribeLimitsError {
     pub fn from_body(body: &str) -> DescribeLimitsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2997,7 +3009,8 @@ impl DescribeTableError {
     pub fn from_body(body: &str) -> DescribeTableError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3081,7 +3094,8 @@ impl DescribeTimeToLiveError {
     pub fn from_body(body: &str) -> DescribeTimeToLiveError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3169,7 +3183,8 @@ impl GetItemError {
     pub fn from_body(body: &str) -> GetItemError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3253,7 +3268,8 @@ impl ListBackupsError {
     pub fn from_body(body: &str) -> ListBackupsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3331,7 +3347,8 @@ impl ListGlobalTablesError {
     pub fn from_body(body: &str) -> ListGlobalTablesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3409,7 +3426,8 @@ impl ListTablesError {
     pub fn from_body(body: &str) -> ListTablesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3487,7 +3505,8 @@ impl ListTagsOfResourceError {
     pub fn from_body(body: &str) -> ListTagsOfResourceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3579,7 +3598,8 @@ impl PutItemError {
     pub fn from_body(body: &str) -> PutItemError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3675,7 +3695,8 @@ impl QueryError {
     pub fn from_body(body: &str) -> QueryError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3769,7 +3790,8 @@ impl RestoreTableFromBackupError {
     pub fn from_body(body: &str) -> RestoreTableFromBackupError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3881,7 +3903,8 @@ impl RestoreTableToPointInTimeError {
     pub fn from_body(body: &str) -> RestoreTableToPointInTimeError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3995,7 +4018,8 @@ impl ScanError {
     pub fn from_body(body: &str) -> ScanError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4085,7 +4109,8 @@ impl TagResourceError {
     pub fn from_body(body: &str) -> TagResourceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4181,7 +4206,8 @@ impl UntagResourceError {
     pub fn from_body(body: &str) -> UntagResourceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4275,7 +4301,8 @@ impl UpdateContinuousBackupsError {
     pub fn from_body(body: &str) -> UpdateContinuousBackupsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4373,7 +4400,8 @@ impl UpdateGlobalTableError {
     pub fn from_body(body: &str) -> UpdateGlobalTableError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4477,7 +4505,8 @@ impl UpdateItemError {
     pub fn from_body(body: &str) -> UpdateItemError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4577,7 +4606,8 @@ impl UpdateTableError {
     pub fn from_body(body: &str) -> UpdateTableError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4673,7 +4703,8 @@ impl UpdateTimeToLiveError {
     pub fn from_body(body: &str) -> UpdateTimeToLiveError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/dynamodbstreams/src/generated.rs
+++ b/rusoto/services/dynamodbstreams/src/generated.rs
@@ -31,7 +31,7 @@ use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 /// <p>Represents the data for an attribute. You can set one, and only one, of the elements.</p> <p>Each attribute in an item is a name-value pair. An attribute can be single-valued or multi-valued set. For example, a book item can have title and authors attributes. Each book has one title but can have many authors. The multi-valued attribute is a set; duplicate values are not allowed.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AttributeValue {
     /// <p>A Binary data type.</p>
     #[serde(rename = "B")]
@@ -80,7 +80,7 @@ pub struct AttributeValue {
 }
 
 /// <p>Represents the input of a <code>DescribeStream</code> operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeStreamInput {
     /// <p>The shard ID of the first item that this operation will evaluate. Use the value that was returned for <code>LastEvaluatedShardId</code> in the previous operation. </p>
     #[serde(rename = "ExclusiveStartShardId")]
@@ -96,7 +96,7 @@ pub struct DescribeStreamInput {
 }
 
 /// <p>Represents the output of a <code>DescribeStream</code> operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeStreamOutput {
     /// <p>A complete description of the stream, including its creation date and time, the DynamoDB table associated with the stream, the shard IDs within the stream, and the beginning and ending sequence numbers of stream records within the shards.</p>
     #[serde(rename = "StreamDescription")]
@@ -105,7 +105,7 @@ pub struct DescribeStreamOutput {
 }
 
 /// <p>Represents the input of a <code>GetRecords</code> operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetRecordsInput {
     /// <p>The maximum number of records to return from the shard. The upper limit is 1000.</p>
     #[serde(rename = "Limit")]
@@ -117,7 +117,7 @@ pub struct GetRecordsInput {
 }
 
 /// <p>Represents the output of a <code>GetRecords</code> operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetRecordsOutput {
     /// <p>The next position in the shard from which to start sequentially reading stream records. If set to <code>null</code>, the shard has been closed and the requested iterator will not return any more data.</p>
     #[serde(rename = "NextShardIterator")]
@@ -130,7 +130,7 @@ pub struct GetRecordsOutput {
 }
 
 /// <p>Represents the input of a <code>GetShardIterator</code> operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetShardIteratorInput {
     /// <p>The sequence number of a stream record in the shard from which to start reading.</p>
     #[serde(rename = "SequenceNumber")]
@@ -148,7 +148,7 @@ pub struct GetShardIteratorInput {
 }
 
 /// <p>Represents the output of a <code>GetShardIterator</code> operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetShardIteratorOutput {
     /// <p>The position in the shard from which to start reading stream records sequentially. A shard iterator specifies this position using the sequence number of a stream record in a shard.</p>
     #[serde(rename = "ShardIterator")]
@@ -157,7 +157,7 @@ pub struct GetShardIteratorOutput {
 }
 
 /// <p>Contains details about the type of identity that made the request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Identity {
     /// <p>A unique identifier for the entity that made the call. For Time To Live, the principalId is "dynamodb.amazonaws.com".</p>
     #[serde(rename = "PrincipalId")]
@@ -170,7 +170,7 @@ pub struct Identity {
 }
 
 /// <p><p>Represents <i>a single element</i> of a key schema. A key schema specifies the attributes that make up the primary key of a table, or the key attributes of an index.</p> <p>A <code>KeySchemaElement</code> represents exactly one attribute of the primary key. For example, a simple primary key (partition key) would be represented by one <code>KeySchemaElement</code>. A composite primary key (partition key and sort key) would require one <code>KeySchemaElement</code> for the partition key, and another <code>KeySchemaElement</code> for the sort key.</p> <note> <p>The partition key of an item is also known as its <i>hash attribute</i>. The term &quot;hash attribute&quot; derives from DynamoDB&#39;s usage of an internal hash function to evenly distribute data items across partitions, based on their partition key values.</p> <p>The sort key of an item is also known as its <i>range attribute</i>. The term &quot;range attribute&quot; derives from the way DynamoDB stores items with the same partition key physically close together, in sorted order by the sort key value.</p> </note></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct KeySchemaElement {
     /// <p>The name of a key attribute.</p>
     #[serde(rename = "AttributeName")]
@@ -181,7 +181,7 @@ pub struct KeySchemaElement {
 }
 
 /// <p>Represents the input of a <code>ListStreams</code> operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListStreamsInput {
     /// <p>The ARN (Amazon Resource Name) of the first item that this operation will evaluate. Use the value that was returned for <code>LastEvaluatedStreamArn</code> in the previous operation. </p>
     #[serde(rename = "ExclusiveStartStreamArn")]
@@ -198,7 +198,7 @@ pub struct ListStreamsInput {
 }
 
 /// <p>Represents the output of a <code>ListStreams</code> operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListStreamsOutput {
     /// <p>The stream ARN of the item where the operation stopped, inclusive of the previous result set. Use this value to start a new operation, excluding this value in the new request.</p> <p>If <code>LastEvaluatedStreamArn</code> is empty, then the "last page" of results has been processed and there is no more data to be retrieved.</p> <p>If <code>LastEvaluatedStreamArn</code> is not empty, it does not necessarily mean that there is more data in the result set. The only way to know when you have reached the end of the result set is when <code>LastEvaluatedStreamArn</code> is empty.</p>
     #[serde(rename = "LastEvaluatedStreamArn")]
@@ -211,7 +211,7 @@ pub struct ListStreamsOutput {
 }
 
 /// <p>A description of a unique event within a stream.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Record {
     /// <p>The region in which the <code>GetRecords</code> request was received.</p>
     #[serde(rename = "awsRegion")]
@@ -244,7 +244,7 @@ pub struct Record {
 }
 
 /// <p>The beginning and ending sequence numbers for the stream records contained within a shard.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SequenceNumberRange {
     /// <p>The last sequence number.</p>
     #[serde(rename = "EndingSequenceNumber")]
@@ -257,7 +257,7 @@ pub struct SequenceNumberRange {
 }
 
 /// <p>A uniquely identified group of stream records within a stream.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Shard {
     /// <p>The shard ID of the current shard's parent.</p>
     #[serde(rename = "ParentShardId")]
@@ -274,7 +274,7 @@ pub struct Shard {
 }
 
 /// <p>Represents all of the data describing a particular stream.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Stream {
     /// <p>The Amazon Resource Name (ARN) for the stream.</p>
     #[serde(rename = "StreamArn")]
@@ -291,7 +291,7 @@ pub struct Stream {
 }
 
 /// <p>Represents all of the data describing a particular stream.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StreamDescription {
     /// <p>The date and time when the request to create this stream was issued.</p>
     #[serde(rename = "CreationRequestDateTime")]
@@ -332,7 +332,7 @@ pub struct StreamDescription {
 }
 
 /// <p>A description of a single data modification that was performed on an item in a DynamoDB table.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StreamRecord {
     /// <p>The approximate date and time when the stream record was created, in <a href="http://www.epochconverter.com/">UNIX epoch time</a> format.</p>
     #[serde(rename = "ApproximateCreationDateTime")]

--- a/rusoto/services/dynamodbstreams/src/generated.rs
+++ b/rusoto/services/dynamodbstreams/src/generated.rs
@@ -385,7 +385,8 @@ impl DescribeStreamError {
     pub fn from_body(body: &str) -> DescribeStreamError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -475,7 +476,8 @@ impl GetRecordsError {
     pub fn from_body(body: &str) -> GetRecordsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -571,7 +573,8 @@ impl GetShardIteratorError {
     pub fn from_body(body: &str) -> GetShardIteratorError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -659,7 +662,8 @@ impl ListStreamsError {
     pub fn from_body(body: &str) -> ListStreamsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/ec2/src/generated.rs
+++ b/rusoto/services/ec2/src/generated.rs
@@ -44,7 +44,7 @@ enum DeserializerNext {
     Element(String),
 }
 /// <p>Contains the parameters for accepting the quote.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AcceptReservedInstancesExchangeQuoteRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -89,7 +89,7 @@ impl AcceptReservedInstancesExchangeQuoteRequestSerializer {
 }
 
 /// <p>The result of the exchange and whether it was <code>successful</code>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AcceptReservedInstancesExchangeQuoteResult {
     /// <p>The ID of the successful exchange.</p>
     pub exchange_id: Option<String>,
@@ -135,7 +135,7 @@ impl AcceptReservedInstancesExchangeQuoteResultDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AcceptVpcEndpointConnectionsRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -172,7 +172,7 @@ impl AcceptVpcEndpointConnectionsRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AcceptVpcEndpointConnectionsResult {
     /// <p>Information about the interface endpoints that were not accepted, if applicable.</p>
     pub unsuccessful: Option<Vec<UnsuccessfulItem>>,
@@ -220,7 +220,7 @@ impl AcceptVpcEndpointConnectionsResultDeserializer {
     }
 }
 /// <p>Contains the parameters for AcceptVpcPeeringConnection.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AcceptVpcPeeringConnectionRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -253,7 +253,7 @@ impl AcceptVpcPeeringConnectionRequestSerializer {
 }
 
 /// <p>Contains the output of AcceptVpcPeeringConnection.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AcceptVpcPeeringConnectionResult {
     /// <p>Information about the VPC peering connection.</p>
     pub vpc_peering_connection: Option<VpcPeeringConnection>,
@@ -303,7 +303,7 @@ impl AcceptVpcPeeringConnectionResultDeserializer {
     }
 }
 /// <p>Describes an account attribute.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AccountAttribute {
     /// <p>The name of the account attribute.</p>
     pub attribute_name: Option<String>,
@@ -415,7 +415,7 @@ impl AccountAttributeNameStringListSerializer {
 }
 
 /// <p>Describes a value of an account attribute.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AccountAttributeValue {
     /// <p>The value of the attribute.</p>
     pub attribute_value: Option<String>,
@@ -506,7 +506,7 @@ impl AccountAttributeValueListDeserializer {
     }
 }
 /// <p>Describes a running instance in a Spot Fleet.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ActiveInstance {
     /// <p>The health status of the instance. If the status of either the instance status check or the system status check is <code>impaired</code>, the health status of the instance is <code>unhealthy</code>. Otherwise, the health status is <code>healthy</code>.</p>
     pub instance_health: Option<String>,
@@ -628,7 +628,7 @@ impl ActivityStatusDeserializer {
     }
 }
 /// <p>Describes an Elastic IP address.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Address {
     /// <p>The ID representing the allocation of the address for use with EC2-VPC.</p>
     pub allocation_id: Option<String>,
@@ -769,7 +769,7 @@ impl AddressListDeserializer {
     }
 }
 /// <p>Contains the parameters for AllocateAddress.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AllocateAddressRequest {
     /// <p>[EC2-VPC] The Elastic IP address to recover.</p>
     pub address: Option<String>,
@@ -810,7 +810,7 @@ impl AllocateAddressRequestSerializer {
 }
 
 /// <p>Contains the output of AllocateAddress.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AllocateAddressResult {
     /// <p>[EC2-VPC] The ID that AWS assigns to represent the allocation of the Elastic IP address for use with instances in a VPC.</p>
     pub allocation_id: Option<String>,
@@ -869,7 +869,7 @@ impl AllocateAddressResultDeserializer {
     }
 }
 /// <p>Contains the parameters for AllocateHosts.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AllocateHostsRequest {
     /// <p>This is enabled by default. This property allows instances to be automatically placed onto available Dedicated Hosts, when you are launching instances without specifying a host ID.</p> <p>Default: Enabled</p>
     pub auto_placement: Option<String>,
@@ -920,7 +920,7 @@ impl AllocateHostsRequestSerializer {
 }
 
 /// <p>Contains the output of AllocateHosts.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AllocateHostsResult {
     /// <p>The ID of the allocated Dedicated Host. This is used when you want to launch an instance onto a specific host.</p>
     pub host_ids: Option<Vec<String>>,
@@ -1009,7 +1009,7 @@ impl AllocationStrategyDeserializer {
     }
 }
 /// <p>Describes a principal.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AllowedPrincipal {
     /// <p>The Amazon Resource Name (ARN) of the principal.</p>
     pub principal: Option<String>,
@@ -1119,7 +1119,7 @@ impl ArchitectureValuesDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AssignIpv6AddressesRequest {
     /// <p>The number of IPv6 addresses to assign to the network interface. Amazon EC2 automatically selects the IPv6 addresses from the subnet range. You can't use this option if specifying specific IPv6 addresses.</p>
     pub ipv_6_address_count: Option<i64>,
@@ -1158,7 +1158,7 @@ impl AssignIpv6AddressesRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AssignIpv6AddressesResult {
     /// <p>The IPv6 addresses assigned to the network interface.</p>
     pub assigned_ipv_6_addresses: Option<Vec<String>>,
@@ -1216,7 +1216,7 @@ impl AssignIpv6AddressesResultDeserializer {
     }
 }
 /// <p>Contains the parameters for AssignPrivateIpAddresses.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AssignPrivateIpAddressesRequest {
     /// <p>Indicates whether to allow an IP address that is already assigned to another network interface or instance to be reassigned to the specified network interface.</p>
     pub allow_reassignment: Option<bool>,
@@ -1264,7 +1264,7 @@ impl AssignPrivateIpAddressesRequestSerializer {
 }
 
 /// <p>Contains the parameters for AssociateAddress.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AssociateAddressRequest {
     /// <p>[EC2-VPC] The allocation ID. This is required for EC2-VPC.</p>
     pub allocation_id: Option<String>,
@@ -1337,7 +1337,7 @@ impl AssociateAddressRequestSerializer {
 }
 
 /// <p>Contains the output of AssociateAddress.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AssociateAddressResult {
     /// <p>[EC2-VPC] The ID that represents the association of the Elastic IP address with an instance.</p>
     pub association_id: Option<String>,
@@ -1386,7 +1386,7 @@ impl AssociateAddressResultDeserializer {
     }
 }
 /// <p>Contains the parameters for AssociateDhcpOptions.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AssociateDhcpOptionsRequest {
     /// <p>The ID of the DHCP options set, or <code>default</code> to associate no DHCP options with the VPC.</p>
     pub dhcp_options_id: String,
@@ -1422,7 +1422,7 @@ impl AssociateDhcpOptionsRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AssociateIamInstanceProfileRequest {
     /// <p>The IAM instance profile.</p>
     pub iam_instance_profile: IamInstanceProfileSpecification,
@@ -1451,7 +1451,7 @@ impl AssociateIamInstanceProfileRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AssociateIamInstanceProfileResult {
     /// <p>Information about the IAM instance profile association.</p>
     pub iam_instance_profile_association: Option<IamInstanceProfileAssociation>,
@@ -1502,7 +1502,7 @@ impl AssociateIamInstanceProfileResultDeserializer {
     }
 }
 /// <p>Contains the parameters for AssociateRouteTable.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AssociateRouteTableRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -1539,7 +1539,7 @@ impl AssociateRouteTableRequestSerializer {
 }
 
 /// <p>Contains the output of AssociateRouteTable.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AssociateRouteTableResult {
     /// <p>The route table association ID (needed to disassociate the route table).</p>
     pub association_id: Option<String>,
@@ -1587,7 +1587,7 @@ impl AssociateRouteTableResultDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AssociateSubnetCidrBlockRequest {
     /// <p>The IPv6 CIDR block for your subnet. The subnet must have a /64 prefix length.</p>
     pub ipv_6_cidr_block: String,
@@ -1615,7 +1615,7 @@ impl AssociateSubnetCidrBlockRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AssociateSubnetCidrBlockResult {
     /// <p>Information about the IPv6 CIDR block association.</p>
     pub ipv_6_cidr_block_association: Option<SubnetIpv6CidrBlockAssociation>,
@@ -1671,7 +1671,7 @@ impl AssociateSubnetCidrBlockResultDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AssociateVpcCidrBlockRequest {
     /// <p>Requests an Amazon-provided IPv6 CIDR block with a /56 prefix length for the VPC. You cannot specify the range of IPv6 addresses, or the size of the CIDR block.</p>
     pub amazon_provided_ipv_6_cidr_block: Option<bool>,
@@ -1709,7 +1709,7 @@ impl AssociateVpcCidrBlockRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AssociateVpcCidrBlockResult {
     /// <p>Information about the IPv4 CIDR block association.</p>
     pub cidr_block_association: Option<VpcCidrBlockAssociation>,
@@ -1785,7 +1785,7 @@ impl AssociationIdListSerializer {
 }
 
 /// <p>Contains the parameters for AttachClassicLinkVpc.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AttachClassicLinkVpcRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -1829,7 +1829,7 @@ impl AttachClassicLinkVpcRequestSerializer {
 }
 
 /// <p>Contains the output of AttachClassicLinkVpc.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AttachClassicLinkVpcResult {
     /// <p>Returns <code>true</code> if the request succeeds; otherwise, it returns an error.</p>
     pub return_: Option<bool>,
@@ -1875,7 +1875,7 @@ impl AttachClassicLinkVpcResultDeserializer {
     }
 }
 /// <p>Contains the parameters for AttachInternetGateway.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AttachInternetGatewayRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -1912,7 +1912,7 @@ impl AttachInternetGatewayRequestSerializer {
 }
 
 /// <p>Contains the parameters for AttachNetworkInterface.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AttachNetworkInterfaceRequest {
     /// <p>The index of the device for the network interface attachment.</p>
     pub device_index: i64,
@@ -1955,7 +1955,7 @@ impl AttachNetworkInterfaceRequestSerializer {
 }
 
 /// <p>Contains the output of AttachNetworkInterface.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AttachNetworkInterfaceResult {
     /// <p>The ID of the network interface attachment.</p>
     pub attachment_id: Option<String>,
@@ -2002,7 +2002,7 @@ impl AttachNetworkInterfaceResultDeserializer {
     }
 }
 /// <p>Contains the parameters for AttachVolume.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AttachVolumeRequest {
     /// <p>The device name (for example, <code>/dev/sdh</code> or <code>xvdh</code>).</p>
     pub device: String,
@@ -2045,7 +2045,7 @@ impl AttachVolumeRequestSerializer {
 }
 
 /// <p>Contains the parameters for AttachVpnGateway.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AttachVpnGatewayRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -2082,7 +2082,7 @@ impl AttachVpnGatewayRequestSerializer {
 }
 
 /// <p>Contains the output of AttachVpnGateway.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AttachVpnGatewayResult {
     /// <p>Information about the attachment.</p>
     pub vpc_attachment: Option<VpcAttachment>,
@@ -2145,7 +2145,7 @@ impl AttachmentStatusDeserializer {
     }
 }
 /// <p>Describes a value for a resource attribute that is a Boolean value.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AttributeBooleanValue {
     /// <p>The attribute value. The valid values are <code>true</code> or <code>false</code>.</p>
     pub value: Option<bool>,
@@ -2210,7 +2210,7 @@ impl AttributeBooleanValueSerializer {
 }
 
 /// <p>Describes a value for a resource attribute that is a String.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AttributeValue {
     /// <p>The attribute value. The value is case-sensitive.</p>
     pub value: Option<String>,
@@ -2275,7 +2275,7 @@ impl AttributeValueSerializer {
 }
 
 /// <p>Contains the parameters for AuthorizeSecurityGroupEgress.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AuthorizeSecurityGroupEgressRequest {
     /// <p>Not supported. Use a set of IP permissions to specify the CIDR.</p>
     pub cidr_ip: Option<String>,
@@ -2363,7 +2363,7 @@ impl AuthorizeSecurityGroupEgressRequestSerializer {
 }
 
 /// <p>Contains the parameters for AuthorizeSecurityGroupIngress.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AuthorizeSecurityGroupIngressRequest {
     /// <p>The CIDR IPv4 address range. You can't specify this parameter when specifying a source security group.</p>
     pub cidr_ip: Option<String>,
@@ -2475,7 +2475,7 @@ impl AutoPlacementDeserializer {
     }
 }
 /// <p>Describes an Availability Zone.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AvailabilityZone {
     /// <p>Any messages about the Availability Zone.</p>
     pub messages: Option<Vec<AvailabilityZoneMessage>>,
@@ -2587,7 +2587,7 @@ impl AvailabilityZoneListDeserializer {
     }
 }
 /// <p>Describes a message about an Availability Zone.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AvailabilityZoneMessage {
     /// <p>The message about the Availability Zone.</p>
     pub message: Option<String>,
@@ -2689,7 +2689,7 @@ impl AvailabilityZoneStateDeserializer {
     }
 }
 /// <p>The capacity information for instances launched onto the Dedicated Host.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AvailableCapacity {
     /// <p>The total number of instances that the Dedicated Host supports.</p>
     pub available_instance_capacity: Option<Vec<InstanceCapacity>>,
@@ -2829,7 +2829,7 @@ impl BlobDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct BlobAttributeValue {
     pub value: Option<Vec<u8>>,
 }
@@ -2855,7 +2855,7 @@ impl BlobAttributeValueSerializer {
 }
 
 /// <p>Describes a block device mapping.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct BlockDeviceMapping {
     /// <p>The device name (for example, <code>/dev/sdh</code> or <code>xvdh</code>).</p>
     pub device_name: Option<String>,
@@ -3048,7 +3048,7 @@ impl BundleIdStringListSerializer {
 }
 
 /// <p>Contains the parameters for BundleInstance.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct BundleInstanceRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -3082,7 +3082,7 @@ impl BundleInstanceRequestSerializer {
 }
 
 /// <p>Contains the output of BundleInstance.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct BundleInstanceResult {
     /// <p>Information about the bundle task.</p>
     pub bundle_task: Option<BundleTask>,
@@ -3131,7 +3131,7 @@ impl BundleInstanceResultDeserializer {
     }
 }
 /// <p>Describes a bundle task.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct BundleTask {
     /// <p>The ID of the bundle task.</p>
     pub bundle_id: Option<String>,
@@ -3222,7 +3222,7 @@ impl BundleTaskDeserializer {
     }
 }
 /// <p>Describes an error for <a>BundleInstance</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct BundleTaskError {
     /// <p>The error code.</p>
     pub code: Option<String>,
@@ -3341,7 +3341,7 @@ impl CancelBatchErrorCodeDeserializer {
     }
 }
 /// <p>Contains the parameters for CancelBundleTask.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CancelBundleTaskRequest {
     /// <p>The ID of the bundle task.</p>
     pub bundle_id: String,
@@ -3372,7 +3372,7 @@ impl CancelBundleTaskRequestSerializer {
 }
 
 /// <p>Contains the output of CancelBundleTask.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CancelBundleTaskResult {
     /// <p>Information about the bundle task.</p>
     pub bundle_task: Option<BundleTask>,
@@ -3421,7 +3421,7 @@ impl CancelBundleTaskResultDeserializer {
     }
 }
 /// <p>Contains the parameters for CancelConversionTask.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CancelConversionRequest {
     /// <p>The ID of the conversion task.</p>
     pub conversion_task_id: String,
@@ -3460,7 +3460,7 @@ impl CancelConversionRequestSerializer {
 }
 
 /// <p>Contains the parameters for CancelExportTask.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CancelExportTaskRequest {
     /// <p>The ID of the export task. This is the ID returned by <code>CreateInstanceExportTask</code>.</p>
     pub export_task_id: String,
@@ -3483,7 +3483,7 @@ impl CancelExportTaskRequestSerializer {
 }
 
 /// <p>Contains the parameters for CancelImportTask.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CancelImportTaskRequest {
     /// <p>The reason for canceling the task.</p>
     pub cancel_reason: Option<String>,
@@ -3524,7 +3524,7 @@ impl CancelImportTaskRequestSerializer {
 }
 
 /// <p>Contains the output for CancelImportTask.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CancelImportTaskResult {
     /// <p>The ID of the task being canceled.</p>
     pub import_task_id: Option<String>,
@@ -3584,7 +3584,7 @@ impl CancelImportTaskResultDeserializer {
     }
 }
 /// <p>Contains the parameters for CancelReservedInstancesListing.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CancelReservedInstancesListingRequest {
     /// <p>The ID of the Reserved Instance listing.</p>
     pub reserved_instances_listing_id: String,
@@ -3607,7 +3607,7 @@ impl CancelReservedInstancesListingRequestSerializer {
 }
 
 /// <p>Contains the output of CancelReservedInstancesListing.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CancelReservedInstancesListingResult {
     /// <p>The Reserved Instance listing.</p>
     pub reserved_instances_listings: Option<Vec<ReservedInstancesListing>>,
@@ -3657,7 +3657,7 @@ impl CancelReservedInstancesListingResultDeserializer {
     }
 }
 /// <p>Describes a Spot Fleet error.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CancelSpotFleetRequestsError {
     /// <p>The error code.</p>
     pub code: String,
@@ -3709,7 +3709,7 @@ impl CancelSpotFleetRequestsErrorDeserializer {
     }
 }
 /// <p>Describes a Spot Fleet request that was not successfully canceled.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CancelSpotFleetRequestsErrorItem {
     /// <p>The error.</p>
     pub error: CancelSpotFleetRequestsError,
@@ -3807,7 +3807,7 @@ impl CancelSpotFleetRequestsErrorSetDeserializer {
     }
 }
 /// <p>Contains the parameters for CancelSpotFleetRequests.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CancelSpotFleetRequestsRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -3845,7 +3845,7 @@ impl CancelSpotFleetRequestsRequestSerializer {
 }
 
 /// <p>Contains the output of CancelSpotFleetRequests.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CancelSpotFleetRequestsResponse {
     /// <p>Information about the Spot Fleet requests that are successfully canceled.</p>
     pub successful_fleet_requests: Option<Vec<CancelSpotFleetRequestsSuccessItem>>,
@@ -3906,7 +3906,7 @@ impl CancelSpotFleetRequestsResponseDeserializer {
     }
 }
 /// <p>Describes a Spot Fleet request that was successfully canceled.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CancelSpotFleetRequestsSuccessItem {
     /// <p>The current state of the Spot Fleet request.</p>
     pub current_spot_fleet_request_state: String,
@@ -4029,7 +4029,7 @@ impl CancelSpotInstanceRequestStateDeserializer {
     }
 }
 /// <p>Contains the parameters for CancelSpotInstanceRequests.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CancelSpotInstanceRequestsRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -4061,7 +4061,7 @@ impl CancelSpotInstanceRequestsRequestSerializer {
 }
 
 /// <p>Contains the output of CancelSpotInstanceRequests.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CancelSpotInstanceRequestsResult {
     /// <p>One or more Spot Instance requests.</p>
     pub cancelled_spot_instance_requests: Option<Vec<CancelledSpotInstanceRequest>>,
@@ -4112,7 +4112,7 @@ impl CancelSpotInstanceRequestsResultDeserializer {
     }
 }
 /// <p>Describes a request to cancel a Spot Instance.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CancelledSpotInstanceRequest {
     /// <p>The ID of the Spot Instance request.</p>
     pub spot_instance_request_id: Option<String>,
@@ -4210,7 +4210,7 @@ impl CancelledSpotInstanceRequestListDeserializer {
     }
 }
 /// <p>Describes an IPv4 CIDR block.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CidrBlock {
     /// <p>The IPv4 CIDR block.</p>
     pub cidr_block: Option<String>,
@@ -4297,7 +4297,7 @@ impl CidrBlockSetDeserializer {
     }
 }
 /// <p>Describes the ClassicLink DNS support status of a VPC.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ClassicLinkDnsSupport {
     /// <p>Indicates whether ClassicLink DNS support is enabled for the VPC.</p>
     pub classic_link_dns_supported: Option<bool>,
@@ -4392,7 +4392,7 @@ impl ClassicLinkDnsSupportListDeserializer {
     }
 }
 /// <p>Describes a linked EC2-Classic instance.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ClassicLinkInstance {
     /// <p>A list of security groups.</p>
     pub groups: Option<Vec<GroupIdentifier>>,
@@ -4498,7 +4498,7 @@ impl ClassicLinkInstanceListDeserializer {
     }
 }
 /// <p>Describes a Classic Load Balancer.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ClassicLoadBalancer {
     /// <p>The name of the load balancer.</p>
     pub name: String,
@@ -4615,7 +4615,7 @@ impl ClassicLoadBalancersSerializer {
 }
 
 /// <p>Describes the Classic Load Balancers to attach to a Spot Fleet. Spot Fleet registers the running Spot Instances with these Classic Load Balancers.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ClassicLoadBalancersConfig {
     /// <p>One or more Classic Load Balancers.</p>
     pub classic_load_balancers: Vec<ClassicLoadBalancer>,
@@ -4683,7 +4683,7 @@ impl ClassicLoadBalancersConfigSerializer {
 }
 
 /// <p>Describes the client-specific data.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ClientData {
     /// <p>A user-defined comment about the disk upload.</p>
     pub comment: Option<String>,
@@ -4732,7 +4732,7 @@ impl ClientDataSerializer {
 }
 
 /// <p>Contains the parameters for ConfirmProductInstance.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ConfirmProductInstanceRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -4769,7 +4769,7 @@ impl ConfirmProductInstanceRequestSerializer {
 }
 
 /// <p>Contains the output of ConfirmProductInstance.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ConfirmProductInstanceResult {
     /// <p>The AWS account ID of the instance owner. This is only present if the product code is attached to the instance.</p>
     pub owner_id: Option<String>,
@@ -4821,7 +4821,7 @@ impl ConfirmProductInstanceResultDeserializer {
     }
 }
 /// <p>Describes a connection notification for a VPC endpoint or VPC endpoint service.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ConnectionNotification {
     /// <p>The events for the notification. Valid values are <code>Accept</code>, <code>Connect</code>, <code>Delete</code>, and <code>Reject</code>.</p>
     pub connection_events: Option<Vec<String>>,
@@ -5011,7 +5011,7 @@ impl ConversionIdStringListSerializer {
 }
 
 /// <p>Describes a conversion task.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ConversionTask {
     /// <p>The ID of the conversion task.</p>
     pub conversion_task_id: String,
@@ -5114,7 +5114,7 @@ impl ConversionTaskStateDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CopyFpgaImageRequest {
     /// <p>Unique, case-sensitive identifier that you provide to ensure the idempotency of the request. For more information, see <a href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Run_Instance_Idempotency.html">Ensuring Idempotency</a>.</p>
     pub client_token: Option<String>,
@@ -5174,7 +5174,7 @@ impl CopyFpgaImageRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CopyFpgaImageResult {
     /// <p>The ID of the new AFI.</p>
     pub fpga_image_id: Option<String>,
@@ -5221,7 +5221,7 @@ impl CopyFpgaImageResultDeserializer {
     }
 }
 /// <p>Contains the parameters for CopyImage.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CopyImageRequest {
     /// <p>Unique, case-sensitive identifier you provide to ensure idempotency of the request. For more information, see <a href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Run_Instance_Idempotency.html">How to Ensure Idempotency</a> in the <i>Amazon Elastic Compute Cloud User Guide</i>.</p>
     pub client_token: Option<String>,
@@ -5296,7 +5296,7 @@ impl CopyImageRequestSerializer {
 }
 
 /// <p>Contains the output of CopyImage.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CopyImageResult {
     /// <p>The ID of the new AMI.</p>
     pub image_id: Option<String>,
@@ -5343,7 +5343,7 @@ impl CopyImageResultDeserializer {
     }
 }
 /// <p>Contains the parameters for CopySnapshot.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CopySnapshotRequest {
     /// <p>A description for the EBS snapshot.</p>
     pub description: Option<String>,
@@ -5420,7 +5420,7 @@ impl CopySnapshotRequestSerializer {
 }
 
 /// <p>Contains the output of CopySnapshot.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CopySnapshotResult {
     /// <p>The ID of the new snapshot.</p>
     pub snapshot_id: Option<String>,
@@ -5467,7 +5467,7 @@ impl CopySnapshotResultDeserializer {
     }
 }
 /// <p>Contains the parameters for CreateCustomerGateway.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateCustomerGatewayRequest {
     /// <p>For devices that support BGP, the customer gateway's BGP ASN.</p> <p>Default: 65000</p>
     pub bgp_asn: i64,
@@ -5510,7 +5510,7 @@ impl CreateCustomerGatewayRequestSerializer {
 }
 
 /// <p>Contains the output of CreateCustomerGateway.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateCustomerGatewayResult {
     /// <p>Information about the customer gateway.</p>
     pub customer_gateway: Option<CustomerGateway>,
@@ -5557,7 +5557,7 @@ impl CreateCustomerGatewayResultDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateDefaultSubnetRequest {
     /// <p>The Availability Zone in which to create the default subnet.</p>
     pub availability_zone: String,
@@ -5587,7 +5587,7 @@ impl CreateDefaultSubnetRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateDefaultSubnetResult {
     /// <p>Information about the subnet.</p>
     pub subnet: Option<Subnet>,
@@ -5633,7 +5633,7 @@ impl CreateDefaultSubnetResultDeserializer {
     }
 }
 /// <p>Contains the parameters for CreateDefaultVpc.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateDefaultVpcRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -5658,7 +5658,7 @@ impl CreateDefaultVpcRequestSerializer {
 }
 
 /// <p>Contains the output of CreateDefaultVpc.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateDefaultVpcResult {
     /// <p>Information about the VPC.</p>
     pub vpc: Option<Vpc>,
@@ -5704,7 +5704,7 @@ impl CreateDefaultVpcResultDeserializer {
     }
 }
 /// <p>Contains the parameters for CreateDhcpOptions.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateDhcpOptionsRequest {
     /// <p>A DHCP configuration option.</p>
     pub dhcp_configurations: Vec<NewDhcpConfiguration>,
@@ -5736,7 +5736,7 @@ impl CreateDhcpOptionsRequestSerializer {
 }
 
 /// <p>Contains the output of CreateDhcpOptions.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateDhcpOptionsResult {
     /// <p>A set of DHCP options.</p>
     pub dhcp_options: Option<DhcpOptions>,
@@ -5784,7 +5784,7 @@ impl CreateDhcpOptionsResultDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateEgressOnlyInternetGatewayRequest {
     /// <p>Unique, case-sensitive identifier you provide to ensure the idempotency of the request. For more information, see <a href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Run_Instance_Idempotency.html">How to Ensure Idempotency</a>.</p>
     pub client_token: Option<String>,
@@ -5822,7 +5822,7 @@ impl CreateEgressOnlyInternetGatewayRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateEgressOnlyInternetGatewayResult {
     /// <p>Unique, case-sensitive identifier you provide to ensure the idempotency of the request.</p>
     pub client_token: Option<String>,
@@ -5878,7 +5878,7 @@ impl CreateEgressOnlyInternetGatewayResultDeserializer {
     }
 }
 /// <p>Contains the parameters for CreateFlowLogs.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateFlowLogsRequest {
     /// <p>Unique, case-sensitive identifier you provide to ensure the idempotency of the request. For more information, see <a href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Run_Instance_Idempotency.html">How to Ensure Idempotency</a>.</p>
     pub client_token: Option<String>,
@@ -5934,7 +5934,7 @@ impl CreateFlowLogsRequestSerializer {
 }
 
 /// <p>Contains the output of CreateFlowLogs.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateFlowLogsResult {
     /// <p>Unique, case-sensitive identifier you provide to ensure the idempotency of the request.</p>
     pub client_token: Option<String>,
@@ -5995,7 +5995,7 @@ impl CreateFlowLogsResultDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateFpgaImageRequest {
     /// <p>Unique, case-sensitive identifier that you provide to ensure the idempotency of the request. For more information, see <a href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Run_Instance_Idempotency.html">Ensuring Idempotency</a>.</p>
     pub client_token: Option<String>,
@@ -6059,7 +6059,7 @@ impl CreateFpgaImageRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateFpgaImageResult {
     /// <p>The global FPGA image identifier (AGFI ID).</p>
     pub fpga_image_global_id: Option<String>,
@@ -6114,7 +6114,7 @@ impl CreateFpgaImageResultDeserializer {
     }
 }
 /// <p>Contains the parameters for CreateImage.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateImageRequest {
     /// <p>Information about one or more block device mappings.</p>
     pub block_device_mappings: Option<Vec<BlockDeviceMapping>>,
@@ -6176,7 +6176,7 @@ impl CreateImageRequestSerializer {
 }
 
 /// <p>Contains the output of CreateImage.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateImageResult {
     /// <p>The ID of the new AMI.</p>
     pub image_id: Option<String>,
@@ -6223,7 +6223,7 @@ impl CreateImageResultDeserializer {
     }
 }
 /// <p>Contains the parameters for CreateInstanceExportTask.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateInstanceExportTaskRequest {
     /// <p>A description for the conversion task or the resource being exported. The maximum length is 255 bytes.</p>
     pub description: Option<String>,
@@ -6271,7 +6271,7 @@ impl CreateInstanceExportTaskRequestSerializer {
 }
 
 /// <p>Contains the output for CreateInstanceExportTask.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateInstanceExportTaskResult {
     /// <p>Information about the instance export task.</p>
     pub export_task: Option<ExportTask>,
@@ -6320,7 +6320,7 @@ impl CreateInstanceExportTaskResultDeserializer {
     }
 }
 /// <p>Contains the parameters for CreateInternetGateway.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateInternetGatewayRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -6345,7 +6345,7 @@ impl CreateInternetGatewayRequestSerializer {
 }
 
 /// <p>Contains the output of CreateInternetGateway.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateInternetGatewayResult {
     /// <p>Information about the Internet gateway.</p>
     pub internet_gateway: Option<InternetGateway>,
@@ -6393,7 +6393,7 @@ impl CreateInternetGatewayResultDeserializer {
     }
 }
 /// <p>Contains the parameters for CreateKeyPair.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateKeyPairRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -6423,7 +6423,7 @@ impl CreateKeyPairRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateLaunchTemplateRequest {
     /// <p>Unique, case-sensitive identifier you provide to ensure the idempotency of the request. For more information, see <a href="http://docs.aws.amazon.com/AWSEC2/latest/APIReference/Run_Instance_Idempotency.html">Ensuring Idempotency</a>.</p>
     pub client_token: Option<String>,
@@ -6476,7 +6476,7 @@ impl CreateLaunchTemplateRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateLaunchTemplateResult {
     /// <p>Information about the launch template.</p>
     pub launch_template: Option<LaunchTemplate>,
@@ -6524,7 +6524,7 @@ impl CreateLaunchTemplateResultDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateLaunchTemplateVersionRequest {
     /// <p>Unique, case-sensitive identifier you provide to ensure the idempotency of the request. For more information, see <a href="http://docs.aws.amazon.com/AWSEC2/latest/APIReference/Run_Instance_Idempotency.html">Ensuring Idempotency</a>.</p>
     pub client_token: Option<String>,
@@ -6595,7 +6595,7 @@ impl CreateLaunchTemplateVersionRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateLaunchTemplateVersionResult {
     /// <p>Information about the launch template version.</p>
     pub launch_template_version: Option<LaunchTemplateVersion>,
@@ -6645,7 +6645,7 @@ impl CreateLaunchTemplateVersionResultDeserializer {
     }
 }
 /// <p>Contains the parameters for CreateNatGateway.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateNatGatewayRequest {
     /// <p>The allocation ID of an Elastic IP address to associate with the NAT gateway. If the Elastic IP address is associated with another resource, you must first disassociate it.</p>
     pub allocation_id: String,
@@ -6682,7 +6682,7 @@ impl CreateNatGatewayRequestSerializer {
 }
 
 /// <p>Contains the output of CreateNatGateway.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateNatGatewayResult {
     /// <p>Unique, case-sensitive identifier to ensure the idempotency of the request. Only returned if a client token was provided in the request.</p>
     pub client_token: Option<String>,
@@ -6737,7 +6737,7 @@ impl CreateNatGatewayResultDeserializer {
     }
 }
 /// <p>Contains the parameters for CreateNetworkAclEntry.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateNetworkAclEntryRequest {
     /// <p>The IPv4 network range to allow or deny, in CIDR notation (for example <code>172.16.0.0/24</code>).</p>
     pub cidr_block: Option<String>,
@@ -6826,7 +6826,7 @@ impl CreateNetworkAclEntryRequestSerializer {
 }
 
 /// <p>Contains the parameters for CreateNetworkAcl.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateNetworkAclRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -6857,7 +6857,7 @@ impl CreateNetworkAclRequestSerializer {
 }
 
 /// <p>Contains the output of CreateNetworkAcl.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateNetworkAclResult {
     /// <p>Information about the network ACL.</p>
     pub network_acl: Option<NetworkAcl>,
@@ -6906,7 +6906,7 @@ impl CreateNetworkAclResultDeserializer {
     }
 }
 /// <p>Contains the parameters for CreateNetworkInterfacePermission.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateNetworkInterfacePermissionRequest {
     /// <p>The AWS account ID.</p>
     pub aws_account_id: Option<String>,
@@ -6959,7 +6959,7 @@ impl CreateNetworkInterfacePermissionRequestSerializer {
 }
 
 /// <p>Contains the output of CreateNetworkInterfacePermission.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateNetworkInterfacePermissionResult {
     /// <p>Information about the permission for the network interface.</p>
     pub interface_permission: Option<NetworkInterfacePermission>,
@@ -7009,7 +7009,7 @@ impl CreateNetworkInterfacePermissionResultDeserializer {
     }
 }
 /// <p>Contains the parameters for CreateNetworkInterface.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateNetworkInterfaceRequest {
     /// <p>A description for the network interface.</p>
     pub description: Option<String>,
@@ -7099,7 +7099,7 @@ impl CreateNetworkInterfaceRequestSerializer {
 }
 
 /// <p>Contains the output of CreateNetworkInterface.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateNetworkInterfaceResult {
     /// <p>Information about the network interface.</p>
     pub network_interface: Option<NetworkInterface>,
@@ -7147,7 +7147,7 @@ impl CreateNetworkInterfaceResultDeserializer {
     }
 }
 /// <p>Contains the parameters for CreatePlacementGroup.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreatePlacementGroupRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -7184,7 +7184,7 @@ impl CreatePlacementGroupRequestSerializer {
 }
 
 /// <p>Contains the parameters for CreateReservedInstancesListing.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateReservedInstancesListingRequest {
     /// <p>Unique, case-sensitive identifier you provide to ensure idempotency of your listings. This helps avoid duplicate listings. For more information, see <a href="http://docs.aws.amazon.com/AWSEC2/latest/APIReference/Run_Instance_Idempotency.html">Ensuring Idempotency</a>.</p>
     pub client_token: String,
@@ -7226,7 +7226,7 @@ impl CreateReservedInstancesListingRequestSerializer {
 }
 
 /// <p>Contains the output of CreateReservedInstancesListing.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateReservedInstancesListingResult {
     /// <p>Information about the Standard Reserved Instance listing.</p>
     pub reserved_instances_listings: Option<Vec<ReservedInstancesListing>>,
@@ -7276,7 +7276,7 @@ impl CreateReservedInstancesListingResultDeserializer {
     }
 }
 /// <p>Contains the parameters for CreateRoute.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateRouteRequest {
     /// <p>The IPv4 CIDR address block used for the destination match. Routing decisions are based on the most specific match.</p>
     pub destination_cidr_block: Option<String>,
@@ -7371,7 +7371,7 @@ impl CreateRouteRequestSerializer {
 }
 
 /// <p>Contains the output of CreateRoute.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateRouteResult {
     /// <p>Returns <code>true</code> if the request succeeds; otherwise, it returns an error.</p>
     pub return_: Option<bool>,
@@ -7417,7 +7417,7 @@ impl CreateRouteResultDeserializer {
     }
 }
 /// <p>Contains the parameters for CreateRouteTable.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateRouteTableRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -7448,7 +7448,7 @@ impl CreateRouteTableRequestSerializer {
 }
 
 /// <p>Contains the output of CreateRouteTable.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateRouteTableResult {
     /// <p>Information about the route table.</p>
     pub route_table: Option<RouteTable>,
@@ -7497,7 +7497,7 @@ impl CreateRouteTableResultDeserializer {
     }
 }
 /// <p>Contains the parameters for CreateSecurityGroup.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateSecurityGroupRequest {
     /// <p>A description for the security group. This is informational only.</p> <p>Constraints: Up to 255 characters in length</p> <p>Constraints for EC2-Classic: ASCII characters</p> <p>Constraints for EC2-VPC: a-z, A-Z, 0-9, spaces, and ._-:/()#,@[]+=&amp;;{}!$*</p>
     pub description: String,
@@ -7542,7 +7542,7 @@ impl CreateSecurityGroupRequestSerializer {
 }
 
 /// <p>Contains the output of CreateSecurityGroup.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateSecurityGroupResult {
     /// <p>The ID of the security group.</p>
     pub group_id: Option<String>,
@@ -7589,7 +7589,7 @@ impl CreateSecurityGroupResultDeserializer {
     }
 }
 /// <p>Contains the parameters for CreateSnapshot.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateSnapshotRequest {
     /// <p>A description for the snapshot.</p>
     pub description: Option<String>,
@@ -7637,7 +7637,7 @@ impl CreateSnapshotRequestSerializer {
 }
 
 /// <p>Contains the parameters for CreateSpotDatafeedSubscription.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateSpotDatafeedSubscriptionRequest {
     /// <p>The Amazon S3 bucket in which to store the Spot Instance data feed.</p>
     pub bucket: String,
@@ -7676,7 +7676,7 @@ impl CreateSpotDatafeedSubscriptionRequestSerializer {
 }
 
 /// <p>Contains the output of CreateSpotDatafeedSubscription.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateSpotDatafeedSubscriptionResult {
     /// <p>The Spot Instance data feed subscription.</p>
     pub spot_datafeed_subscription: Option<SpotDatafeedSubscription>,
@@ -7726,7 +7726,7 @@ impl CreateSpotDatafeedSubscriptionResultDeserializer {
     }
 }
 /// <p>Contains the parameters for CreateSubnet.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateSubnetRequest {
     /// <p>The Availability Zone for the subnet.</p> <p>Default: AWS selects one for you. If you create more than one subnet in your VPC, we may not necessarily select a different zone for each subnet.</p>
     pub availability_zone: Option<String>,
@@ -7779,7 +7779,7 @@ impl CreateSubnetRequestSerializer {
 }
 
 /// <p>Contains the output of CreateSubnet.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateSubnetResult {
     /// <p>Information about the subnet.</p>
     pub subnet: Option<Subnet>,
@@ -7825,7 +7825,7 @@ impl CreateSubnetResultDeserializer {
     }
 }
 /// <p>Contains the parameters for CreateTags.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateTagsRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -7860,7 +7860,7 @@ impl CreateTagsRequestSerializer {
 }
 
 /// <p>Describes the user or group to be added or removed from the permissions for a volume.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateVolumePermission {
     /// <p>The specific group that is to be added or removed from a volume's list of create volume permissions.</p>
     pub group: Option<String>,
@@ -7992,7 +7992,7 @@ impl CreateVolumePermissionListSerializer {
 }
 
 /// <p>Describes modifications to the permissions for a volume.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateVolumePermissionModifications {
     /// <p>Adds a specific AWS account ID or group to a volume's list of create volume permissions.</p>
     pub add: Option<Vec<CreateVolumePermission>>,
@@ -8027,7 +8027,7 @@ impl CreateVolumePermissionModificationsSerializer {
 }
 
 /// <p>Contains the parameters for CreateVolume.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateVolumeRequest {
     /// <p>The Availability Zone in which to create the volume. Use <a>DescribeAvailabilityZones</a> to list the Availability Zones that are currently available to you.</p>
     pub availability_zone: String,
@@ -8114,7 +8114,7 @@ impl CreateVolumeRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateVpcEndpointConnectionNotificationRequest {
     /// <p>Unique, case-sensitive identifier you provide to ensure the idempotency of the request. For more information, see <a href="http://docs.aws.amazon.com/AWSEC2/latest/APIReference/Run_Instance_Idempotency.html">How to Ensure Idempotency</a>.</p>
     pub client_token: Option<String>,
@@ -8179,7 +8179,7 @@ impl CreateVpcEndpointConnectionNotificationRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateVpcEndpointConnectionNotificationResult {
     /// <p>Unique, case-sensitive identifier you provide to ensure the idempotency of the request.</p>
     pub client_token: Option<String>,
@@ -8235,7 +8235,7 @@ impl CreateVpcEndpointConnectionNotificationResultDeserializer {
     }
 }
 /// <p>Contains the parameters for CreateVpcEndpoint.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateVpcEndpointRequest {
     /// <p>Unique, case-sensitive identifier you provide to ensure the idempotency of the request. For more information, see <a href="http://docs.aws.amazon.com/AWSEC2/latest/APIReference/Run_Instance_Idempotency.html">How to Ensure Idempotency</a>.</p>
     pub client_token: Option<String>,
@@ -8331,7 +8331,7 @@ impl CreateVpcEndpointRequestSerializer {
 }
 
 /// <p>Contains the output of CreateVpcEndpoint.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateVpcEndpointResult {
     /// <p>Unique, case-sensitive identifier you provide to ensure the idempotency of the request.</p>
     pub client_token: Option<String>,
@@ -8385,7 +8385,7 @@ impl CreateVpcEndpointResultDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateVpcEndpointServiceConfigurationRequest {
     /// <p>Indicate whether requests from service consumers to create an endpoint to your service must be accepted. To accept a request, use <a>AcceptVpcEndpointConnections</a>.</p>
     pub acceptance_required: Option<bool>,
@@ -8436,7 +8436,7 @@ impl CreateVpcEndpointServiceConfigurationRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateVpcEndpointServiceConfigurationResult {
     /// <p>Unique, case-sensitive identifier you provide to ensure the idempotency of the request.</p>
     pub client_token: Option<String>,
@@ -8492,7 +8492,7 @@ impl CreateVpcEndpointServiceConfigurationResultDeserializer {
     }
 }
 /// <p>Contains the parameters for CreateVpcPeeringConnection.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateVpcPeeringConnectionRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -8549,7 +8549,7 @@ impl CreateVpcPeeringConnectionRequestSerializer {
 }
 
 /// <p>Contains the output of CreateVpcPeeringConnection.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateVpcPeeringConnectionResult {
     /// <p>Information about the VPC peering connection.</p>
     pub vpc_peering_connection: Option<VpcPeeringConnection>,
@@ -8599,7 +8599,7 @@ impl CreateVpcPeeringConnectionResultDeserializer {
     }
 }
 /// <p>Contains the parameters for CreateVpc.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateVpcRequest {
     /// <p>Requests an Amazon-provided IPv6 CIDR block with a /56 prefix length for the VPC. You cannot specify the range of IP addresses, or the size of the CIDR block.</p>
     pub amazon_provided_ipv_6_cidr_block: Option<bool>,
@@ -8646,7 +8646,7 @@ impl CreateVpcRequestSerializer {
 }
 
 /// <p>Contains the output of CreateVpc.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateVpcResult {
     /// <p>Information about the VPC.</p>
     pub vpc: Option<Vpc>,
@@ -8692,7 +8692,7 @@ impl CreateVpcResultDeserializer {
     }
 }
 /// <p>Contains the parameters for CreateVpnConnection.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateVpnConnectionRequest {
     /// <p>The ID of the customer gateway.</p>
     pub customer_gateway_id: String,
@@ -8744,7 +8744,7 @@ impl CreateVpnConnectionRequestSerializer {
 }
 
 /// <p>Contains the output of CreateVpnConnection.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateVpnConnectionResult {
     /// <p>Information about the VPN connection.</p>
     pub vpn_connection: Option<VpnConnection>,
@@ -8793,7 +8793,7 @@ impl CreateVpnConnectionResultDeserializer {
     }
 }
 /// <p>Contains the parameters for CreateVpnConnectionRoute.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateVpnConnectionRouteRequest {
     /// <p>The CIDR block associated with the local subnet of the customer network.</p>
     pub destination_cidr_block: String,
@@ -8822,7 +8822,7 @@ impl CreateVpnConnectionRouteRequestSerializer {
 }
 
 /// <p>Contains the parameters for CreateVpnGateway.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateVpnGatewayRequest {
     /// <p>A private Autonomous System Number (ASN) for the Amazon side of a BGP session. If you're using a 16-bit ASN, it must be in the 64512 to 65534 range. If you're using a 32-bit ASN, it must be in the 4200000000 to 4294967294 range.</p> <p>Default: 64512</p>
     pub amazon_side_asn: Option<i64>,
@@ -8869,7 +8869,7 @@ impl CreateVpnGatewayRequestSerializer {
 }
 
 /// <p>Contains the output of CreateVpnGateway.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateVpnGatewayResult {
     /// <p>Information about the virtual private gateway.</p>
     pub vpn_gateway: Option<VpnGateway>,
@@ -8918,7 +8918,7 @@ impl CreateVpnGatewayResultDeserializer {
     }
 }
 /// <p>Describes the credit option for CPU usage of a T2 instance.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreditSpecification {
     /// <p>The credit option for CPU usage of a T2 instance.</p>
     pub cpu_credits: Option<String>,
@@ -8965,7 +8965,7 @@ impl CreditSpecificationDeserializer {
     }
 }
 /// <p>The credit option for CPU usage of a T2 instance.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreditSpecificationRequest {
     /// <p>The credit option for CPU usage of a T2 instance. Valid values are <code>standard</code> and <code>unlimited</code>.</p>
     pub cpu_credits: String,
@@ -9002,7 +9002,7 @@ impl CurrencyCodeValuesDeserializer {
     }
 }
 /// <p>Describes a customer gateway.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CustomerGateway {
     /// <p>The customer gateway's Border Gateway Protocol (BGP) Autonomous System Number (ASN).</p>
     pub bgp_asn: Option<String>,
@@ -9159,7 +9159,7 @@ impl DateTimeDeserializer {
     }
 }
 /// <p>Contains the parameters for DeleteCustomerGateway.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteCustomerGatewayRequest {
     /// <p>The ID of the customer gateway.</p>
     pub customer_gateway_id: String,
@@ -9190,7 +9190,7 @@ impl DeleteCustomerGatewayRequestSerializer {
 }
 
 /// <p>Contains the parameters for DeleteDhcpOptions.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteDhcpOptionsRequest {
     /// <p>The ID of the DHCP options set.</p>
     pub dhcp_options_id: String,
@@ -9220,7 +9220,7 @@ impl DeleteDhcpOptionsRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteEgressOnlyInternetGatewayRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -9250,7 +9250,7 @@ impl DeleteEgressOnlyInternetGatewayRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteEgressOnlyInternetGatewayResult {
     /// <p>Returns <code>true</code> if the request succeeds; otherwise, it returns an error.</p>
     pub return_code: Option<bool>,
@@ -9297,7 +9297,7 @@ impl DeleteEgressOnlyInternetGatewayResultDeserializer {
     }
 }
 /// <p>Contains the parameters for DeleteFlowLogs.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteFlowLogsRequest {
     /// <p>One or more flow log IDs.</p>
     pub flow_log_ids: Vec<String>,
@@ -9321,7 +9321,7 @@ impl DeleteFlowLogsRequestSerializer {
 }
 
 /// <p>Contains the output of DeleteFlowLogs.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteFlowLogsResult {
     /// <p>Information about the flow logs that could not be deleted successfully.</p>
     pub unsuccessful: Option<Vec<UnsuccessfulItem>>,
@@ -9368,7 +9368,7 @@ impl DeleteFlowLogsResultDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteFpgaImageRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -9398,7 +9398,7 @@ impl DeleteFpgaImageRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteFpgaImageResult {
     /// <p>Is <code>true</code> if the request succeeds, and an error otherwise.</p>
     pub return_: Option<bool>,
@@ -9444,7 +9444,7 @@ impl DeleteFpgaImageResultDeserializer {
     }
 }
 /// <p>Contains the parameters for DeleteInternetGateway.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteInternetGatewayRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -9475,7 +9475,7 @@ impl DeleteInternetGatewayRequestSerializer {
 }
 
 /// <p>Contains the parameters for DeleteKeyPair.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteKeyPairRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -9505,7 +9505,7 @@ impl DeleteKeyPairRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteLaunchTemplateRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -9545,7 +9545,7 @@ impl DeleteLaunchTemplateRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteLaunchTemplateResult {
     /// <p>Information about the launch template.</p>
     pub launch_template: Option<LaunchTemplate>,
@@ -9593,7 +9593,7 @@ impl DeleteLaunchTemplateResultDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteLaunchTemplateVersionsRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -9641,7 +9641,7 @@ impl DeleteLaunchTemplateVersionsRequestSerializer {
 }
 
 /// <p>Describes a launch template version that could not be deleted.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteLaunchTemplateVersionsResponseErrorItem {
     /// <p>The ID of the launch template.</p>
     pub launch_template_id: Option<String>,
@@ -9756,7 +9756,7 @@ impl DeleteLaunchTemplateVersionsResponseErrorSetDeserializer {
     }
 }
 /// <p>Describes a launch template version that was successfully deleted.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteLaunchTemplateVersionsResponseSuccessItem {
     /// <p>The ID of the launch template.</p>
     pub launch_template_id: Option<String>,
@@ -9858,7 +9858,7 @@ impl DeleteLaunchTemplateVersionsResponseSuccessSetDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteLaunchTemplateVersionsResult {
     /// <p>Information about the launch template versions that were successfully deleted.</p>
     pub successfully_deleted_launch_template_versions:
@@ -9913,7 +9913,7 @@ impl DeleteLaunchTemplateVersionsResultDeserializer {
     }
 }
 /// <p>Contains the parameters for DeleteNatGateway.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteNatGatewayRequest {
     /// <p>The ID of the NAT gateway.</p>
     pub nat_gateway_id: String,
@@ -9936,7 +9936,7 @@ impl DeleteNatGatewayRequestSerializer {
 }
 
 /// <p>Contains the output of DeleteNatGateway.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteNatGatewayResult {
     /// <p>The ID of the NAT gateway.</p>
     pub nat_gateway_id: Option<String>,
@@ -9983,7 +9983,7 @@ impl DeleteNatGatewayResultDeserializer {
     }
 }
 /// <p>Contains the parameters for DeleteNetworkAclEntry.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteNetworkAclEntryRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -10026,7 +10026,7 @@ impl DeleteNetworkAclEntryRequestSerializer {
 }
 
 /// <p>Contains the parameters for DeleteNetworkAcl.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteNetworkAclRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -10057,7 +10057,7 @@ impl DeleteNetworkAclRequestSerializer {
 }
 
 /// <p>Contains the parameters for DeleteNetworkInterfacePermission.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteNetworkInterfacePermissionRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -10096,7 +10096,7 @@ impl DeleteNetworkInterfacePermissionRequestSerializer {
 }
 
 /// <p>Contains the output for DeleteNetworkInterfacePermission.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteNetworkInterfacePermissionResult {
     /// <p>Returns <code>true</code> if the request succeeds, otherwise returns an error.</p>
     pub return_: Option<bool>,
@@ -10142,7 +10142,7 @@ impl DeleteNetworkInterfacePermissionResultDeserializer {
     }
 }
 /// <p>Contains the parameters for DeleteNetworkInterface.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteNetworkInterfaceRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -10173,7 +10173,7 @@ impl DeleteNetworkInterfaceRequestSerializer {
 }
 
 /// <p>Contains the parameters for DeletePlacementGroup.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeletePlacementGroupRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -10204,7 +10204,7 @@ impl DeletePlacementGroupRequestSerializer {
 }
 
 /// <p>Contains the parameters for DeleteRoute.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteRouteRequest {
     /// <p>The IPv4 CIDR range for the route. The value you specify must match the CIDR for the route exactly.</p>
     pub destination_cidr_block: Option<String>,
@@ -10251,7 +10251,7 @@ impl DeleteRouteRequestSerializer {
 }
 
 /// <p>Contains the parameters for DeleteRouteTable.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteRouteTableRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -10282,7 +10282,7 @@ impl DeleteRouteTableRequestSerializer {
 }
 
 /// <p>Contains the parameters for DeleteSecurityGroup.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteSecurityGroupRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -10323,7 +10323,7 @@ impl DeleteSecurityGroupRequestSerializer {
 }
 
 /// <p>Contains the parameters for DeleteSnapshot.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteSnapshotRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -10354,7 +10354,7 @@ impl DeleteSnapshotRequestSerializer {
 }
 
 /// <p>Contains the parameters for DeleteSpotDatafeedSubscription.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteSpotDatafeedSubscriptionRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -10379,7 +10379,7 @@ impl DeleteSpotDatafeedSubscriptionRequestSerializer {
 }
 
 /// <p>Contains the parameters for DeleteSubnet.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteSubnetRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -10410,7 +10410,7 @@ impl DeleteSubnetRequestSerializer {
 }
 
 /// <p>Contains the parameters for DeleteTags.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteTagsRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -10447,7 +10447,7 @@ impl DeleteTagsRequestSerializer {
 }
 
 /// <p>Contains the parameters for DeleteVolume.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteVolumeRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -10477,7 +10477,7 @@ impl DeleteVolumeRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteVpcEndpointConnectionNotificationsRequest {
     /// <p>One or more notification IDs.</p>
     pub connection_notification_ids: Vec<String>,
@@ -10512,7 +10512,7 @@ impl DeleteVpcEndpointConnectionNotificationsRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteVpcEndpointConnectionNotificationsResult {
     /// <p>Information about the notifications that could not be deleted successfully.</p>
     pub unsuccessful: Option<Vec<UnsuccessfulItem>>,
@@ -10559,7 +10559,7 @@ impl DeleteVpcEndpointConnectionNotificationsResultDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteVpcEndpointServiceConfigurationsRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -10594,7 +10594,7 @@ impl DeleteVpcEndpointServiceConfigurationsRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteVpcEndpointServiceConfigurationsResult {
     /// <p>Information about the service configurations that were not deleted, if applicable.</p>
     pub unsuccessful: Option<Vec<UnsuccessfulItem>>,
@@ -10642,7 +10642,7 @@ impl DeleteVpcEndpointServiceConfigurationsResultDeserializer {
     }
 }
 /// <p>Contains the parameters for DeleteVpcEndpoints.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteVpcEndpointsRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -10674,7 +10674,7 @@ impl DeleteVpcEndpointsRequestSerializer {
 }
 
 /// <p>Contains the output of DeleteVpcEndpoints.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteVpcEndpointsResult {
     /// <p>Information about the VPC endpoints that were not successfully deleted.</p>
     pub unsuccessful: Option<Vec<UnsuccessfulItem>>,
@@ -10722,7 +10722,7 @@ impl DeleteVpcEndpointsResultDeserializer {
     }
 }
 /// <p>Contains the parameters for DeleteVpcPeeringConnection.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteVpcPeeringConnectionRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -10753,7 +10753,7 @@ impl DeleteVpcPeeringConnectionRequestSerializer {
 }
 
 /// <p>Contains the output of DeleteVpcPeeringConnection.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteVpcPeeringConnectionResult {
     /// <p>Returns <code>true</code> if the request succeeds; otherwise, it returns an error.</p>
     pub return_: Option<bool>,
@@ -10799,7 +10799,7 @@ impl DeleteVpcPeeringConnectionResultDeserializer {
     }
 }
 /// <p>Contains the parameters for DeleteVpc.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteVpcRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -10830,7 +10830,7 @@ impl DeleteVpcRequestSerializer {
 }
 
 /// <p>Contains the parameters for DeleteVpnConnection.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteVpnConnectionRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -10861,7 +10861,7 @@ impl DeleteVpnConnectionRequestSerializer {
 }
 
 /// <p>Contains the parameters for DeleteVpnConnectionRoute.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteVpnConnectionRouteRequest {
     /// <p>The CIDR block associated with the local subnet of the customer network.</p>
     pub destination_cidr_block: String,
@@ -10890,7 +10890,7 @@ impl DeleteVpnConnectionRouteRequestSerializer {
 }
 
 /// <p>Contains the parameters for DeleteVpnGateway.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteVpnGatewayRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -10921,7 +10921,7 @@ impl DeleteVpnGatewayRequestSerializer {
 }
 
 /// <p>Contains the parameters for DeregisterImage.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeregisterImageRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -10952,7 +10952,7 @@ impl DeregisterImageRequestSerializer {
 }
 
 /// <p>Contains the parameters for DescribeAccountAttributes.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeAccountAttributesRequest {
     /// <p>One or more account attribute names.</p>
     pub attribute_names: Option<Vec<String>>,
@@ -10986,7 +10986,7 @@ impl DescribeAccountAttributesRequestSerializer {
 }
 
 /// <p>Contains the output of DescribeAccountAttributes.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeAccountAttributesResult {
     /// <p>Information about one or more account attributes.</p>
     pub account_attributes: Option<Vec<AccountAttribute>>,
@@ -11036,7 +11036,7 @@ impl DescribeAccountAttributesResultDeserializer {
     }
 }
 /// <p>Contains the parameters for DescribeAddresses.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeAddressesRequest {
     /// <p>[EC2-VPC] One or more allocation IDs.</p> <p>Default: Describes all your Elastic IP addresses.</p>
     pub allocation_ids: Option<Vec<String>>,
@@ -11088,7 +11088,7 @@ impl DescribeAddressesRequestSerializer {
 }
 
 /// <p>Contains the output of DescribeAddresses.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeAddressesResult {
     /// <p>Information about one or more Elastic IP addresses.</p>
     pub addresses: Option<Vec<Address>>,
@@ -11136,7 +11136,7 @@ impl DescribeAddressesResultDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeAggregateIdFormatRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -11160,7 +11160,7 @@ impl DescribeAggregateIdFormatRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeAggregateIdFormatResult {
     /// <p>Information about each resource's ID format.</p>
     pub statuses: Option<Vec<IdFormat>>,
@@ -11217,7 +11217,7 @@ impl DescribeAggregateIdFormatResultDeserializer {
     }
 }
 /// <p>Contains the parameters for DescribeAvailabilityZones.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeAvailabilityZonesRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -11260,7 +11260,7 @@ impl DescribeAvailabilityZonesRequestSerializer {
 }
 
 /// <p>Contains the output of DescribeAvailabiltyZones.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeAvailabilityZonesResult {
     /// <p>Information about one or more Availability Zones.</p>
     pub availability_zones: Option<Vec<AvailabilityZone>>,
@@ -11310,7 +11310,7 @@ impl DescribeAvailabilityZonesResultDeserializer {
     }
 }
 /// <p>Contains the parameters for DescribeBundleTasks.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeBundleTasksRequest {
     /// <p>One or more bundle task IDs.</p> <p>Default: Describes all your bundle tasks.</p>
     pub bundle_ids: Option<Vec<String>>,
@@ -11353,7 +11353,7 @@ impl DescribeBundleTasksRequestSerializer {
 }
 
 /// <p>Contains the output of DescribeBundleTasks.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeBundleTasksResult {
     /// <p>Information about one or more bundle tasks.</p>
     pub bundle_tasks: Option<Vec<BundleTask>>,
@@ -11402,7 +11402,7 @@ impl DescribeBundleTasksResultDeserializer {
     }
 }
 /// <p>Contains the parameters for DescribeClassicLinkInstances.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeClassicLinkInstancesRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -11461,7 +11461,7 @@ impl DescribeClassicLinkInstancesRequestSerializer {
 }
 
 /// <p>Contains the output of DescribeClassicLinkInstances.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeClassicLinkInstancesResult {
     /// <p>Information about one or more linked EC2-Classic instances.</p>
     pub instances: Option<Vec<ClassicLinkInstance>>,
@@ -11555,7 +11555,7 @@ impl DescribeConversionTaskListDeserializer {
     }
 }
 /// <p>Contains the parameters for DescribeConversionTasks.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeConversionTasksRequest {
     /// <p>One or more conversion task IDs.</p>
     pub conversion_task_ids: Option<Vec<String>>,
@@ -11589,7 +11589,7 @@ impl DescribeConversionTasksRequestSerializer {
 }
 
 /// <p>Contains the output for DescribeConversionTasks.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeConversionTasksResult {
     /// <p>Information about the conversion tasks.</p>
     pub conversion_tasks: Option<Vec<ConversionTask>>,
@@ -11639,7 +11639,7 @@ impl DescribeConversionTasksResultDeserializer {
     }
 }
 /// <p>Contains the parameters for DescribeCustomerGateways.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeCustomerGatewaysRequest {
     /// <p>One or more customer gateway IDs.</p> <p>Default: Describes all your customer gateways.</p>
     pub customer_gateway_ids: Option<Vec<String>>,
@@ -11682,7 +11682,7 @@ impl DescribeCustomerGatewaysRequestSerializer {
 }
 
 /// <p>Contains the output of DescribeCustomerGateways.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeCustomerGatewaysResult {
     /// <p>Information about one or more customer gateways.</p>
     pub customer_gateways: Option<Vec<CustomerGateway>>,
@@ -11732,7 +11732,7 @@ impl DescribeCustomerGatewaysResultDeserializer {
     }
 }
 /// <p>Contains the parameters for DescribeDhcpOptions.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeDhcpOptionsRequest {
     /// <p>The IDs of one or more DHCP options sets.</p> <p>Default: Describes all your DHCP options sets.</p>
     pub dhcp_options_ids: Option<Vec<String>>,
@@ -11775,7 +11775,7 @@ impl DescribeDhcpOptionsRequestSerializer {
 }
 
 /// <p>Contains the output of DescribeDhcpOptions.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeDhcpOptionsResult {
     /// <p>Information about one or more DHCP options sets.</p>
     pub dhcp_options: Option<Vec<DhcpOptions>>,
@@ -11823,7 +11823,7 @@ impl DescribeDhcpOptionsResultDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeEgressOnlyInternetGatewaysRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -11872,7 +11872,7 @@ impl DescribeEgressOnlyInternetGatewaysRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeEgressOnlyInternetGatewaysResult {
     /// <p>Information about the egress-only Internet gateways.</p>
     pub egress_only_internet_gateways: Option<Vec<EgressOnlyInternetGateway>>,
@@ -11928,7 +11928,7 @@ impl DescribeEgressOnlyInternetGatewaysResultDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeElasticGpusRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -11986,7 +11986,7 @@ impl DescribeElasticGpusRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeElasticGpusResult {
     /// <p>Information about the Elastic GPUs.</p>
     pub elastic_gpu_set: Option<Vec<ElasticGpus>>,
@@ -12047,7 +12047,7 @@ impl DescribeElasticGpusResultDeserializer {
     }
 }
 /// <p>Contains the parameters for DescribeExportTasks.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeExportTasksRequest {
     /// <p>One or more export task IDs.</p>
     pub export_task_ids: Option<Vec<String>>,
@@ -12073,7 +12073,7 @@ impl DescribeExportTasksRequestSerializer {
 }
 
 /// <p>Contains the output for DescribeExportTasks.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeExportTasksResult {
     /// <p>Information about the export tasks.</p>
     pub export_tasks: Option<Vec<ExportTask>>,
@@ -12122,7 +12122,7 @@ impl DescribeExportTasksResultDeserializer {
     }
 }
 /// <p>Contains the parameters for DescribeFlowLogs.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeFlowLogsRequest {
     /// <p><p>One or more filters.</p> <ul> <li> <p> <code>deliver-log-status</code> - The status of the logs delivery (<code>SUCCESS</code> | <code>FAILED</code>).</p> </li> <li> <p> <code>flow-log-id</code> - The ID of the flow log.</p> </li> <li> <p> <code>log-group-name</code> - The name of the log group.</p> </li> <li> <p> <code>resource-id</code> - The ID of the VPC, subnet, or network interface.</p> </li> <li> <p> <code>traffic-type</code> - The type of traffic (<code>ACCEPT</code> | <code>REJECT</code> | <code>ALL</code>)</p> </li> </ul></p>
     pub filter: Option<Vec<Filter>>,
@@ -12173,7 +12173,7 @@ impl DescribeFlowLogsRequestSerializer {
 }
 
 /// <p>Contains the output of DescribeFlowLogs.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeFlowLogsResult {
     /// <p>Information about the flow logs.</p>
     pub flow_logs: Option<Vec<FlowLog>>,
@@ -12227,7 +12227,7 @@ impl DescribeFlowLogsResultDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeFpgaImageAttributeRequest {
     /// <p>The AFI attribute.</p>
     pub attribute: String,
@@ -12263,7 +12263,7 @@ impl DescribeFpgaImageAttributeRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeFpgaImageAttributeResult {
     /// <p>Information about the attribute.</p>
     pub fpga_image_attribute: Option<FpgaImageAttribute>,
@@ -12312,7 +12312,7 @@ impl DescribeFpgaImageAttributeResultDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeFpgaImagesRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -12379,7 +12379,7 @@ impl DescribeFpgaImagesRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeFpgaImagesResult {
     /// <p>Information about one or more FPGA images.</p>
     pub fpga_images: Option<Vec<FpgaImage>>,
@@ -12433,7 +12433,7 @@ impl DescribeFpgaImagesResultDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeHostReservationOfferingsRequest {
     /// <p><p>One or more filters.</p> <ul> <li> <p> <code>instance-family</code> - The instance family of the offering (e.g., <code>m4</code>).</p> </li> <li> <p> <code>payment-option</code> - The payment option (<code>NoUpfront</code> | <code>PartialUpfront</code> | <code>AllUpfront</code>).</p> </li> </ul></p>
     pub filter: Option<Vec<Filter>>,
@@ -12498,7 +12498,7 @@ impl DescribeHostReservationOfferingsRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeHostReservationOfferingsResult {
     /// <p>The token to use to retrieve the next page of results. This value is <code>null</code> when there are no more results to return.</p>
     pub next_token: Option<String>,
@@ -12552,7 +12552,7 @@ impl DescribeHostReservationOfferingsResultDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeHostReservationsRequest {
     /// <p><p>One or more filters.</p> <ul> <li> <p> <code>instance-family</code> - The instance family (e.g., <code>m4</code>).</p> </li> <li> <p> <code>payment-option</code> - The payment option (<code>NoUpfront</code> | <code>PartialUpfront</code> | <code>AllUpfront</code>).</p> </li> <li> <p> <code>state</code> - The state of the reservation (<code>payment-pending</code> | <code>payment-failed</code> | <code>active</code> | <code>retired</code>).</p> </li> </ul></p>
     pub filter: Option<Vec<Filter>>,
@@ -12602,7 +12602,7 @@ impl DescribeHostReservationsRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeHostReservationsResult {
     /// <p>Details about the reservation's configuration.</p>
     pub host_reservation_set: Option<Vec<HostReservation>>,
@@ -12658,7 +12658,7 @@ impl DescribeHostReservationsResultDeserializer {
     }
 }
 /// <p>Contains the parameters for DescribeHosts.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeHostsRequest {
     /// <p><p>One or more filters.</p> <ul> <li> <p> <code>instance-type</code> - The instance type size that the Dedicated Host is configured to support.</p> </li> <li> <p> <code>auto-placement</code> - Whether auto-placement is enabled or disabled (<code>on</code> | <code>off</code>).</p> </li> <li> <p> <code>host-reservation-id</code> - The ID of the reservation assigned to this host.</p> </li> <li> <p> <code>client-token</code> - The idempotency token you provided when you launched the instance</p> </li> <li> <p> <code>state</code>- The allocation state of the Dedicated Host (<code>available</code> | <code>under-assessment</code> | <code>permanent-failure</code> | <code>released</code> | <code>released-permanent-failure</code>).</p> </li> <li> <p> <code>availability-zone</code> - The Availability Zone of the host.</p> </li> </ul></p>
     pub filter: Option<Vec<Filter>>,
@@ -12709,7 +12709,7 @@ impl DescribeHostsRequestSerializer {
 }
 
 /// <p>Contains the output of DescribeHosts.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeHostsResult {
     /// <p>Information about the Dedicated Hosts.</p>
     pub hosts: Option<Vec<Host>>,
@@ -12760,7 +12760,7 @@ impl DescribeHostsResultDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeIamInstanceProfileAssociationsRequest {
     /// <p>One or more IAM instance profile associations.</p>
     pub association_ids: Option<Vec<String>>,
@@ -12814,7 +12814,7 @@ impl DescribeIamInstanceProfileAssociationsRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeIamInstanceProfileAssociationsResult {
     /// <p>Information about one or more IAM instance profile associations.</p>
     pub iam_instance_profile_associations: Option<Vec<IamInstanceProfileAssociation>>,
@@ -12871,7 +12871,7 @@ impl DescribeIamInstanceProfileAssociationsResultDeserializer {
     }
 }
 /// <p>Contains the parameters for DescribeIdFormat.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeIdFormatRequest {
     /// <p>The type of resource: <code>bundle</code> | <code>conversion-task</code> | <code>customer-gateway</code> | <code>dhcp-options</code> | <code>elastic-ip-allocation</code> | <code>elastic-ip-association</code> | <code>export-task</code> | <code>flow-log</code> | <code>image</code> | <code>import-task</code> | <code>instance</code> | <code>internet-gateway</code> | <code>network-acl</code> | <code>network-acl-association</code> | <code>network-interface</code> | <code>network-interface-attachment</code> | <code>prefix-list</code> | <code>reservation</code> | <code>route-table</code> | <code>route-table-association</code> | <code>security-group</code> | <code>snapshot</code> | <code>subnet</code> | <code>subnet-cidr-block-association</code> | <code>volume</code> | <code>vpc</code> | <code>vpc-cidr-block-association</code> | <code>vpc-endpoint</code> | <code>vpc-peering-connection</code> | <code>vpn-connection</code> | <code>vpn-gateway</code> </p>
     pub resource: Option<String>,
@@ -12896,7 +12896,7 @@ impl DescribeIdFormatRequestSerializer {
 }
 
 /// <p>Contains the output of DescribeIdFormat.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeIdFormatResult {
     /// <p>Information about the ID format for the resource.</p>
     pub statuses: Option<Vec<IdFormat>>,
@@ -12945,7 +12945,7 @@ impl DescribeIdFormatResultDeserializer {
     }
 }
 /// <p>Contains the parameters for DescribeIdentityIdFormat.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeIdentityIdFormatRequest {
     /// <p>The ARN of the principal, which can be an IAM role, IAM user, or the root user.</p>
     pub principal_arn: String,
@@ -12976,7 +12976,7 @@ impl DescribeIdentityIdFormatRequestSerializer {
 }
 
 /// <p>Contains the output of DescribeIdentityIdFormat.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeIdentityIdFormatResult {
     /// <p>Information about the ID format for the resources.</p>
     pub statuses: Option<Vec<IdFormat>>,
@@ -13025,7 +13025,7 @@ impl DescribeIdentityIdFormatResultDeserializer {
     }
 }
 /// <p>Contains the parameters for DescribeImageAttribute.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeImageAttributeRequest {
     /// <p>The AMI attribute.</p> <p> <b>Note</b>: Depending on your account privileges, the <code>blockDeviceMapping</code> attribute may return a <code>Client.AuthFailure</code> error. If this happens, use <a>DescribeImages</a> to get information about the block device mapping for the AMI.</p>
     pub attribute: String,
@@ -13062,7 +13062,7 @@ impl DescribeImageAttributeRequestSerializer {
 }
 
 /// <p>Contains the parameters for DescribeImages.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeImagesRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -13123,7 +13123,7 @@ impl DescribeImagesRequestSerializer {
 }
 
 /// <p>Contains the output of DescribeImages.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeImagesResult {
     /// <p>Information about one or more images.</p>
     pub images: Option<Vec<Image>>,
@@ -13170,7 +13170,7 @@ impl DescribeImagesResultDeserializer {
     }
 }
 /// <p>Contains the parameters for DescribeImportImageTasks.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeImportImageTasksRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -13229,7 +13229,7 @@ impl DescribeImportImageTasksRequestSerializer {
 }
 
 /// <p>Contains the output for DescribeImportImageTasks.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeImportImageTasksResult {
     /// <p>A list of zero or more import image tasks that are currently active or were completed or canceled in the previous 7 days.</p>
     pub import_image_tasks: Option<Vec<ImportImageTask>>,
@@ -13285,7 +13285,7 @@ impl DescribeImportImageTasksResultDeserializer {
     }
 }
 /// <p>Contains the parameters for DescribeImportSnapshotTasks.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeImportSnapshotTasksRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -13344,7 +13344,7 @@ impl DescribeImportSnapshotTasksRequestSerializer {
 }
 
 /// <p>Contains the output for DescribeImportSnapshotTasks.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeImportSnapshotTasksResult {
     /// <p>A list of zero or more import snapshot tasks that are currently active or were completed or canceled in the previous 7 days.</p>
     pub import_snapshot_tasks: Option<Vec<ImportSnapshotTask>>,
@@ -13400,7 +13400,7 @@ impl DescribeImportSnapshotTasksResultDeserializer {
     }
 }
 /// <p>Contains the parameters for DescribeInstanceAttribute.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeInstanceAttributeRequest {
     /// <p>The instance attribute.</p> <p>Note: The <code>enaSupport</code> attribute is not supported at this time.</p>
     pub attribute: String,
@@ -13436,7 +13436,7 @@ impl DescribeInstanceAttributeRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeInstanceCreditSpecificationsRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -13498,7 +13498,7 @@ impl DescribeInstanceCreditSpecificationsRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeInstanceCreditSpecificationsResult {
     /// <p>Information about the credit option for CPU usage of an instance.</p>
     pub instance_credit_specifications: Option<Vec<InstanceCreditSpecification>>,
@@ -13555,7 +13555,7 @@ impl DescribeInstanceCreditSpecificationsResultDeserializer {
     }
 }
 /// <p>Contains the parameters for DescribeInstanceStatus.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeInstanceStatusRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -13622,7 +13622,7 @@ impl DescribeInstanceStatusRequestSerializer {
 }
 
 /// <p>Contains the output of DescribeInstanceStatus.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeInstanceStatusResult {
     /// <p>One or more instance status descriptions.</p>
     pub instance_statuses: Option<Vec<InstanceStatus>>,
@@ -13676,7 +13676,7 @@ impl DescribeInstanceStatusResultDeserializer {
     }
 }
 /// <p>Contains the parameters for DescribeInstances.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeInstancesRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -13735,7 +13735,7 @@ impl DescribeInstancesRequestSerializer {
 }
 
 /// <p>Contains the output of DescribeInstances.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeInstancesResult {
     /// <p>The token to use to retrieve the next page of results. This value is <code>null</code> when there are no more results to return.</p>
     pub next_token: Option<String>,
@@ -13790,7 +13790,7 @@ impl DescribeInstancesResultDeserializer {
     }
 }
 /// <p>Contains the parameters for DescribeInternetGateways.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeInternetGatewaysRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -13833,7 +13833,7 @@ impl DescribeInternetGatewaysRequestSerializer {
 }
 
 /// <p>Contains the output of DescribeInternetGateways.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeInternetGatewaysResult {
     /// <p>Information about one or more Internet gateways.</p>
     pub internet_gateways: Option<Vec<InternetGateway>>,
@@ -13883,7 +13883,7 @@ impl DescribeInternetGatewaysResultDeserializer {
     }
 }
 /// <p>Contains the parameters for DescribeKeyPairs.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeKeyPairsRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -13926,7 +13926,7 @@ impl DescribeKeyPairsRequestSerializer {
 }
 
 /// <p>Contains the output of DescribeKeyPairs.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeKeyPairsResult {
     /// <p>Information about one or more key pairs.</p>
     pub key_pairs: Option<Vec<KeyPairInfo>>,
@@ -13972,7 +13972,7 @@ impl DescribeKeyPairsResultDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeLaunchTemplateVersionsRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -14062,7 +14062,7 @@ impl DescribeLaunchTemplateVersionsRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeLaunchTemplateVersionsResult {
     /// <p>Information about the launch template versions.</p>
     pub launch_template_versions: Option<Vec<LaunchTemplateVersion>>,
@@ -14117,7 +14117,7 @@ impl DescribeLaunchTemplateVersionsResultDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeLaunchTemplatesRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -14184,7 +14184,7 @@ impl DescribeLaunchTemplatesRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeLaunchTemplatesResult {
     /// <p>Information about the launch templates.</p>
     pub launch_templates: Option<Vec<LaunchTemplate>>,
@@ -14238,7 +14238,7 @@ impl DescribeLaunchTemplatesResultDeserializer {
     }
 }
 /// <p>Contains the parameters for DescribeMovingAddresses.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeMovingAddressesRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -14297,7 +14297,7 @@ impl DescribeMovingAddressesRequestSerializer {
 }
 
 /// <p>Contains the output of DescribeMovingAddresses.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeMovingAddressesResult {
     /// <p>The status for each Elastic IP address.</p>
     pub moving_address_statuses: Option<Vec<MovingAddressStatus>>,
@@ -14353,7 +14353,7 @@ impl DescribeMovingAddressesResultDeserializer {
     }
 }
 /// <p>Contains the parameters for DescribeNatGateways.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeNatGatewaysRequest {
     /// <p><p>One or more filters.</p> <ul> <li> <p> <code>nat-gateway-id</code> - The ID of the NAT gateway.</p> </li> <li> <p> <code>state</code> - The state of the NAT gateway (<code>pending</code> | <code>failed</code> | <code>available</code> | <code>deleting</code> | <code>deleted</code>).</p> </li> <li> <p> <code>subnet-id</code> - The ID of the subnet in which the NAT gateway resides.</p> </li> <li> <p> <code>tag</code>:<i>key</i>=<i>value</i> - The key/value combination of a tag assigned to the resource. Specify the key of the tag in the filter name and the value of the tag in the filter value. For example, for the tag Purpose=X, specify <code>tag:Purpose</code> for the filter name and <code>X</code> for the filter value.</p> </li> <li> <p> <code>tag-key</code> - The key of a tag assigned to the resource. This filter is independent of the <code>tag-value</code> filter. For example, if you use both the filter &quot;tag-key=Purpose&quot; and the filter &quot;tag-value=X&quot;, you get any resources assigned both the tag key Purpose (regardless of what the tag&#39;s value is), and the tag value X (regardless of what the tag&#39;s key is). If you want to list only resources where Purpose is X, see the <code>tag</code>:<i>key</i>=<i>value</i> filter.</p> </li> <li> <p> <code>tag-value</code> - The value of a tag assigned to the resource. This filter is independent of the <code>tag-key</code> filter.</p> </li> <li> <p> <code>vpc-id</code> - The ID of the VPC in which the NAT gateway resides.</p> </li> </ul></p>
     pub filter: Option<Vec<Filter>>,
@@ -14404,7 +14404,7 @@ impl DescribeNatGatewaysRequestSerializer {
 }
 
 /// <p>Contains the output of DescribeNatGateways.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeNatGatewaysResult {
     /// <p>Information about the NAT gateways.</p>
     pub nat_gateways: Option<Vec<NatGateway>>,
@@ -14459,7 +14459,7 @@ impl DescribeNatGatewaysResultDeserializer {
     }
 }
 /// <p>Contains the parameters for DescribeNetworkAcls.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeNetworkAclsRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -14502,7 +14502,7 @@ impl DescribeNetworkAclsRequestSerializer {
 }
 
 /// <p>Contains the output of DescribeNetworkAcls.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeNetworkAclsResult {
     /// <p>Information about one or more network ACLs.</p>
     pub network_acls: Option<Vec<NetworkAcl>>,
@@ -14551,7 +14551,7 @@ impl DescribeNetworkAclsResultDeserializer {
     }
 }
 /// <p>Contains the parameters for DescribeNetworkInterfaceAttribute.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeNetworkInterfaceAttributeRequest {
     /// <p>The attribute of the network interface. This parameter is required.</p>
     pub attribute: Option<String>,
@@ -14590,7 +14590,7 @@ impl DescribeNetworkInterfaceAttributeRequestSerializer {
 }
 
 /// <p>Contains the output of DescribeNetworkInterfaceAttribute.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeNetworkInterfaceAttributeResult {
     /// <p>The attachment (if any) of the network interface.</p>
     pub attachment: Option<NetworkInterfaceAttachment>,
@@ -14672,7 +14672,7 @@ impl DescribeNetworkInterfaceAttributeResultDeserializer {
     }
 }
 /// <p>Contains the parameters for DescribeNetworkInterfacePermissions.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeNetworkInterfacePermissionsRequest {
     /// <p><p>One or more filters.</p> <ul> <li> <p> <code>network-interface-permission.network-interface-permission-id</code> - The ID of the permission.</p> </li> <li> <p> <code>network-interface-permission.network-interface-id</code> - The ID of the network interface.</p> </li> <li> <p> <code>network-interface-permission.aws-account-id</code> - The AWS account ID.</p> </li> <li> <p> <code>network-interface-permission.aws-service</code> - The AWS service.</p> </li> <li> <p> <code>network-interface-permission.permission</code> - The type of permission (<code>INSTANCE-ATTACH</code> | <code>EIP-ASSOCIATE</code>).</p> </li> </ul></p>
     pub filters: Option<Vec<Filter>>,
@@ -14727,7 +14727,7 @@ impl DescribeNetworkInterfacePermissionsRequestSerializer {
 }
 
 /// <p>Contains the output for DescribeNetworkInterfacePermissions.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeNetworkInterfacePermissionsResult {
     /// <p>The network interface permissions.</p>
     pub network_interface_permissions: Option<Vec<NetworkInterfacePermission>>,
@@ -14784,7 +14784,7 @@ impl DescribeNetworkInterfacePermissionsResultDeserializer {
     }
 }
 /// <p>Contains the parameters for DescribeNetworkInterfaces.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeNetworkInterfacesRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -14827,7 +14827,7 @@ impl DescribeNetworkInterfacesRequestSerializer {
 }
 
 /// <p>Contains the output of DescribeNetworkInterfaces.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeNetworkInterfacesResult {
     /// <p>Information about one or more network interfaces.</p>
     pub network_interfaces: Option<Vec<NetworkInterface>>,
@@ -14877,7 +14877,7 @@ impl DescribeNetworkInterfacesResultDeserializer {
     }
 }
 /// <p>Contains the parameters for DescribePlacementGroups.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribePlacementGroupsRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -14920,7 +14920,7 @@ impl DescribePlacementGroupsRequestSerializer {
 }
 
 /// <p>Contains the output of DescribePlacementGroups.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribePlacementGroupsResult {
     /// <p>One or more placement groups.</p>
     pub placement_groups: Option<Vec<PlacementGroup>>,
@@ -14968,7 +14968,7 @@ impl DescribePlacementGroupsResultDeserializer {
     }
 }
 /// <p>Contains the parameters for DescribePrefixLists.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribePrefixListsRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -15027,7 +15027,7 @@ impl DescribePrefixListsRequestSerializer {
 }
 
 /// <p>Contains the output of DescribePrefixLists.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribePrefixListsResult {
     /// <p>The token to use when requesting the next set of items. If there are no additional items to return, the string is empty.</p>
     pub next_token: Option<String>,
@@ -15081,7 +15081,7 @@ impl DescribePrefixListsResultDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribePrincipalIdFormatRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -15130,7 +15130,7 @@ impl DescribePrincipalIdFormatRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribePrincipalIdFormatResult {
     /// <p>The token to use to retrieve the next page of results. This value is null when there are no more results to return.</p>
     pub next_token: Option<String>,
@@ -15184,7 +15184,7 @@ impl DescribePrincipalIdFormatResultDeserializer {
     }
 }
 /// <p>Contains the parameters for DescribeRegions.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeRegionsRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -15227,7 +15227,7 @@ impl DescribeRegionsRequestSerializer {
 }
 
 /// <p>Contains the output of DescribeRegions.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeRegionsResult {
     /// <p>Information about one or more regions.</p>
     pub regions: Option<Vec<Region>>,
@@ -15276,7 +15276,7 @@ impl DescribeRegionsResultDeserializer {
     }
 }
 /// <p>Contains the parameters for DescribeReservedInstancesListings.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeReservedInstancesListingsRequest {
     /// <p><p>One or more filters.</p> <ul> <li> <p> <code>reserved-instances-id</code> - The ID of the Reserved Instances.</p> </li> <li> <p> <code>reserved-instances-listing-id</code> - The ID of the Reserved Instances listing.</p> </li> <li> <p> <code>status</code> - The status of the Reserved Instance listing (<code>pending</code> | <code>active</code> | <code>cancelled</code> | <code>closed</code>).</p> </li> <li> <p> <code>status-message</code> - The reason for the status.</p> </li> </ul></p>
     pub filters: Option<Vec<Filter>>,
@@ -15318,7 +15318,7 @@ impl DescribeReservedInstancesListingsRequestSerializer {
 }
 
 /// <p>Contains the output of DescribeReservedInstancesListings.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeReservedInstancesListingsResult {
     /// <p>Information about the Reserved Instance listing.</p>
     pub reserved_instances_listings: Option<Vec<ReservedInstancesListing>>,
@@ -15368,7 +15368,7 @@ impl DescribeReservedInstancesListingsResultDeserializer {
     }
 }
 /// <p>Contains the parameters for DescribeReservedInstancesModifications.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeReservedInstancesModificationsRequest {
     /// <p><p>One or more filters.</p> <ul> <li> <p> <code>client-token</code> - The idempotency token for the modification request.</p> </li> <li> <p> <code>create-date</code> - The time when the modification request was created.</p> </li> <li> <p> <code>effective-date</code> - The time when the modification becomes effective.</p> </li> <li> <p> <code>modification-result.reserved-instances-id</code> - The ID for the Reserved Instances created as part of the modification request. This ID is only available when the status of the modification is <code>fulfilled</code>.</p> </li> <li> <p> <code>modification-result.target-configuration.availability-zone</code> - The Availability Zone for the new Reserved Instances.</p> </li> <li> <p> <code>modification-result.target-configuration.instance-count </code> - The number of new Reserved Instances.</p> </li> <li> <p> <code>modification-result.target-configuration.instance-type</code> - The instance type of the new Reserved Instances.</p> </li> <li> <p> <code>modification-result.target-configuration.platform</code> - The network platform of the new Reserved Instances (<code>EC2-Classic</code> | <code>EC2-VPC</code>).</p> </li> <li> <p> <code>reserved-instances-id</code> - The ID of the Reserved Instances modified.</p> </li> <li> <p> <code>reserved-instances-modification-id</code> - The ID of the modification request.</p> </li> <li> <p> <code>status</code> - The status of the Reserved Instances modification request (<code>processing</code> | <code>fulfilled</code> | <code>failed</code>).</p> </li> <li> <p> <code>status-message</code> - The reason for the status.</p> </li> <li> <p> <code>update-date</code> - The time when the modification request was last updated.</p> </li> </ul></p>
     pub filters: Option<Vec<Filter>>,
@@ -15415,7 +15415,7 @@ impl DescribeReservedInstancesModificationsRequestSerializer {
 }
 
 /// <p>Contains the output of DescribeReservedInstancesModifications.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeReservedInstancesModificationsResult {
     /// <p>The token to use to retrieve the next page of results. This value is <code>null</code> when there are no more results to return.</p>
     pub next_token: Option<String>,
@@ -15472,7 +15472,7 @@ impl DescribeReservedInstancesModificationsResultDeserializer {
     }
 }
 /// <p>Contains the parameters for DescribeReservedInstancesOfferings.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeReservedInstancesOfferingsRequest {
     /// <p>The Availability Zone in which the Reserved Instance can be used.</p>
     pub availability_zone: Option<String>,
@@ -15611,7 +15611,7 @@ impl DescribeReservedInstancesOfferingsRequestSerializer {
 }
 
 /// <p>Contains the output of DescribeReservedInstancesOfferings.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeReservedInstancesOfferingsResult {
     /// <p>The token to use to retrieve the next page of results. This value is <code>null</code> when there are no more results to return.</p>
     pub next_token: Option<String>,
@@ -15668,7 +15668,7 @@ impl DescribeReservedInstancesOfferingsResultDeserializer {
     }
 }
 /// <p>Contains the parameters for DescribeReservedInstances.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeReservedInstancesRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -15727,7 +15727,7 @@ impl DescribeReservedInstancesRequestSerializer {
 }
 
 /// <p>Contains the output for DescribeReservedInstances.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeReservedInstancesResult {
     /// <p>A list of Reserved Instances.</p>
     pub reserved_instances: Option<Vec<ReservedInstances>>,
@@ -15777,7 +15777,7 @@ impl DescribeReservedInstancesResultDeserializer {
     }
 }
 /// <p>Contains the parameters for DescribeRouteTables.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeRouteTablesRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -15820,7 +15820,7 @@ impl DescribeRouteTablesRequestSerializer {
 }
 
 /// <p>Contains the output of DescribeRouteTables.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeRouteTablesResult {
     /// <p>Information about one or more route tables.</p>
     pub route_tables: Option<Vec<RouteTable>>,
@@ -15869,7 +15869,7 @@ impl DescribeRouteTablesResultDeserializer {
     }
 }
 /// <p>Contains the parameters for DescribeScheduledInstanceAvailability.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeScheduledInstanceAvailabilityRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -15953,7 +15953,7 @@ impl DescribeScheduledInstanceAvailabilityRequestSerializer {
 }
 
 /// <p>Contains the output of DescribeScheduledInstanceAvailability.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeScheduledInstanceAvailabilityResult {
     /// <p>The token required to retrieve the next set of results. This value is <code>null</code> when there are no more results to return.</p>
     pub next_token: Option<String>,
@@ -16010,7 +16010,7 @@ impl DescribeScheduledInstanceAvailabilityResultDeserializer {
     }
 }
 /// <p>Contains the parameters for DescribeScheduledInstances.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeScheduledInstancesRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -16078,7 +16078,7 @@ impl DescribeScheduledInstancesRequestSerializer {
 }
 
 /// <p>Contains the output of DescribeScheduledInstances.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeScheduledInstancesResult {
     /// <p>The token required to retrieve the next set of results. This value is <code>null</code> when there are no more results to return.</p>
     pub next_token: Option<String>,
@@ -16133,7 +16133,7 @@ impl DescribeScheduledInstancesResultDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeSecurityGroupReferencesRequest {
     /// <p>Checks whether you have the required permissions for the operation, without actually making the request, and provides an error response. If you have the required permissions, the error response is DryRunOperation. Otherwise, it is UnauthorizedOperation.</p>
     pub dry_run: Option<bool>,
@@ -16160,7 +16160,7 @@ impl DescribeSecurityGroupReferencesRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeSecurityGroupReferencesResult {
     /// <p>Information about the VPCs with the referencing security groups.</p>
     pub security_group_reference_set: Option<Vec<SecurityGroupReference>>,
@@ -16210,7 +16210,7 @@ impl DescribeSecurityGroupReferencesResultDeserializer {
     }
 }
 /// <p>Contains the parameters for DescribeSecurityGroups.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeSecurityGroupsRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -16278,7 +16278,7 @@ impl DescribeSecurityGroupsRequestSerializer {
 }
 
 /// <p>Contains the output of DescribeSecurityGroups.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeSecurityGroupsResult {
     /// <p>The token to use to retrieve the next page of results. This value is <code>null</code> when there are no more results to return.</p>
     pub next_token: Option<String>,
@@ -16332,7 +16332,7 @@ impl DescribeSecurityGroupsResultDeserializer {
     }
 }
 /// <p>Contains the parameters for DescribeSnapshotAttribute.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeSnapshotAttributeRequest {
     /// <p>The snapshot attribute you would like to view.</p>
     pub attribute: String,
@@ -16369,7 +16369,7 @@ impl DescribeSnapshotAttributeRequestSerializer {
 }
 
 /// <p>Contains the output of DescribeSnapshotAttribute.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeSnapshotAttributeResult {
     /// <p>A list of permissions for creating volumes from the snapshot.</p>
     pub create_volume_permissions: Option<Vec<CreateVolumePermission>>,
@@ -16433,7 +16433,7 @@ impl DescribeSnapshotAttributeResultDeserializer {
     }
 }
 /// <p>Contains the parameters for DescribeSnapshots.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeSnapshotsRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -16510,7 +16510,7 @@ impl DescribeSnapshotsRequestSerializer {
 }
 
 /// <p>Contains the output of DescribeSnapshots.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeSnapshotsResult {
     /// <p>The <code>NextToken</code> value to include in a future <code>DescribeSnapshots</code> request. When the results of a <code>DescribeSnapshots</code> request exceed <code>MaxResults</code>, this value can be used to retrieve the next page of results. This value is <code>null</code> when there are no more results to return.</p>
     pub next_token: Option<String>,
@@ -16565,7 +16565,7 @@ impl DescribeSnapshotsResultDeserializer {
     }
 }
 /// <p>Contains the parameters for DescribeSpotDatafeedSubscription.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeSpotDatafeedSubscriptionRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -16590,7 +16590,7 @@ impl DescribeSpotDatafeedSubscriptionRequestSerializer {
 }
 
 /// <p>Contains the output of DescribeSpotDatafeedSubscription.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeSpotDatafeedSubscriptionResult {
     /// <p>The Spot Instance data feed subscription.</p>
     pub spot_datafeed_subscription: Option<SpotDatafeedSubscription>,
@@ -16640,7 +16640,7 @@ impl DescribeSpotDatafeedSubscriptionResultDeserializer {
     }
 }
 /// <p>Contains the parameters for DescribeSpotFleetInstances.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeSpotFleetInstancesRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -16687,7 +16687,7 @@ impl DescribeSpotFleetInstancesRequestSerializer {
 }
 
 /// <p>Contains the output of DescribeSpotFleetInstances.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeSpotFleetInstancesResponse {
     /// <p>The running instances. Note that this list is refreshed periodically and might be out of date.</p>
     pub active_instances: Vec<ActiveInstance>,
@@ -16748,7 +16748,7 @@ impl DescribeSpotFleetInstancesResponseDeserializer {
     }
 }
 /// <p>Contains the parameters for DescribeSpotFleetRequestHistory.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeSpotFleetRequestHistoryRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -16809,7 +16809,7 @@ impl DescribeSpotFleetRequestHistoryRequestSerializer {
 }
 
 /// <p>Contains the output of DescribeSpotFleetRequestHistory.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeSpotFleetRequestHistoryResponse {
     /// <p>Information about the events in the history of the Spot Fleet request.</p>
     pub history_records: Vec<HistoryRecord>,
@@ -16884,7 +16884,7 @@ impl DescribeSpotFleetRequestHistoryResponseDeserializer {
     }
 }
 /// <p>Contains the parameters for DescribeSpotFleetRequests.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeSpotFleetRequestsRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -16934,7 +16934,7 @@ impl DescribeSpotFleetRequestsRequestSerializer {
 }
 
 /// <p>Contains the output of DescribeSpotFleetRequests.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeSpotFleetRequestsResponse {
     /// <p>The token required to retrieve the next set of results. This value is <code>null</code> when there are no more results to return.</p>
     pub next_token: Option<String>,
@@ -16990,7 +16990,7 @@ impl DescribeSpotFleetRequestsResponseDeserializer {
     }
 }
 /// <p>Contains the parameters for DescribeSpotInstanceRequests.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeSpotInstanceRequestsRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -17033,7 +17033,7 @@ impl DescribeSpotInstanceRequestsRequestSerializer {
 }
 
 /// <p>Contains the output of DescribeSpotInstanceRequests.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeSpotInstanceRequestsResult {
     /// <p>One or more Spot Instance requests.</p>
     pub spot_instance_requests: Option<Vec<SpotInstanceRequest>>,
@@ -17083,7 +17083,7 @@ impl DescribeSpotInstanceRequestsResultDeserializer {
     }
 }
 /// <p>Contains the parameters for DescribeSpotPriceHistory.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeSpotPriceHistoryRequest {
     /// <p>Filters the results by the specified Availability Zone.</p>
     pub availability_zone: Option<String>,
@@ -17175,7 +17175,7 @@ impl DescribeSpotPriceHistoryRequestSerializer {
 }
 
 /// <p>Contains the output of DescribeSpotPriceHistory.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeSpotPriceHistoryResult {
     /// <p>The token required to retrieve the next set of results. This value is null or an empty string when there are no more results to return.</p>
     pub next_token: Option<String>,
@@ -17230,7 +17230,7 @@ impl DescribeSpotPriceHistoryResultDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeStaleSecurityGroupsRequest {
     /// <p>Checks whether you have the required permissions for the operation, without actually making the request, and provides an error response. If you have the required permissions, the error response is DryRunOperation. Otherwise, it is UnauthorizedOperation.</p>
     pub dry_run: Option<bool>,
@@ -17276,7 +17276,7 @@ impl DescribeStaleSecurityGroupsRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeStaleSecurityGroupsResult {
     /// <p>The token to use when requesting the next set of items. If there are no additional items to return, the string is empty.</p>
     pub next_token: Option<String>,
@@ -17332,7 +17332,7 @@ impl DescribeStaleSecurityGroupsResultDeserializer {
     }
 }
 /// <p>Contains the parameters for DescribeSubnets.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeSubnetsRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -17375,7 +17375,7 @@ impl DescribeSubnetsRequestSerializer {
 }
 
 /// <p>Contains the output of DescribeSubnets.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeSubnetsResult {
     /// <p>Information about one or more subnets.</p>
     pub subnets: Option<Vec<Subnet>>,
@@ -17424,7 +17424,7 @@ impl DescribeSubnetsResultDeserializer {
     }
 }
 /// <p>Contains the parameters for DescribeTags.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeTagsRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -17474,7 +17474,7 @@ impl DescribeTagsRequestSerializer {
 }
 
 /// <p>Contains the output of DescribeTags.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeTagsResult {
     /// <p>The token to use to retrieve the next page of results. This value is <code>null</code> when there are no more results to return..</p>
     pub next_token: Option<String>,
@@ -17528,7 +17528,7 @@ impl DescribeTagsResultDeserializer {
     }
 }
 /// <p>Contains the parameters for DescribeVolumeAttribute.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeVolumeAttributeRequest {
     /// <p>The attribute of the volume. This parameter is required.</p>
     pub attribute: Option<String>,
@@ -17567,7 +17567,7 @@ impl DescribeVolumeAttributeRequestSerializer {
 }
 
 /// <p>Contains the output of DescribeVolumeAttribute.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeVolumeAttributeResult {
     /// <p>The state of <code>autoEnableIO</code> attribute.</p>
     pub auto_enable_io: Option<AttributeBooleanValue>,
@@ -17629,7 +17629,7 @@ impl DescribeVolumeAttributeResultDeserializer {
     }
 }
 /// <p>Contains the parameters for DescribeVolumeStatus.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeVolumeStatusRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -17688,7 +17688,7 @@ impl DescribeVolumeStatusRequestSerializer {
 }
 
 /// <p>Contains the output of DescribeVolumeStatus.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeVolumeStatusResult {
     /// <p>The token to use to retrieve the next page of results. This value is <code>null</code> when there are no more results to return.</p>
     pub next_token: Option<String>,
@@ -17741,7 +17741,7 @@ impl DescribeVolumeStatusResultDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeVolumesModificationsRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -17799,7 +17799,7 @@ impl DescribeVolumesModificationsRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeVolumesModificationsResult {
     /// <p>Token for pagination, null if there are no more results </p>
     pub next_token: Option<String>,
@@ -17855,7 +17855,7 @@ impl DescribeVolumesModificationsResultDeserializer {
     }
 }
 /// <p>Contains the parameters for DescribeVolumes.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeVolumesRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -17914,7 +17914,7 @@ impl DescribeVolumesRequestSerializer {
 }
 
 /// <p>Contains the output of DescribeVolumes.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeVolumesResult {
     /// <p>The <code>NextToken</code> value to include in a future <code>DescribeVolumes</code> request. When the results of a <code>DescribeVolumes</code> request exceed <code>MaxResults</code>, this value can be used to retrieve the next page of results. This value is <code>null</code> when there are no more results to return.</p>
     pub next_token: Option<String>,
@@ -17969,7 +17969,7 @@ impl DescribeVolumesResultDeserializer {
     }
 }
 /// <p>Contains the parameters for DescribeVpcAttribute.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeVpcAttributeRequest {
     /// <p>The VPC attribute.</p>
     pub attribute: String,
@@ -18006,7 +18006,7 @@ impl DescribeVpcAttributeRequestSerializer {
 }
 
 /// <p>Contains the output of DescribeVpcAttribute.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeVpcAttributeResult {
     /// <p>Indicates whether the instances launched in the VPC get DNS hostnames. If this attribute is <code>true</code>, instances in the VPC get DNS hostnames; otherwise, they do not.</p>
     pub enable_dns_hostnames: Option<AttributeBooleanValue>,
@@ -18070,7 +18070,7 @@ impl DescribeVpcAttributeResultDeserializer {
     }
 }
 /// <p>Contains the parameters for DescribeVpcClassicLinkDnsSupport.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeVpcClassicLinkDnsSupportRequest {
     /// <p>The maximum number of items to return for this request. The request returns a token that you can specify in a subsequent call to get the next set of results.</p>
     pub max_results: Option<i64>,
@@ -18112,7 +18112,7 @@ impl DescribeVpcClassicLinkDnsSupportRequestSerializer {
 }
 
 /// <p>Contains the output of DescribeVpcClassicLinkDnsSupport.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeVpcClassicLinkDnsSupportResult {
     /// <p>The token to use when requesting the next set of items.</p>
     pub next_token: Option<String>,
@@ -18166,7 +18166,7 @@ impl DescribeVpcClassicLinkDnsSupportResultDeserializer {
     }
 }
 /// <p>Contains the parameters for DescribeVpcClassicLink.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeVpcClassicLinkRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -18209,7 +18209,7 @@ impl DescribeVpcClassicLinkRequestSerializer {
 }
 
 /// <p>Contains the output of DescribeVpcClassicLink.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeVpcClassicLinkResult {
     /// <p>The ClassicLink status of one or more VPCs.</p>
     pub vpcs: Option<Vec<VpcClassicLink>>,
@@ -18256,7 +18256,7 @@ impl DescribeVpcClassicLinkResultDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeVpcEndpointConnectionNotificationsRequest {
     /// <p>The ID of the notification.</p>
     pub connection_notification_id: Option<String>,
@@ -18317,7 +18317,7 @@ impl DescribeVpcEndpointConnectionNotificationsRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeVpcEndpointConnectionNotificationsResult {
     /// <p>One or more notifications.</p>
     pub connection_notification_set: Option<Vec<ConnectionNotification>>,
@@ -18372,7 +18372,7 @@ impl DescribeVpcEndpointConnectionNotificationsResultDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeVpcEndpointConnectionsRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -18421,7 +18421,7 @@ impl DescribeVpcEndpointConnectionsRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeVpcEndpointConnectionsResult {
     /// <p>The token to use to retrieve the next page of results. This value is <code>null</code> when there are no more results to return.</p>
     pub next_token: Option<String>,
@@ -18476,7 +18476,7 @@ impl DescribeVpcEndpointConnectionsResultDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeVpcEndpointServiceConfigurationsRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -18538,7 +18538,7 @@ impl DescribeVpcEndpointServiceConfigurationsRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeVpcEndpointServiceConfigurationsResult {
     /// <p>The token to use to retrieve the next page of results. This value is <code>null</code> when there are no more results to return.</p>
     pub next_token: Option<String>,
@@ -18593,7 +18593,7 @@ impl DescribeVpcEndpointServiceConfigurationsResultDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeVpcEndpointServicePermissionsRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -18652,7 +18652,7 @@ impl DescribeVpcEndpointServicePermissionsRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeVpcEndpointServicePermissionsResult {
     /// <p>Information about one or more allowed principals.</p>
     pub allowed_principals: Option<Vec<AllowedPrincipal>>,
@@ -18708,7 +18708,7 @@ impl DescribeVpcEndpointServicePermissionsResultDeserializer {
     }
 }
 /// <p>Contains the parameters for DescribeVpcEndpointServices.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeVpcEndpointServicesRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -18767,7 +18767,7 @@ impl DescribeVpcEndpointServicesRequestSerializer {
 }
 
 /// <p>Contains the output of DescribeVpcEndpointServices.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeVpcEndpointServicesResult {
     /// <p>The token to use when requesting the next set of items. If there are no additional items to return, the string is empty.</p>
     pub next_token: Option<String>,
@@ -18829,7 +18829,7 @@ impl DescribeVpcEndpointServicesResultDeserializer {
     }
 }
 /// <p>Contains the parameters for DescribeVpcEndpoints.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeVpcEndpointsRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -18888,7 +18888,7 @@ impl DescribeVpcEndpointsRequestSerializer {
 }
 
 /// <p>Contains the output of DescribeVpcEndpoints.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeVpcEndpointsResult {
     /// <p>The token to use when requesting the next set of items. If there are no additional items to return, the string is empty.</p>
     pub next_token: Option<String>,
@@ -18943,7 +18943,7 @@ impl DescribeVpcEndpointsResultDeserializer {
     }
 }
 /// <p>Contains the parameters for DescribeVpcPeeringConnections.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeVpcPeeringConnectionsRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -18986,7 +18986,7 @@ impl DescribeVpcPeeringConnectionsRequestSerializer {
 }
 
 /// <p>Contains the output of DescribeVpcPeeringConnections.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeVpcPeeringConnectionsResult {
     /// <p>Information about the VPC peering connections.</p>
     pub vpc_peering_connections: Option<Vec<VpcPeeringConnection>>,
@@ -19036,7 +19036,7 @@ impl DescribeVpcPeeringConnectionsResultDeserializer {
     }
 }
 /// <p>Contains the parameters for DescribeVpcs.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeVpcsRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -19079,7 +19079,7 @@ impl DescribeVpcsRequestSerializer {
 }
 
 /// <p>Contains the output of DescribeVpcs.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeVpcsResult {
     /// <p>Information about one or more VPCs.</p>
     pub vpcs: Option<Vec<Vpc>>,
@@ -19125,7 +19125,7 @@ impl DescribeVpcsResultDeserializer {
     }
 }
 /// <p>Contains the parameters for DescribeVpnConnections.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeVpnConnectionsRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -19168,7 +19168,7 @@ impl DescribeVpnConnectionsRequestSerializer {
 }
 
 /// <p>Contains the output of DescribeVpnConnections.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeVpnConnectionsResult {
     /// <p>Information about one or more VPN connections.</p>
     pub vpn_connections: Option<Vec<VpnConnection>>,
@@ -19216,7 +19216,7 @@ impl DescribeVpnConnectionsResultDeserializer {
     }
 }
 /// <p>Contains the parameters for DescribeVpnGateways.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeVpnGatewaysRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -19259,7 +19259,7 @@ impl DescribeVpnGatewaysRequestSerializer {
 }
 
 /// <p>Contains the output of DescribeVpnGateways.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeVpnGatewaysResult {
     /// <p>Information about one or more virtual private gateways.</p>
     pub vpn_gateways: Option<Vec<VpnGateway>>,
@@ -19308,7 +19308,7 @@ impl DescribeVpnGatewaysResultDeserializer {
     }
 }
 /// <p>Contains the parameters for DetachClassicLinkVpc.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DetachClassicLinkVpcRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -19345,7 +19345,7 @@ impl DetachClassicLinkVpcRequestSerializer {
 }
 
 /// <p>Contains the output of DetachClassicLinkVpc.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DetachClassicLinkVpcResult {
     /// <p>Returns <code>true</code> if the request succeeds; otherwise, it returns an error.</p>
     pub return_: Option<bool>,
@@ -19391,7 +19391,7 @@ impl DetachClassicLinkVpcResultDeserializer {
     }
 }
 /// <p>Contains the parameters for DetachInternetGateway.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DetachInternetGatewayRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -19428,7 +19428,7 @@ impl DetachInternetGatewayRequestSerializer {
 }
 
 /// <p>Contains the parameters for DetachNetworkInterface.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DetachNetworkInterfaceRequest {
     /// <p>The ID of the attachment.</p>
     pub attachment_id: String,
@@ -19467,7 +19467,7 @@ impl DetachNetworkInterfaceRequestSerializer {
 }
 
 /// <p>Contains the parameters for DetachVolume.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DetachVolumeRequest {
     /// <p>The device name.</p>
     pub device: Option<String>,
@@ -19522,7 +19522,7 @@ impl DetachVolumeRequestSerializer {
 }
 
 /// <p>Contains the parameters for DetachVpnGateway.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DetachVpnGatewayRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -19573,7 +19573,7 @@ impl DeviceTypeDeserializer {
     }
 }
 /// <p>Describes a DHCP configuration option.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DhcpConfiguration {
     /// <p>The name of a DHCP option.</p>
     pub key: Option<String>,
@@ -19708,7 +19708,7 @@ impl DhcpConfigurationValueListDeserializer {
     }
 }
 /// <p>Describes a set of DHCP options.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DhcpOptions {
     /// <p>One or more DHCP options in the set.</p>
     pub dhcp_configurations: Option<Vec<DhcpConfiguration>>,
@@ -19823,7 +19823,7 @@ impl DhcpOptionsListDeserializer {
     }
 }
 /// <p>Contains the parameters for DisableVgwRoutePropagation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DisableVgwRoutePropagationRequest {
     /// <p>The ID of the virtual private gateway.</p>
     pub gateway_id: String,
@@ -19852,7 +19852,7 @@ impl DisableVgwRoutePropagationRequestSerializer {
 }
 
 /// <p>Contains the parameters for DisableVpcClassicLinkDnsSupport.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DisableVpcClassicLinkDnsSupportRequest {
     /// <p>The ID of the VPC.</p>
     pub vpc_id: Option<String>,
@@ -19877,7 +19877,7 @@ impl DisableVpcClassicLinkDnsSupportRequestSerializer {
 }
 
 /// <p>Contains the output of DisableVpcClassicLinkDnsSupport.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DisableVpcClassicLinkDnsSupportResult {
     /// <p>Returns <code>true</code> if the request succeeds; otherwise, it returns an error.</p>
     pub return_: Option<bool>,
@@ -19923,7 +19923,7 @@ impl DisableVpcClassicLinkDnsSupportResultDeserializer {
     }
 }
 /// <p>Contains the parameters for DisableVpcClassicLink.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DisableVpcClassicLinkRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -19954,7 +19954,7 @@ impl DisableVpcClassicLinkRequestSerializer {
 }
 
 /// <p>Contains the output of DisableVpcClassicLink.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DisableVpcClassicLinkResult {
     /// <p>Returns <code>true</code> if the request succeeds; otherwise, it returns an error.</p>
     pub return_: Option<bool>,
@@ -20000,7 +20000,7 @@ impl DisableVpcClassicLinkResultDeserializer {
     }
 }
 /// <p>Contains the parameters for DisassociateAddress.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DisassociateAddressRequest {
     /// <p>[EC2-VPC] The association ID. Required for EC2-VPC.</p>
     pub association_id: Option<String>,
@@ -20040,7 +20040,7 @@ impl DisassociateAddressRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DisassociateIamInstanceProfileRequest {
     /// <p>The ID of the IAM instance profile association.</p>
     pub association_id: String,
@@ -20062,7 +20062,7 @@ impl DisassociateIamInstanceProfileRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DisassociateIamInstanceProfileResult {
     /// <p>Information about the IAM instance profile association.</p>
     pub iam_instance_profile_association: Option<IamInstanceProfileAssociation>,
@@ -20113,7 +20113,7 @@ impl DisassociateIamInstanceProfileResultDeserializer {
     }
 }
 /// <p>Contains the parameters for DisassociateRouteTable.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DisassociateRouteTableRequest {
     /// <p>The association ID representing the current association between the route table and subnet.</p>
     pub association_id: String,
@@ -20143,7 +20143,7 @@ impl DisassociateRouteTableRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DisassociateSubnetCidrBlockRequest {
     /// <p>The association ID for the CIDR block.</p>
     pub association_id: String,
@@ -20165,7 +20165,7 @@ impl DisassociateSubnetCidrBlockRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DisassociateSubnetCidrBlockResult {
     /// <p>Information about the IPv6 CIDR block association.</p>
     pub ipv_6_cidr_block_association: Option<SubnetIpv6CidrBlockAssociation>,
@@ -20221,7 +20221,7 @@ impl DisassociateSubnetCidrBlockResultDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DisassociateVpcCidrBlockRequest {
     /// <p>The association ID for the CIDR block.</p>
     pub association_id: String,
@@ -20243,7 +20243,7 @@ impl DisassociateVpcCidrBlockRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DisassociateVpcCidrBlockResult {
     /// <p>Information about the IPv4 CIDR block association.</p>
     pub cidr_block_association: Option<VpcCidrBlockAssociation>,
@@ -20307,7 +20307,7 @@ impl DisassociateVpcCidrBlockResultDeserializer {
     }
 }
 /// <p>Describes a disk image.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DiskImage {
     /// <p>A description of the disk image.</p>
     pub description: Option<String>,
@@ -20350,7 +20350,7 @@ impl DiskImageSerializer {
 }
 
 /// <p>Describes a disk image.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DiskImageDescription {
     /// <p>The checksum computed for the disk image.</p>
     pub checksum: Option<String>,
@@ -20414,7 +20414,7 @@ impl DiskImageDescriptionDeserializer {
     }
 }
 /// <p>Describes a disk image.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DiskImageDetail {
     /// <p>The size of the disk image, in GiB.</p>
     pub bytes: i64,
@@ -20475,7 +20475,7 @@ impl DiskImageListSerializer {
 }
 
 /// <p>Describes a disk image volume.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DiskImageVolumeDescription {
     /// <p>The volume identifier.</p>
     pub id: String,
@@ -20526,7 +20526,7 @@ impl DiskImageVolumeDescriptionDeserializer {
     }
 }
 /// <p>Describes a DNS entry.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DnsEntry {
     /// <p>The DNS name.</p>
     pub dns_name: Option<String>,
@@ -20647,7 +20647,7 @@ impl DoubleDeserializer {
     }
 }
 /// <p>Describes a block device for an EBS volume.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct EbsBlockDevice {
     /// <p>Indicates whether the EBS volume is deleted on instance termination.</p>
     pub delete_on_termination: Option<bool>,
@@ -20788,7 +20788,7 @@ impl EbsBlockDeviceSerializer {
 }
 
 /// <p>Describes a parameter used to set up an EBS volume in a block device mapping.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct EbsInstanceBlockDevice {
     /// <p>The time stamp when the attachment initiated.</p>
     pub attach_time: Option<String>,
@@ -20856,7 +20856,7 @@ impl EbsInstanceBlockDeviceDeserializer {
     }
 }
 /// <p>Describes information used to set up an EBS volume specified in a block device mapping.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct EbsInstanceBlockDeviceSpecification {
     /// <p>Indicates whether the volume is deleted on instance termination.</p>
     pub delete_on_termination: Option<bool>,
@@ -20889,7 +20889,7 @@ impl EbsInstanceBlockDeviceSpecificationSerializer {
 }
 
 /// <p>Describes an egress-only Internet gateway.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct EgressOnlyInternetGateway {
     /// <p>Information about the attachment of the egress-only Internet gateway.</p>
     pub attachments: Option<Vec<InternetGatewayAttachment>>,
@@ -21017,7 +21017,7 @@ impl EgressOnlyInternetGatewayListDeserializer {
     }
 }
 /// <p>Describes the association between an instance and an Elastic GPU.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ElasticGpuAssociation {
     /// <p>The ID of the association.</p>
     pub elastic_gpu_association_id: Option<String>,
@@ -21127,7 +21127,7 @@ impl ElasticGpuAssociationListDeserializer {
     }
 }
 /// <p>Describes the status of an Elastic GPU.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ElasticGpuHealth {
     /// <p>The health status.</p>
     pub status: Option<String>,
@@ -21227,7 +21227,7 @@ impl ElasticGpuSetDeserializer {
     }
 }
 /// <p>A specification for an Elastic GPU.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ElasticGpuSpecification {
     /// <p>The type of Elastic GPU.</p>
     pub type_: String,
@@ -21261,7 +21261,7 @@ impl ElasticGpuSpecificationListSerializer {
 }
 
 /// <p>Describes an elastic GPU.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ElasticGpuSpecificationResponse {
     /// <p>The elastic GPU type.</p>
     pub type_: Option<String>,
@@ -21389,7 +21389,7 @@ impl ElasticGpuStatusDeserializer {
     }
 }
 /// <p>Describes an Elastic GPU.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ElasticGpus {
     /// <p>The Availability Zone in the which the Elastic GPU resides.</p>
     pub availability_zone: Option<String>,
@@ -21472,7 +21472,7 @@ impl ElasticGpusDeserializer {
     }
 }
 /// <p>Contains the parameters for EnableVgwRoutePropagation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct EnableVgwRoutePropagationRequest {
     /// <p>The ID of the virtual private gateway.</p>
     pub gateway_id: String,
@@ -21501,7 +21501,7 @@ impl EnableVgwRoutePropagationRequestSerializer {
 }
 
 /// <p>Contains the parameters for EnableVolumeIO.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct EnableVolumeIORequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -21532,7 +21532,7 @@ impl EnableVolumeIORequestSerializer {
 }
 
 /// <p>Contains the parameters for EnableVpcClassicLinkDnsSupport.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct EnableVpcClassicLinkDnsSupportRequest {
     /// <p>The ID of the VPC.</p>
     pub vpc_id: Option<String>,
@@ -21557,7 +21557,7 @@ impl EnableVpcClassicLinkDnsSupportRequestSerializer {
 }
 
 /// <p>Contains the output of EnableVpcClassicLinkDnsSupport.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct EnableVpcClassicLinkDnsSupportResult {
     /// <p>Returns <code>true</code> if the request succeeds; otherwise, it returns an error.</p>
     pub return_: Option<bool>,
@@ -21603,7 +21603,7 @@ impl EnableVpcClassicLinkDnsSupportResultDeserializer {
     }
 }
 /// <p>Contains the parameters for EnableVpcClassicLink.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct EnableVpcClassicLinkRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -21634,7 +21634,7 @@ impl EnableVpcClassicLinkRequestSerializer {
 }
 
 /// <p>Contains the output of EnableVpcClassicLink.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct EnableVpcClassicLinkResult {
     /// <p>Returns <code>true</code> if the request succeeds; otherwise, it returns an error.</p>
     pub return_: Option<bool>,
@@ -21694,7 +21694,7 @@ impl EventCodeDeserializer {
     }
 }
 /// <p>Describes a Spot Fleet event.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct EventInformation {
     /// <p>The description of the event.</p>
     pub event_description: Option<String>,
@@ -21809,7 +21809,7 @@ impl ExportEnvironmentDeserializer {
     }
 }
 /// <p>Describes an instance export task.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ExportTask {
     /// <p>A description of the resource being exported.</p>
     pub description: Option<String>,
@@ -21957,7 +21957,7 @@ impl ExportTaskStateDeserializer {
     }
 }
 /// <p>Describes the format and location for an instance export task.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ExportToS3Task {
     /// <p>The container format used to combine disk images with metadata (such as OVF). If absent, only the disk image is exported.</p>
     pub container_format: Option<String>,
@@ -22023,7 +22023,7 @@ impl ExportToS3TaskDeserializer {
     }
 }
 /// <p>Describes an instance export task.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ExportToS3TaskSpecification {
     /// <p>The container format used to combine disk images with metadata (such as OVF). If absent, only the disk image is exported.</p>
     pub container_format: Option<String>,
@@ -22072,7 +22072,7 @@ impl ExportToS3TaskSpecificationSerializer {
 }
 
 /// <p>A filter name and value pair that is used to return a more specific list of results. Filters can be used to match a set of resources by various criteria, such as tags, attributes, or IDs.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Filter {
     /// <p>The name of the filter. Filter names are case-sensitive.</p>
     pub name: Option<String>,
@@ -22117,7 +22117,7 @@ impl FilterListSerializer {
 }
 
 /// <p>Describes a launch template.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct FleetLaunchTemplateSpecification {
     /// <p>The ID of the launch template. You must specify either a template ID or a template name.</p>
     pub launch_template_id: Option<String>,
@@ -22239,7 +22239,7 @@ impl FloatDeserializer {
     }
 }
 /// <p>Describes a flow log.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct FlowLog {
     /// <p>The date and time the flow log was created.</p>
     pub creation_time: Option<String>,
@@ -22384,7 +22384,7 @@ impl FlowLogSetDeserializer {
     }
 }
 /// <p>Describes an Amazon FPGA image (AFI).</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct FpgaImage {
     /// <p>The date and time the AFI was created.</p>
     pub create_time: Option<String>,
@@ -22510,7 +22510,7 @@ impl FpgaImageDeserializer {
     }
 }
 /// <p>Describes an Amazon FPGA image (AFI) attribute.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct FpgaImageAttribute {
     /// <p>The description of the AFI.</p>
     pub description: Option<String>,
@@ -22635,7 +22635,7 @@ impl FpgaImageListDeserializer {
     }
 }
 /// <p>Describes the state of the bitstream generation process for an Amazon FPGA image (AFI).</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct FpgaImageState {
     /// <p><p>The state. The following are the possible values:</p> <ul> <li> <p> <code>pending</code> - AFI bitstream generation is in progress.</p> </li> <li> <p> <code>available</code> - The AFI is available for use.</p> </li> <li> <p> <code>failed</code> - AFI bitstream generation failed.</p> </li> <li> <p> <code>unavailable</code> - The AFI is no longer available for use.</p> </li> </ul></p>
     pub code: Option<String>,
@@ -22716,7 +22716,7 @@ impl GatewayTypeDeserializer {
     }
 }
 /// <p>Contains the parameters for GetConsoleOutput.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetConsoleOutputRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -22747,7 +22747,7 @@ impl GetConsoleOutputRequestSerializer {
 }
 
 /// <p>Contains the output of GetConsoleOutput.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetConsoleOutputResult {
     /// <p>The ID of the instance.</p>
     pub instance_id: Option<String>,
@@ -22805,7 +22805,7 @@ impl GetConsoleOutputResultDeserializer {
     }
 }
 /// <p>Contains the parameters for the request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetConsoleScreenshotRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -22844,7 +22844,7 @@ impl GetConsoleScreenshotRequestSerializer {
 }
 
 /// <p>Contains the output of the request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetConsoleScreenshotResult {
     /// <p>The data that comprises the image.</p>
     pub image_data: Option<String>,
@@ -22896,7 +22896,7 @@ impl GetConsoleScreenshotResultDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetHostReservationPurchasePreviewRequest {
     /// <p>The ID/s of the Dedicated Host/s that the reservation will be associated with.</p>
     pub host_id_set: Vec<String>,
@@ -22925,7 +22925,7 @@ impl GetHostReservationPurchasePreviewRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetHostReservationPurchasePreviewResult {
     /// <p>The currency in which the <code>totalUpfrontPrice</code> and <code>totalHourlyPrice</code> amounts are specified. At this time, the only supported currency is <code>USD</code>.</p>
     pub currency_code: Option<String>,
@@ -22995,7 +22995,7 @@ impl GetHostReservationPurchasePreviewResultDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetLaunchTemplateDataRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -23025,7 +23025,7 @@ impl GetLaunchTemplateDataRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetLaunchTemplateDataResult {
     /// <p>The instance data.</p>
     pub launch_template_data: Option<ResponseLaunchTemplateData>,
@@ -23075,7 +23075,7 @@ impl GetLaunchTemplateDataResultDeserializer {
     }
 }
 /// <p>Contains the parameters for GetPasswordData.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetPasswordDataRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -23106,7 +23106,7 @@ impl GetPasswordDataRequestSerializer {
 }
 
 /// <p>Contains the output of GetPasswordData.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetPasswordDataResult {
     /// <p>The ID of the Windows instance.</p>
     pub instance_id: Option<String>,
@@ -23165,7 +23165,7 @@ impl GetPasswordDataResultDeserializer {
     }
 }
 /// <p>Contains the parameters for GetReservedInstanceExchangeQuote.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetReservedInstancesExchangeQuoteRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -23206,7 +23206,7 @@ impl GetReservedInstancesExchangeQuoteRequestSerializer {
 }
 
 /// <p>Contains the output of GetReservedInstancesExchangeQuote.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetReservedInstancesExchangeQuoteResult {
     /// <p>The currency of the transaction.</p>
     pub currency_code: Option<String>,
@@ -23372,7 +23372,7 @@ impl GroupIdStringListSerializer {
 }
 
 /// <p>Describes a security group.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GroupIdentifier {
     /// <p>The ID of the security group.</p>
     pub group_id: Option<String>,
@@ -23569,7 +23569,7 @@ impl GroupNameStringListSerializer {
 }
 
 /// <p>Describes an event in the history of the Spot Fleet request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct HistoryRecord {
     /// <p>Information about the event.</p>
     pub event_information: EventInformation,
@@ -23669,7 +23669,7 @@ impl HistoryRecordsDeserializer {
     }
 }
 /// <p>Describes the properties of the Dedicated Host.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Host {
     /// <p>Whether auto-placement is on or off.</p>
     pub auto_placement: Option<String>,
@@ -23775,7 +23775,7 @@ impl HostDeserializer {
     }
 }
 /// <p>Describes an instance running on a Dedicated Host.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct HostInstance {
     /// <p>the IDs of instances that are running on the Dedicated Host.</p>
     pub instance_id: Option<String>,
@@ -23908,7 +23908,7 @@ impl HostListDeserializer {
     }
 }
 /// <p>Details about the Dedicated Host Reservation offering.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct HostOffering {
     /// <p>The currency of the offering.</p>
     pub currency_code: Option<String>,
@@ -24036,7 +24036,7 @@ impl HostOfferingSetDeserializer {
     }
 }
 /// <p>Describes properties of a Dedicated Host.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct HostProperties {
     /// <p>The number of cores on the Dedicated Host.</p>
     pub cores: Option<i64>,
@@ -24100,7 +24100,7 @@ impl HostPropertiesDeserializer {
     }
 }
 /// <p>Details about the Dedicated Host Reservation and associated Dedicated Hosts.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct HostReservation {
     /// <p>The number of Dedicated Hosts the reservation is associated with.</p>
     pub count: Option<i64>,
@@ -24294,7 +24294,7 @@ impl HypervisorTypeDeserializer {
     }
 }
 /// <p>Describes an IAM instance profile.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct IamInstanceProfile {
     /// <p>The Amazon Resource Name (ARN) of the instance profile.</p>
     pub arn: Option<String>,
@@ -24345,7 +24345,7 @@ impl IamInstanceProfileDeserializer {
     }
 }
 /// <p>Describes an association between an IAM instance profile and an instance.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct IamInstanceProfileAssociation {
     /// <p>The ID of the association.</p>
     pub association_id: Option<String>,
@@ -24480,7 +24480,7 @@ impl IamInstanceProfileAssociationStateDeserializer {
     }
 }
 /// <p>Describes an IAM instance profile.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct IamInstanceProfileSpecification {
     /// <p>The Amazon Resource Name (ARN) of the instance profile.</p>
     pub arn: Option<String>,
@@ -24556,7 +24556,7 @@ impl IamInstanceProfileSpecificationSerializer {
 }
 
 /// <p>Describes the ICMP type and code.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct IcmpTypeCode {
     /// <p>The ICMP code. A value of -1 means all codes for the specified ICMP type.</p>
     pub code: Option<i64>,
@@ -24632,7 +24632,7 @@ impl IcmpTypeCodeSerializer {
 }
 
 /// <p>Describes the ID format for a resource.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct IdFormat {
     /// <p>The date in UTC at which you are permanently switched over to using longer IDs. If a deadline is not yet available for this resource type, this field is not returned.</p>
     pub deadline: Option<String>,
@@ -24731,7 +24731,7 @@ impl IdFormatListDeserializer {
     }
 }
 /// <p>Describes an image.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Image {
     /// <p>The architecture of the image.</p>
     pub architecture: Option<String>,
@@ -24943,7 +24943,7 @@ impl ImageDeserializer {
     }
 }
 /// <p>Describes an image attribute.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ImageAttribute {
     /// <p>One or more block device mapping entries.</p>
     pub block_device_mappings: Option<Vec<BlockDeviceMapping>>,
@@ -25045,7 +25045,7 @@ impl ImageAttributeDeserializer {
     }
 }
 /// <p>Describes the disk container object for an import image task.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ImageDiskContainer {
     /// <p>The description of the disk image.</p>
     pub description: Option<String>,
@@ -25201,7 +25201,7 @@ impl ImageTypeValuesDeserializer {
     }
 }
 /// <p>Contains the parameters for ImportImage.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ImportImageRequest {
     /// <p>The architecture of the virtual machine.</p> <p>Valid values: <code>i386</code> | <code>x86_64</code> </p>
     pub architecture: Option<String>,
@@ -25300,7 +25300,7 @@ impl ImportImageRequestSerializer {
 }
 
 /// <p>Contains the output for ImportImage.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ImportImageResult {
     /// <p>The architecture of the virtual machine.</p>
     pub architecture: Option<String>,
@@ -25409,7 +25409,7 @@ impl ImportImageResultDeserializer {
     }
 }
 /// <p>Describes an import image task.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ImportImageTask {
     /// <p>The architecture of the virtual machine.</p> <p>Valid values: <code>i386</code> | <code>x86_64</code> </p>
     pub architecture: Option<String>,
@@ -25560,7 +25560,7 @@ impl ImportImageTaskListDeserializer {
     }
 }
 /// <p>Describes the launch specification for VM import.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ImportInstanceLaunchSpecification {
     /// <p>Reserved.</p>
     pub additional_info: Option<String>,
@@ -25669,7 +25669,7 @@ impl ImportInstanceLaunchSpecificationSerializer {
 }
 
 /// <p>Contains the parameters for ImportInstance.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ImportInstanceRequest {
     /// <p>A description for the instance being imported.</p>
     pub description: Option<String>,
@@ -25726,7 +25726,7 @@ impl ImportInstanceRequestSerializer {
 }
 
 /// <p>Contains the output for ImportInstance.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ImportInstanceResult {
     /// <p>Information about the conversion task.</p>
     pub conversion_task: Option<ConversionTask>,
@@ -25775,7 +25775,7 @@ impl ImportInstanceResultDeserializer {
     }
 }
 /// <p>Describes an import instance task.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ImportInstanceTaskDetails {
     /// <p>A description of the task.</p>
     pub description: Option<String>,
@@ -25842,7 +25842,7 @@ impl ImportInstanceTaskDetailsDeserializer {
     }
 }
 /// <p>Describes an import volume task.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ImportInstanceVolumeDetailItem {
     /// <p>The Availability Zone where the resulting instance will reside.</p>
     pub availability_zone: String,
@@ -25970,7 +25970,7 @@ impl ImportInstanceVolumeDetailSetDeserializer {
     }
 }
 /// <p>Contains the parameters for ImportKeyPair.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ImportKeyPairRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -26009,7 +26009,7 @@ impl ImportKeyPairRequestSerializer {
 }
 
 /// <p>Contains the output of ImportKeyPair.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ImportKeyPairResult {
     /// <p>The MD5 public key fingerprint as specified in section 4 of RFC 4716.</p>
     pub key_fingerprint: Option<String>,
@@ -26064,7 +26064,7 @@ impl ImportKeyPairResultDeserializer {
     }
 }
 /// <p>Contains the parameters for ImportSnapshot.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ImportSnapshotRequest {
     /// <p>The client-specific data.</p>
     pub client_data: Option<ClientData>,
@@ -26131,7 +26131,7 @@ impl ImportSnapshotRequestSerializer {
 }
 
 /// <p>Contains the output for ImportSnapshot.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ImportSnapshotResult {
     /// <p>A description of the import snapshot task.</p>
     pub description: Option<String>,
@@ -26193,7 +26193,7 @@ impl ImportSnapshotResultDeserializer {
     }
 }
 /// <p>Describes an import snapshot task.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ImportSnapshotTask {
     /// <p>A description of the import snapshot task.</p>
     pub description: Option<String>,
@@ -26309,7 +26309,7 @@ impl ImportTaskIdListSerializer {
 }
 
 /// <p>Contains the parameters for ImportVolume.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ImportVolumeRequest {
     /// <p>The Availability Zone for the resulting EBS volume.</p>
     pub availability_zone: String,
@@ -26354,7 +26354,7 @@ impl ImportVolumeRequestSerializer {
 }
 
 /// <p>Contains the output for ImportVolume.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ImportVolumeResult {
     /// <p>Information about the conversion task.</p>
     pub conversion_task: Option<ConversionTask>,
@@ -26403,7 +26403,7 @@ impl ImportVolumeResultDeserializer {
     }
 }
 /// <p>Describes an import volume task.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ImportVolumeTaskDetails {
     /// <p>The Availability Zone where the resulting volume will reside.</p>
     pub availability_zone: String,
@@ -26476,7 +26476,7 @@ impl ImportVolumeTaskDetailsDeserializer {
     }
 }
 /// <p>Describes an instance.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Instance {
     /// <p>The AMI launch index, which can be used to find this instance in the launch group.</p>
     pub ami_launch_index: Option<i64>,
@@ -26802,7 +26802,7 @@ impl InstanceDeserializer {
     }
 }
 /// <p>Describes an instance attribute.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct InstanceAttribute {
     /// <p>The block device mapping of the instance.</p>
     pub block_device_mappings: Option<Vec<InstanceBlockDeviceMapping>>,
@@ -26959,7 +26959,7 @@ impl InstanceAttributeDeserializer {
     }
 }
 /// <p>Describes a block device mapping.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct InstanceBlockDeviceMapping {
     /// <p>The device name (for example, <code>/dev/sdh</code> or <code>xvdh</code>).</p>
     pub device_name: Option<String>,
@@ -27055,7 +27055,7 @@ impl InstanceBlockDeviceMappingListDeserializer {
     }
 }
 /// <p>Describes a block device mapping entry.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct InstanceBlockDeviceMappingSpecification {
     /// <p>The device name (for example, <code>/dev/sdh</code> or <code>xvdh</code>).</p>
     pub device_name: Option<String>,
@@ -27120,7 +27120,7 @@ impl InstanceBlockDeviceMappingSpecificationListSerializer {
 }
 
 /// <p>Information about the instance type that the Dedicated Host supports.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct InstanceCapacity {
     /// <p>The number of instances that can still be launched onto the Dedicated Host.</p>
     pub available_capacity: Option<i64>,
@@ -27183,7 +27183,7 @@ impl InstanceCapacityDeserializer {
     }
 }
 /// <p>Describes a Reserved Instance listing state.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct InstanceCount {
     /// <p>The number of listed Reserved Instances in the state specified by the <code>state</code>.</p>
     pub instance_count: Option<i64>,
@@ -27278,7 +27278,7 @@ impl InstanceCountListDeserializer {
     }
 }
 /// <p>Describes the credit option for CPU usage of a T2 instance. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct InstanceCreditSpecification {
     /// <p>The credit option for CPU usage of the instance. Valid values are <code>standard</code> and <code>unlimited</code>.</p>
     pub cpu_credits: Option<String>,
@@ -27385,7 +27385,7 @@ impl InstanceCreditSpecificationListRequestSerializer {
 }
 
 /// <p>Describes the credit option for CPU usage of a T2 instance.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct InstanceCreditSpecificationRequest {
     /// <p>The credit option for CPU usage of the instance. Valid values are <code>standard</code> and <code>unlimited</code>.</p>
     pub cpu_credits: Option<String>,
@@ -27418,7 +27418,7 @@ impl InstanceCreditSpecificationRequestSerializer {
 }
 
 /// <p>Describes an instance to export.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct InstanceExportDetails {
     /// <p>The ID of the resource being exported.</p>
     pub instance_id: Option<String>,
@@ -27552,7 +27552,7 @@ impl InstanceInterruptionBehaviorDeserializer {
     }
 }
 /// <p>Describes an IPv6 address.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct InstanceIpv6Address {
     /// <p>The IPv6 address.</p>
     pub ipv_6_address: Option<String>,
@@ -27683,7 +27683,7 @@ impl InstanceIpv6AddressListRequestSerializer {
 }
 
 /// <p>Describes an IPv6 address.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct InstanceIpv6AddressRequest {
     /// <p>The IPv6 address.</p>
     pub ipv_6_address: Option<String>,
@@ -27762,7 +27762,7 @@ impl InstanceListDeserializer {
     }
 }
 /// <p>Describes the market (purchasing) option for the instances.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct InstanceMarketOptionsRequest {
     /// <p>The market type.</p>
     pub market_type: Option<String>,
@@ -27796,7 +27796,7 @@ impl InstanceMarketOptionsRequestSerializer {
 }
 
 /// <p>Describes the monitoring of an instance.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct InstanceMonitoring {
     /// <p>The ID of the instance.</p>
     pub instance_id: Option<String>,
@@ -27893,7 +27893,7 @@ impl InstanceMonitoringListDeserializer {
     }
 }
 /// <p>Describes a network interface.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct InstanceNetworkInterface {
     /// <p>The association information for an Elastic IPv4 associated with the network interface.</p>
     pub association: Option<InstanceNetworkInterfaceAssociation>,
@@ -28047,7 +28047,7 @@ impl InstanceNetworkInterfaceDeserializer {
     }
 }
 /// <p>Describes association information for an Elastic IP address (IPv4).</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct InstanceNetworkInterfaceAssociation {
     /// <p>The ID of the owner of the Elastic IP address.</p>
     pub ip_owner_id: Option<String>,
@@ -28108,7 +28108,7 @@ impl InstanceNetworkInterfaceAssociationDeserializer {
     }
 }
 /// <p>Describes a network interface attachment.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct InstanceNetworkInterfaceAttachment {
     /// <p>The time stamp when the attachment initiated.</p>
     pub attach_time: Option<String>,
@@ -28224,7 +28224,7 @@ impl InstanceNetworkInterfaceListDeserializer {
     }
 }
 /// <p>Describes a network interface.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct InstanceNetworkInterfaceSpecification {
     /// <p>Indicates whether to assign a public IPv4 address to an instance you launch in a VPC. The public IP address can only be assigned to a network interface for eth0, and can only be assigned to a new network interface, not an existing one. You cannot specify more than one network interface in the request. If launching into a default subnet, the default value is <code>true</code>.</p>
     pub associate_public_ip_address: Option<bool>,
@@ -28507,7 +28507,7 @@ impl InstanceNetworkInterfaceSpecificationListSerializer {
 }
 
 /// <p>Describes a private IPv4 address.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct InstancePrivateIpAddress {
     /// <p>The association information for an Elastic IP address for the network interface.</p>
     pub association: Option<InstanceNetworkInterfaceAssociation>,
@@ -28622,7 +28622,7 @@ impl InstancePrivateIpAddressListDeserializer {
     }
 }
 /// <p>Describes the current state of an instance.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct InstanceState {
     /// <p><p>The low byte represents the state. The high byte is an opaque internal value and should be ignored.</p> <ul> <li> <p> <code>0</code> : <code>pending</code> </p> </li> <li> <p> <code>16</code> : <code>running</code> </p> </li> <li> <p> <code>32</code> : <code>shutting-down</code> </p> </li> <li> <p> <code>48</code> : <code>terminated</code> </p> </li> <li> <p> <code>64</code> : <code>stopping</code> </p> </li> <li> <p> <code>80</code> : <code>stopped</code> </p> </li> </ul></p>
     pub code: Option<i64>,
@@ -28675,7 +28675,7 @@ impl InstanceStateDeserializer {
     }
 }
 /// <p>Describes an instance state change.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct InstanceStateChange {
     /// <p>The current state of the instance.</p>
     pub current_state: Option<InstanceState>,
@@ -28794,7 +28794,7 @@ impl InstanceStateNameDeserializer {
     }
 }
 /// <p>Describes the status of an instance.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct InstanceStatus {
     /// <p>The Availability Zone of the instance.</p>
     pub availability_zone: Option<String>,
@@ -28879,7 +28879,7 @@ impl InstanceStatusDeserializer {
     }
 }
 /// <p>Describes the instance status.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct InstanceStatusDetails {
     /// <p>The time when a status check failed. For an instance that was launched and impaired, this is the time when the instance was launched.</p>
     pub impaired_since: Option<String>,
@@ -28981,7 +28981,7 @@ impl InstanceStatusDetailsListDeserializer {
     }
 }
 /// <p>Describes a scheduled event for an instance.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct InstanceStatusEvent {
     /// <p>The event code.</p>
     pub code: Option<String>,
@@ -29127,7 +29127,7 @@ impl InstanceStatusListDeserializer {
     }
 }
 /// <p>Describes the status of an instance.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct InstanceStatusSummary {
     /// <p>The system instance health or application instance health.</p>
     pub details: Option<Vec<InstanceStatusDetails>>,
@@ -29236,7 +29236,7 @@ impl InterfacePermissionTypeDeserializer {
     }
 }
 /// <p>Describes an Internet gateway.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct InternetGateway {
     /// <p>Any VPCs attached to the Internet gateway.</p>
     pub attachments: Option<Vec<InternetGatewayAttachment>>,
@@ -29300,7 +29300,7 @@ impl InternetGatewayDeserializer {
     }
 }
 /// <p>Describes the attachment of a VPC to an Internet gateway or an egress-only Internet gateway.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct InternetGatewayAttachment {
     /// <p>The current state of the attachment. For an Internet gateway, the state is <code>available</code> when attached to a VPC; otherwise, this value is not returned.</p>
     pub state: Option<String>,
@@ -29437,7 +29437,7 @@ impl InternetGatewayListDeserializer {
     }
 }
 /// <p>Describes a set of permissions for a security group rule.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct IpPermission {
     /// <p>The start of port range for the TCP and UDP protocols, or an ICMP/ICMPv6 type number. A value of <code>-1</code> indicates all ICMP/ICMPv6 types. If you specify all ICMP/ICMPv6 types, you must specify all codes.</p>
     pub from_port: Option<i64>,
@@ -29635,7 +29635,7 @@ impl IpPermissionListSerializer {
 }
 
 /// <p>Describes an IPv4 range.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct IpRange {
     /// <p>The IPv4 CIDR range. You can either specify a CIDR range or a source security group, not both. To specify a single IPv4 address, use the /32 prefix length.</p>
     pub cidr_ip: Option<String>,
@@ -29856,7 +29856,7 @@ impl Ipv6AddressListSerializer {
 }
 
 /// <p>Describes an IPv6 CIDR block.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Ipv6CidrBlock {
     /// <p>The IPv6 CIDR block.</p>
     pub ipv_6_cidr_block: Option<String>,
@@ -29945,7 +29945,7 @@ impl Ipv6CidrBlockSetDeserializer {
     }
 }
 /// <p>[EC2-VPC only] Describes an IPv6 range.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Ipv6Range {
     /// <p>The IPv6 CIDR range. You can either specify a CIDR range or a source security group, not both. To specify a single IPv6 address, use the /128 prefix length.</p>
     pub cidr_ipv_6: Option<String>,
@@ -30086,7 +30086,7 @@ impl KeyNameStringListSerializer {
 }
 
 /// <p>Describes a key pair.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct KeyPair {
     /// <p>The SHA-1 digest of the DER encoded private key.</p>
     pub key_fingerprint: Option<String>,
@@ -30147,7 +30147,7 @@ impl KeyPairDeserializer {
     }
 }
 /// <p>Describes a key pair.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct KeyPairInfo {
     /// <p>If you used <a>CreateKeyPair</a> to create the key pair, this is the SHA-1 digest of the DER encoded private key. If you used <a>ImportKeyPair</a> to provide AWS the public key, this is the MD5 public key fingerprint as specified in section 4 of RFC4716.</p>
     pub key_fingerprint: Option<String>,
@@ -30242,7 +30242,7 @@ impl KeyPairListDeserializer {
     }
 }
 /// <p>Describes a launch permission.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct LaunchPermission {
     /// <p>The name of the group.</p>
     pub group: Option<String>,
@@ -30374,7 +30374,7 @@ impl LaunchPermissionListSerializer {
 }
 
 /// <p>Describes a launch permission modification.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct LaunchPermissionModifications {
     /// <p>The AWS account ID to add to the list of launch permissions for the AMI.</p>
     pub add: Option<Vec<LaunchPermission>>,
@@ -30409,7 +30409,7 @@ impl LaunchPermissionModificationsSerializer {
 }
 
 /// <p>Describes the launch specification for an instance.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct LaunchSpecification {
     /// <p>Deprecated.</p>
     pub addressing_type: Option<String>,
@@ -30617,7 +30617,7 @@ impl LaunchSpecsListSerializer {
 }
 
 /// <p>Describes a launch template.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct LaunchTemplate {
     /// <p>The time launch template was created.</p>
     pub create_time: Option<String>,
@@ -30708,7 +30708,7 @@ impl LaunchTemplateDeserializer {
     }
 }
 /// <p>Describes a block device mapping.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct LaunchTemplateBlockDeviceMapping {
     /// <p>The device name.</p>
     pub device_name: Option<String>,
@@ -30818,7 +30818,7 @@ impl LaunchTemplateBlockDeviceMappingListDeserializer {
     }
 }
 /// <p>Describes a block device mapping.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct LaunchTemplateBlockDeviceMappingRequest {
     /// <p>The device name (for example, /dev/sdh or xvdh).</p>
     pub device_name: Option<String>,
@@ -30883,7 +30883,7 @@ impl LaunchTemplateBlockDeviceMappingRequestListSerializer {
 }
 
 /// <p>Describes a launch template and overrides.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct LaunchTemplateConfig {
     /// <p>The launch template.</p>
     pub launch_template_specification: Option<FleetLaunchTemplateSpecification>,
@@ -31024,7 +31024,7 @@ impl LaunchTemplateConfigListSerializer {
 }
 
 /// <p>Describes a block device for an EBS volume.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct LaunchTemplateEbsBlockDevice {
     /// <p>Indicates whether the EBS volume is deleted on instance termination.</p>
     pub delete_on_termination: Option<bool>,
@@ -31110,7 +31110,7 @@ impl LaunchTemplateEbsBlockDeviceDeserializer {
     }
 }
 /// <p>The parameters for a block device for an EBS volume.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct LaunchTemplateEbsBlockDeviceRequest {
     /// <p>Indicates whether the EBS volume is deleted on instance termination.</p>
     pub delete_on_termination: Option<bool>,
@@ -31197,7 +31197,7 @@ impl LaunchTemplateErrorCodeDeserializer {
     }
 }
 /// <p>Describes an IAM instance profile.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct LaunchTemplateIamInstanceProfileSpecification {
     /// <p>The Amazon Resource Name (ARN) of the instance profile.</p>
     pub arn: Option<String>,
@@ -31248,7 +31248,7 @@ impl LaunchTemplateIamInstanceProfileSpecificationDeserializer {
     }
 }
 /// <p>An IAM instance profile.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct LaunchTemplateIamInstanceProfileSpecificationRequest {
     /// <p>The Amazon Resource Name (ARN) of the instance profile.</p>
     pub arn: Option<String>,
@@ -31285,7 +31285,7 @@ impl LaunchTemplateIamInstanceProfileSpecificationRequestSerializer {
 }
 
 /// <p>The market (purchasing) option for the instances.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct LaunchTemplateInstanceMarketOptions {
     /// <p>The market type.</p>
     pub market_type: Option<String>,
@@ -31344,7 +31344,7 @@ impl LaunchTemplateInstanceMarketOptionsDeserializer {
     }
 }
 /// <p>The market (purchasing) option for the instances.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct LaunchTemplateInstanceMarketOptionsRequest {
     /// <p>The market type.</p>
     pub market_type: Option<String>,
@@ -31382,7 +31382,7 @@ impl LaunchTemplateInstanceMarketOptionsRequestSerializer {
 }
 
 /// <p>Describes a network interface.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct LaunchTemplateInstanceNetworkInterfaceSpecification {
     /// <p>Indicates whether to associate a public IPv4 address with eth0 for a new network interface.</p>
     pub associate_public_ip_address: Option<bool>,
@@ -31555,7 +31555,7 @@ impl LaunchTemplateInstanceNetworkInterfaceSpecificationListDeserializer {
     }
 }
 /// <p>The parameters for a network interface.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct LaunchTemplateInstanceNetworkInterfaceSpecificationRequest {
     /// <p>Associates a public IPv4 address with eth0 for a new network interface.</p>
     pub associate_public_ip_address: Option<bool>,
@@ -31718,7 +31718,7 @@ impl LaunchTemplateNameStringListSerializer {
 }
 
 /// <p>Describes overrides for a launch template.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct LaunchTemplateOverrides {
     /// <p>The Availability Zone in which to launch the instances.</p>
     pub availability_zone: Option<String>,
@@ -31892,7 +31892,7 @@ impl LaunchTemplateOverridesListSerializer {
 }
 
 /// <p>Describes the placement of an instance.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct LaunchTemplatePlacement {
     /// <p>The affinity setting for the instance on the Dedicated Host.</p>
     pub affinity: Option<String>,
@@ -31970,7 +31970,7 @@ impl LaunchTemplatePlacementDeserializer {
     }
 }
 /// <p>The placement for the instance.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct LaunchTemplatePlacementRequest {
     /// <p>The affinity setting for an instance on a Dedicated Host.</p>
     pub affinity: Option<String>,
@@ -32075,7 +32075,7 @@ impl LaunchTemplateSetDeserializer {
     }
 }
 /// <p>The launch template to use. You must specify either the launch template ID or launch template name in the request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct LaunchTemplateSpecification {
     /// <p>The ID of the launch template.</p>
     pub launch_template_id: Option<String>,
@@ -32116,7 +32116,7 @@ impl LaunchTemplateSpecificationSerializer {
 }
 
 /// <p>The options for Spot Instances.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct LaunchTemplateSpotMarketOptions {
     /// <p>The required duration for the Spot Instances (also known as Spot blocks), in minutes. This value must be a multiple of 60 (60, 120, 180, 240, 300, or 360).</p>
     pub block_duration_minutes: Option<i64>,
@@ -32193,7 +32193,7 @@ impl LaunchTemplateSpotMarketOptionsDeserializer {
     }
 }
 /// <p>The options for Spot Instances.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct LaunchTemplateSpotMarketOptionsRequest {
     /// <p>The required duration for the Spot Instances (also known as Spot blocks), in minutes. This value must be a multiple of 60 (60, 120, 180, 240, 300, or 360).</p>
     pub block_duration_minutes: Option<i64>,
@@ -32250,7 +32250,7 @@ impl LaunchTemplateSpotMarketOptionsRequestSerializer {
 }
 
 /// <p>The tag specification for the launch template.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct LaunchTemplateTagSpecification {
     /// <p>The type of resource.</p>
     pub resource_type: Option<String>,
@@ -32346,7 +32346,7 @@ impl LaunchTemplateTagSpecificationListDeserializer {
     }
 }
 /// <p>The tags specification for the launch template.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct LaunchTemplateTagSpecificationRequest {
     /// <p>The type of resource to tag. Currently, the resource types that support tagging on creation are <code>instance</code> and <code>volume</code>.</p>
     pub resource_type: Option<String>,
@@ -32391,7 +32391,7 @@ impl LaunchTemplateTagSpecificationRequestListSerializer {
 }
 
 /// <p>Describes a launch template version.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct LaunchTemplateVersion {
     /// <p>The time the version was created.</p>
     pub create_time: Option<String>,
@@ -32535,7 +32535,7 @@ impl LaunchTemplateVersionSetDeserializer {
     }
 }
 /// <p>Describes the monitoring for the instance.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct LaunchTemplatesMonitoring {
     /// <p>Indicates whether detailed monitoring is enabled. Otherwise, basic monitoring is enabled.</p>
     pub enabled: Option<bool>,
@@ -32582,7 +32582,7 @@ impl LaunchTemplatesMonitoringDeserializer {
     }
 }
 /// <p>Describes the monitoring for the instance.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct LaunchTemplatesMonitoringRequest {
     /// <p>Specify <code>true</code> to enable detailed monitoring. Otherwise, basic monitoring is enabled.</p>
     pub enabled: Option<bool>,
@@ -32635,7 +32635,7 @@ impl ListingStatusDeserializer {
     }
 }
 /// <p>Describes the Classic Load Balancers and target groups to attach to a Spot Fleet request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct LoadBalancersConfig {
     /// <p>The Classic Load Balancers.</p>
     pub classic_load_balancers_config: Option<ClassicLoadBalancersConfig>,
@@ -32721,7 +32721,7 @@ impl LoadBalancersConfigSerializer {
 }
 
 /// <p>Describes a load permission.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct LoadPermission {
     /// <p>The name of the group.</p>
     pub group: Option<String>,
@@ -32826,7 +32826,7 @@ impl LoadPermissionListRequestSerializer {
 }
 
 /// <p>Describes modifications to the load permissions of an Amazon FPGA image (AFI).</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct LoadPermissionModifications {
     /// <p>The load permissions to add.</p>
     pub add: Option<Vec<LoadPermissionRequest>>,
@@ -32861,7 +32861,7 @@ impl LoadPermissionModificationsSerializer {
 }
 
 /// <p>Describes a load permission.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct LoadPermissionRequest {
     /// <p>The name of the group.</p>
     pub group: Option<String>,
@@ -32921,7 +32921,7 @@ impl MarketTypeDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyFpgaImageAttributeRequest {
     /// <p>The name of the attribute.</p>
     pub attribute: Option<String>,
@@ -33019,7 +33019,7 @@ impl ModifyFpgaImageAttributeRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyFpgaImageAttributeResult {
     /// <p>Information about the attribute.</p>
     pub fpga_image_attribute: Option<FpgaImageAttribute>,
@@ -33069,7 +33069,7 @@ impl ModifyFpgaImageAttributeResultDeserializer {
     }
 }
 /// <p>Contains the parameters for ModifyHosts.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyHostsRequest {
     /// <p>Specify whether to enable or disable auto-placement.</p>
     pub auto_placement: String,
@@ -33099,7 +33099,7 @@ impl ModifyHostsRequestSerializer {
 }
 
 /// <p>Contains the output of ModifyHosts.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyHostsResult {
     /// <p>The IDs of the Dedicated Hosts that were successfully modified.</p>
     pub successful: Option<Vec<String>>,
@@ -33155,7 +33155,7 @@ impl ModifyHostsResultDeserializer {
     }
 }
 /// <p>Contains the parameters of ModifyIdFormat.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyIdFormatRequest {
     /// <p>The type of resource: <code>bundle</code> | <code>conversion-task</code> | <code>customer-gateway</code> | <code>dhcp-options</code> | <code>elastic-ip-allocation</code> | <code>elastic-ip-association</code> | <code>export-task</code> | <code>flow-log</code> | <code>image</code> | <code>import-task</code> | <code>internet-gateway</code> | <code>network-acl</code> | <code>network-acl-association</code> | <code>network-interface</code> | <code>network-interface-attachment</code> | <code>prefix-list</code> | <code>route-table</code> | <code>route-table-association</code> | <code>security-group</code> | <code>subnet</code> | <code>subnet-cidr-block-association</code> | <code>vpc</code> | <code>vpc-cidr-block-association</code> | <code>vpc-endpoint</code> | <code>vpc-peering-connection</code> | <code>vpn-connection</code> | <code>vpn-gateway</code>.</p> <p>Alternatively, use the <code>all-current</code> option to include all resource types that are currently within their opt-in period for longer IDs.</p>
     pub resource: String,
@@ -33184,7 +33184,7 @@ impl ModifyIdFormatRequestSerializer {
 }
 
 /// <p>Contains the parameters of ModifyIdentityIdFormat.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyIdentityIdFormatRequest {
     /// <p>The ARN of the principal, which can be an IAM user, IAM role, or the root user. Specify <code>all</code> to modify the ID format for all IAM users, IAM roles, and the root user of the account.</p>
     pub principal_arn: String,
@@ -33219,7 +33219,7 @@ impl ModifyIdentityIdFormatRequestSerializer {
 }
 
 /// <p>Contains the parameters for ModifyImageAttribute.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyImageAttributeRequest {
     /// <p>The name of the attribute to modify. The valid values are <code>description</code>, <code>launchPermission</code>, and <code>productCodes</code>.</p>
     pub attribute: Option<String>,
@@ -33319,7 +33319,7 @@ impl ModifyImageAttributeRequestSerializer {
 }
 
 /// <p>Contains the parameters for ModifyInstanceAttribute.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyInstanceAttributeRequest {
     /// <p>The name of the attribute.</p>
     pub attribute: Option<String>,
@@ -33473,7 +33473,7 @@ impl ModifyInstanceAttributeRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyInstanceCreditSpecificationRequest {
     /// <p>A unique, case-sensitive token that you provide to ensure idempotency of your modification request. For more information, see <a href="http://docs.aws.amazon.com/AWSEC2/latest/APIReference/Run_Instance_Idempotency.html">Ensuring Idempotency</a>.</p>
     pub client_token: Option<String>,
@@ -33512,7 +33512,7 @@ impl ModifyInstanceCreditSpecificationRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyInstanceCreditSpecificationResult {
     /// <p>Information about the instances whose credit option for CPU usage was successfully modified.</p>
     pub successful_instance_credit_specifications:
@@ -33575,7 +33575,7 @@ impl ModifyInstanceCreditSpecificationResultDeserializer {
     }
 }
 /// <p>Contains the parameters for ModifyInstancePlacement.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyInstancePlacementRequest {
     /// <p>The affinity setting for the instance.</p>
     pub affinity: Option<String>,
@@ -33630,7 +33630,7 @@ impl ModifyInstancePlacementRequestSerializer {
 }
 
 /// <p>Contains the output of ModifyInstancePlacement.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyInstancePlacementResult {
     /// <p>Is <code>true</code> if the request succeeds, and an error otherwise.</p>
     pub return_: Option<bool>,
@@ -33675,7 +33675,7 @@ impl ModifyInstancePlacementResultDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyLaunchTemplateRequest {
     /// <p>Unique, case-sensitive identifier you provide to ensure the idempotency of the request. For more information, see <a href="http://docs.aws.amazon.com/AWSEC2/latest/APIReference/Run_Instance_Idempotency.html">Ensuring Idempotency</a>.</p>
     pub client_token: Option<String>,
@@ -33731,7 +33731,7 @@ impl ModifyLaunchTemplateRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyLaunchTemplateResult {
     /// <p>Information about the launch template.</p>
     pub launch_template: Option<LaunchTemplate>,
@@ -33780,7 +33780,7 @@ impl ModifyLaunchTemplateResultDeserializer {
     }
 }
 /// <p>Contains the parameters for ModifyNetworkInterfaceAttribute.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyNetworkInterfaceAttributeRequest {
     /// <p>Information about the interface attachment. If modifying the 'delete on termination' attribute, you must specify the ID of the interface attachment.</p>
     pub attachment: Option<NetworkInterfaceAttachmentChanges>,
@@ -33847,7 +33847,7 @@ impl ModifyNetworkInterfaceAttributeRequestSerializer {
 }
 
 /// <p>Contains the parameters for ModifyReservedInstances.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyReservedInstancesRequest {
     /// <p>A unique, case-sensitive token you provide to ensure idempotency of your modification request. For more information, see <a href="http://docs.aws.amazon.com/AWSEC2/latest/APIReference/Run_Instance_Idempotency.html">Ensuring Idempotency</a>.</p>
     pub client_token: Option<String>,
@@ -33886,7 +33886,7 @@ impl ModifyReservedInstancesRequestSerializer {
 }
 
 /// <p>Contains the output of ModifyReservedInstances.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyReservedInstancesResult {
     /// <p>The ID for the modification.</p>
     pub reserved_instances_modification_id: Option<String>,
@@ -33936,7 +33936,7 @@ impl ModifyReservedInstancesResultDeserializer {
     }
 }
 /// <p>Contains the parameters for ModifySnapshotAttribute.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifySnapshotAttributeRequest {
     /// <p><p>The snapshot attribute to modify.</p> <note> <p>Only volume creation permissions may be modified at the customer level.</p> </note></p>
     pub attribute: Option<String>,
@@ -34010,7 +34010,7 @@ impl ModifySnapshotAttributeRequestSerializer {
 }
 
 /// <p>Contains the parameters for ModifySpotFleetRequest.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifySpotFleetRequestRequest {
     /// <p>Indicates whether running Spot Instances should be terminated if the target capacity of the Spot Fleet request is decreased below the current size of the Spot Fleet.</p>
     pub excess_capacity_termination_policy: Option<String>,
@@ -34049,7 +34049,7 @@ impl ModifySpotFleetRequestRequestSerializer {
 }
 
 /// <p>Contains the output of ModifySpotFleetRequest.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifySpotFleetRequestResponse {
     /// <p>Is <code>true</code> if the request succeeds, and an error otherwise.</p>
     pub return_: Option<bool>,
@@ -34095,7 +34095,7 @@ impl ModifySpotFleetRequestResponseDeserializer {
     }
 }
 /// <p>Contains the parameters for ModifySubnetAttribute.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifySubnetAttributeRequest {
     /// <p>Specify <code>true</code> to indicate that network interfaces created in the specified subnet should be assigned an IPv6 address. This includes a network interface that's created when launching an instance into the subnet (the instance therefore receives an IPv6 address). </p> <p>If you enable the IPv6 addressing feature for your subnet, your network interface or instance only receives an IPv6 address if it's created using version <code>2016-11-15</code> or later of the Amazon EC2 API.</p>
     pub assign_ipv_6_address_on_creation: Option<AttributeBooleanValue>,
@@ -34136,7 +34136,7 @@ impl ModifySubnetAttributeRequestSerializer {
 }
 
 /// <p>Contains the parameters for ModifyVolumeAttribute.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyVolumeAttributeRequest {
     /// <p>Indicates whether the volume should be auto-enabled for I/O operations.</p>
     pub auto_enable_io: Option<AttributeBooleanValue>,
@@ -34175,7 +34175,7 @@ impl ModifyVolumeAttributeRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyVolumeRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -34229,7 +34229,7 @@ impl ModifyVolumeRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyVolumeResult {
     /// <p>A <a>VolumeModification</a> object.</p>
     pub volume_modification: Option<VolumeModification>,
@@ -34279,7 +34279,7 @@ impl ModifyVolumeResultDeserializer {
     }
 }
 /// <p>Contains the parameters for ModifyVpcAttribute.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyVpcAttributeRequest {
     /// <p>Indicates whether the instances launched in the VPC get DNS hostnames. If enabled, instances in the VPC get DNS hostnames; otherwise, they do not.</p> <p>You cannot modify the DNS resolution and DNS hostnames attributes in the same request. Use separate requests for each attribute. You can only enable DNS hostnames if you've enabled DNS support.</p>
     pub enable_dns_hostnames: Option<AttributeBooleanValue>,
@@ -34319,7 +34319,7 @@ impl ModifyVpcAttributeRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyVpcEndpointConnectionNotificationRequest {
     /// <p>One or more events for the endpoint. Valid values are <code>Accept</code>, <code>Connect</code>, <code>Delete</code>, and <code>Reject</code>.</p>
     pub connection_events: Option<Vec<String>>,
@@ -34370,7 +34370,7 @@ impl ModifyVpcEndpointConnectionNotificationRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyVpcEndpointConnectionNotificationResult {
     /// <p>Returns <code>true</code> if the request succeeds; otherwise, it returns an error.</p>
     pub return_value: Option<bool>,
@@ -34417,7 +34417,7 @@ impl ModifyVpcEndpointConnectionNotificationResultDeserializer {
     }
 }
 /// <p>Contains the parameters for ModifyVpcEndpoint.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyVpcEndpointRequest {
     /// <p>(Gateway endpoint) One or more route tables IDs to associate with the endpoint.</p>
     pub add_route_table_ids: Option<Vec<String>>,
@@ -34525,7 +34525,7 @@ impl ModifyVpcEndpointRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyVpcEndpointResult {
     /// <p>Returns <code>true</code> if the request succeeds; otherwise, it returns an error.</p>
     pub return_: Option<bool>,
@@ -34570,7 +34570,7 @@ impl ModifyVpcEndpointResultDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyVpcEndpointServiceConfigurationRequest {
     /// <p>Indicate whether requests to create an endpoint to your service must be accepted.</p>
     pub acceptance_required: Option<bool>,
@@ -34630,7 +34630,7 @@ impl ModifyVpcEndpointServiceConfigurationRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyVpcEndpointServiceConfigurationResult {
     /// <p>Returns <code>true</code> if the request succeeds; otherwise, it returns an error.</p>
     pub return_: Option<bool>,
@@ -34675,7 +34675,7 @@ impl ModifyVpcEndpointServiceConfigurationResultDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyVpcEndpointServicePermissionsRequest {
     /// <p>One or more Amazon Resource Names (ARNs) of principals for which to allow permission. Specify <code>*</code> to allow all principals.</p>
     pub add_allowed_principals: Option<Vec<String>>,
@@ -34727,7 +34727,7 @@ impl ModifyVpcEndpointServicePermissionsRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyVpcEndpointServicePermissionsResult {
     /// <p>Returns <code>true</code> if the request succeeds; otherwise, it returns an error.</p>
     pub return_value: Option<bool>,
@@ -34773,7 +34773,7 @@ impl ModifyVpcEndpointServicePermissionsResultDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyVpcPeeringConnectionOptionsRequest {
     /// <p>The VPC peering connection options for the accepter VPC.</p>
     pub accepter_peering_connection_options: Option<PeeringConnectionOptionsRequest>,
@@ -34821,7 +34821,7 @@ impl ModifyVpcPeeringConnectionOptionsRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyVpcPeeringConnectionOptionsResult {
     /// <p>Information about the VPC peering connection options for the accepter VPC.</p>
     pub accepter_peering_connection_options: Option<PeeringConnectionOptions>,
@@ -34880,7 +34880,7 @@ impl ModifyVpcPeeringConnectionOptionsResultDeserializer {
     }
 }
 /// <p>Contains the parameters for ModifyVpcTenancy.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyVpcTenancyRequest {
     /// <p>Checks whether you have the required permissions for the operation, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -34917,7 +34917,7 @@ impl ModifyVpcTenancyRequestSerializer {
 }
 
 /// <p>Contains the output of ModifyVpcTenancy.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyVpcTenancyResult {
     /// <p>Returns <code>true</code> if the request succeeds; otherwise, returns an error.</p>
     pub return_value: Option<bool>,
@@ -34964,7 +34964,7 @@ impl ModifyVpcTenancyResultDeserializer {
     }
 }
 /// <p>Contains the parameters for MonitorInstances.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct MonitorInstancesRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -34996,7 +34996,7 @@ impl MonitorInstancesRequestSerializer {
 }
 
 /// <p>Contains the output of MonitorInstances.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct MonitorInstancesResult {
     /// <p>The monitoring information.</p>
     pub instance_monitorings: Option<Vec<InstanceMonitoring>>,
@@ -35044,7 +35044,7 @@ impl MonitorInstancesResultDeserializer {
     }
 }
 /// <p>Describes the monitoring of an instance.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Monitoring {
     /// <p>Indicates whether detailed monitoring is enabled. Otherwise, basic monitoring is enabled.</p>
     pub state: Option<String>,
@@ -35106,7 +35106,7 @@ impl MonitoringStateDeserializer {
     }
 }
 /// <p>Contains the parameters for MoveAddressToVpc.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct MoveAddressToVpcRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -35137,7 +35137,7 @@ impl MoveAddressToVpcRequestSerializer {
 }
 
 /// <p>Contains the output of MoveAddressToVpc.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct MoveAddressToVpcResult {
     /// <p>The allocation ID for the Elastic IP address.</p>
     pub allocation_id: Option<String>,
@@ -35203,7 +35203,7 @@ impl MoveStatusDeserializer {
     }
 }
 /// <p>Describes the status of a moving Elastic IP address.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct MovingAddressStatus {
     /// <p>The status of the Elastic IP address that's being moved to the EC2-VPC platform, or restored to the EC2-Classic platform.</p>
     pub move_status: Option<String>,
@@ -35300,7 +35300,7 @@ impl MovingAddressStatusSetDeserializer {
     }
 }
 /// <p>Describes a NAT gateway.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct NatGateway {
     /// <p>The date and time the NAT gateway was created.</p>
     pub create_time: Option<String>,
@@ -35414,7 +35414,7 @@ impl NatGatewayDeserializer {
     }
 }
 /// <p>Describes the IP addresses and network interface associated with a NAT gateway.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct NatGatewayAddress {
     /// <p>The allocation ID of the Elastic IP address that's associated with the NAT gateway.</p>
     pub allocation_id: Option<String>,
@@ -35577,7 +35577,7 @@ impl NatGatewayStateDeserializer {
     }
 }
 /// <p>Describes a network ACL.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct NetworkAcl {
     /// <p>Any associations between the network ACL and one or more subnets</p>
     pub associations: Option<Vec<NetworkAclAssociation>>,
@@ -35656,7 +35656,7 @@ impl NetworkAclDeserializer {
     }
 }
 /// <p>Describes an association between a network ACL and a subnet.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct NetworkAclAssociation {
     /// <p>The ID of the association between a network ACL and a subnet.</p>
     pub network_acl_association_id: Option<String>,
@@ -35758,7 +35758,7 @@ impl NetworkAclAssociationListDeserializer {
     }
 }
 /// <p>Describes an entry in a network ACL.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct NetworkAclEntry {
     /// <p>The IPv4 network range to allow or deny, in CIDR notation.</p>
     pub cidr_block: Option<String>,
@@ -35934,7 +35934,7 @@ impl NetworkAclListDeserializer {
     }
 }
 /// <p>Describes a network interface.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct NetworkInterface {
     /// <p>The association information for an Elastic IP address (IPv4) associated with the network interface.</p>
     pub association: Option<NetworkInterfaceAssociation>,
@@ -36122,7 +36122,7 @@ impl NetworkInterfaceDeserializer {
     }
 }
 /// <p>Describes association information for an Elastic IP address (IPv4 only).</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct NetworkInterfaceAssociation {
     /// <p>The allocation ID.</p>
     pub allocation_id: Option<String>,
@@ -36197,7 +36197,7 @@ impl NetworkInterfaceAssociationDeserializer {
     }
 }
 /// <p>Describes a network interface attachment.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct NetworkInterfaceAttachment {
     /// <p>The timestamp indicating when the attachment initiated.</p>
     pub attach_time: Option<String>,
@@ -36285,7 +36285,7 @@ impl NetworkInterfaceAttachmentDeserializer {
     }
 }
 /// <p>Describes an attachment change.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct NetworkInterfaceAttachmentChanges {
     /// <p>The ID of the network interface attachment.</p>
     pub attachment_id: Option<String>,
@@ -36329,7 +36329,7 @@ impl NetworkInterfaceIdListSerializer {
 }
 
 /// <p>Describes an IPv6 address associated with a network interface.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct NetworkInterfaceIpv6Address {
     /// <p>The IPv6 address.</p>
     pub ipv_6_address: Option<String>,
@@ -36460,7 +36460,7 @@ impl NetworkInterfaceListDeserializer {
     }
 }
 /// <p>Describes a permission for a network interface.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct NetworkInterfacePermission {
     /// <p>The AWS account ID.</p>
     pub aws_account_id: Option<String>,
@@ -36599,7 +36599,7 @@ impl NetworkInterfacePermissionListDeserializer {
     }
 }
 /// <p>Describes the state of a network interface permission.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct NetworkInterfacePermissionState {
     /// <p>The state of the permission.</p>
     pub state: Option<String>,
@@ -36671,7 +36671,7 @@ impl NetworkInterfacePermissionStateCodeDeserializer {
     }
 }
 /// <p>Describes the private IPv4 address of a network interface.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct NetworkInterfacePrivateIpAddress {
     /// <p>The association information for an Elastic IP address (IPv4) associated with the network interface.</p>
     pub association: Option<NetworkInterfaceAssociation>,
@@ -36814,7 +36814,7 @@ impl NetworkInterfaceTypeDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct NewDhcpConfiguration {
     pub key: Option<String>,
     pub values: Option<Vec<String>>,
@@ -36977,7 +36977,7 @@ impl PaymentOptionDeserializer {
     }
 }
 /// <p>Describes the data that identifies an Amazon FPGA image (AFI) on the PCI bus.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PciId {
     /// <p>The ID of the device.</p>
     pub device_id: Option<String>,
@@ -37044,7 +37044,7 @@ impl PciIdDeserializer {
     }
 }
 /// <p>Describes the VPC peering connection options.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PeeringConnectionOptions {
     /// <p>If true, the public DNS hostnames of instances in the specified VPC resolve to private IP addresses when queried from instances in the peer VPC.</p>
     pub allow_dns_resolution_from_remote_vpc: Option<bool>,
@@ -37112,7 +37112,7 @@ impl PeeringConnectionOptionsDeserializer {
     }
 }
 /// <p>The VPC peering connection options.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PeeringConnectionOptionsRequest {
     /// <p>If true, enables a local VPC to resolve public DNS hostnames to private IP addresses when queried from instances in the peer VPC.</p>
     pub allow_dns_resolution_from_remote_vpc: Option<bool>,
@@ -37167,7 +37167,7 @@ impl PermissionGroupDeserializer {
     }
 }
 /// <p>Describes the placement of an instance.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Placement {
     /// <p>The affinity setting for the instance on the Dedicated Host. This parameter is not supported for the <a>ImportInstance</a> command.</p>
     pub affinity: Option<String>,
@@ -37294,7 +37294,7 @@ impl PlacementSerializer {
 }
 
 /// <p>Describes a placement group.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PlacementGroup {
     /// <p>The name of the placement group.</p>
     pub group_name: Option<String>,
@@ -37449,7 +37449,7 @@ impl PlatformValuesDeserializer {
     }
 }
 /// <p>Describes a range of ports.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PortRange {
     /// <p>The first port in the range.</p>
     pub from: Option<i64>,
@@ -37525,7 +37525,7 @@ impl PortRangeSerializer {
 }
 
 /// <p>Describes prefixes for AWS services.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PrefixList {
     /// <p>The IP address range of the AWS service.</p>
     pub cidrs: Option<Vec<String>>,
@@ -37587,7 +37587,7 @@ impl PrefixListDeserializer {
     }
 }
 /// <p>[EC2-VPC only] The ID of the prefix.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PrefixListId {
     /// <p>A description for the security group rule that references this prefix list ID.</p> <p>Constraints: Up to 255 characters in length. Allowed characters are a-z, A-Z, 0-9, spaces, and ._-:/()#,@[]+=;{}!$*</p>
     pub description: Option<String>,
@@ -37797,7 +37797,7 @@ impl PrefixListSetDeserializer {
     }
 }
 /// <p>Describes the price for a Reserved Instance.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PriceSchedule {
     /// <p>The current price schedule, as determined by the term remaining for the Reserved Instance in the listing.</p> <p>A specific price schedule is always in effect, but only one price schedule can be active at any time. Take, for example, a Reserved Instance listing that has five months remaining in its term. When you specify price schedules for five months and two months, this means that schedule 1, covering the first three months of the remaining term, will be active during months 5, 4, and 3. Then schedule 2, covering the last two months of the term, will be active for months 2 and 1.</p>
     pub active: Option<bool>,
@@ -37900,7 +37900,7 @@ impl PriceScheduleListDeserializer {
     }
 }
 /// <p>Describes the price for a Reserved Instance.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PriceScheduleSpecification {
     /// <p>The currency for transacting the Reserved Instance resale. At this time, the only supported currency is <code>USD</code>.</p>
     pub currency_code: Option<String>,
@@ -37952,7 +37952,7 @@ impl PriceScheduleSpecificationListSerializer {
 }
 
 /// <p>Describes a Reserved Instance offering.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PricingDetail {
     /// <p>The number of reservations available for the price.</p>
     pub count: Option<i64>,
@@ -38043,7 +38043,7 @@ impl PricingDetailsListDeserializer {
     }
 }
 /// <p>PrincipalIdFormat description</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PrincipalIdFormat {
     /// <p>PrincipalIdFormatARN description</p>
     pub arn: Option<String>,
@@ -38169,7 +38169,7 @@ impl PrivateIpAddressConfigSetSerializer {
 }
 
 /// <p>Describes a secondary private IPv4 address for a network interface.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PrivateIpAddressSpecification {
     /// <p>Indicates whether the private IPv4 address is the primary private IPv4 address. Only one IPv4 address can be designated as primary.</p>
     pub primary: Option<bool>,
@@ -38310,7 +38310,7 @@ impl PrivateIpAddressStringListSerializer {
 }
 
 /// <p>Describes a product code.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ProductCode {
     /// <p>The product code.</p>
     pub product_code_id: Option<String>,
@@ -38442,7 +38442,7 @@ impl ProductDescriptionListSerializer {
 }
 
 /// <p>Describes a virtual private gateway propagating route.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PropagatingVgw {
     /// <p>The ID of the virtual private gateway (VGW).</p>
     pub gateway_id: Option<String>,
@@ -38529,7 +38529,7 @@ impl PropagatingVgwListDeserializer {
     }
 }
 /// <p>Reserved. If you need to sustain traffic greater than the <a href="http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/vpc-nat-gateway.html">documented limits</a>, contact us through the <a href="https://console.aws.amazon.com/support/home?">Support Center</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ProvisionedBandwidth {
     /// <p>Reserved. If you need to sustain traffic greater than the <a href="http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/vpc-nat-gateway.html">documented limits</a>, contact us through the <a href="https://console.aws.amazon.com/support/home?">Support Center</a>.</p>
     pub provision_time: Option<String>,
@@ -38615,7 +38615,7 @@ impl PublicIpStringListSerializer {
 }
 
 /// <p>Describes the result of the purchase.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Purchase {
     /// <p>The currency in which the <code>UpfrontPrice</code> and <code>HourlyPrice</code> amounts are specified. At this time, the only supported currency is <code>USD</code>.</p>
     pub currency_code: Option<String>,
@@ -38712,7 +38712,7 @@ impl PurchaseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PurchaseHostReservationRequest {
     /// <p>Unique, case-sensitive identifier you provide to ensure idempotency of the request. For more information, see <a href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Run_Instance_Idempotency.html">How to Ensure Idempotency</a> in the <i>Amazon Elastic Compute Cloud User Guide</i>.</p>
     pub client_token: Option<String>,
@@ -38765,7 +38765,7 @@ impl PurchaseHostReservationRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PurchaseHostReservationResult {
     /// <p>Unique, case-sensitive identifier you provide to ensure idempotency of the request. For more information, see <a href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Run_Instance_Idempotency.html">How to Ensure Idempotency</a> in the <i>Amazon Elastic Compute Cloud User Guide</i> </p>
     pub client_token: Option<String>,
@@ -38842,7 +38842,7 @@ impl PurchaseHostReservationResultDeserializer {
     }
 }
 /// <p>Describes a request to purchase Scheduled Instances.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PurchaseRequest {
     /// <p>The number of instances.</p>
     pub instance_count: i64,
@@ -38882,7 +38882,7 @@ impl PurchaseRequestSetSerializer {
 }
 
 /// <p>Contains the parameters for PurchaseReservedInstancesOffering.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PurchaseReservedInstancesOfferingRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -38928,7 +38928,7 @@ impl PurchaseReservedInstancesOfferingRequestSerializer {
 }
 
 /// <p>Contains the output of PurchaseReservedInstancesOffering.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PurchaseReservedInstancesOfferingResult {
     /// <p>The IDs of the purchased Reserved Instances.</p>
     pub reserved_instances_id: Option<String>,
@@ -38977,7 +38977,7 @@ impl PurchaseReservedInstancesOfferingResultDeserializer {
     }
 }
 /// <p>Contains the parameters for PurchaseScheduledInstances.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PurchaseScheduledInstancesRequest {
     /// <p>Unique, case-sensitive identifier that ensures the idempotency of the request. For more information, see <a href="http://docs.aws.amazon.com/AWSEC2/latest/APIReference/Run_Instance_Idempotency.html">Ensuring Idempotency</a>.</p>
     pub client_token: Option<String>,
@@ -39017,7 +39017,7 @@ impl PurchaseScheduledInstancesRequestSerializer {
 }
 
 /// <p>Contains the output of PurchaseScheduledInstances.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PurchaseScheduledInstancesResult {
     /// <p>Information about the Scheduled Instances.</p>
     pub scheduled_instance_set: Option<Vec<ScheduledInstance>>,
@@ -39176,7 +39176,7 @@ impl ReasonCodesListSerializer {
 }
 
 /// <p>Contains the parameters for RebootInstances.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RebootInstancesRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -39208,7 +39208,7 @@ impl RebootInstancesRequestSerializer {
 }
 
 /// <p>Describes a recurring charge.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RecurringCharge {
     /// <p>The amount of the recurring charge.</p>
     pub amount: Option<f64>,
@@ -39317,7 +39317,7 @@ impl RecurringChargesListDeserializer {
     }
 }
 /// <p>Describes a region.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Region {
     /// <p>The region service endpoint.</p>
     pub endpoint: Option<String>,
@@ -39424,7 +39424,7 @@ impl RegionNameStringListSerializer {
 }
 
 /// <p>Contains the parameters for RegisterImage.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RegisterImageRequest {
     /// <p>The architecture of the AMI.</p> <p>Default: For Amazon EBS-backed AMIs, <code>i386</code>. For instance store-backed AMIs, the architecture specified in the manifest file.</p>
     pub architecture: Option<String>,
@@ -39545,7 +39545,7 @@ impl RegisterImageRequestSerializer {
 }
 
 /// <p>Contains the output of RegisterImage.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RegisterImageResult {
     /// <p>The ID of the newly registered AMI.</p>
     pub image_id: Option<String>,
@@ -39591,7 +39591,7 @@ impl RegisterImageResultDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RejectVpcEndpointConnectionsRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -39628,7 +39628,7 @@ impl RejectVpcEndpointConnectionsRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RejectVpcEndpointConnectionsResult {
     /// <p>Information about the endpoints that were not rejected, if applicable.</p>
     pub unsuccessful: Option<Vec<UnsuccessfulItem>>,
@@ -39676,7 +39676,7 @@ impl RejectVpcEndpointConnectionsResultDeserializer {
     }
 }
 /// <p>Contains the parameters for RejectVpcPeeringConnection.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RejectVpcPeeringConnectionRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -39707,7 +39707,7 @@ impl RejectVpcPeeringConnectionRequestSerializer {
 }
 
 /// <p>Contains the output of RejectVpcPeeringConnection.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RejectVpcPeeringConnectionResult {
     /// <p>Returns <code>true</code> if the request succeeds; otherwise, it returns an error.</p>
     pub return_: Option<bool>,
@@ -39753,7 +39753,7 @@ impl RejectVpcPeeringConnectionResultDeserializer {
     }
 }
 /// <p>Contains the parameters for ReleaseAddress.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ReleaseAddressRequest {
     /// <p>[EC2-VPC] The allocation ID. Required for EC2-VPC.</p>
     pub allocation_id: Option<String>,
@@ -39794,7 +39794,7 @@ impl ReleaseAddressRequestSerializer {
 }
 
 /// <p>Contains the parameters for ReleaseHosts.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ReleaseHostsRequest {
     /// <p>The IDs of the Dedicated Hosts you want to release.</p>
     pub host_ids: Vec<String>,
@@ -39818,7 +39818,7 @@ impl ReleaseHostsRequestSerializer {
 }
 
 /// <p>Contains the output of ReleaseHosts.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ReleaseHostsResult {
     /// <p>The IDs of the Dedicated Hosts that were successfully released.</p>
     pub successful: Option<Vec<String>>,
@@ -39873,7 +39873,7 @@ impl ReleaseHostsResultDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ReplaceIamInstanceProfileAssociationRequest {
     /// <p>The ID of the existing IAM instance profile association.</p>
     pub association_id: String,
@@ -39906,7 +39906,7 @@ impl ReplaceIamInstanceProfileAssociationRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ReplaceIamInstanceProfileAssociationResult {
     /// <p>Information about the IAM instance profile association.</p>
     pub iam_instance_profile_association: Option<IamInstanceProfileAssociation>,
@@ -39957,7 +39957,7 @@ impl ReplaceIamInstanceProfileAssociationResultDeserializer {
     }
 }
 /// <p>Contains the parameters for ReplaceNetworkAclAssociation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ReplaceNetworkAclAssociationRequest {
     /// <p>The ID of the current association between the original network ACL and the subnet.</p>
     pub association_id: String,
@@ -39994,7 +39994,7 @@ impl ReplaceNetworkAclAssociationRequestSerializer {
 }
 
 /// <p>Contains the output of ReplaceNetworkAclAssociation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ReplaceNetworkAclAssociationResult {
     /// <p>The ID of the new association.</p>
     pub new_association_id: Option<String>,
@@ -40043,7 +40043,7 @@ impl ReplaceNetworkAclAssociationResultDeserializer {
     }
 }
 /// <p>Contains the parameters for ReplaceNetworkAclEntry.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ReplaceNetworkAclEntryRequest {
     /// <p>The IPv4 network range to allow or deny, in CIDR notation (for example <code>172.16.0.0/24</code>).</p>
     pub cidr_block: Option<String>,
@@ -40132,7 +40132,7 @@ impl ReplaceNetworkAclEntryRequestSerializer {
 }
 
 /// <p>Contains the parameters for ReplaceRoute.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ReplaceRouteRequest {
     /// <p>The IPv4 CIDR address block used for the destination match. The value you provide must match the CIDR of an existing route in the table.</p>
     pub destination_cidr_block: Option<String>,
@@ -40227,7 +40227,7 @@ impl ReplaceRouteRequestSerializer {
 }
 
 /// <p>Contains the parameters for ReplaceRouteTableAssociation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ReplaceRouteTableAssociationRequest {
     /// <p>The association ID.</p>
     pub association_id: String,
@@ -40264,7 +40264,7 @@ impl ReplaceRouteTableAssociationRequestSerializer {
 }
 
 /// <p>Contains the output of ReplaceRouteTableAssociation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ReplaceRouteTableAssociationResult {
     /// <p>The ID of the new association.</p>
     pub new_association_id: Option<String>,
@@ -40313,7 +40313,7 @@ impl ReplaceRouteTableAssociationResultDeserializer {
     }
 }
 /// <p>Contains the parameters for ReportInstanceStatus.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ReportInstanceStatusRequest {
     /// <p>Descriptive text about the health state of your instance.</p>
     pub description: Option<String>,
@@ -40404,7 +40404,7 @@ impl RequestHostIdSetSerializer {
 }
 
 /// <p>The information to include in the launch template.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RequestLaunchTemplateData {
     /// <p><p>The block device mapping.</p> <important> <p>Supplying both a snapshot ID and an encryption value as arguments for block-device mapping results in an error. This is because only blank volumes can be encrypted on start, and these are not created from a snapshot. If a snapshot is the basis for the volume, it contains data by definition and its encryption status cannot be changed using this action.</p> </important></p>
     pub block_device_mappings: Option<Vec<LaunchTemplateBlockDeviceMappingRequest>>,
@@ -40592,7 +40592,7 @@ impl RequestLaunchTemplateDataSerializer {
 }
 
 /// <p>Contains the parameters for RequestSpotFleet.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RequestSpotFleetRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -40624,7 +40624,7 @@ impl RequestSpotFleetRequestSerializer {
 }
 
 /// <p>Contains the output of RequestSpotFleet.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RequestSpotFleetResponse {
     /// <p>The ID of the Spot Fleet request.</p>
     pub spot_fleet_request_id: String,
@@ -40671,7 +40671,7 @@ impl RequestSpotFleetResponseDeserializer {
     }
 }
 /// <p>Contains the parameters for RequestSpotInstances.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RequestSpotInstancesRequest {
     /// <p>The user-specified name for a logical grouping of requests.</p> <p>When you specify an Availability Zone group in a Spot Instance request, all Spot Instances in the request are launched in the same Availability Zone. Instance proximity is maintained with this parameter, but the choice of Availability Zone is not. The group applies only to requests for Spot Instances of the same instance type. Any additional Spot Instance requests that are specified with the same Availability Zone group name are launched in that same Availability Zone, as long as at least one instance from the group is still active.</p> <p>If there is no active instance running in the Availability Zone group that you specify for a new Spot Instance request (all instances are terminated, the request is expired, or the maximum price you specified falls below current Spot price), then Amazon EC2 launches the instance in any Availability Zone where the constraint can be met. Consequently, the subsequent set of Spot Instances could be placed in a different zone from the original request, even if you specified the same Availability Zone group.</p> <p>Default: Instances are launched in any available Availability Zone.</p>
     pub availability_zone_group: Option<String>,
@@ -40785,7 +40785,7 @@ impl RequestSpotInstancesRequestSerializer {
 }
 
 /// <p>Contains the output of RequestSpotInstances.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RequestSpotInstancesResult {
     /// <p>One or more Spot Instance requests.</p>
     pub spot_instance_requests: Option<Vec<SpotInstanceRequest>>,
@@ -40835,7 +40835,7 @@ impl RequestSpotInstancesResultDeserializer {
     }
 }
 /// <p>Describes the launch specification for an instance.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RequestSpotLaunchSpecification {
     /// <p>Deprecated.</p>
     pub addressing_type: Option<String>,
@@ -40987,7 +40987,7 @@ impl RequestSpotLaunchSpecificationSerializer {
 }
 
 /// <p>Describes a reservation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Reservation {
     /// <p>[EC2-Classic only] One or more security groups.</p>
     pub groups: Option<Vec<GroupIdentifier>>,
@@ -41117,7 +41117,7 @@ impl ReservationStateDeserializer {
     }
 }
 /// <p>The cost associated with the Reserved Instance.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ReservationValue {
     /// <p>The hourly rate of the reservation.</p>
     pub hourly_price: Option<String>,
@@ -41192,7 +41192,7 @@ impl ReservedInstanceIdSetSerializer {
 }
 
 /// <p>Describes the limit price of a Reserved Instance offering.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ReservedInstanceLimitPrice {
     /// <p>Used for Reserved Instance Marketplace offerings. Specifies the limit price on the total order (instanceCount * price).</p>
     pub amount: Option<f64>,
@@ -41225,7 +41225,7 @@ impl ReservedInstanceLimitPriceSerializer {
 }
 
 /// <p>The total value of the Convertible Reserved Instance.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ReservedInstanceReservationValue {
     /// <p>The total value of the Convertible Reserved Instance that you are exchanging.</p>
     pub reservation_value: Option<ReservationValue>,
@@ -41339,7 +41339,7 @@ impl ReservedInstanceStateDeserializer {
     }
 }
 /// <p>Describes a Reserved Instance.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ReservedInstances {
     /// <p>The Availability Zone in which the Reserved Instance can be used.</p>
     pub availability_zone: Option<String>,
@@ -41503,7 +41503,7 @@ impl ReservedInstancesDeserializer {
     }
 }
 /// <p>Describes the configuration settings for the modified Reserved Instances.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ReservedInstancesConfiguration {
     /// <p>The Availability Zone for the modified Reserved Instances.</p>
     pub availability_zone: Option<String>,
@@ -41633,7 +41633,7 @@ impl ReservedInstancesConfigurationListSerializer {
 }
 
 /// <p>Describes the ID of a Reserved Instance.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ReservedInstancesId {
     /// <p>The ID of the Reserved Instance.</p>
     pub reserved_instances_id: Option<String>,
@@ -41736,7 +41736,7 @@ impl ReservedInstancesListDeserializer {
     }
 }
 /// <p>Describes a Reserved Instance listing.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ReservedInstancesListing {
     /// <p>A unique, case-sensitive key supplied by the client to ensure that the request is idempotent. For more information, see <a href="http://docs.aws.amazon.com/AWSEC2/latest/APIReference/Run_Instance_Idempotency.html">Ensuring Idempotency</a>.</p>
     pub client_token: Option<String>,
@@ -41886,7 +41886,7 @@ impl ReservedInstancesListingListDeserializer {
     }
 }
 /// <p>Describes a Reserved Instance modification.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ReservedInstancesModification {
     /// <p>A unique, case-sensitive key supplied by the client to ensure that the request is idempotent. For more information, see <a href="http://docs.aws.amazon.com/AWSEC2/latest/APIReference/Run_Instance_Idempotency.html">Ensuring Idempotency</a>.</p>
     pub client_token: Option<String>,
@@ -42048,7 +42048,7 @@ impl ReservedInstancesModificationListDeserializer {
     }
 }
 /// <p>Describes the modification request/s.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ReservedInstancesModificationResult {
     /// <p>The ID for the Reserved Instances that were created as part of the modification request. This field is only available when the modification is fulfilled.</p>
     pub reserved_instances_id: Option<String>,
@@ -42151,7 +42151,7 @@ impl ReservedInstancesModificationResultListDeserializer {
     }
 }
 /// <p>Describes a Reserved Instance offering.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ReservedInstancesOffering {
     /// <p>The Availability Zone in which the Reserved Instance can be used.</p>
     pub availability_zone: Option<String>,
@@ -42392,7 +42392,7 @@ impl ReservedIntancesIdsDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ResetFpgaImageAttributeRequest {
     /// <p>The attribute.</p>
     pub attribute: Option<String>,
@@ -42430,7 +42430,7 @@ impl ResetFpgaImageAttributeRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ResetFpgaImageAttributeResult {
     /// <p>Is <code>true</code> if the request succeeds, and an error otherwise.</p>
     pub return_: Option<bool>,
@@ -42476,7 +42476,7 @@ impl ResetFpgaImageAttributeResultDeserializer {
     }
 }
 /// <p>Contains the parameters for ResetImageAttribute.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ResetImageAttributeRequest {
     /// <p>The attribute to reset (currently you can only reset the launch permission attribute).</p>
     pub attribute: String,
@@ -42513,7 +42513,7 @@ impl ResetImageAttributeRequestSerializer {
 }
 
 /// <p>Contains the parameters for ResetInstanceAttribute.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ResetInstanceAttributeRequest {
     /// <p><p>The attribute to reset.</p> <important> <p>You can only reset the following attributes: <code>kernel</code> | <code>ramdisk</code> | <code>sourceDestCheck</code>. To change an instance attribute, use <a>ModifyInstanceAttribute</a>.</p> </important></p>
     pub attribute: String,
@@ -42550,7 +42550,7 @@ impl ResetInstanceAttributeRequestSerializer {
 }
 
 /// <p>Contains the parameters for ResetNetworkInterfaceAttribute.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ResetNetworkInterfaceAttributeRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -42589,7 +42589,7 @@ impl ResetNetworkInterfaceAttributeRequestSerializer {
 }
 
 /// <p>Contains the parameters for ResetSnapshotAttribute.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ResetSnapshotAttributeRequest {
     /// <p>The attribute to reset. Currently, only the attribute for permission to create volumes can be reset.</p>
     pub attribute: String,
@@ -42662,7 +42662,7 @@ impl ResourceTypeDeserializer {
     }
 }
 /// <p>Describes the error that's returned when you cannot delete a launch template version.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ResponseError {
     /// <p>The error code.</p>
     pub code: Option<String>,
@@ -42795,7 +42795,7 @@ impl ResponseHostIdSetDeserializer {
     }
 }
 /// <p>The information for a launch template. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ResponseLaunchTemplateData {
     /// <p>The block device mappings.</p>
     pub block_device_mappings: Option<Vec<LaunchTemplateBlockDeviceMapping>>,
@@ -43004,7 +43004,7 @@ impl RestorableByStringListSerializer {
 }
 
 /// <p>Contains the parameters for RestoreAddressToClassic.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RestoreAddressToClassicRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -43035,7 +43035,7 @@ impl RestoreAddressToClassicRequestSerializer {
 }
 
 /// <p>Contains the output of RestoreAddressToClassic.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RestoreAddressToClassicResult {
     /// <p>The Elastic IP address.</p>
     pub public_ip: Option<String>,
@@ -43087,7 +43087,7 @@ impl RestoreAddressToClassicResultDeserializer {
     }
 }
 /// <p>Contains the parameters for RevokeSecurityGroupEgress.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RevokeSecurityGroupEgressRequest {
     /// <p>Not supported. Use a set of IP permissions to specify the CIDR.</p>
     pub cidr_ip: Option<String>,
@@ -43175,7 +43175,7 @@ impl RevokeSecurityGroupEgressRequestSerializer {
 }
 
 /// <p>Contains the parameters for RevokeSecurityGroupIngress.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RevokeSecurityGroupIngressRequest {
     /// <p>The CIDR IP address range. You can't specify this parameter when specifying a source security group.</p>
     pub cidr_ip: Option<String>,
@@ -43273,7 +43273,7 @@ impl RevokeSecurityGroupIngressRequestSerializer {
 }
 
 /// <p>Describes a route in a route table.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Route {
     /// <p>The IPv4 CIDR block used for the destination match.</p>
     pub destination_cidr_block: Option<String>,
@@ -43463,7 +43463,7 @@ impl RouteStateDeserializer {
     }
 }
 /// <p>Describes a route table.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RouteTable {
     /// <p>The associations between the route table and one or more subnets.</p>
     pub associations: Option<Vec<RouteTableAssociation>>,
@@ -43542,7 +43542,7 @@ impl RouteTableDeserializer {
     }
 }
 /// <p>Describes an association between a route table and a subnet.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RouteTableAssociation {
     /// <p>Indicates whether this is the main route table.</p>
     pub main: Option<bool>,
@@ -43703,7 +43703,7 @@ impl RuleActionDeserializer {
     }
 }
 /// <p>Describes the monitoring of an instance.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RunInstancesMonitoringEnabled {
     /// <p>Indicates whether detailed monitoring is enabled. Otherwise, basic monitoring is enabled.</p>
     pub enabled: bool,
@@ -43766,7 +43766,7 @@ impl RunInstancesMonitoringEnabledSerializer {
 }
 
 /// <p>Contains the parameters for RunInstances.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RunInstancesRequest {
     /// <p>Reserved.</p>
     pub additional_info: Option<String>,
@@ -44032,7 +44032,7 @@ impl RunInstancesRequestSerializer {
 }
 
 /// <p>Contains the parameters for RunScheduledInstances.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RunScheduledInstancesRequest {
     /// <p>Unique, case-sensitive identifier that ensures the idempotency of the request. For more information, see <a href="http://docs.aws.amazon.com/AWSEC2/latest/APIReference/Run_Instance_Idempotency.html">Ensuring Idempotency</a>.</p>
     pub client_token: Option<String>,
@@ -44086,7 +44086,7 @@ impl RunScheduledInstancesRequestSerializer {
 }
 
 /// <p>Contains the output of RunScheduledInstances.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RunScheduledInstancesResult {
     /// <p>The IDs of the newly launched instances.</p>
     pub instance_id_set: Option<Vec<String>>,
@@ -44135,7 +44135,7 @@ impl RunScheduledInstancesResultDeserializer {
     }
 }
 /// <p>Describes the storage parameters for S3 and S3 buckets for an instance store-backed AMI.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct S3Storage {
     /// <p>The access key ID of the owner of the bucket. Before you specify a value for your access key ID, review and follow the guidance in <a href="http://docs.aws.amazon.com/general/latest/gr/aws-access-keys-best-practices.html">Best Practices for Managing AWS Access Keys</a>.</p>
     pub aws_access_key_id: Option<String>,
@@ -44253,7 +44253,7 @@ impl S3StorageSerializer {
 }
 
 /// <p>Describes a Scheduled Instance.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ScheduledInstance {
     /// <p>The Availability Zone.</p>
     pub availability_zone: Option<String>,
@@ -44406,7 +44406,7 @@ impl ScheduledInstanceDeserializer {
     }
 }
 /// <p>Describes a schedule that is available for your Scheduled Instances.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ScheduledInstanceAvailability {
     /// <p>The Availability Zone.</p>
     pub availability_zone: Option<String>,
@@ -44596,7 +44596,7 @@ impl ScheduledInstanceIdRequestSetSerializer {
 }
 
 /// <p>Describes the recurring schedule for a Scheduled Instance.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ScheduledInstanceRecurrence {
     /// <p>The frequency (<code>Daily</code>, <code>Weekly</code>, or <code>Monthly</code>).</p>
     pub frequency: Option<String>,
@@ -44671,7 +44671,7 @@ impl ScheduledInstanceRecurrenceDeserializer {
     }
 }
 /// <p>Describes the recurring schedule for a Scheduled Instance.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ScheduledInstanceRecurrenceRequest {
     /// <p>The frequency (<code>Daily</code>, <code>Weekly</code>, or <code>Monthly</code>).</p>
     pub frequency: Option<String>,
@@ -44771,7 +44771,7 @@ impl ScheduledInstanceSetDeserializer {
     }
 }
 /// <p>Describes a block device mapping for a Scheduled Instance.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ScheduledInstancesBlockDeviceMapping {
     /// <p>The device name (for example, <code>/dev/sdh</code> or <code>xvdh</code>).</p>
     pub device_name: Option<String>,
@@ -44832,7 +44832,7 @@ impl ScheduledInstancesBlockDeviceMappingSetSerializer {
 }
 
 /// <p>Describes an EBS volume for a Scheduled Instance.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ScheduledInstancesEbs {
     /// <p>Indicates whether the volume is deleted on instance termination.</p>
     pub delete_on_termination: Option<bool>,
@@ -44897,7 +44897,7 @@ impl ScheduledInstancesEbsSerializer {
 }
 
 /// <p>Describes an IAM instance profile for a Scheduled Instance.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ScheduledInstancesIamInstanceProfile {
     /// <p>The Amazon Resource Name (ARN).</p>
     pub arn: Option<String>,
@@ -44930,7 +44930,7 @@ impl ScheduledInstancesIamInstanceProfileSerializer {
 }
 
 /// <p>Describes an IPv6 address.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ScheduledInstancesIpv6Address {
     /// <p>The IPv6 address.</p>
     pub ipv_6_address: Option<String>,
@@ -44966,7 +44966,7 @@ impl ScheduledInstancesIpv6AddressListSerializer {
 }
 
 /// <p>Describes the launch specification for a Scheduled Instance.</p> <p>If you are launching the Scheduled Instance in EC2-VPC, you must specify the ID of the subnet. You can specify the subnet using either <code>SubnetId</code> or <code>NetworkInterface</code>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ScheduledInstancesLaunchSpecification {
     /// <p>One or more block device mapping entries.</p>
     pub block_device_mappings: Option<Vec<ScheduledInstancesBlockDeviceMapping>>,
@@ -45099,7 +45099,7 @@ impl ScheduledInstancesLaunchSpecificationSerializer {
 }
 
 /// <p>Describes whether monitoring is enabled for a Scheduled Instance.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ScheduledInstancesMonitoring {
     /// <p>Indicates whether monitoring is enabled.</p>
     pub enabled: Option<bool>,
@@ -45124,7 +45124,7 @@ impl ScheduledInstancesMonitoringSerializer {
 }
 
 /// <p>Describes a network interface for a Scheduled Instance.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ScheduledInstancesNetworkInterface {
     /// <p>Indicates whether to assign a public IPv4 address to instances launched in a VPC. The public IPv4 address can only be assigned to a network interface for eth0, and can only be assigned to a new network interface, not an existing one. You cannot specify more than one network interface in the request. If launching into a default subnet, the default value is <code>true</code>.</p>
     pub associate_public_ip_address: Option<bool>,
@@ -45251,7 +45251,7 @@ impl ScheduledInstancesNetworkInterfaceSetSerializer {
 }
 
 /// <p>Describes the placement for a Scheduled Instance.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ScheduledInstancesPlacement {
     /// <p>The Availability Zone.</p>
     pub availability_zone: Option<String>,
@@ -45284,7 +45284,7 @@ impl ScheduledInstancesPlacementSerializer {
 }
 
 /// <p>Describes a private IPv4 address for a Scheduled Instance.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ScheduledInstancesPrivateIpAddressConfig {
     /// <p>Indicates whether this is a primary IPv4 address. Otherwise, this is a secondary IPv4 address.</p>
     pub primary: Option<bool>,
@@ -45342,7 +45342,7 @@ impl ScopeDeserializer {
     }
 }
 /// <p>Describes a security group</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SecurityGroup {
     /// <p>A description of the security group.</p>
     pub description: Option<String>,
@@ -45489,7 +45489,7 @@ impl SecurityGroupIdStringListSerializer {
 }
 
 /// <p>Describes a security group.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SecurityGroupIdentifier {
     /// <p>The ID of the security group.</p>
     pub group_id: Option<String>,
@@ -45582,7 +45582,7 @@ impl SecurityGroupListDeserializer {
     }
 }
 /// <p>Describes a VPC with a security group that references your security group.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SecurityGroupReference {
     /// <p>The ID of your security group.</p>
     pub group_id: String,
@@ -45695,7 +45695,7 @@ impl SecurityGroupStringListSerializer {
 }
 
 /// <p>Describes a service configuration for a VPC endpoint service.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ServiceConfiguration {
     /// <p>Indicates whether requests from other AWS accounts to create an endpoint to the service must first be accepted.</p>
     pub acceptance_required: Option<bool>,
@@ -45846,7 +45846,7 @@ impl ServiceConfigurationSetDeserializer {
     }
 }
 /// <p>Describes a VPC endpoint service.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ServiceDetail {
     /// <p>Indicates whether VPC endpoint connection requests to the service must be accepted by the service owner.</p>
     pub acceptance_required: Option<bool>,
@@ -46012,7 +46012,7 @@ impl ServiceTypeDeserializer {
     }
 }
 /// <p>Describes the type of service for a VPC endpoint.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ServiceTypeDetail {
     /// <p>The type of service.</p>
     pub service_type: Option<String>,
@@ -46117,7 +46117,7 @@ impl ShutdownBehaviorDeserializer {
     }
 }
 /// <p>Describes the time period for a Scheduled Instance to start its first schedule. The time period must span less than one day.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SlotDateTimeRangeRequest {
     /// <p>The earliest date and time, in UTC, for the Scheduled Instance to start.</p>
     pub earliest_time: String,
@@ -46146,7 +46146,7 @@ impl SlotDateTimeRangeRequestSerializer {
 }
 
 /// <p>Describes the time period for a Scheduled Instance to start its first schedule.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SlotStartTimeRangeRequest {
     /// <p>The earliest date and time, in UTC, for the Scheduled Instance to start.</p>
     pub earliest_time: Option<String>,
@@ -46179,7 +46179,7 @@ impl SlotStartTimeRangeRequestSerializer {
 }
 
 /// <p>Describes a snapshot.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Snapshot {
     /// <p>The data encryption key identifier for the snapshot. This value is a unique identifier that corresponds to the data encryption key that was used to encrypt the original volume or snapshot copy. Because data encryption keys are inherited by volumes created from snapshots, and vice versa, if snapshots share the same data encryption key identifier, then they belong to the same volume/snapshot lineage. This parameter is only returned by the <a>DescribeSnapshots</a> API operation.</p>
     pub data_encryption_key_id: Option<String>,
@@ -46308,7 +46308,7 @@ impl SnapshotDeserializer {
     }
 }
 /// <p>Describes the snapshot created from the imported disk.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SnapshotDetail {
     /// <p>A description for the snapshot.</p>
     pub description: Option<String>,
@@ -46452,7 +46452,7 @@ impl SnapshotDetailListDeserializer {
     }
 }
 /// <p>The disk container object for the import snapshot request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SnapshotDiskContainer {
     /// <p>The description of the disk image being imported.</p>
     pub description: Option<String>,
@@ -46567,7 +46567,7 @@ impl SnapshotStateDeserializer {
     }
 }
 /// <p>Details about the import snapshot task.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SnapshotTaskDetail {
     /// <p>The description of the snapshot.</p>
     pub description: Option<String>,
@@ -46665,7 +46665,7 @@ impl SnapshotTaskDetailDeserializer {
     }
 }
 /// <p>Describes the data feed for a Spot Instance.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SpotDatafeedSubscription {
     /// <p>The Amazon S3 bucket where the Spot Instance data feed is located.</p>
     pub bucket: Option<String>,
@@ -46736,7 +46736,7 @@ impl SpotDatafeedSubscriptionDeserializer {
     }
 }
 /// <p>Describes the launch specification for one or more Spot Instances.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SpotFleetLaunchSpecification {
     /// <p>Deprecated.</p>
     pub addressing_type: Option<String>,
@@ -47041,7 +47041,7 @@ impl SpotFleetLaunchSpecificationSerializer {
 }
 
 /// <p>Describes whether monitoring is enabled.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SpotFleetMonitoring {
     /// <p>Enables monitoring for the instance.</p> <p>Default: <code>false</code> </p>
     pub enabled: Option<bool>,
@@ -47107,7 +47107,7 @@ impl SpotFleetMonitoringSerializer {
 }
 
 /// <p>Describes a Spot Fleet request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SpotFleetRequestConfig {
     /// <p>The progress of the Spot Fleet request. If there is an error, the status is <code>error</code>. After all requests are placed, the status is <code>pending_fulfillment</code>. If the size of the fleet is equal to or greater than its target capacity, the status is <code>fulfilled</code>. If the size of the fleet is decreased, the status is <code>pending_termination</code> while Spot Instances are terminating.</p>
     pub activity_status: Option<String>,
@@ -47185,7 +47185,7 @@ impl SpotFleetRequestConfigDeserializer {
     }
 }
 /// <p>Describes the configuration of a Spot Fleet request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SpotFleetRequestConfigData {
     /// <p>Indicates how to allocate the target capacity across the Spot pools specified by the Spot Fleet request. The default is <code>lowestPrice</code>.</p>
     pub allocation_strategy: Option<String>,
@@ -47494,7 +47494,7 @@ impl SpotFleetRequestConfigSetDeserializer {
     }
 }
 /// <p>The tags for a Spot Fleet resource.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SpotFleetTagSpecification {
     /// <p>The type of resource. Currently, the only resource type that is supported is <code>instance</code>.</p>
     pub resource_type: Option<String>,
@@ -47624,7 +47624,7 @@ impl SpotFleetTagSpecificationListSerializer {
 }
 
 /// <p>Describes a Spot Instance request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SpotInstanceRequest {
     /// <p>If you specified a duration and your Spot Instance request was fulfilled, this is the fixed hourly price in effect for the Spot Instance while it runs.</p>
     pub actual_block_hourly_price: Option<String>,
@@ -47867,7 +47867,7 @@ impl SpotInstanceStateDeserializer {
     }
 }
 /// <p>Describes a Spot Instance state change.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SpotInstanceStateFault {
     /// <p>The reason code for the Spot Instance state change.</p>
     pub code: Option<String>,
@@ -47918,7 +47918,7 @@ impl SpotInstanceStateFaultDeserializer {
     }
 }
 /// <p>Describes the status of a Spot Instance request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SpotInstanceStatus {
     /// <p>The status code. For a list of status codes, see <a href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-bid-status.html#spot-instance-bid-status-understand">Spot Status Codes</a> in the <i>Amazon Elastic Compute Cloud User Guide</i>.</p>
     pub code: Option<String>,
@@ -47989,7 +47989,7 @@ impl SpotInstanceTypeDeserializer {
     }
 }
 /// <p>The options for Spot Instances.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SpotMarketOptions {
     /// <p>The required duration for the Spot Instances (also known as Spot blocks), in minutes. This value must be a multiple of 60 (60, 120, 180, 240, 300, or 360).</p>
     pub block_duration_minutes: Option<i64>,
@@ -48046,7 +48046,7 @@ impl SpotMarketOptionsSerializer {
 }
 
 /// <p>Describes Spot Instance placement.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SpotPlacement {
     /// <p>The Availability Zone.</p> <p>[Spot Fleet only] To specify multiple Availability Zones, separate them using commas; for example, "us-west-2a, us-west-2b".</p>
     pub availability_zone: Option<String>,
@@ -48138,7 +48138,7 @@ impl SpotPlacementSerializer {
 }
 
 /// <p>Describes the maximum price per hour that you are willing to pay for a Spot Instance.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SpotPrice {
     /// <p>The Availability Zone.</p>
     pub availability_zone: Option<String>,
@@ -48256,7 +48256,7 @@ impl SpotPriceHistoryListDeserializer {
     }
 }
 /// <p>Describes a stale rule in a security group.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct StaleIpPermission {
     /// <p>The start of the port range for the TCP and UDP protocols, or an ICMP type number. A value of <code>-1</code> indicates all ICMP types. </p>
     pub from_port: Option<i64>,
@@ -48377,7 +48377,7 @@ impl StaleIpPermissionSetDeserializer {
     }
 }
 /// <p>Describes a stale security group (a security group that contains stale rules).</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct StaleSecurityGroup {
     /// <p>The description of the security group.</p>
     pub description: Option<String>,
@@ -48500,7 +48500,7 @@ impl StaleSecurityGroupSetDeserializer {
     }
 }
 /// <p>Contains the parameters for StartInstances.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct StartInstancesRequest {
     /// <p>Reserved.</p>
     pub additional_info: Option<String>,
@@ -48540,7 +48540,7 @@ impl StartInstancesRequestSerializer {
 }
 
 /// <p>Contains the output of StartInstances.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct StartInstancesResult {
     /// <p>Information about one or more started instances.</p>
     pub starting_instances: Option<Vec<InstanceStateChange>>,
@@ -48602,7 +48602,7 @@ impl StateDeserializer {
     }
 }
 /// <p>Describes a state change.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct StateReason {
     /// <p>The reason code for the state change.</p>
     pub code: Option<String>,
@@ -48695,7 +48695,7 @@ impl StatusTypeDeserializer {
     }
 }
 /// <p>Contains the parameters for StopInstances.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct StopInstancesRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -48735,7 +48735,7 @@ impl StopInstancesRequestSerializer {
 }
 
 /// <p>Contains the output of StopInstances.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct StopInstancesResult {
     /// <p>Information about one or more stopped instances.</p>
     pub stopping_instances: Option<Vec<InstanceStateChange>>,
@@ -48783,7 +48783,7 @@ impl StopInstancesResultDeserializer {
     }
 }
 /// <p>Describes the storage location for an instance store-backed AMI.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Storage {
     /// <p>An Amazon S3 storage location.</p>
     pub s3: Option<S3Storage>,
@@ -48845,7 +48845,7 @@ impl StorageSerializer {
 }
 
 /// <p>Describes a storage location in Amazon S3.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct StorageLocation {
     /// <p>The name of the S3 bucket.</p>
     pub bucket: Option<String>,
@@ -48892,7 +48892,7 @@ impl StringDeserializer {
     }
 }
 /// <p>Describes a subnet.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Subnet {
     /// <p>Indicates whether a network interface created in this subnet (including a network interface created by <a>RunInstances</a>) receives an IPv6 address.</p>
     pub assign_ipv_6_address_on_creation: Option<bool>,
@@ -49009,7 +49009,7 @@ impl SubnetDeserializer {
     }
 }
 /// <p>Describes the state of a CIDR block.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SubnetCidrBlockState {
     /// <p>The state of a CIDR block.</p>
     pub state: Option<String>,
@@ -49091,7 +49091,7 @@ impl SubnetIdStringListSerializer {
 }
 
 /// <p>Describes an IPv6 CIDR block associated with a subnet.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SubnetIpv6CidrBlockAssociation {
     /// <p>The association ID for the CIDR block.</p>
     pub association_id: Option<String>,
@@ -49253,7 +49253,7 @@ impl SubnetStateDeserializer {
     }
 }
 /// <p>Describes the T2 instance whose credit option for CPU usage was successfully modified.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SuccessfulInstanceCreditSpecificationItem {
     /// <p>The ID of the instance.</p>
     pub instance_id: Option<String>,
@@ -49358,7 +49358,7 @@ impl SummaryStatusDeserializer {
     }
 }
 /// <p>Describes a tag.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Tag {
     /// <p>The key of the tag.</p> <p>Constraints: Tag keys are case-sensitive and accept a maximum of 127 Unicode characters. May not begin with <code>aws:</code> </p>
     pub key: Option<String>,
@@ -49434,7 +49434,7 @@ impl TagSerializer {
 }
 
 /// <p>Describes a tag.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct TagDescription {
     /// <p>The tag key.</p>
     pub key: Option<String>,
@@ -49591,7 +49591,7 @@ impl TagListSerializer {
 }
 
 /// <p>The tags to apply to a resource when the resource is being created.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct TagSpecification {
     /// <p>The type of resource to tag. Currently, the resource types that support tagging on creation are <code>instance</code> and <code>volume</code>. </p>
     pub resource_type: Option<String>,
@@ -49632,7 +49632,7 @@ impl TagSpecificationListSerializer {
 }
 
 /// <p>Information about the Convertible Reserved Instance offering.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct TargetConfiguration {
     /// <p>The number of instances the Convertible Reserved Instance offering can be applied to. This parameter is reserved and cannot be specified in a request</p>
     pub instance_count: Option<i64>,
@@ -49687,7 +49687,7 @@ impl TargetConfigurationDeserializer {
     }
 }
 /// <p>Details about the target configuration.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct TargetConfigurationRequest {
     /// <p>The number of instances the Covertible Reserved Instance offering can be applied to. This parameter is reserved and cannot be specified in a request</p>
     pub instance_count: Option<i64>,
@@ -49729,7 +49729,7 @@ impl TargetConfigurationRequestSetSerializer {
 }
 
 /// <p>Describes a load balancer target group.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct TargetGroup {
     /// <p>The Amazon Resource Name (ARN) of the target group.</p>
     pub arn: String,
@@ -49844,7 +49844,7 @@ impl TargetGroupsSerializer {
 }
 
 /// <p>Describes the target groups to attach to a Spot Fleet. Spot Fleet registers the running Spot Instances with these target groups.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct TargetGroupsConfig {
     /// <p>One or more target groups.</p>
     pub target_groups: Vec<TargetGroup>,
@@ -49909,7 +49909,7 @@ impl TargetGroupsConfigSerializer {
 }
 
 /// <p>The total value of the new Convertible Reserved Instances.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct TargetReservationValue {
     /// <p>The total value of the Convertible Reserved Instances that make up the exchange. This is the sum of the list value, remaining upfront price, and additional upfront cost of the exchange.</p>
     pub reservation_value: Option<ReservationValue>,
@@ -50036,7 +50036,7 @@ impl TenancyDeserializer {
     }
 }
 /// <p>Contains the parameters for TerminateInstances.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct TerminateInstancesRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -50068,7 +50068,7 @@ impl TerminateInstancesRequestSerializer {
 }
 
 /// <p>Contains the output of TerminateInstances.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct TerminateInstancesResult {
     /// <p>Information about one or more terminated instances.</p>
     pub terminating_instances: Option<Vec<InstanceStateChange>>,
@@ -50141,7 +50141,7 @@ impl TunnelOptionsListSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UnassignIpv6AddressesRequest {
     /// <p>The IPv6 addresses to unassign from the network interface.</p>
     pub ipv_6_addresses: Vec<String>,
@@ -50170,7 +50170,7 @@ impl UnassignIpv6AddressesRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UnassignIpv6AddressesResult {
     /// <p>The ID of the network interface.</p>
     pub network_interface_id: Option<String>,
@@ -50228,7 +50228,7 @@ impl UnassignIpv6AddressesResultDeserializer {
     }
 }
 /// <p>Contains the parameters for UnassignPrivateIpAddresses.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UnassignPrivateIpAddressesRequest {
     /// <p>The ID of the network interface.</p>
     pub network_interface_id: String,
@@ -50258,7 +50258,7 @@ impl UnassignPrivateIpAddressesRequestSerializer {
 }
 
 /// <p>Contains the parameters for UnmonitorInstances.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UnmonitorInstancesRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -50290,7 +50290,7 @@ impl UnmonitorInstancesRequestSerializer {
 }
 
 /// <p>Contains the output of UnmonitorInstances.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UnmonitorInstancesResult {
     /// <p>The monitoring information.</p>
     pub instance_monitorings: Option<Vec<InstanceMonitoring>>,
@@ -50352,7 +50352,7 @@ impl UnsuccessfulInstanceCreditSpecificationErrorCodeDeserializer {
     }
 }
 /// <p>Describes the T2 instance whose credit option for CPU usage was not modified.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UnsuccessfulInstanceCreditSpecificationItem {
     /// <p>The applicable error for the T2 instance whose credit option for CPU usage was not modified.</p>
     pub error: Option<UnsuccessfulInstanceCreditSpecificationItemError>,
@@ -50404,7 +50404,7 @@ impl UnsuccessfulInstanceCreditSpecificationItemDeserializer {
     }
 }
 /// <p>Information about the error for the T2 instance whose credit option for CPU usage was not modified.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UnsuccessfulInstanceCreditSpecificationItemError {
     /// <p>The error code.</p>
     pub code: Option<String>,
@@ -50499,7 +50499,7 @@ impl UnsuccessfulInstanceCreditSpecificationSetDeserializer {
     }
 }
 /// <p>Information about items that were not successfully processed in a batch call.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UnsuccessfulItem {
     /// <p>Information about the error.</p>
     pub error: UnsuccessfulItemError,
@@ -50553,7 +50553,7 @@ impl UnsuccessfulItemDeserializer {
     }
 }
 /// <p>Information about the error that occurred. For more information about errors, see <a href="http://docs.aws.amazon.com/AWSEC2/latest/APIReference/errors-overview.html">Error Codes</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UnsuccessfulItemError {
     /// <p>The error code.</p>
     pub code: String,
@@ -50688,7 +50688,7 @@ impl UnsuccessfulItemSetDeserializer {
     }
 }
 /// <p>Contains the parameters for UpdateSecurityGroupRuleDescriptionsEgress.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateSecurityGroupRuleDescriptionsEgressRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -50740,7 +50740,7 @@ impl UpdateSecurityGroupRuleDescriptionsEgressRequestSerializer {
 }
 
 /// <p>Contains the output of UpdateSecurityGroupRuleDescriptionsEgress.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateSecurityGroupRuleDescriptionsEgressResult {
     /// <p>Returns <code>true</code> if the request succeeds; otherwise, returns an error.</p>
     pub return_: Option<bool>,
@@ -50786,7 +50786,7 @@ impl UpdateSecurityGroupRuleDescriptionsEgressResultDeserializer {
     }
 }
 /// <p>Contains the parameters for UpdateSecurityGroupRuleDescriptionsIngress.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateSecurityGroupRuleDescriptionsIngressRequest {
     /// <p>Checks whether you have the required permissions for the action, without actually making the request, and provides an error response. If you have the required permissions, the error response is <code>DryRunOperation</code>. Otherwise, it is <code>UnauthorizedOperation</code>.</p>
     pub dry_run: Option<bool>,
@@ -50838,7 +50838,7 @@ impl UpdateSecurityGroupRuleDescriptionsIngressRequestSerializer {
 }
 
 /// <p>Contains the output of UpdateSecurityGroupRuleDescriptionsIngress.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateSecurityGroupRuleDescriptionsIngressResult {
     /// <p>Returns <code>true</code> if the request succeeds; otherwise, returns an error.</p>
     pub return_: Option<bool>,
@@ -50884,7 +50884,7 @@ impl UpdateSecurityGroupRuleDescriptionsIngressResultDeserializer {
     }
 }
 /// <p>Describes the S3 bucket for the disk image.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UserBucket {
     /// <p>The name of the S3 bucket where the disk image is located.</p>
     pub s3_bucket: Option<String>,
@@ -50917,7 +50917,7 @@ impl UserBucketSerializer {
 }
 
 /// <p>Describes the S3 bucket for the disk image.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UserBucketDetails {
     /// <p>The S3 bucket from which the disk image was created.</p>
     pub s3_bucket: Option<String>,
@@ -50969,7 +50969,7 @@ impl UserBucketDetailsDeserializer {
     }
 }
 /// <p>Describes the user data for an instance.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UserData {
     /// <p>The user data. If you are using an AWS SDK or command line tool, Base64-encoding is performed for you, and you can load the text from a file. Otherwise, you must provide Base64-encoded text.</p>
     pub data: Option<String>,
@@ -51005,7 +51005,7 @@ impl UserGroupStringListSerializer {
 }
 
 /// <p>Describes a security group and AWS account ID pair.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UserIdGroupPair {
     /// <p>A description for the security group rule that references this user ID group pair.</p> <p>Constraints: Up to 255 characters in length. Allowed characters are a-z, A-Z, 0-9, spaces, and ._-:/()#,@[]+=;{}!$*</p>
     pub description: Option<String>,
@@ -51330,7 +51330,7 @@ impl VersionStringListSerializer {
 }
 
 /// <p>Describes telemetry for a VPN tunnel.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct VgwTelemetry {
     /// <p>The number of accepted routes.</p>
     pub accepted_route_count: Option<i64>,
@@ -51464,7 +51464,7 @@ impl VirtualizationTypeDeserializer {
     }
 }
 /// <p>Describes a volume.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Volume {
     /// <p>Information about the volume attachments.</p>
     pub attachments: Option<Vec<VolumeAttachment>>,
@@ -51579,7 +51579,7 @@ impl VolumeDeserializer {
     }
 }
 /// <p>Describes volume attachment details.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct VolumeAttachment {
     /// <p>The time stamp when the attachment initiated.</p>
     pub attach_time: Option<String>,
@@ -51714,7 +51714,7 @@ impl VolumeAttachmentStateDeserializer {
     }
 }
 /// <p>Describes an EBS volume.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct VolumeDetail {
     /// <p>The size of the volume, in GiB.</p>
     pub size: i64,
@@ -51788,7 +51788,7 @@ impl VolumeListDeserializer {
     }
 }
 /// <p>Describes the modification status of an EBS volume.</p> <p>If the volume has never been modified, some element values will be null.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct VolumeModification {
     /// <p>Modification completion or failure time.</p>
     pub end_time: Option<String>,
@@ -51983,7 +51983,7 @@ impl VolumeStateDeserializer {
     }
 }
 /// <p>Describes a volume status operation code.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct VolumeStatusAction {
     /// <p>The code identifying the operation, for example, <code>enable-volume-io</code>.</p>
     pub code: Option<String>,
@@ -52089,7 +52089,7 @@ impl VolumeStatusActionsListDeserializer {
     }
 }
 /// <p>Describes a volume status.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct VolumeStatusDetails {
     /// <p>The name of the volume status.</p>
     pub name: Option<String>,
@@ -52184,7 +52184,7 @@ impl VolumeStatusDetailsListDeserializer {
     }
 }
 /// <p>Describes a volume status event.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct VolumeStatusEvent {
     /// <p>A description of the event.</p>
     pub description: Option<String>,
@@ -52297,7 +52297,7 @@ impl VolumeStatusEventsListDeserializer {
     }
 }
 /// <p>Describes the status of a volume.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct VolumeStatusInfo {
     /// <p>The details of the volume status.</p>
     pub details: Option<Vec<VolumeStatusDetails>>,
@@ -52366,7 +52366,7 @@ impl VolumeStatusInfoStatusDeserializer {
     }
 }
 /// <p>Describes the volume status.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct VolumeStatusItem {
     /// <p>The details of the operation.</p>
     pub actions: Option<Vec<VolumeStatusAction>>,
@@ -52515,7 +52515,7 @@ impl VolumeTypeDeserializer {
     }
 }
 /// <p>Describes a VPC.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Vpc {
     /// <p>The primary IPv4 CIDR block for the VPC.</p>
     pub cidr_block: Option<String>,
@@ -52618,7 +52618,7 @@ impl VpcDeserializer {
     }
 }
 /// <p>Describes an attachment between a virtual private gateway and a VPC.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct VpcAttachment {
     /// <p>The current state of the attachment.</p>
     pub state: Option<String>,
@@ -52711,7 +52711,7 @@ impl VpcAttachmentListDeserializer {
     }
 }
 /// <p>Describes an IPv4 CIDR block associated with a VPC.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct VpcCidrBlockAssociation {
     /// <p>The association ID for the IPv4 CIDR block.</p>
     pub association_id: Option<String>,
@@ -52815,7 +52815,7 @@ impl VpcCidrBlockAssociationSetDeserializer {
     }
 }
 /// <p>Describes the state of a CIDR block.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct VpcCidrBlockState {
     /// <p>The state of the CIDR block.</p>
     pub state: Option<String>,
@@ -52885,7 +52885,7 @@ impl VpcCidrBlockStateCodeDeserializer {
     }
 }
 /// <p>Describes whether a VPC is enabled for ClassicLink.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct VpcClassicLink {
     /// <p>Indicates whether the VPC is enabled for ClassicLink.</p>
     pub classic_link_enabled: Option<bool>,
@@ -52996,7 +52996,7 @@ impl VpcClassicLinkListDeserializer {
     }
 }
 /// <p>Describes a VPC endpoint.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct VpcEndpoint {
     /// <p>The date and time the VPC endpoint was created.</p>
     pub creation_timestamp: Option<String>,
@@ -53132,7 +53132,7 @@ impl VpcEndpointDeserializer {
     }
 }
 /// <p>Describes a VPC endpoint connection to a service.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct VpcEndpointConnection {
     /// <p>The date and time the VPC endpoint was created.</p>
     pub creation_timestamp: Option<String>,
@@ -53319,7 +53319,7 @@ impl VpcIdStringListSerializer {
 }
 
 /// <p>Describes an IPv6 CIDR block associated with a VPC.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct VpcIpv6CidrBlockAssociation {
     /// <p>The association ID for the IPv6 CIDR block.</p>
     pub association_id: Option<String>,
@@ -53465,7 +53465,7 @@ impl VpcListDeserializer {
     }
 }
 /// <p>Describes a VPC peering connection.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct VpcPeeringConnection {
     /// <p>Information about the accepter VPC. CIDR block information is only returned when describing an active VPC peering connection.</p>
     pub accepter_vpc_info: Option<VpcPeeringConnectionVpcInfo>,
@@ -53595,7 +53595,7 @@ impl VpcPeeringConnectionListDeserializer {
     }
 }
 /// <p>Describes the VPC peering connection options.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct VpcPeeringConnectionOptionsDescription {
     /// <p>Indicates whether a local VPC can resolve public DNS hostnames to private IP addresses when queried from instances in a peer VPC.</p>
     pub allow_dns_resolution_from_remote_vpc: Option<bool>,
@@ -53663,7 +53663,7 @@ impl VpcPeeringConnectionOptionsDescriptionDeserializer {
     }
 }
 /// <p>Describes the status of a VPC peering connection.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct VpcPeeringConnectionStateReason {
     /// <p>The status of the VPC peering connection.</p>
     pub code: Option<String>,
@@ -53732,7 +53732,7 @@ impl VpcPeeringConnectionStateReasonCodeDeserializer {
     }
 }
 /// <p>Describes a VPC in a VPC peering connection.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct VpcPeeringConnectionVpcInfo {
     /// <p>The IPv4 CIDR block for the VPC.</p>
     pub cidr_block: Option<String>,
@@ -53834,7 +53834,7 @@ impl VpcStateDeserializer {
     }
 }
 /// <p>Describes a VPN connection.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct VpnConnection {
     /// <p>The category of the VPN connection. A value of <code>VPN</code> indicates an AWS VPN connection. A value of <code>VPN-Classic</code> indicates an AWS Classic VPN connection. For more information, see <a href="http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_VPN.html#vpn-categories">AWS Managed VPN Categories</a> in the <i>Amazon Virtual Private Cloud User Guide</i>.</p>
     pub category: Option<String>,
@@ -53999,7 +53999,7 @@ impl VpnConnectionListDeserializer {
     }
 }
 /// <p>Describes VPN connection options.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct VpnConnectionOptions {
     /// <p>Indicates whether the VPN connection uses static routes only. Static routes must be used for devices that don't support BGP.</p>
     pub static_routes_only: Option<bool>,
@@ -54048,7 +54048,7 @@ impl VpnConnectionOptionsDeserializer {
     }
 }
 /// <p>Describes VPN connection options.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct VpnConnectionOptionsSpecification {
     /// <p>Indicate whether the VPN connection uses static routes only. If you are creating a VPN connection for a device that does not support BGP, you must specify <code>true</code>. Use <a>CreateVpnConnectionRoute</a> to create a static route.</p> <p>Default: <code>false</code> </p>
     pub static_routes_only: Option<bool>,
@@ -54082,7 +54082,7 @@ impl VpnConnectionOptionsSpecificationSerializer {
 }
 
 /// <p>Describes a virtual private gateway.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct VpnGateway {
     /// <p>The private Autonomous System Number (ASN) for the Amazon side of a BGP session.</p>
     pub amazon_side_asn: Option<i64>,
@@ -54231,7 +54231,7 @@ impl VpnStateDeserializer {
     }
 }
 /// <p>Describes a static route for a VPN connection.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct VpnStaticRoute {
     /// <p>The CIDR block associated with the local subnet of the customer data center.</p>
     pub destination_cidr_block: Option<String>,
@@ -54346,7 +54346,7 @@ impl VpnStaticRouteSourceDeserializer {
     }
 }
 /// <p>The tunnel options for a VPN connection.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct VpnTunnelOptionsSpecification {
     /// <p>The pre-shared key (PSK) to establish initial authentication between the virtual private gateway and customer gateway.</p> <p>Constraints: Allowed characters are alphanumeric characters and ._. Must be between 8 and 64 characters in length and cannot start with zero (0).</p>
     pub pre_shared_key: Option<String>,

--- a/rusoto/services/ec2/src/generated.rs
+++ b/rusoto/services/ec2/src/generated.rs
@@ -29,8 +29,9 @@ use hyper::StatusCode;
 use rusoto_core::param::{Params, ServiceParams};
 use rusoto_core::signature::SignedRequest;
 use rusoto_core::xmlerror::*;
-use rusoto_core::xmlutil::{characters, end_element, find_start_element, peek_at_name, skip_tree,
-                           start_element};
+use rusoto_core::xmlutil::{
+    characters, end_element, find_start_element, peek_at_name, skip_tree, start_element,
+};
 use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
 use std::str::FromStr;
 use xml::reader::ParserConfig;

--- a/rusoto/services/ecr/src/generated.rs
+++ b/rusoto/services/ecr/src/generated.rs
@@ -960,7 +960,8 @@ impl BatchCheckLayerAvailabilityError {
     pub fn from_body(body: &str) -> BatchCheckLayerAvailabilityError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1056,7 +1057,8 @@ impl BatchDeleteImageError {
     pub fn from_body(body: &str) -> BatchDeleteImageError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1144,7 +1146,8 @@ impl BatchGetImageError {
     pub fn from_body(body: &str) -> BatchGetImageError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1242,7 +1245,8 @@ impl CompleteLayerUploadError {
     pub fn from_body(body: &str) -> CompleteLayerUploadError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1356,7 +1360,8 @@ impl CreateRepositoryError {
     pub fn from_body(body: &str) -> CreateRepositoryError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1450,7 +1455,8 @@ impl DeleteLifecyclePolicyError {
     pub fn from_body(body: &str) -> DeleteLifecyclePolicyError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1550,7 +1556,8 @@ impl DeleteRepositoryError {
     pub fn from_body(body: &str) -> DeleteRepositoryError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1644,7 +1651,8 @@ impl DeleteRepositoryPolicyError {
     pub fn from_body(body: &str) -> DeleteRepositoryPolicyError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1744,7 +1752,8 @@ impl DescribeImagesError {
     pub fn from_body(body: &str) -> DescribeImagesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1836,7 +1845,8 @@ impl DescribeRepositoriesError {
     pub fn from_body(body: &str) -> DescribeRepositoriesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1926,7 +1936,8 @@ impl GetAuthorizationTokenError {
     pub fn from_body(body: &str) -> GetAuthorizationTokenError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2018,7 +2029,8 @@ impl GetDownloadUrlForLayerError {
     pub fn from_body(body: &str) -> GetDownloadUrlForLayerError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2120,7 +2132,8 @@ impl GetLifecyclePolicyError {
     pub fn from_body(body: &str) -> GetLifecyclePolicyError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2220,7 +2233,8 @@ impl GetLifecyclePolicyPreviewError {
     pub fn from_body(body: &str) -> GetLifecyclePolicyPreviewError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2324,7 +2338,8 @@ impl GetRepositoryPolicyError {
     pub fn from_body(body: &str) -> GetRepositoryPolicyError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2422,7 +2437,8 @@ impl InitiateLayerUploadError {
     pub fn from_body(body: &str) -> InitiateLayerUploadError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2514,7 +2530,8 @@ impl ListImagesError {
     pub fn from_body(body: &str) -> ListImagesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2606,7 +2623,8 @@ impl PutImageError {
     pub fn from_body(body: &str) -> PutImageError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2704,7 +2722,8 @@ impl PutLifecyclePolicyError {
     pub fn from_body(body: &str) -> PutLifecyclePolicyError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2796,7 +2815,8 @@ impl SetRepositoryPolicyError {
     pub fn from_body(body: &str) -> SetRepositoryPolicyError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2892,7 +2912,8 @@ impl StartLifecyclePolicyPreviewError {
     pub fn from_body(body: &str) -> StartLifecyclePolicyPreviewError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3006,7 +3027,8 @@ impl UploadLayerPartError {
     pub fn from_body(body: &str) -> UploadLayerPartError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/ecr/src/generated.rs
+++ b/rusoto/services/ecr/src/generated.rs
@@ -31,7 +31,7 @@ use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 /// <p>An object representing authorization data for an Amazon ECR registry.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AuthorizationData {
     /// <p>A base64-encoded string that contains authorization data for the specified Amazon ECR registry. When the string is decoded, it is presented in the format <code>user:password</code> for private registry authentication using <code>docker login</code>.</p>
     #[serde(rename = "authorizationToken")]
@@ -47,7 +47,7 @@ pub struct AuthorizationData {
     pub proxy_endpoint: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct BatchCheckLayerAvailabilityRequest {
     /// <p>The digests of the image layers to check.</p>
     #[serde(rename = "layerDigests")]
@@ -61,7 +61,7 @@ pub struct BatchCheckLayerAvailabilityRequest {
     pub repository_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BatchCheckLayerAvailabilityResponse {
     /// <p>Any failures associated with the call.</p>
     #[serde(rename = "failures")]
@@ -74,7 +74,7 @@ pub struct BatchCheckLayerAvailabilityResponse {
 }
 
 /// <p>Deletes specified images within a specified repository. Images are specified with either the <code>imageTag</code> or <code>imageDigest</code>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct BatchDeleteImageRequest {
     /// <p>A list of image ID references that correspond to images to delete. The format of the <code>imageIds</code> reference is <code>imageTag=tag</code> or <code>imageDigest=digest</code>.</p>
     #[serde(rename = "imageIds")]
@@ -88,7 +88,7 @@ pub struct BatchDeleteImageRequest {
     pub repository_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BatchDeleteImageResponse {
     /// <p>Any failures associated with the call.</p>
     #[serde(rename = "failures")]
@@ -100,7 +100,7 @@ pub struct BatchDeleteImageResponse {
     pub image_ids: Option<Vec<ImageIdentifier>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct BatchGetImageRequest {
     /// <p>The accepted media types for the request.</p> <p>Valid values: <code>application/vnd.docker.distribution.manifest.v1+json</code> | <code>application/vnd.docker.distribution.manifest.v2+json</code> | <code>application/vnd.oci.image.manifest.v1+json</code> </p>
     #[serde(rename = "acceptedMediaTypes")]
@@ -118,7 +118,7 @@ pub struct BatchGetImageRequest {
     pub repository_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BatchGetImageResponse {
     /// <p>Any failures associated with the call.</p>
     #[serde(rename = "failures")]
@@ -130,7 +130,7 @@ pub struct BatchGetImageResponse {
     pub images: Option<Vec<Image>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CompleteLayerUploadRequest {
     /// <p>The <code>sha256</code> digest of the image layer.</p>
     #[serde(rename = "layerDigests")]
@@ -147,7 +147,7 @@ pub struct CompleteLayerUploadRequest {
     pub upload_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CompleteLayerUploadResponse {
     /// <p>The <code>sha256</code> digest of the image layer.</p>
     #[serde(rename = "layerDigest")]
@@ -167,14 +167,14 @@ pub struct CompleteLayerUploadResponse {
     pub upload_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateRepositoryRequest {
     /// <p>The name to use for the repository. The repository name may be specified on its own (such as <code>nginx-web-app</code>) or it can be prepended with a namespace to group the repository into a category (such as <code>project-a/nginx-web-app</code>).</p>
     #[serde(rename = "repositoryName")]
     pub repository_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateRepositoryResponse {
     /// <p>The repository that was created.</p>
     #[serde(rename = "repository")]
@@ -182,7 +182,7 @@ pub struct CreateRepositoryResponse {
     pub repository: Option<Repository>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteLifecyclePolicyRequest {
     /// <p>The AWS account ID associated with the registry that contains the repository. If you do not specify a registry, the default registry is assumed.</p>
     #[serde(rename = "registryId")]
@@ -193,7 +193,7 @@ pub struct DeleteLifecyclePolicyRequest {
     pub repository_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteLifecyclePolicyResponse {
     /// <p>The time stamp of the last time that the lifecycle policy was run.</p>
     #[serde(rename = "lastEvaluatedAt")]
@@ -213,7 +213,7 @@ pub struct DeleteLifecyclePolicyResponse {
     pub repository_name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteRepositoryPolicyRequest {
     /// <p>The AWS account ID associated with the registry that contains the repository policy to delete. If you do not specify a registry, the default registry is assumed.</p>
     #[serde(rename = "registryId")]
@@ -224,7 +224,7 @@ pub struct DeleteRepositoryPolicyRequest {
     pub repository_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteRepositoryPolicyResponse {
     /// <p>The JSON repository policy that was deleted from the repository.</p>
     #[serde(rename = "policyText")]
@@ -240,7 +240,7 @@ pub struct DeleteRepositoryPolicyResponse {
     pub repository_name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteRepositoryRequest {
     /// <p> If a repository contains images, forces the deletion.</p>
     #[serde(rename = "force")]
@@ -255,7 +255,7 @@ pub struct DeleteRepositoryRequest {
     pub repository_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteRepositoryResponse {
     /// <p>The repository that was deleted.</p>
     #[serde(rename = "repository")]
@@ -264,7 +264,7 @@ pub struct DeleteRepositoryResponse {
 }
 
 /// <p>An object representing a filter on a <a>DescribeImages</a> operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeImagesFilter {
     /// <p>The tag status with which to filter your <a>DescribeImages</a> results. You can filter results based on whether they are <code>TAGGED</code> or <code>UNTAGGED</code>.</p>
     #[serde(rename = "tagStatus")]
@@ -272,7 +272,7 @@ pub struct DescribeImagesFilter {
     pub tag_status: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeImagesRequest {
     /// <p>The filter key and value with which to filter your <code>DescribeImages</code> results.</p>
     #[serde(rename = "filter")]
@@ -299,7 +299,7 @@ pub struct DescribeImagesRequest {
     pub repository_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeImagesResponse {
     /// <p>A list of <a>ImageDetail</a> objects that contain data about the image.</p>
     #[serde(rename = "imageDetails")]
@@ -311,7 +311,7 @@ pub struct DescribeImagesResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeRepositoriesRequest {
     /// <p>The maximum number of repository results returned by <code>DescribeRepositories</code> in paginated output. When this parameter is used, <code>DescribeRepositories</code> only returns <code>maxResults</code> results in a single page along with a <code>nextToken</code> response element. The remaining results of the initial request can be seen by sending another <code>DescribeRepositories</code> request with the returned <code>nextToken</code> value. This value can be between 1 and 100. If this parameter is not used, then <code>DescribeRepositories</code> returns up to 100 results and a <code>nextToken</code> value, if applicable. This option cannot be used when you specify repositories with <code>repositoryNames</code>.</p>
     #[serde(rename = "maxResults")]
@@ -331,7 +331,7 @@ pub struct DescribeRepositoriesRequest {
     pub repository_names: Option<Vec<String>>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeRepositoriesResponse {
     /// <p>The <code>nextToken</code> value to include in a future <code>DescribeRepositories</code> request. When the results of a <code>DescribeRepositories</code> request exceed <code>maxResults</code>, this value can be used to retrieve the next page of results. This value is <code>null</code> when there are no more results to return.</p>
     #[serde(rename = "nextToken")]
@@ -343,7 +343,7 @@ pub struct DescribeRepositoriesResponse {
     pub repositories: Option<Vec<Repository>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetAuthorizationTokenRequest {
     /// <p>A list of AWS account IDs that are associated with the registries for which to get authorization tokens. If you do not specify a registry, the default registry is assumed.</p>
     #[serde(rename = "registryIds")]
@@ -351,7 +351,7 @@ pub struct GetAuthorizationTokenRequest {
     pub registry_ids: Option<Vec<String>>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetAuthorizationTokenResponse {
     /// <p>A list of authorization token data objects that correspond to the <code>registryIds</code> values in the request.</p>
     #[serde(rename = "authorizationData")]
@@ -359,7 +359,7 @@ pub struct GetAuthorizationTokenResponse {
     pub authorization_data: Option<Vec<AuthorizationData>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetDownloadUrlForLayerRequest {
     /// <p>The digest of the image layer to download.</p>
     #[serde(rename = "layerDigest")]
@@ -373,7 +373,7 @@ pub struct GetDownloadUrlForLayerRequest {
     pub repository_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetDownloadUrlForLayerResponse {
     /// <p>The pre-signed Amazon S3 download URL for the requested layer.</p>
     #[serde(rename = "downloadUrl")]
@@ -385,7 +385,7 @@ pub struct GetDownloadUrlForLayerResponse {
     pub layer_digest: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetLifecyclePolicyPreviewRequest {
     /// <p>An optional parameter that filters results based on image tag status and all tags, if tagged.</p>
     #[serde(rename = "filter")]
@@ -412,7 +412,7 @@ pub struct GetLifecyclePolicyPreviewRequest {
     pub repository_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetLifecyclePolicyPreviewResponse {
     /// <p>The JSON lifecycle policy text.</p>
     #[serde(rename = "lifecyclePolicyText")]
@@ -444,7 +444,7 @@ pub struct GetLifecyclePolicyPreviewResponse {
     pub summary: Option<LifecyclePolicyPreviewSummary>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetLifecyclePolicyRequest {
     /// <p>The AWS account ID associated with the registry that contains the repository. If you do not specify a registry, the default registry is assumed.</p>
     #[serde(rename = "registryId")]
@@ -455,7 +455,7 @@ pub struct GetLifecyclePolicyRequest {
     pub repository_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetLifecyclePolicyResponse {
     /// <p>The time stamp of the last time that the lifecycle policy was run.</p>
     #[serde(rename = "lastEvaluatedAt")]
@@ -475,7 +475,7 @@ pub struct GetLifecyclePolicyResponse {
     pub repository_name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetRepositoryPolicyRequest {
     /// <p>The AWS account ID associated with the registry that contains the repository. If you do not specify a registry, the default registry is assumed.</p>
     #[serde(rename = "registryId")]
@@ -486,7 +486,7 @@ pub struct GetRepositoryPolicyRequest {
     pub repository_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetRepositoryPolicyResponse {
     /// <p>The JSON repository policy text associated with the repository.</p>
     #[serde(rename = "policyText")]
@@ -503,7 +503,7 @@ pub struct GetRepositoryPolicyResponse {
 }
 
 /// <p>An object representing an Amazon ECR image.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Image {
     /// <p>An object containing the image tag and image digest associated with an image.</p>
     #[serde(rename = "imageId")]
@@ -524,7 +524,7 @@ pub struct Image {
 }
 
 /// <p>An object that describes an image returned by a <a>DescribeImages</a> operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ImageDetail {
     /// <p>The <code>sha256</code> digest of the image manifest.</p>
     #[serde(rename = "imageDigest")]
@@ -553,7 +553,7 @@ pub struct ImageDetail {
 }
 
 /// <p>An object representing an Amazon ECR image failure.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ImageFailure {
     /// <p>The code associated with the failure.</p>
     #[serde(rename = "failureCode")]
@@ -570,7 +570,7 @@ pub struct ImageFailure {
 }
 
 /// <p>An object with identifying information for an Amazon ECR image.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ImageIdentifier {
     /// <p>The <code>sha256</code> digest of the image manifest.</p>
     #[serde(rename = "imageDigest")]
@@ -582,7 +582,7 @@ pub struct ImageIdentifier {
     pub image_tag: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct InitiateLayerUploadRequest {
     /// <p>The AWS account ID associated with the registry to which you intend to upload layers. If you do not specify a registry, the default registry is assumed.</p>
     #[serde(rename = "registryId")]
@@ -593,7 +593,7 @@ pub struct InitiateLayerUploadRequest {
     pub repository_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct InitiateLayerUploadResponse {
     /// <p>The size, in bytes, that Amazon ECR expects future layer part uploads to be.</p>
     #[serde(rename = "partSize")]
@@ -606,7 +606,7 @@ pub struct InitiateLayerUploadResponse {
 }
 
 /// <p>An object representing an Amazon ECR image layer.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Layer {
     /// <p>The availability status of the image layer.</p>
     #[serde(rename = "layerAvailability")]
@@ -627,7 +627,7 @@ pub struct Layer {
 }
 
 /// <p>An object representing an Amazon ECR image layer failure.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct LayerFailure {
     /// <p>The failure code associated with the failure.</p>
     #[serde(rename = "failureCode")]
@@ -644,7 +644,7 @@ pub struct LayerFailure {
 }
 
 /// <p>The filter for the lifecycle policy preview.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct LifecyclePolicyPreviewFilter {
     /// <p>The tag status of the image.</p>
     #[serde(rename = "tagStatus")]
@@ -653,7 +653,7 @@ pub struct LifecyclePolicyPreviewFilter {
 }
 
 /// <p>The result of the lifecycle policy preview.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct LifecyclePolicyPreviewResult {
     /// <p>The type of action to be taken.</p>
     #[serde(rename = "action")]
@@ -678,7 +678,7 @@ pub struct LifecyclePolicyPreviewResult {
 }
 
 /// <p>The summary of the lifecycle policy preview request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct LifecyclePolicyPreviewSummary {
     /// <p>The number of expiring images.</p>
     #[serde(rename = "expiringImageTotalCount")]
@@ -687,7 +687,7 @@ pub struct LifecyclePolicyPreviewSummary {
 }
 
 /// <p>The type of action to be taken.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct LifecyclePolicyRuleAction {
     /// <p>The type of action to be taken.</p>
     #[serde(rename = "type")]
@@ -696,7 +696,7 @@ pub struct LifecyclePolicyRuleAction {
 }
 
 /// <p>An object representing a filter on a <a>ListImages</a> operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListImagesFilter {
     /// <p>The tag status with which to filter your <a>ListImages</a> results. You can filter results based on whether they are <code>TAGGED</code> or <code>UNTAGGED</code>.</p>
     #[serde(rename = "tagStatus")]
@@ -704,7 +704,7 @@ pub struct ListImagesFilter {
     pub tag_status: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListImagesRequest {
     /// <p>The filter key and value with which to filter your <code>ListImages</code> results.</p>
     #[serde(rename = "filter")]
@@ -727,7 +727,7 @@ pub struct ListImagesRequest {
     pub repository_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListImagesResponse {
     /// <p>The list of image IDs for the requested repository.</p>
     #[serde(rename = "imageIds")]
@@ -739,7 +739,7 @@ pub struct ListImagesResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PutImageRequest {
     /// <p>The image manifest corresponding to the image to be uploaded.</p>
     #[serde(rename = "imageManifest")]
@@ -757,7 +757,7 @@ pub struct PutImageRequest {
     pub repository_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PutImageResponse {
     /// <p>Details of the image uploaded.</p>
     #[serde(rename = "image")]
@@ -765,7 +765,7 @@ pub struct PutImageResponse {
     pub image: Option<Image>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PutLifecyclePolicyRequest {
     /// <p>The JSON repository policy text to apply to the repository.</p>
     #[serde(rename = "lifecyclePolicyText")]
@@ -779,7 +779,7 @@ pub struct PutLifecyclePolicyRequest {
     pub repository_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PutLifecyclePolicyResponse {
     /// <p>The JSON repository policy text.</p>
     #[serde(rename = "lifecyclePolicyText")]
@@ -796,7 +796,7 @@ pub struct PutLifecyclePolicyResponse {
 }
 
 /// <p>An object representing a repository.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Repository {
     /// <p>The date and time, in JavaScript date format, when the repository was created.</p>
     #[serde(rename = "createdAt")]
@@ -820,7 +820,7 @@ pub struct Repository {
     pub repository_uri: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SetRepositoryPolicyRequest {
     /// <p>If the policy you are attempting to set on a repository policy would prevent you from setting another policy in the future, you must force the <a>SetRepositoryPolicy</a> operation. This is intended to prevent accidental repository lock outs.</p>
     #[serde(rename = "force")]
@@ -838,7 +838,7 @@ pub struct SetRepositoryPolicyRequest {
     pub repository_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SetRepositoryPolicyResponse {
     /// <p>The JSON repository policy text applied to the repository.</p>
     #[serde(rename = "policyText")]
@@ -854,7 +854,7 @@ pub struct SetRepositoryPolicyResponse {
     pub repository_name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StartLifecyclePolicyPreviewRequest {
     /// <p>The policy to be evaluated against. If you do not specify a policy, the current policy for the repository is used.</p>
     #[serde(rename = "lifecyclePolicyText")]
@@ -869,7 +869,7 @@ pub struct StartLifecyclePolicyPreviewRequest {
     pub repository_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StartLifecyclePolicyPreviewResponse {
     /// <p>The JSON repository policy text.</p>
     #[serde(rename = "lifecyclePolicyText")]
@@ -889,7 +889,7 @@ pub struct StartLifecyclePolicyPreviewResponse {
     pub status: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UploadLayerPartRequest {
     /// <p>The base64-encoded layer part payload.</p>
     #[serde(rename = "layerPartBlob")]
@@ -917,7 +917,7 @@ pub struct UploadLayerPartRequest {
     pub upload_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UploadLayerPartResponse {
     /// <p>The integer value of the last byte received in the request.</p>
     #[serde(rename = "lastByteReceived")]

--- a/rusoto/services/ecs/src/generated.rs
+++ b/rusoto/services/ecs/src/generated.rs
@@ -2157,7 +2157,8 @@ impl CreateClusterError {
     pub fn from_body(body: &str) -> CreateClusterError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2253,7 +2254,8 @@ impl CreateServiceError {
     pub fn from_body(body: &str) -> CreateServiceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2361,7 +2363,8 @@ impl DeleteAttributesError {
     pub fn from_body(body: &str) -> DeleteAttributesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2459,7 +2462,8 @@ impl DeleteClusterError {
     pub fn from_body(body: &str) -> DeleteClusterError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2567,7 +2571,8 @@ impl DeleteServiceError {
     pub fn from_body(body: &str) -> DeleteServiceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2663,7 +2668,8 @@ impl DeregisterContainerInstanceError {
     pub fn from_body(body: &str) -> DeregisterContainerInstanceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2763,7 +2769,8 @@ impl DeregisterTaskDefinitionError {
     pub fn from_body(body: &str) -> DeregisterTaskDefinitionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2855,7 +2862,8 @@ impl DescribeClustersError {
     pub fn from_body(body: &str) -> DescribeClustersError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2943,7 +2951,8 @@ impl DescribeContainerInstancesError {
     pub fn from_body(body: &str) -> DescribeContainerInstancesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3043,7 +3052,8 @@ impl DescribeServicesError {
     pub fn from_body(body: &str) -> DescribeServicesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3133,7 +3143,8 @@ impl DescribeTaskDefinitionError {
     pub fn from_body(body: &str) -> DescribeTaskDefinitionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3227,7 +3238,8 @@ impl DescribeTasksError {
     pub fn from_body(body: &str) -> DescribeTasksError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3315,7 +3327,8 @@ impl DiscoverPollEndpointError {
     pub fn from_body(body: &str) -> DiscoverPollEndpointError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3401,7 +3414,8 @@ impl ListAttributesError {
     pub fn from_body(body: &str) -> ListAttributesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3487,7 +3501,8 @@ impl ListClustersError {
     pub fn from_body(body: &str) -> ListClustersError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3575,7 +3590,8 @@ impl ListContainerInstancesError {
     pub fn from_body(body: &str) -> ListContainerInstancesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3673,7 +3689,8 @@ impl ListServicesError {
     pub fn from_body(body: &str) -> ListServicesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3763,7 +3780,8 @@ impl ListTaskDefinitionFamiliesError {
     pub fn from_body(body: &str) -> ListTaskDefinitionFamiliesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3857,7 +3875,8 @@ impl ListTaskDefinitionsError {
     pub fn from_body(body: &str) -> ListTaskDefinitionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3953,7 +3972,8 @@ impl ListTasksError {
     pub fn from_body(body: &str) -> ListTasksError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4047,7 +4067,8 @@ impl PutAttributesError {
     pub fn from_body(body: &str) -> PutAttributesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4141,7 +4162,8 @@ impl RegisterContainerInstanceError {
     pub fn from_body(body: &str) -> RegisterContainerInstanceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4235,7 +4257,8 @@ impl RegisterTaskDefinitionError {
     pub fn from_body(body: &str) -> RegisterTaskDefinitionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4339,7 +4362,8 @@ impl RunTaskError {
     pub fn from_body(body: &str) -> RunTaskError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4449,7 +4473,8 @@ impl StartTaskError {
     pub fn from_body(body: &str) -> StartTaskError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4539,7 +4564,8 @@ impl StopTaskError {
     pub fn from_body(body: &str) -> StopTaskError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4627,7 +4653,8 @@ impl SubmitContainerStateChangeError {
     pub fn from_body(body: &str) -> SubmitContainerStateChangeError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4719,7 +4746,8 @@ impl SubmitTaskStateChangeError {
     pub fn from_body(body: &str) -> SubmitTaskStateChangeError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4819,7 +4847,8 @@ impl UpdateContainerAgentError {
     pub fn from_body(body: &str) -> UpdateContainerAgentError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4929,7 +4958,8 @@ impl UpdateContainerInstancesStateError {
     pub fn from_body(body: &str) -> UpdateContainerInstancesStateError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5041,7 +5071,8 @@ impl UpdateServiceError {
     pub fn from_body(body: &str) -> UpdateServiceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/ecs/src/generated.rs
+++ b/rusoto/services/ecs/src/generated.rs
@@ -31,7 +31,7 @@ use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 /// <p>An object representing a container instance or task attachment.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Attachment {
     /// <p>Details of the attachment. For Elastic Network Interfaces, this includes the network interface ID, the MAC address, the subnet ID, and the private IPv4 address.</p>
     #[serde(rename = "details")]
@@ -52,7 +52,7 @@ pub struct Attachment {
 }
 
 /// <p>An object representing a change in state for a task attachment.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AttachmentStateChange {
     /// <p>The Amazon Resource Name (ARN) of the attachment.</p>
     #[serde(rename = "attachmentArn")]
@@ -63,7 +63,7 @@ pub struct AttachmentStateChange {
 }
 
 /// <p>An attribute is a name-value pair associated with an Amazon ECS object. Attributes enable you to extend the Amazon ECS data model by adding custom metadata to your resources. For more information, see <a href="http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-placement-constraints.html#attributes">Attributes</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Attribute {
     /// <p>The name of the attribute. Up to 128 letters (uppercase and lowercase), numbers, hyphens, underscores, and periods are allowed.</p>
     #[serde(rename = "name")]
@@ -83,7 +83,7 @@ pub struct Attribute {
 }
 
 /// <p>An object representing the networking details for a task or service.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct AwsVpcConfiguration {
     /// <p>Whether the task's elastic network interface receives a public IP address.</p>
     #[serde(rename = "assignPublicIp")]
@@ -99,7 +99,7 @@ pub struct AwsVpcConfiguration {
 }
 
 /// <p>A regional grouping of one or more container instances on which you can run task requests. Each account receives a default cluster the first time you use the Amazon ECS service, but you may also create other clusters. Clusters may contain more than one instance type simultaneously.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Cluster {
     /// <p>The number of services that are running on the cluster in an <code>ACTIVE</code> state. You can view these services with <a>ListServices</a>.</p>
     #[serde(rename = "activeServicesCount")]
@@ -136,7 +136,7 @@ pub struct Cluster {
 }
 
 /// <p>A Docker container that is part of a task.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Container {
     /// <p>The Amazon Resource Name (ARN) of the container.</p>
     #[serde(rename = "containerArn")]
@@ -177,7 +177,7 @@ pub struct Container {
 }
 
 /// <p>Container definitions are used in task definitions to describe the different containers that are launched as part of a task.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ContainerDefinition {
     /// <p>The command that is passed to the container. This parameter maps to <code>Cmd</code> in the <a href="https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container">Create a container</a> section of the <a href="https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/">Docker Remote API</a> and the <code>COMMAND</code> parameter to <a href="https://docs.docker.com/engine/reference/run/">docker run</a>. For more information, see <a href="https://docs.docker.com/engine/reference/builder/#cmd">https://docs.docker.com/engine/reference/builder/#cmd</a>.</p>
     #[serde(rename = "command")]
@@ -294,7 +294,7 @@ pub struct ContainerDefinition {
 }
 
 /// <p>An EC2 instance that is running the Amazon ECS agent and has been registered with a cluster.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ContainerInstance {
     /// <p>This parameter returns <code>true</code> if the agent is connected to Amazon ECS. Registered instances with an agent that may be unhealthy or stopped return <code>false</code>. Instances without a connected agent can't accept placement requests.</p>
     #[serde(rename = "agentConnected")]
@@ -355,7 +355,7 @@ pub struct ContainerInstance {
 }
 
 /// <p>The overrides that should be sent to a container.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ContainerOverride {
     /// <p>The command to send to the container that overrides the default command from the Docker image or the task definition. You must also specify a container name.</p>
     #[serde(rename = "command")]
@@ -384,7 +384,7 @@ pub struct ContainerOverride {
 }
 
 /// <p>An object representing a change in state for a container.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ContainerStateChange {
     /// <p>The name of the container.</p>
     #[serde(rename = "containerName")]
@@ -408,7 +408,7 @@ pub struct ContainerStateChange {
     pub status: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateClusterRequest {
     /// <p>The name of your cluster. If you do not specify a name for your cluster, you create a cluster named <code>default</code>. Up to 255 letters (uppercase and lowercase), numbers, hyphens, and underscores are allowed.</p>
     #[serde(rename = "clusterName")]
@@ -416,7 +416,7 @@ pub struct CreateClusterRequest {
     pub cluster_name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateClusterResponse {
     /// <p>The full description of your new cluster.</p>
     #[serde(rename = "cluster")]
@@ -424,7 +424,7 @@ pub struct CreateClusterResponse {
     pub cluster: Option<Cluster>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateServiceRequest {
     /// <p>Unique, case-sensitive identifier you provide to ensure the idempotency of the request. Up to 32 ASCII characters are allowed.</p>
     #[serde(rename = "clientToken")]
@@ -485,7 +485,7 @@ pub struct CreateServiceRequest {
     pub task_definition: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateServiceResponse {
     /// <p>The full description of your service following the create call.</p>
     #[serde(rename = "service")]
@@ -493,7 +493,7 @@ pub struct CreateServiceResponse {
     pub service: Option<Service>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteAttributesRequest {
     /// <p>The attributes to delete from your resource. You can specify up to 10 attributes per request. For custom attributes, specify the attribute name and target ID, but do not specify the value. If you specify the target ID using the short form, you must also specify the target type.</p>
     #[serde(rename = "attributes")]
@@ -504,7 +504,7 @@ pub struct DeleteAttributesRequest {
     pub cluster: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteAttributesResponse {
     /// <p>A list of attribute objects that were successfully deleted from your resource.</p>
     #[serde(rename = "attributes")]
@@ -512,14 +512,14 @@ pub struct DeleteAttributesResponse {
     pub attributes: Option<Vec<Attribute>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteClusterRequest {
     /// <p>The short name or full Amazon Resource Name (ARN) of the cluster to delete.</p>
     #[serde(rename = "cluster")]
     pub cluster: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteClusterResponse {
     /// <p>The full description of the deleted cluster.</p>
     #[serde(rename = "cluster")]
@@ -527,7 +527,7 @@ pub struct DeleteClusterResponse {
     pub cluster: Option<Cluster>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteServiceRequest {
     /// <p>The short name or full Amazon Resource Name (ARN) of the cluster that hosts the service to delete. If you do not specify a cluster, the default cluster is assumed.</p>
     #[serde(rename = "cluster")]
@@ -538,7 +538,7 @@ pub struct DeleteServiceRequest {
     pub service: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteServiceResponse {
     /// <p>The full description of the deleted service.</p>
     #[serde(rename = "service")]
@@ -547,7 +547,7 @@ pub struct DeleteServiceResponse {
 }
 
 /// <p>The details of an Amazon ECS service deployment.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Deployment {
     /// <p>The Unix time stamp for when the service was created.</p>
     #[serde(rename = "createdAt")]
@@ -596,7 +596,7 @@ pub struct Deployment {
 }
 
 /// <p>Optional deployment parameters that control how many tasks run during the deployment and the ordering of stopping and starting tasks.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct DeploymentConfiguration {
     /// <p>The upper limit (as a percentage of the service's <code>desiredCount</code>) of the number of tasks that are allowed in the <code>RUNNING</code> or <code>PENDING</code> state in a service during a deployment. The maximum number of tasks during a deployment is the <code>desiredCount</code> multiplied by <code>maximumPercent</code>/100, rounded down to the nearest integer value.</p>
     #[serde(rename = "maximumPercent")]
@@ -608,7 +608,7 @@ pub struct DeploymentConfiguration {
     pub minimum_healthy_percent: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeregisterContainerInstanceRequest {
     /// <p>The short name or full Amazon Resource Name (ARN) of the cluster that hosts the container instance to deregister. If you do not specify a cluster, the default cluster is assumed.</p>
     #[serde(rename = "cluster")]
@@ -623,7 +623,7 @@ pub struct DeregisterContainerInstanceRequest {
     pub force: Option<bool>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeregisterContainerInstanceResponse {
     /// <p>The container instance that was deregistered.</p>
     #[serde(rename = "containerInstance")]
@@ -631,14 +631,14 @@ pub struct DeregisterContainerInstanceResponse {
     pub container_instance: Option<ContainerInstance>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeregisterTaskDefinitionRequest {
     /// <p>The <code>family</code> and <code>revision</code> (<code>family:revision</code>) or full Amazon Resource Name (ARN) of the task definition to deregister. You must specify a <code>revision</code>.</p>
     #[serde(rename = "taskDefinition")]
     pub task_definition: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeregisterTaskDefinitionResponse {
     /// <p>The full description of the deregistered task.</p>
     #[serde(rename = "taskDefinition")]
@@ -646,7 +646,7 @@ pub struct DeregisterTaskDefinitionResponse {
     pub task_definition: Option<TaskDefinition>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeClustersRequest {
     /// <p>A list of up to 100 cluster names or full cluster Amazon Resource Name (ARN) entries. If you do not specify a cluster, the default cluster is assumed.</p>
     #[serde(rename = "clusters")]
@@ -658,7 +658,7 @@ pub struct DescribeClustersRequest {
     pub include: Option<Vec<String>>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeClustersResponse {
     /// <p>The list of clusters.</p>
     #[serde(rename = "clusters")]
@@ -670,7 +670,7 @@ pub struct DescribeClustersResponse {
     pub failures: Option<Vec<Failure>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeContainerInstancesRequest {
     /// <p>The short name or full Amazon Resource Name (ARN) of the cluster that hosts the container instances to describe. If you do not specify a cluster, the default cluster is assumed.</p>
     #[serde(rename = "cluster")]
@@ -681,7 +681,7 @@ pub struct DescribeContainerInstancesRequest {
     pub container_instances: Vec<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeContainerInstancesResponse {
     /// <p>The list of container instances.</p>
     #[serde(rename = "containerInstances")]
@@ -693,7 +693,7 @@ pub struct DescribeContainerInstancesResponse {
     pub failures: Option<Vec<Failure>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeServicesRequest {
     /// <p>The short name or full Amazon Resource Name (ARN)the cluster that hosts the service to describe. If you do not specify a cluster, the default cluster is assumed.</p>
     #[serde(rename = "cluster")]
@@ -704,7 +704,7 @@ pub struct DescribeServicesRequest {
     pub services: Vec<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeServicesResponse {
     /// <p>Any failures associated with the call.</p>
     #[serde(rename = "failures")]
@@ -716,14 +716,14 @@ pub struct DescribeServicesResponse {
     pub services: Option<Vec<Service>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeTaskDefinitionRequest {
     /// <p>The <code>family</code> for the latest <code>ACTIVE</code> revision, <code>family</code> and <code>revision</code> (<code>family:revision</code>) for a specific revision in the family, or full Amazon Resource Name (ARN) of the task definition to describe.</p>
     #[serde(rename = "taskDefinition")]
     pub task_definition: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeTaskDefinitionResponse {
     /// <p>The full task definition description.</p>
     #[serde(rename = "taskDefinition")]
@@ -731,7 +731,7 @@ pub struct DescribeTaskDefinitionResponse {
     pub task_definition: Option<TaskDefinition>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeTasksRequest {
     /// <p>The short name or full Amazon Resource Name (ARN) of the cluster that hosts the task to describe. If you do not specify a cluster, the default cluster is assumed.</p>
     #[serde(rename = "cluster")]
@@ -742,7 +742,7 @@ pub struct DescribeTasksRequest {
     pub tasks: Vec<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeTasksResponse {
     /// <p>Any failures associated with the call.</p>
     #[serde(rename = "failures")]
@@ -755,7 +755,7 @@ pub struct DescribeTasksResponse {
 }
 
 /// <p>An object representing a container instance host device.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Device {
     /// <p>The path inside the container at which to expose the host device.</p>
     #[serde(rename = "containerPath")]
@@ -770,7 +770,7 @@ pub struct Device {
     pub permissions: Option<Vec<String>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DiscoverPollEndpointRequest {
     /// <p>The short name or full Amazon Resource Name (ARN) of the cluster that the container instance belongs to.</p>
     #[serde(rename = "cluster")]
@@ -782,7 +782,7 @@ pub struct DiscoverPollEndpointRequest {
     pub container_instance: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DiscoverPollEndpointResponse {
     /// <p>The endpoint for the Amazon ECS agent to poll.</p>
     #[serde(rename = "endpoint")]
@@ -795,7 +795,7 @@ pub struct DiscoverPollEndpointResponse {
 }
 
 /// <p>A failed resource.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Failure {
     /// <p>The Amazon Resource Name (ARN) of the failed resource.</p>
     #[serde(rename = "arn")]
@@ -808,7 +808,7 @@ pub struct Failure {
 }
 
 /// <p>An object representing a container health check. Health check parameters that are specified in a container definition override any Docker health checks that exist in the container image (such as those specified in a parent image or from the image's Dockerfile).</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct HealthCheck {
     /// <p>A string array representing the command that the container runs to determine if it is healthy. The string array must start with <code>CMD</code> to execute the command arguments directly, or <code>CMD-SHELL</code> to run the command with the container's default shell. For example:</p> <p> <code>[ "CMD-SHELL", "curl -f http://localhost/ || exit 1" ]</code> </p> <p>An exit code of 0 indicates success, and non-zero exit code indicates failure. For more information, see <code>HealthCheck</code> in the <a href="https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container">Create a container</a> section of the <a href="https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/">Docker Remote API</a>.</p>
     #[serde(rename = "command")]
@@ -832,7 +832,7 @@ pub struct HealthCheck {
 }
 
 /// <p>Hostnames and IP address entries that are added to the <code>/etc/hosts</code> file of a container via the <code>extraHosts</code> parameter of its <a>ContainerDefinition</a>. </p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct HostEntry {
     /// <p>The hostname to use in the <code>/etc/hosts</code> entry.</p>
     #[serde(rename = "hostname")]
@@ -843,7 +843,7 @@ pub struct HostEntry {
 }
 
 /// <p>Details on a container instance host volume.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct HostVolumeProperties {
     /// <p>The path on the host container instance that is presented to the container. If this parameter is empty, then the Docker daemon has assigned a host path for you. If the <code>host</code> parameter contains a <code>sourcePath</code> file location, then the data volume persists at the specified location on the host container instance until you delete it manually. If the <code>sourcePath</code> value does not exist on the host container instance, the Docker daemon creates it. If the location does exist, the contents of the source path folder are exported.</p> <p>If you are using the Fargate launch type, the <code>sourcePath</code> parameter is not supported.</p>
     #[serde(rename = "sourcePath")]
@@ -852,7 +852,7 @@ pub struct HostVolumeProperties {
 }
 
 /// <p>The Linux capabilities for the container that are added to or dropped from the default configuration provided by Docker. For more information on the default capabilities and the non-default available capabilities, see <a href="https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities">Runtime privilege and Linux capabilities</a> in the <i>Docker run reference</i>. For more detailed information on these Linux capabilities, see the <a href="http://man7.org/linux/man-pages/man7/capabilities.7.html">capabilities(7)</a> Linux manual page.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct KernelCapabilities {
     /// <p>The Linux capabilities for the container that have been added to the default configuration provided by Docker. This parameter maps to <code>CapAdd</code> in the <a href="https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container">Create a container</a> section of the <a href="https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/">Docker Remote API</a> and the <code>--cap-add</code> option to <a href="https://docs.docker.com/engine/reference/run/">docker run</a>.</p> <note> <p>If you are using tasks that use the Fargate launch type, the <code>add</code> parameter is not supported.</p> </note> <p>Valid values: <code>"ALL" | "AUDIT_CONTROL" | "AUDIT_WRITE" | "BLOCK_SUSPEND" | "CHOWN" | "DAC_OVERRIDE" | "DAC_READ_SEARCH" | "FOWNER" | "FSETID" | "IPC_LOCK" | "IPC_OWNER" | "KILL" | "LEASE" | "LINUX_IMMUTABLE" | "MAC_ADMIN" | "MAC_OVERRIDE" | "MKNOD" | "NET_ADMIN" | "NET_BIND_SERVICE" | "NET_BROADCAST" | "NET_RAW" | "SETFCAP" | "SETGID" | "SETPCAP" | "SETUID" | "SYS_ADMIN" | "SYS_BOOT" | "SYS_CHROOT" | "SYS_MODULE" | "SYS_NICE" | "SYS_PACCT" | "SYS_PTRACE" | "SYS_RAWIO" | "SYS_RESOURCE" | "SYS_TIME" | "SYS_TTY_CONFIG" | "SYSLOG" | "WAKE_ALARM"</code> </p>
     #[serde(rename = "add")]
@@ -865,7 +865,7 @@ pub struct KernelCapabilities {
 }
 
 /// <p>A key and value pair object.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct KeyValuePair {
     /// <p>The name of the key value pair. For environment variables, this is the name of the environment variable.</p>
     #[serde(rename = "name")]
@@ -878,7 +878,7 @@ pub struct KeyValuePair {
 }
 
 /// <p>Linux-specific options that are applied to the container, such as Linux <a>KernelCapabilities</a>.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct LinuxParameters {
     /// <p><p>The Linux capabilities for the container that are added to or dropped from the default configuration provided by Docker.</p> <note> <p>If you are using tasks that use the Fargate launch type, <code>capabilities</code> is supported but the <code>add</code> parameter is not supported.</p> </note></p>
     #[serde(rename = "capabilities")]
@@ -902,7 +902,7 @@ pub struct LinuxParameters {
     pub tmpfs: Option<Vec<Tmpfs>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListAttributesRequest {
     /// <p>The name of the attribute with which to filter the results. </p>
     #[serde(rename = "attributeName")]
@@ -929,7 +929,7 @@ pub struct ListAttributesRequest {
     pub target_type: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListAttributesResponse {
     /// <p>A list of attribute objects that meet the criteria of the request.</p>
     #[serde(rename = "attributes")]
@@ -941,7 +941,7 @@ pub struct ListAttributesResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListClustersRequest {
     /// <p>The maximum number of cluster results returned by <code>ListClusters</code> in paginated output. When this parameter is used, <code>ListClusters</code> only returns <code>maxResults</code> results in a single page along with a <code>nextToken</code> response element. The remaining results of the initial request can be seen by sending another <code>ListClusters</code> request with the returned <code>nextToken</code> value. This value can be between 1 and 100. If this parameter is not used, then <code>ListClusters</code> returns up to 100 results and a <code>nextToken</code> value if applicable.</p>
     #[serde(rename = "maxResults")]
@@ -953,7 +953,7 @@ pub struct ListClustersRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListClustersResponse {
     /// <p>The list of full Amazon Resource Name (ARN) entries for each cluster associated with your account.</p>
     #[serde(rename = "clusterArns")]
@@ -965,7 +965,7 @@ pub struct ListClustersResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListContainerInstancesRequest {
     /// <p>The short name or full Amazon Resource Name (ARN) of the cluster that hosts the container instances to list. If you do not specify a cluster, the default cluster is assumed.</p>
     #[serde(rename = "cluster")]
@@ -989,7 +989,7 @@ pub struct ListContainerInstancesRequest {
     pub status: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListContainerInstancesResponse {
     /// <p>The list of container instances with full ARN entries for each container instance associated with the specified cluster.</p>
     #[serde(rename = "containerInstanceArns")]
@@ -1001,7 +1001,7 @@ pub struct ListContainerInstancesResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListServicesRequest {
     /// <p>The short name or full Amazon Resource Name (ARN) of the cluster that hosts the services to list. If you do not specify a cluster, the default cluster is assumed.</p>
     #[serde(rename = "cluster")]
@@ -1021,7 +1021,7 @@ pub struct ListServicesRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListServicesResponse {
     /// <p>The <code>nextToken</code> value to include in a future <code>ListServices</code> request. When the results of a <code>ListServices</code> request exceed <code>maxResults</code>, this value can be used to retrieve the next page of results. This value is <code>null</code> when there are no more results to return.</p>
     #[serde(rename = "nextToken")]
@@ -1033,7 +1033,7 @@ pub struct ListServicesResponse {
     pub service_arns: Option<Vec<String>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListTaskDefinitionFamiliesRequest {
     /// <p>The <code>familyPrefix</code> is a string that is used to filter the results of <code>ListTaskDefinitionFamilies</code>. If you specify a <code>familyPrefix</code>, only task definition family names that begin with the <code>familyPrefix</code> string are returned.</p>
     #[serde(rename = "familyPrefix")]
@@ -1053,7 +1053,7 @@ pub struct ListTaskDefinitionFamiliesRequest {
     pub status: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListTaskDefinitionFamiliesResponse {
     /// <p>The list of task definition family names that match the <code>ListTaskDefinitionFamilies</code> request.</p>
     #[serde(rename = "families")]
@@ -1065,7 +1065,7 @@ pub struct ListTaskDefinitionFamiliesResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListTaskDefinitionsRequest {
     /// <p>The full family name with which to filter the <code>ListTaskDefinitions</code> results. Specifying a <code>familyPrefix</code> limits the listed task definitions to task definition revisions that belong to that family.</p>
     #[serde(rename = "familyPrefix")]
@@ -1089,7 +1089,7 @@ pub struct ListTaskDefinitionsRequest {
     pub status: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListTaskDefinitionsResponse {
     /// <p>The <code>nextToken</code> value to include in a future <code>ListTaskDefinitions</code> request. When the results of a <code>ListTaskDefinitions</code> request exceed <code>maxResults</code>, this value can be used to retrieve the next page of results. This value is <code>null</code> when there are no more results to return.</p>
     #[serde(rename = "nextToken")]
@@ -1101,7 +1101,7 @@ pub struct ListTaskDefinitionsResponse {
     pub task_definition_arns: Option<Vec<String>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListTasksRequest {
     /// <p>The short name or full Amazon Resource Name (ARN) of the cluster that hosts the tasks to list. If you do not specify a cluster, the default cluster is assumed.</p>
     #[serde(rename = "cluster")]
@@ -1141,7 +1141,7 @@ pub struct ListTasksRequest {
     pub started_by: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListTasksResponse {
     /// <p>The <code>nextToken</code> value to include in a future <code>ListTasks</code> request. When the results of a <code>ListTasks</code> request exceed <code>maxResults</code>, this value can be used to retrieve the next page of results. This value is <code>null</code> when there are no more results to return.</p>
     #[serde(rename = "nextToken")]
@@ -1154,7 +1154,7 @@ pub struct ListTasksResponse {
 }
 
 /// <p>Details on a load balancer that is used with a service.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct LoadBalancer {
     /// <p>The name of the container (as it appears in a container definition) to associate with the load balancer.</p>
     #[serde(rename = "containerName")]
@@ -1175,7 +1175,7 @@ pub struct LoadBalancer {
 }
 
 /// <p>Log configuration options to send to a custom log driver for the container.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct LogConfiguration {
     /// <p>The log driver to use for the container. The valid values listed for this parameter are log drivers that the Amazon ECS container agent can communicate with by default. If using the Fargate launch type, the only supported value is <code>awslogs</code>. For more information about using the <code>awslogs</code> driver, see <a href="http://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_awslogs.html">Using the awslogs Log Driver</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p> <note> <p>If you have a custom driver that is not listed above that you would like to work with the Amazon ECS container agent, you can fork the Amazon ECS container agent project that is <a href="https://github.com/aws/amazon-ecs-agent">available on GitHub</a> and customize it to work with that driver. We encourage you to submit pull requests for changes that you would like to have included. However, Amazon Web Services does not currently support running modified copies of this software.</p> </note> <p>This parameter requires version 1.18 of the Docker Remote API or greater on your container instance. To check the Docker Remote API version on your container instance, log in to your container instance and run the following command: <code>sudo docker version | grep "Server API version"</code> </p>
     #[serde(rename = "logDriver")]
@@ -1187,7 +1187,7 @@ pub struct LogConfiguration {
 }
 
 /// <p>Details on a volume mount point that is used in a container definition.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct MountPoint {
     /// <p>The path on the container to mount the host volume at.</p>
     #[serde(rename = "containerPath")]
@@ -1204,7 +1204,7 @@ pub struct MountPoint {
 }
 
 /// <p>Details on the network bindings between a container and its host container instance. After a task reaches the <code>RUNNING</code> status, manual and automatic host and container port assignments are visible in the <code>networkBindings</code> section of <a>DescribeTasks</a> API responses.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct NetworkBinding {
     /// <p>The IP address that the container is bound to on the container instance.</p>
     #[serde(rename = "bindIP")]
@@ -1225,7 +1225,7 @@ pub struct NetworkBinding {
 }
 
 /// <p>An object representing the network configuration for a task or service.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct NetworkConfiguration {
     /// <p>The VPC subnets and security groups associated with a task.</p>
     #[serde(rename = "awsvpcConfiguration")]
@@ -1234,7 +1234,7 @@ pub struct NetworkConfiguration {
 }
 
 /// <p>An object representing the Elastic Network Interface for tasks that use the <code>awsvpc</code> network mode.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct NetworkInterface {
     /// <p>The attachment ID for the network interface.</p>
     #[serde(rename = "attachmentId")]
@@ -1251,7 +1251,7 @@ pub struct NetworkInterface {
 }
 
 /// <p>An object representing a constraint on task placement. For more information, see <a href="http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-placement-constraints.html">Task Placement Constraints</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct PlacementConstraint {
     /// <p>A cluster query language expression to apply to the constraint. Note you cannot specify an expression if the constraint type is <code>distinctInstance</code>. For more information, see <a href="http://docs.aws.amazon.com/AmazonECS/latest/developerguide/cluster-query-language.html">Cluster Query Language</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>
     #[serde(rename = "expression")]
@@ -1264,7 +1264,7 @@ pub struct PlacementConstraint {
 }
 
 /// <p>The task placement strategy for a task or service. For more information, see <a href="http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-placement-strategies.html">Task Placement Strategies</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct PlacementStrategy {
     /// <p>The field to apply the placement strategy against. For the <code>spread</code> placement strategy, valid values are <code>instanceId</code> (or <code>host</code>, which has the same effect), or any platform or custom attribute that is applied to a container instance, such as <code>attribute:ecs.availability-zone</code>. For the <code>binpack</code> placement strategy, valid values are <code>cpu</code> and <code>memory</code>. For the <code>random</code> placement strategy, this field is not used.</p>
     #[serde(rename = "field")]
@@ -1277,7 +1277,7 @@ pub struct PlacementStrategy {
 }
 
 /// <p>Port mappings allow containers to access ports on the host container instance to send or receive traffic. Port mappings are specified as part of the container definition.</p> <p>If using containers in a task with the <code>awsvpc</code> or <code>host</code> network mode, exposed ports should be specified using <code>containerPort</code>. The <code>hostPort</code> can be left blank or it must be the same value as the <code>containerPort</code>.</p> <p>After a task reaches the <code>RUNNING</code> status, manual and automatic host and container port assignments are visible in the <code>networkBindings</code> section of <a>DescribeTasks</a> API responses.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct PortMapping {
     /// <p>The port number on the container that is bound to the user-specified or automatically assigned host port.</p> <p>If using containers in a task with the <code>awsvpc</code> or <code>host</code> network mode, exposed ports should be specified using <code>containerPort</code>.</p> <p>If using containers in a task with the <code>bridge</code> network mode and you specify a container port and not a host port, your container automatically receives a host port in the ephemeral port range (for more information, see <code>hostPort</code>). Port mappings that are automatically assigned in this way do not count toward the 100 reserved ports limit of a container instance.</p>
     #[serde(rename = "containerPort")]
@@ -1293,7 +1293,7 @@ pub struct PortMapping {
     pub protocol: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PutAttributesRequest {
     /// <p>The attributes to apply to your resource. You can specify up to 10 custom attributes per resource. You can specify up to 10 attributes in a single call.</p>
     #[serde(rename = "attributes")]
@@ -1304,7 +1304,7 @@ pub struct PutAttributesRequest {
     pub cluster: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PutAttributesResponse {
     /// <p>The attributes applied to your resource.</p>
     #[serde(rename = "attributes")]
@@ -1312,7 +1312,7 @@ pub struct PutAttributesResponse {
     pub attributes: Option<Vec<Attribute>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RegisterContainerInstanceRequest {
     /// <p>The container instance attributes that this container instance supports.</p>
     #[serde(rename = "attributes")]
@@ -1344,7 +1344,7 @@ pub struct RegisterContainerInstanceRequest {
     pub version_info: Option<VersionInfo>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RegisterContainerInstanceResponse {
     /// <p>The container instance that was registered.</p>
     #[serde(rename = "containerInstance")]
@@ -1352,7 +1352,7 @@ pub struct RegisterContainerInstanceResponse {
     pub container_instance: Option<ContainerInstance>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RegisterTaskDefinitionRequest {
     /// <p>A list of container definitions in JSON format that describe the different containers that make up your task.</p>
     #[serde(rename = "containerDefinitions")]
@@ -1394,7 +1394,7 @@ pub struct RegisterTaskDefinitionRequest {
     pub volumes: Option<Vec<Volume>>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RegisterTaskDefinitionResponse {
     /// <p>The full description of the registered task definition.</p>
     #[serde(rename = "taskDefinition")]
@@ -1403,7 +1403,7 @@ pub struct RegisterTaskDefinitionResponse {
 }
 
 /// <p>Describes the resources available for a container instance.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Resource {
     /// <p>When the <code>doubleValue</code> type is set, the value of the resource must be a double precision floating-point type.</p>
     #[serde(rename = "doubleValue")]
@@ -1431,7 +1431,7 @@ pub struct Resource {
     pub type_: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RunTaskRequest {
     /// <p>The short name or full Amazon Resource Name (ARN) of the cluster on which to run your task. If you do not specify a cluster, the default cluster is assumed.</p>
     #[serde(rename = "cluster")]
@@ -1478,7 +1478,7 @@ pub struct RunTaskRequest {
     pub task_definition: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RunTaskResponse {
     /// <p>Any failures associated with the call.</p>
     #[serde(rename = "failures")]
@@ -1491,7 +1491,7 @@ pub struct RunTaskResponse {
 }
 
 /// <p>Details on a service within a cluster</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Service {
     /// <p>The Amazon Resource Name (ARN) of the cluster that hosts the service.</p>
     #[serde(rename = "clusterArn")]
@@ -1580,7 +1580,7 @@ pub struct Service {
 }
 
 /// <p>Details on an event associated with a service.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ServiceEvent {
     /// <p>The Unix time stamp for when the event was triggered.</p>
     #[serde(rename = "createdAt")]
@@ -1597,7 +1597,7 @@ pub struct ServiceEvent {
 }
 
 /// <p>Details of the service registry.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ServiceRegistry {
     /// <p>The port value used if your Service Discovery service specified an SRV record.</p>
     #[serde(rename = "port")]
@@ -1609,7 +1609,7 @@ pub struct ServiceRegistry {
     pub registry_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StartTaskRequest {
     /// <p>The short name or full Amazon Resource Name (ARN) of the cluster on which to start your task. If you do not specify a cluster, the default cluster is assumed.</p>
     #[serde(rename = "cluster")]
@@ -1639,7 +1639,7 @@ pub struct StartTaskRequest {
     pub task_definition: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StartTaskResponse {
     /// <p>Any failures associated with the call.</p>
     #[serde(rename = "failures")]
@@ -1651,7 +1651,7 @@ pub struct StartTaskResponse {
     pub tasks: Option<Vec<Task>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StopTaskRequest {
     /// <p>The short name or full Amazon Resource Name (ARN) of the cluster that hosts the task to stop. If you do not specify a cluster, the default cluster is assumed.</p>
     #[serde(rename = "cluster")]
@@ -1666,7 +1666,7 @@ pub struct StopTaskRequest {
     pub task: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StopTaskResponse {
     /// <p>The task that was stopped.</p>
     #[serde(rename = "task")]
@@ -1674,7 +1674,7 @@ pub struct StopTaskResponse {
     pub task: Option<Task>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SubmitContainerStateChangeRequest {
     /// <p>The short name or full ARN of the cluster that hosts the container.</p>
     #[serde(rename = "cluster")]
@@ -1706,7 +1706,7 @@ pub struct SubmitContainerStateChangeRequest {
     pub task: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SubmitContainerStateChangeResponse {
     /// <p>Acknowledgement of the state change.</p>
     #[serde(rename = "acknowledgment")]
@@ -1714,7 +1714,7 @@ pub struct SubmitContainerStateChangeResponse {
     pub acknowledgment: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SubmitTaskStateChangeRequest {
     /// <p>Any attachments associated with the state change request.</p>
     #[serde(rename = "attachments")]
@@ -1754,7 +1754,7 @@ pub struct SubmitTaskStateChangeRequest {
     pub task: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SubmitTaskStateChangeResponse {
     /// <p>Acknowledgement of the state change.</p>
     #[serde(rename = "acknowledgment")]
@@ -1763,7 +1763,7 @@ pub struct SubmitTaskStateChangeResponse {
 }
 
 /// <p>Details on a task in a cluster.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Task {
     /// <p>The Elastic Network Adapter associated with the task if the task uses the <code>awsvpc</code> network mode.</p>
     #[serde(rename = "attachments")]
@@ -1876,7 +1876,7 @@ pub struct Task {
 }
 
 /// <p>Details of a task definition.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct TaskDefinition {
     /// <p>The launch type to use with your task. For more information, see <a href="http://docs.aws.amazon.com/AmazonECS/latest/developerguide/launch_types.html">Amazon ECS Launch Types</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>
     #[serde(rename = "compatibilities")]
@@ -1941,7 +1941,7 @@ pub struct TaskDefinition {
 }
 
 /// <p>An object representing a constraint on task placement in the task definition.</p> <p>If you are using the Fargate launch type, task placement constraints are not supported.</p> <p>For more information, see <a href="http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-placement-constraints.html">Task Placement Constraints</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TaskDefinitionPlacementConstraint {
     /// <p>A cluster query language expression to apply to the constraint. For more information, see <a href="http://docs.aws.amazon.com/AmazonECS/latest/developerguide/cluster-query-language.html">Cluster Query Language</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>
     #[serde(rename = "expression")]
@@ -1954,7 +1954,7 @@ pub struct TaskDefinitionPlacementConstraint {
 }
 
 /// <p>The overrides associated with a task.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TaskOverride {
     /// <p>One or more container overrides sent to a task.</p>
     #[serde(rename = "containerOverrides")]
@@ -1971,7 +1971,7 @@ pub struct TaskOverride {
 }
 
 /// <p>The container path, mount options, and size of the tmpfs mount.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Tmpfs {
     /// <p>The absolute file path where the tmpfs volume will be mounted.</p>
     #[serde(rename = "containerPath")]
@@ -1986,7 +1986,7 @@ pub struct Tmpfs {
 }
 
 /// <p>The <code>ulimit</code> settings to pass to the container.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Ulimit {
     /// <p>The hard limit for the ulimit type.</p>
     #[serde(rename = "hardLimit")]
@@ -1999,7 +1999,7 @@ pub struct Ulimit {
     pub soft_limit: i64,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateContainerAgentRequest {
     /// <p>The short name or full Amazon Resource Name (ARN) of the cluster that your container instance is running on. If you do not specify a cluster, the default cluster is assumed.</p>
     #[serde(rename = "cluster")]
@@ -2010,7 +2010,7 @@ pub struct UpdateContainerAgentRequest {
     pub container_instance: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateContainerAgentResponse {
     /// <p>The container instance for which the container agent was updated.</p>
     #[serde(rename = "containerInstance")]
@@ -2018,7 +2018,7 @@ pub struct UpdateContainerAgentResponse {
     pub container_instance: Option<ContainerInstance>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateContainerInstancesStateRequest {
     /// <p>The short name or full Amazon Resource Name (ARN) of the cluster that hosts the container instance to update. If you do not specify a cluster, the default cluster is assumed.</p>
     #[serde(rename = "cluster")]
@@ -2032,7 +2032,7 @@ pub struct UpdateContainerInstancesStateRequest {
     pub status: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateContainerInstancesStateResponse {
     /// <p>The list of container instances.</p>
     #[serde(rename = "containerInstances")]
@@ -2044,7 +2044,7 @@ pub struct UpdateContainerInstancesStateResponse {
     pub failures: Option<Vec<Failure>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateServiceRequest {
     /// <p>The short name or full Amazon Resource Name (ARN) of the cluster that your service is running on. If you do not specify a cluster, the default cluster is assumed.</p>
     #[serde(rename = "cluster")]
@@ -2083,7 +2083,7 @@ pub struct UpdateServiceRequest {
     pub task_definition: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateServiceResponse {
     /// <p>The full description of your service following the update call.</p>
     #[serde(rename = "service")]
@@ -2092,7 +2092,7 @@ pub struct UpdateServiceResponse {
 }
 
 /// <p>The Docker and Amazon ECS container agent version information about a container instance.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct VersionInfo {
     /// <p>The Git commit hash for the Amazon ECS container agent build on the <a href="https://github.com/aws/amazon-ecs-agent/commits/master">amazon-ecs-agent </a> GitHub repository.</p>
     #[serde(rename = "agentHash")]
@@ -2109,7 +2109,7 @@ pub struct VersionInfo {
 }
 
 /// <p>A data volume used in a task definition.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Volume {
     /// <p>The contents of the <code>host</code> parameter determine whether your data volume persists on the host container instance and where it is stored. If the host parameter is empty, then the Docker daemon assigns a host path for your data volume, but the data is not guaranteed to persist after the containers associated with it stop running.</p> <p>Windows containers can mount whole directories on the same drive as <code>$env:ProgramData</code>. Windows containers cannot mount directories on a different drive, and mount point cannot be across drives. For example, you can mount <code>C:\my\path:C:\my\path</code> and <code>D:\:D:\</code>, but not <code>D:\my\path:C:\my\path</code> or <code>D:\:C:\my\path</code>.</p>
     #[serde(rename = "host")]
@@ -2122,7 +2122,7 @@ pub struct Volume {
 }
 
 /// <p>Details on a data volume from another container in the same task definition.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct VolumeFrom {
     /// <p>If this value is <code>true</code>, the container has read-only access to the volume. If this value is <code>false</code>, then the container can write to the volume. The default value is <code>false</code>.</p>
     #[serde(rename = "readOnly")]

--- a/rusoto/services/efs/src/generated.rs
+++ b/rusoto/services/efs/src/generated.rs
@@ -30,7 +30,7 @@ use rusoto_core::signature::SignedRequest;
 use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateFileSystemRequest {
     /// <p>String of up to 64 ASCII characters. Amazon EFS uses this to ensure idempotent creation.</p>
     #[serde(rename = "CreationToken")]
@@ -50,7 +50,7 @@ pub struct CreateFileSystemRequest {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateMountTargetRequest {
     /// <p>ID of the file system for which to create the mount target.</p>
     #[serde(rename = "FileSystemId")]
@@ -69,7 +69,7 @@ pub struct CreateMountTargetRequest {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateTagsRequest {
     /// <p>ID of the file system whose tags you want to modify (String). This operation modifies the tags only, not the file system.</p>
     #[serde(rename = "FileSystemId")]
@@ -80,7 +80,7 @@ pub struct CreateTagsRequest {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteFileSystemRequest {
     /// <p>ID of the file system you want to delete.</p>
     #[serde(rename = "FileSystemId")]
@@ -88,7 +88,7 @@ pub struct DeleteFileSystemRequest {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteMountTargetRequest {
     /// <p>ID of the mount target to delete (String).</p>
     #[serde(rename = "MountTargetId")]
@@ -96,7 +96,7 @@ pub struct DeleteMountTargetRequest {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteTagsRequest {
     /// <p>ID of the file system whose tags you want to delete (String).</p>
     #[serde(rename = "FileSystemId")]
@@ -107,7 +107,7 @@ pub struct DeleteTagsRequest {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeFileSystemsRequest {
     /// <p>(Optional) Restricts the list to the file system with this creation token (String). You specify a creation token when you create an Amazon EFS file system.</p>
     #[serde(rename = "CreationToken")]
@@ -127,7 +127,7 @@ pub struct DescribeFileSystemsRequest {
     pub max_items: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeFileSystemsResponse {
     /// <p>Array of file system descriptions.</p>
     #[serde(rename = "FileSystems")]
@@ -144,14 +144,14 @@ pub struct DescribeFileSystemsResponse {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeMountTargetSecurityGroupsRequest {
     /// <p>ID of the mount target whose security groups you want to retrieve.</p>
     #[serde(rename = "MountTargetId")]
     pub mount_target_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeMountTargetSecurityGroupsResponse {
     /// <p>Array of security groups.</p>
     #[serde(rename = "SecurityGroups")]
@@ -159,7 +159,7 @@ pub struct DescribeMountTargetSecurityGroupsResponse {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeMountTargetsRequest {
     /// <p>(Optional) ID of the file system whose mount targets you want to list (String). It must be included in your request if <code>MountTargetId</code> is not included.</p>
     #[serde(rename = "FileSystemId")]
@@ -180,7 +180,7 @@ pub struct DescribeMountTargetsRequest {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeMountTargetsResponse {
     /// <p>If the request included the <code>Marker</code>, the response returns that value in this field.</p>
     #[serde(rename = "Marker")]
@@ -197,7 +197,7 @@ pub struct DescribeMountTargetsResponse {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeTagsRequest {
     /// <p>ID of the file system whose tag set you want to retrieve.</p>
     #[serde(rename = "FileSystemId")]
@@ -213,7 +213,7 @@ pub struct DescribeTagsRequest {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeTagsResponse {
     /// <p>If the request included a <code>Marker</code>, the response returns that value in this field.</p>
     #[serde(rename = "Marker")]
@@ -229,7 +229,7 @@ pub struct DescribeTagsResponse {
 }
 
 /// <p>Description of the file system.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct FileSystemDescription {
     /// <p>Time that the file system was created, in seconds (since 1970-01-01T00:00:00Z).</p>
     #[serde(rename = "CreationTime")]
@@ -270,7 +270,7 @@ pub struct FileSystemDescription {
 }
 
 /// <p>Latest known metered size (in bytes) of data stored in the file system, in its <code>Value</code> field, and the time at which that size was determined in its <code>Timestamp</code> field. Note that the value does not represent the size of a consistent snapshot of the file system, but it is eventually consistent when there are no writes to the file system. That is, the value will represent the actual size only if the file system is not modified for a period longer than a couple of hours. Otherwise, the value is not necessarily the exact size the file system was at any instant in time.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct FileSystemSize {
     /// <p>Time at which the size of data, returned in the <code>Value</code> field, was determined. The value is the integer number of seconds since 1970-01-01T00:00:00Z.</p>
     #[serde(rename = "Timestamp")]
@@ -282,7 +282,7 @@ pub struct FileSystemSize {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ModifyMountTargetSecurityGroupsRequest {
     /// <p>ID of the mount target whose security groups you want to modify.</p>
     #[serde(rename = "MountTargetId")]
@@ -294,7 +294,7 @@ pub struct ModifyMountTargetSecurityGroupsRequest {
 }
 
 /// <p>Provides a description of a mount target.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct MountTargetDescription {
     /// <p>ID of the file system for which the mount target is intended.</p>
     #[serde(rename = "FileSystemId")]
@@ -323,7 +323,7 @@ pub struct MountTargetDescription {
 }
 
 /// <p>A tag is a key-value pair. Allowed characters: letters, whitespace, and numbers, representable in UTF-8, and the following characters:<code> + - = . _ : /</code> </p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Tag {
     /// <p>Tag key (String). The key can't start with <code>aws:</code>.</p>
     #[serde(rename = "Key")]

--- a/rusoto/services/efs/src/generated.rs
+++ b/rusoto/services/efs/src/generated.rs
@@ -358,7 +358,8 @@ impl CreateFileSystemError {
     pub fn from_body(body: &str) -> CreateFileSystemError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -468,7 +469,8 @@ impl CreateMountTargetError {
     pub fn from_body(body: &str) -> CreateMountTargetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -602,7 +604,8 @@ impl CreateTagsError {
     pub fn from_body(body: &str) -> CreateTagsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -690,7 +693,8 @@ impl DeleteFileSystemError {
     pub fn from_body(body: &str) -> DeleteFileSystemError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -784,7 +788,8 @@ impl DeleteMountTargetError {
     pub fn from_body(body: &str) -> DeleteMountTargetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -878,7 +883,8 @@ impl DeleteTagsError {
     pub fn from_body(body: &str) -> DeleteTagsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -964,7 +970,8 @@ impl DescribeFileSystemsError {
     pub fn from_body(body: &str) -> DescribeFileSystemsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1058,7 +1065,8 @@ impl DescribeMountTargetSecurityGroupsError {
     pub fn from_body(body: &str) -> DescribeMountTargetSecurityGroupsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1162,7 +1170,8 @@ impl DescribeMountTargetsError {
     pub fn from_body(body: &str) -> DescribeMountTargetsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1258,7 +1267,8 @@ impl DescribeTagsError {
     pub fn from_body(body: &str) -> DescribeTagsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1352,7 +1362,8 @@ impl ModifyMountTargetSecurityGroupsError {
     pub fn from_body(body: &str) -> ModifyMountTargetSecurityGroupsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/elasticache/src/generated.rs
+++ b/rusoto/services/elasticache/src/generated.rs
@@ -44,7 +44,7 @@ enum DeserializerNext {
     Element(String),
 }
 /// <p>Represents the input of an AddTagsToResource operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AddTagsToResourceMessage {
     /// <p>The Amazon Resource Name (ARN) of the resource to which the tags are to be added, for example <code>arn:aws:elasticache:us-west-2:0123456789:cluster:myCluster</code> or <code>arn:aws:elasticache:us-west-2:0123456789:snapshot:mySnapshot</code>. ElastiCache resources are <i>cluster</i> and <i>snapshot</i>.</p> <p>For more information about ARNs, see <a href="http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html">Amazon Resource Names (ARNs) and AWS Service Namespaces</a>.</p>
     pub resource_name: String,
@@ -70,7 +70,7 @@ impl AddTagsToResourceMessageSerializer {
 }
 
 /// <p>Represents the allowed node types you can use to modify your cluster or replication group.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AllowedNodeTypeModificationsMessage {
     /// <p>A string list, each element of which specifies a cache node type which you can use to scale your cluster or replication group.</p> <p>When scaling up a Redis cluster or replication group using <code>ModifyCacheCluster</code> or <code>ModifyReplicationGroup</code>, use a value from this list for the <code>CacheNodeType</code> parameter.</p>
     pub scale_up_modifications: Option<Vec<String>>,
@@ -118,7 +118,7 @@ impl AllowedNodeTypeModificationsMessageDeserializer {
     }
 }
 /// <p>Represents the input of an AuthorizeCacheSecurityGroupIngress operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AuthorizeCacheSecurityGroupIngressMessage {
     /// <p>The cache security group that allows network ingress.</p>
     pub cache_security_group_name: String,
@@ -152,7 +152,7 @@ impl AuthorizeCacheSecurityGroupIngressMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AuthorizeCacheSecurityGroupIngressResult {
     pub cache_security_group: Option<CacheSecurityGroup>,
 }
@@ -215,7 +215,7 @@ impl AutomaticFailoverStatusDeserializer {
     }
 }
 /// <p>Describes an Availability Zone in which the cluster is launched.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AvailabilityZone {
     /// <p>The name of the Availability Zone.</p>
     pub name: Option<String>,
@@ -344,7 +344,7 @@ impl BooleanOptionalDeserializer {
     }
 }
 /// <p>Contains all of the attributes of a specific cluster.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CacheCluster {
     /// <p>A flag that enables encryption at-rest when set to <code>true</code>.</p> <p>You cannot modify the value of <code>AtRestEncryptionEnabled</code> after the cluster is created. To enable at-rest encryption on a cluster you must set <code>AtRestEncryptionEnabled</code> to <code>true</code> when you create a cluster.</p> <p>Default: <code>false</code> </p>
     pub at_rest_encryption_enabled: Option<bool>,
@@ -627,7 +627,7 @@ impl CacheClusterListDeserializer {
     }
 }
 /// <p>Represents the output of a <code>DescribeCacheClusters</code> operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CacheClusterMessage {
     /// <p>A list of clusters. Each item in the list contains detailed information about one cluster.</p>
     pub cache_clusters: Option<Vec<CacheCluster>>,
@@ -681,7 +681,7 @@ impl CacheClusterMessageDeserializer {
     }
 }
 /// <p>Provides all of the details about a particular cache engine version.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CacheEngineVersion {
     /// <p>The description of the cache engine.</p>
     pub cache_engine_description: Option<String>,
@@ -800,7 +800,7 @@ impl CacheEngineVersionListDeserializer {
     }
 }
 /// <p>Represents the output of a <a>DescribeCacheEngineVersions</a> operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CacheEngineVersionMessage {
     /// <p>A list of cache engine version details. Each element in the list contains detailed information about one cache engine version.</p>
     pub cache_engine_versions: Option<Vec<CacheEngineVersion>>,
@@ -855,7 +855,7 @@ impl CacheEngineVersionMessageDeserializer {
     }
 }
 /// <p>Represents an individual cache node within a cluster. Each cache node runs its own instance of the cluster's protocol-compliant caching software - either Memcached or Redis.</p> <p>The following node types are supported by ElastiCache. Generally speaking, the current generation types provide more memory and computational power at lower cost when compared to their equivalent previous generation counterparts.</p> <ul> <li> <p>General purpose:</p> <ul> <li> <p>Current generation: </p> <p> <b>T2 node types:</b> <code>cache.t2.micro</code>, <code>cache.t2.small</code>, <code>cache.t2.medium</code> </p> <p> <b>M3 node types:</b> <code>cache.m3.medium</code>, <code>cache.m3.large</code>, <code>cache.m3.xlarge</code>, <code>cache.m3.2xlarge</code> </p> <p> <b>M4 node types:</b> <code>cache.m4.large</code>, <code>cache.m4.xlarge</code>, <code>cache.m4.2xlarge</code>, <code>cache.m4.4xlarge</code>, <code>cache.m4.10xlarge</code> </p> </li> <li> <p>Previous generation: (not recommended)</p> <p> <b>T1 node types:</b> <code>cache.t1.micro</code> </p> <p> <b>M1 node types:</b> <code>cache.m1.small</code>, <code>cache.m1.medium</code>, <code>cache.m1.large</code>, <code>cache.m1.xlarge</code> </p> </li> </ul> </li> <li> <p>Compute optimized:</p> <ul> <li> <p>Previous generation: (not recommended)</p> <p> <b>C1 node types:</b> <code>cache.c1.xlarge</code> </p> </li> </ul> </li> <li> <p>Memory optimized:</p> <ul> <li> <p>Current generation: </p> <p> <b>R3 node types:</b> <code>cache.r3.large</code>, <code>cache.r3.xlarge</code>, <code>cache.r3.2xlarge</code>, <code>cache.r3.4xlarge</code>, <code>cache.r3.8xlarge</code> </p> </li> <li> <p>Previous generation: (not recommended)</p> <p> <b>M2 node types:</b> <code>cache.m2.xlarge</code>, <code>cache.m2.2xlarge</code>, <code>cache.m2.4xlarge</code> </p> </li> </ul> </li> </ul> <p> <b>Notes:</b> </p> <ul> <li> <p>All T2 instances are created in an Amazon Virtual Private Cloud (Amazon VPC).</p> </li> <li> <p>Redis (cluster mode disabled): Redis backup/restore is not supported on T1 and T2 instances. </p> </li> <li> <p>Redis (cluster mode enabled): Backup/restore is not supported on T1 instances.</p> </li> <li> <p>Redis Append-only files (AOF) functionality is not supported for T1 or T2 instances.</p> </li> </ul> <p>For a complete listing of node types and specifications, see <a href="http://aws.amazon.com/elasticache/details">Amazon ElastiCache Product Features and Details</a> and either <a href="http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Memcached.html#ParameterGroups.Memcached.NodeSpecific">Cache Node Type-Specific Parameters for Memcached</a> or <a href="http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Redis.html#ParameterGroups.Redis.NodeSpecific">Cache Node Type-Specific Parameters for Redis</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CacheNode {
     /// <p>The date and time when the cache node was created.</p>
     pub cache_node_create_time: Option<String>,
@@ -1039,7 +1039,7 @@ impl CacheNodeListDeserializer {
     }
 }
 /// <p>A parameter that has a different value for each cache node type it is applied to. For example, in a Redis cluster, a <code>cache.m1.large</code> cache node type would have a larger <code>maxmemory</code> value than a <code>cache.m1.small</code> type.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CacheNodeTypeSpecificParameter {
     /// <p>The valid range of values for the parameter.</p>
     pub allowed_values: Option<String>,
@@ -1192,7 +1192,7 @@ impl CacheNodeTypeSpecificParametersListDeserializer {
     }
 }
 /// <p>A value that applies only to a certain cache node type.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CacheNodeTypeSpecificValue {
     /// <p>The cache node type for which this value applies.</p>
     pub cache_node_type: Option<String>,
@@ -1289,7 +1289,7 @@ impl CacheNodeTypeSpecificValueListDeserializer {
     }
 }
 /// <p>Represents the output of a <code>CreateCacheParameterGroup</code> operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CacheParameterGroup {
     /// <p>The name of the cache parameter group family that this cache parameter group is compatible with.</p> <p>Valid values are: <code>memcached1.4</code> | <code>redis2.6</code> | <code>redis2.8</code> | <code>redis3.2</code> </p>
     pub cache_parameter_group_family: Option<String>,
@@ -1350,7 +1350,7 @@ impl CacheParameterGroupDeserializer {
     }
 }
 /// <p>Represents the output of a <code>DescribeCacheParameters</code> operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CacheParameterGroupDetails {
     /// <p>A list of parameters specific to a particular cache node type. Each element in the list contains detailed information about one parameter.</p>
     pub cache_node_type_specific_parameters: Option<Vec<CacheNodeTypeSpecificParameter>>,
@@ -1457,7 +1457,7 @@ impl CacheParameterGroupListDeserializer {
     }
 }
 /// <p><p>Represents the output of one of the following operations:</p> <ul> <li> <p> <code>ModifyCacheParameterGroup</code> </p> </li> <li> <p> <code>ResetCacheParameterGroup</code> </p> </li> </ul></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CacheParameterGroupNameMessage {
     /// <p>The name of the cache parameter group.</p>
     pub cache_parameter_group_name: Option<String>,
@@ -1505,7 +1505,7 @@ impl CacheParameterGroupNameMessageDeserializer {
     }
 }
 /// <p>Status of the cache parameter group.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CacheParameterGroupStatus {
     /// <p>A list of the cache node IDs which need to be rebooted for parameter changes to be applied. A node ID is a numeric identifier (0001, 0002, etc.).</p>
     pub cache_node_ids_to_reboot: Option<Vec<String>>,
@@ -1570,7 +1570,7 @@ impl CacheParameterGroupStatusDeserializer {
     }
 }
 /// <p>Represents the output of a <code>DescribeCacheParameterGroups</code> operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CacheParameterGroupsMessage {
     /// <p>A list of cache parameter groups. Each element in the list contains detailed information about one cache parameter group.</p>
     pub cache_parameter_groups: Option<Vec<CacheParameterGroup>>,
@@ -1625,7 +1625,7 @@ impl CacheParameterGroupsMessageDeserializer {
     }
 }
 /// <p><p>Represents the output of one of the following operations:</p> <ul> <li> <p> <code>AuthorizeCacheSecurityGroupIngress</code> </p> </li> <li> <p> <code>CreateCacheSecurityGroup</code> </p> </li> <li> <p> <code>RevokeCacheSecurityGroupIngress</code> </p> </li> </ul></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CacheSecurityGroup {
     /// <p>The name of the cache security group.</p>
     pub cache_security_group_name: Option<String>,
@@ -1694,7 +1694,7 @@ impl CacheSecurityGroupDeserializer {
     }
 }
 /// <p>Represents a cluster's status within a particular cache security group.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CacheSecurityGroupMembership {
     /// <p>The name of the cache security group.</p>
     pub cache_security_group_name: Option<String>,
@@ -1790,7 +1790,7 @@ impl CacheSecurityGroupMembershipListDeserializer {
     }
 }
 /// <p>Represents the output of a <code>DescribeCacheSecurityGroups</code> operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CacheSecurityGroupMessage {
     /// <p>A list of cache security groups. Each element in the list contains detailed information about one group.</p>
     pub cache_security_groups: Option<Vec<CacheSecurityGroup>>,
@@ -1900,7 +1900,7 @@ impl CacheSecurityGroupsDeserializer {
     }
 }
 /// <p><p>Represents the output of one of the following operations:</p> <ul> <li> <p> <code>CreateCacheSubnetGroup</code> </p> </li> <li> <p> <code>ModifyCacheSubnetGroup</code> </p> </li> </ul></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CacheSubnetGroup {
     /// <p>The description of the cache subnet group.</p>
     pub cache_subnet_group_description: Option<String>,
@@ -1967,7 +1967,7 @@ impl CacheSubnetGroupDeserializer {
     }
 }
 /// <p>Represents the output of a <code>DescribeCacheSubnetGroups</code> operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CacheSubnetGroupMessage {
     /// <p>A list of cache subnet groups. Each element in the list contains detailed information about one group.</p>
     pub cache_subnet_groups: Option<Vec<CacheSubnetGroup>>,
@@ -2117,7 +2117,7 @@ impl ClusterIdListDeserializer {
     }
 }
 /// <p>Represents the input of a <code>CopySnapshotMessage</code> operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CopySnapshotMessage {
     /// <p>The name of an existing snapshot from which to make a copy.</p>
     pub source_snapshot_name: String,
@@ -2153,7 +2153,7 @@ impl CopySnapshotMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CopySnapshotResult {
     pub snapshot: Option<Snapshot>,
 }
@@ -2199,7 +2199,7 @@ impl CopySnapshotResultDeserializer {
     }
 }
 /// <p>Represents the input of a CreateCacheCluster operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateCacheClusterMessage {
     /// <p>Specifies whether the nodes in this Memcached cluster are created in a single Availability Zone or created across multiple Availability Zones in the cluster's region.</p> <p>This parameter is only supported for Memcached clusters.</p> <p>If the <code>AZMode</code> and <code>PreferredAvailabilityZones</code> are not specified, ElastiCache assumes <code>single-az</code> mode.</p>
     pub az_mode: Option<String>,
@@ -2398,7 +2398,7 @@ impl CreateCacheClusterMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateCacheClusterResult {
     pub cache_cluster: Option<CacheCluster>,
 }
@@ -2446,7 +2446,7 @@ impl CreateCacheClusterResultDeserializer {
     }
 }
 /// <p>Represents the input of a <code>CreateCacheParameterGroup</code> operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateCacheParameterGroupMessage {
     /// <p>The name of the cache parameter group family that the cache parameter group can be used with.</p> <p>Valid values are: <code>memcached1.4</code> | <code>redis2.6</code> | <code>redis2.8</code> | <code>redis3.2</code> </p>
     pub cache_parameter_group_family: String,
@@ -2480,7 +2480,7 @@ impl CreateCacheParameterGroupMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateCacheParameterGroupResult {
     pub cache_parameter_group: Option<CacheParameterGroup>,
 }
@@ -2529,7 +2529,7 @@ impl CreateCacheParameterGroupResultDeserializer {
     }
 }
 /// <p>Represents the input of a <code>CreateCacheSecurityGroup</code> operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateCacheSecurityGroupMessage {
     /// <p>A name for the cache security group. This value is stored as a lowercase string.</p> <p>Constraints: Must contain no more than 255 alphanumeric characters. Cannot be the word "Default".</p> <p>Example: <code>mysecuritygroup</code> </p>
     pub cache_security_group_name: String,
@@ -2557,7 +2557,7 @@ impl CreateCacheSecurityGroupMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateCacheSecurityGroupResult {
     pub cache_security_group: Option<CacheSecurityGroup>,
 }
@@ -2606,7 +2606,7 @@ impl CreateCacheSecurityGroupResultDeserializer {
     }
 }
 /// <p>Represents the input of a <code>CreateCacheSubnetGroup</code> operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateCacheSubnetGroupMessage {
     /// <p>A description for the cache subnet group.</p>
     pub cache_subnet_group_description: String,
@@ -2641,7 +2641,7 @@ impl CreateCacheSubnetGroupMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateCacheSubnetGroupResult {
     pub cache_subnet_group: Option<CacheSubnetGroup>,
 }
@@ -2688,7 +2688,7 @@ impl CreateCacheSubnetGroupResultDeserializer {
     }
 }
 /// <p>Represents the input of a <code>CreateReplicationGroup</code> operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateReplicationGroupMessage {
     /// <p>A flag that enables encryption at rest when set to <code>true</code>.</p> <p>You cannot modify the value of <code>AtRestEncryptionEnabled</code> after the replication group is created. To enable encryption at rest on a replication group you must set <code>AtRestEncryptionEnabled</code> to <code>true</code> when you create the replication group. </p> <note> <p>This parameter is valid only if the <code>Engine</code> parameter is <code>redis</code> and the cluster is being created in an Amazon VPC.</p> </note> <p>Default: <code>false</code> </p>
     pub at_rest_encryption_enabled: Option<bool>,
@@ -2926,7 +2926,7 @@ impl CreateReplicationGroupMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateReplicationGroupResult {
     pub replication_group: Option<ReplicationGroup>,
 }
@@ -2973,7 +2973,7 @@ impl CreateReplicationGroupResultDeserializer {
     }
 }
 /// <p>Represents the input of a <code>CreateSnapshot</code> operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateSnapshotMessage {
     /// <p>The identifier of an existing cluster. The snapshot is created from this cluster.</p>
     pub cache_cluster_id: Option<String>,
@@ -3011,7 +3011,7 @@ impl CreateSnapshotMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateSnapshotResult {
     pub snapshot: Option<Snapshot>,
 }
@@ -3057,7 +3057,7 @@ impl CreateSnapshotResultDeserializer {
     }
 }
 /// <p>Represents the input of a <code>DeleteCacheCluster</code> operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteCacheClusterMessage {
     /// <p>The cluster identifier for the cluster to be deleted. This parameter is not case sensitive.</p>
     pub cache_cluster_id: String,
@@ -3087,7 +3087,7 @@ impl DeleteCacheClusterMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteCacheClusterResult {
     pub cache_cluster: Option<CacheCluster>,
 }
@@ -3135,7 +3135,7 @@ impl DeleteCacheClusterResultDeserializer {
     }
 }
 /// <p>Represents the input of a <code>DeleteCacheParameterGroup</code> operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteCacheParameterGroupMessage {
     /// <p><p>The name of the cache parameter group to delete.</p> <note> <p>The specified cache security group must not be associated with any clusters.</p> </note></p>
     pub cache_parameter_group_name: String,
@@ -3158,7 +3158,7 @@ impl DeleteCacheParameterGroupMessageSerializer {
 }
 
 /// <p>Represents the input of a <code>DeleteCacheSecurityGroup</code> operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteCacheSecurityGroupMessage {
     /// <p><p>The name of the cache security group to delete.</p> <note> <p>You cannot delete the default security group.</p> </note></p>
     pub cache_security_group_name: String,
@@ -3181,7 +3181,7 @@ impl DeleteCacheSecurityGroupMessageSerializer {
 }
 
 /// <p>Represents the input of a <code>DeleteCacheSubnetGroup</code> operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteCacheSubnetGroupMessage {
     /// <p>The name of the cache subnet group to delete.</p> <p>Constraints: Must contain no more than 255 alphanumeric characters or hyphens.</p>
     pub cache_subnet_group_name: String,
@@ -3204,7 +3204,7 @@ impl DeleteCacheSubnetGroupMessageSerializer {
 }
 
 /// <p>Represents the input of a <code>DeleteReplicationGroup</code> operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteReplicationGroupMessage {
     /// <p>The name of a final node group (shard) snapshot. ElastiCache creates the snapshot from the primary node in the cluster, rather than one of the replicas; this is to ensure that it captures the freshest data. After the final snapshot is taken, the replication group is immediately deleted.</p>
     pub final_snapshot_identifier: Option<String>,
@@ -3242,7 +3242,7 @@ impl DeleteReplicationGroupMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteReplicationGroupResult {
     pub replication_group: Option<ReplicationGroup>,
 }
@@ -3289,7 +3289,7 @@ impl DeleteReplicationGroupResultDeserializer {
     }
 }
 /// <p>Represents the input of a <code>DeleteSnapshot</code> operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteSnapshotMessage {
     /// <p>The name of the snapshot to be deleted.</p>
     pub snapshot_name: String,
@@ -3311,7 +3311,7 @@ impl DeleteSnapshotMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteSnapshotResult {
     pub snapshot: Option<Snapshot>,
 }
@@ -3357,7 +3357,7 @@ impl DeleteSnapshotResultDeserializer {
     }
 }
 /// <p>Represents the input of a <code>DescribeCacheClusters</code> operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeCacheClustersMessage {
     /// <p>The user-supplied cluster identifier. If this parameter is specified, only information about that specific cluster is returned. This parameter isn't case sensitive.</p>
     pub cache_cluster_id: Option<String>,
@@ -3414,7 +3414,7 @@ impl DescribeCacheClustersMessageSerializer {
 }
 
 /// <p>Represents the input of a <code>DescribeCacheEngineVersions</code> operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeCacheEngineVersionsMessage {
     /// <p><p>The name of a specific cache parameter group family to return details for.</p> <p>Valid values are: <code>memcached1.4</code> | <code>redis2.6</code> | <code>redis2.8</code> | <code>redis3.2</code> </p> <p>Constraints:</p> <ul> <li> <p>Must be 1 to 255 alphanumeric characters</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul></p>
     pub cache_parameter_group_family: Option<String>,
@@ -3479,7 +3479,7 @@ impl DescribeCacheEngineVersionsMessageSerializer {
 }
 
 /// <p>Represents the input of a <code>DescribeCacheParameterGroups</code> operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeCacheParameterGroupsMessage {
     /// <p>The name of a specific cache parameter group to return details for.</p>
     pub cache_parameter_group_name: Option<String>,
@@ -3520,7 +3520,7 @@ impl DescribeCacheParameterGroupsMessageSerializer {
 }
 
 /// <p>Represents the input of a <code>DescribeCacheParameters</code> operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeCacheParametersMessage {
     /// <p>The name of a specific cache parameter group to return details for.</p>
     pub cache_parameter_group_name: String,
@@ -3567,7 +3567,7 @@ impl DescribeCacheParametersMessageSerializer {
 }
 
 /// <p>Represents the input of a <code>DescribeCacheSecurityGroups</code> operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeCacheSecurityGroupsMessage {
     /// <p>The name of the cache security group to return details for.</p>
     pub cache_security_group_name: Option<String>,
@@ -3608,7 +3608,7 @@ impl DescribeCacheSecurityGroupsMessageSerializer {
 }
 
 /// <p>Represents the input of a <code>DescribeCacheSubnetGroups</code> operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeCacheSubnetGroupsMessage {
     /// <p>The name of the cache subnet group to return details for.</p>
     pub cache_subnet_group_name: Option<String>,
@@ -3649,7 +3649,7 @@ impl DescribeCacheSubnetGroupsMessageSerializer {
 }
 
 /// <p>Represents the input of a <code>DescribeEngineDefaultParameters</code> operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeEngineDefaultParametersMessage {
     /// <p>The name of the cache parameter group family.</p> <p>Valid values are: <code>memcached1.4</code> | <code>redis2.6</code> | <code>redis2.8</code> | <code>redis3.2</code> </p>
     pub cache_parameter_group_family: String,
@@ -3687,7 +3687,7 @@ impl DescribeEngineDefaultParametersMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeEngineDefaultParametersResult {
     pub engine_defaults: Option<EngineDefaults>,
 }
@@ -3735,7 +3735,7 @@ impl DescribeEngineDefaultParametersResultDeserializer {
     }
 }
 /// <p>Represents the input of a <code>DescribeEvents</code> operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeEventsMessage {
     /// <p>The number of minutes worth of events to retrieve.</p>
     pub duration: Option<i64>,
@@ -3808,7 +3808,7 @@ impl DescribeEventsMessageSerializer {
 }
 
 /// <p>Represents the input of a <code>DescribeReplicationGroups</code> operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeReplicationGroupsMessage {
     /// <p>An optional marker returned from a prior request. Use this marker for pagination of results from this operation. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>.</p>
     pub marker: Option<String>,
@@ -3849,7 +3849,7 @@ impl DescribeReplicationGroupsMessageSerializer {
 }
 
 /// <p>Represents the input of a <code>DescribeReservedCacheNodes</code> operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeReservedCacheNodesMessage {
     /// <p>The cache node type filter value. Use this parameter to show only those reservations matching the specified cache node type.</p> <p>The following node types are supported by ElastiCache. Generally speaking, the current generation types provide more memory and computational power at lower cost when compared to their equivalent previous generation counterparts.</p> <ul> <li> <p>General purpose:</p> <ul> <li> <p>Current generation: </p> <p> <b>T2 node types:</b> <code>cache.t2.micro</code>, <code>cache.t2.small</code>, <code>cache.t2.medium</code> </p> <p> <b>M3 node types:</b> <code>cache.m3.medium</code>, <code>cache.m3.large</code>, <code>cache.m3.xlarge</code>, <code>cache.m3.2xlarge</code> </p> <p> <b>M4 node types:</b> <code>cache.m4.large</code>, <code>cache.m4.xlarge</code>, <code>cache.m4.2xlarge</code>, <code>cache.m4.4xlarge</code>, <code>cache.m4.10xlarge</code> </p> </li> <li> <p>Previous generation: (not recommended)</p> <p> <b>T1 node types:</b> <code>cache.t1.micro</code> </p> <p> <b>M1 node types:</b> <code>cache.m1.small</code>, <code>cache.m1.medium</code>, <code>cache.m1.large</code>, <code>cache.m1.xlarge</code> </p> </li> </ul> </li> <li> <p>Compute optimized:</p> <ul> <li> <p>Previous generation: (not recommended)</p> <p> <b>C1 node types:</b> <code>cache.c1.xlarge</code> </p> </li> </ul> </li> <li> <p>Memory optimized:</p> <ul> <li> <p>Current generation: </p> <p> <b>R3 node types:</b> <code>cache.r3.large</code>, <code>cache.r3.xlarge</code>, <code>cache.r3.2xlarge</code>, <code>cache.r3.4xlarge</code>, <code>cache.r3.8xlarge</code> </p> </li> <li> <p>Previous generation: (not recommended)</p> <p> <b>M2 node types:</b> <code>cache.m2.xlarge</code>, <code>cache.m2.2xlarge</code>, <code>cache.m2.4xlarge</code> </p> </li> </ul> </li> </ul> <p> <b>Notes:</b> </p> <ul> <li> <p>All T2 instances are created in an Amazon Virtual Private Cloud (Amazon VPC).</p> </li> <li> <p>Redis (cluster mode disabled): Redis backup/restore is not supported on T1 and T2 instances. </p> </li> <li> <p>Redis (cluster mode enabled): Backup/restore is not supported on T1 instances.</p> </li> <li> <p>Redis Append-only files (AOF) functionality is not supported for T1 or T2 instances.</p> </li> </ul> <p>For a complete listing of node types and specifications, see <a href="http://aws.amazon.com/elasticache/details">Amazon ElastiCache Product Features and Details</a> and either <a href="http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Memcached.html#ParameterGroups.Memcached.NodeSpecific">Cache Node Type-Specific Parameters for Memcached</a> or <a href="http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Redis.html#ParameterGroups.Redis.NodeSpecific">Cache Node Type-Specific Parameters for Redis</a>.</p>
     pub cache_node_type: Option<String>,
@@ -3930,7 +3930,7 @@ impl DescribeReservedCacheNodesMessageSerializer {
 }
 
 /// <p>Represents the input of a <code>DescribeReservedCacheNodesOfferings</code> operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeReservedCacheNodesOfferingsMessage {
     /// <p>The cache node type filter value. Use this parameter to show only the available offerings matching the specified cache node type.</p> <p>The following node types are supported by ElastiCache. Generally speaking, the current generation types provide more memory and computational power at lower cost when compared to their equivalent previous generation counterparts.</p> <ul> <li> <p>General purpose:</p> <ul> <li> <p>Current generation: </p> <p> <b>T2 node types:</b> <code>cache.t2.micro</code>, <code>cache.t2.small</code>, <code>cache.t2.medium</code> </p> <p> <b>M3 node types:</b> <code>cache.m3.medium</code>, <code>cache.m3.large</code>, <code>cache.m3.xlarge</code>, <code>cache.m3.2xlarge</code> </p> <p> <b>M4 node types:</b> <code>cache.m4.large</code>, <code>cache.m4.xlarge</code>, <code>cache.m4.2xlarge</code>, <code>cache.m4.4xlarge</code>, <code>cache.m4.10xlarge</code> </p> </li> <li> <p>Previous generation: (not recommended)</p> <p> <b>T1 node types:</b> <code>cache.t1.micro</code> </p> <p> <b>M1 node types:</b> <code>cache.m1.small</code>, <code>cache.m1.medium</code>, <code>cache.m1.large</code>, <code>cache.m1.xlarge</code> </p> </li> </ul> </li> <li> <p>Compute optimized:</p> <ul> <li> <p>Previous generation: (not recommended)</p> <p> <b>C1 node types:</b> <code>cache.c1.xlarge</code> </p> </li> </ul> </li> <li> <p>Memory optimized:</p> <ul> <li> <p>Current generation: </p> <p> <b>R3 node types:</b> <code>cache.r3.large</code>, <code>cache.r3.xlarge</code>, <code>cache.r3.2xlarge</code>, <code>cache.r3.4xlarge</code>, <code>cache.r3.8xlarge</code> </p> </li> <li> <p>Previous generation: (not recommended)</p> <p> <b>M2 node types:</b> <code>cache.m2.xlarge</code>, <code>cache.m2.2xlarge</code>, <code>cache.m2.4xlarge</code> </p> </li> </ul> </li> </ul> <p> <b>Notes:</b> </p> <ul> <li> <p>All T2 instances are created in an Amazon Virtual Private Cloud (Amazon VPC).</p> </li> <li> <p>Redis (cluster mode disabled): Redis backup/restore is not supported on T1 and T2 instances. </p> </li> <li> <p>Redis (cluster mode enabled): Backup/restore is not supported on T1 instances.</p> </li> <li> <p>Redis Append-only files (AOF) functionality is not supported for T1 or T2 instances.</p> </li> </ul> <p>For a complete listing of node types and specifications, see <a href="http://aws.amazon.com/elasticache/details">Amazon ElastiCache Product Features and Details</a> and either <a href="http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Memcached.html#ParameterGroups.Memcached.NodeSpecific">Cache Node Type-Specific Parameters for Memcached</a> or <a href="http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Redis.html#ParameterGroups.Redis.NodeSpecific">Cache Node Type-Specific Parameters for Redis</a>.</p>
     pub cache_node_type: Option<String>,
@@ -4007,7 +4007,7 @@ impl DescribeReservedCacheNodesOfferingsMessageSerializer {
 }
 
 /// <p>Represents the output of a <code>DescribeSnapshots</code> operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeSnapshotsListMessage {
     /// <p>An optional marker returned from a prior request. Use this marker for pagination of results from this operation. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>.</p>
     pub marker: Option<String>,
@@ -4061,7 +4061,7 @@ impl DescribeSnapshotsListMessageDeserializer {
     }
 }
 /// <p>Represents the input of a <code>DescribeSnapshotsMessage</code> operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeSnapshotsMessage {
     /// <p>A user-supplied cluster identifier. If this parameter is specified, only snapshots associated with that specific cluster are described.</p>
     pub cache_cluster_id: Option<String>,
@@ -4148,7 +4148,7 @@ impl DoubleDeserializer {
     }
 }
 /// <p>Provides ownership and status information for an Amazon EC2 security group.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct EC2SecurityGroup {
     /// <p>The name of the Amazon EC2 security group.</p>
     pub ec2_security_group_name: Option<String>,
@@ -4252,7 +4252,7 @@ impl EC2SecurityGroupListDeserializer {
     }
 }
 /// <p>Represents the information required for client programs to connect to a cache node.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Endpoint {
     /// <p>The DNS hostname of the cache node.</p>
     pub address: Option<String>,
@@ -4303,7 +4303,7 @@ impl EndpointDeserializer {
     }
 }
 /// <p>Represents the output of a <code>DescribeEngineDefaultParameters</code> operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct EngineDefaults {
     /// <p>A list of parameters specific to a particular cache node type. Each element in the list contains detailed information about one parameter.</p>
     pub cache_node_type_specific_parameters: Option<Vec<CacheNodeTypeSpecificParameter>>,
@@ -4374,7 +4374,7 @@ impl EngineDefaultsDeserializer {
     }
 }
 /// <p>Represents a single occurrence of something interesting within the system. Some examples of events are creating a cluster, adding or removing a cache node, or rebooting a node.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Event {
     /// <p>The date and time when the event occurred.</p>
     pub date: Option<String>,
@@ -4481,7 +4481,7 @@ impl EventListDeserializer {
     }
 }
 /// <p>Represents the output of a <code>DescribeEvents</code> operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct EventsMessage {
     /// <p>A list of events. Each element in the list contains detailed information about one event.</p>
     pub events: Option<Vec<Event>>,
@@ -4573,7 +4573,7 @@ impl KeyListSerializer {
 }
 
 /// <p>The input parameters for the <code>ListAllowedNodeTypeModifications</code> operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListAllowedNodeTypeModificationsMessage {
     /// <p><p>The name of the cluster you want to scale up to a larger node instanced type. ElastiCache uses the cluster id to identify the current node type of this cluster and from that to create a list of node types you can scale up to.</p> <important> <p>You must provide a value for either the <code>CacheClusterId</code> or the <code>ReplicationGroupId</code>.</p> </important></p>
     pub cache_cluster_id: Option<String>,
@@ -4606,7 +4606,7 @@ impl ListAllowedNodeTypeModificationsMessageSerializer {
 }
 
 /// <p>The input parameters for the <code>ListTagsForResource</code> operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListTagsForResourceMessage {
     /// <p>The Amazon Resource Name (ARN) of the resource for which you want the list of tags, for example <code>arn:aws:elasticache:us-west-2:0123456789:cluster:myCluster</code> or <code>arn:aws:elasticache:us-west-2:0123456789:snapshot:mySnapshot</code>.</p> <p>For more information about ARNs, see <a href="http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html">Amazon Resource Names (ARNs) and AWS Service Namespaces</a>.</p>
     pub resource_name: String,
@@ -4629,7 +4629,7 @@ impl ListTagsForResourceMessageSerializer {
 }
 
 /// <p>Represents the input of a <code>ModifyCacheCluster</code> operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyCacheClusterMessage {
     /// <p><p>Specifies whether the new nodes in this Memcached cluster are all created in a single Availability Zone or created across multiple Availability Zones.</p> <p>Valid values: <code>single-az</code> | <code>cross-az</code>.</p> <p>This option is only supported for Memcached clusters.</p> <note> <p>You cannot specify <code>single-az</code> if the Memcached cluster already has cache nodes in different Availability Zones. If <code>cross-az</code> is specified, existing Memcached nodes remain in their current Availability Zone.</p> <p>Only newly created nodes are located in different Availability Zones. For instructions on how to move existing Memcached nodes to different Availability Zones, see the <b>Availability Zone Considerations</b> section of <a href="http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheNode.Memcached.html">Cache Node Considerations for Memcached</a>.</p> </note></p>
     pub az_mode: Option<String>,
@@ -4783,7 +4783,7 @@ impl ModifyCacheClusterMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyCacheClusterResult {
     pub cache_cluster: Option<CacheCluster>,
 }
@@ -4831,7 +4831,7 @@ impl ModifyCacheClusterResultDeserializer {
     }
 }
 /// <p>Represents the input of a <code>ModifyCacheParameterGroup</code> operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyCacheParameterGroupMessage {
     /// <p>The name of the cache parameter group to modify.</p>
     pub cache_parameter_group_name: String,
@@ -4861,7 +4861,7 @@ impl ModifyCacheParameterGroupMessageSerializer {
 }
 
 /// <p>Represents the input of a <code>ModifyCacheSubnetGroup</code> operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyCacheSubnetGroupMessage {
     /// <p>A description of the cache subnet group.</p>
     pub cache_subnet_group_description: Option<String>,
@@ -4900,7 +4900,7 @@ impl ModifyCacheSubnetGroupMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyCacheSubnetGroupResult {
     pub cache_subnet_group: Option<CacheSubnetGroup>,
 }
@@ -4947,7 +4947,7 @@ impl ModifyCacheSubnetGroupResultDeserializer {
     }
 }
 /// <p>Represents the input of a <code>ModifyReplicationGroups</code> operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyReplicationGroupMessage {
     /// <p>If <code>true</code>, this parameter causes the modifications in this request and any pending modifications to be applied, asynchronously and as soon as possible, regardless of the <code>PreferredMaintenanceWindow</code> setting for the replication group.</p> <p>If <code>false</code>, changes to the nodes in the replication group are applied on the next maintenance reboot, or the next failure reboot, whichever occurs first.</p> <p>Valid values: <code>true</code> | <code>false</code> </p> <p>Default: <code>false</code> </p>
     pub apply_immediately: Option<bool>,
@@ -5107,7 +5107,7 @@ impl ModifyReplicationGroupMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyReplicationGroupResult {
     pub replication_group: Option<ReplicationGroup>,
 }
@@ -5154,7 +5154,7 @@ impl ModifyReplicationGroupResultDeserializer {
     }
 }
 /// <p>Represents the input for a <code>ModifyReplicationGroupShardConfiguration</code> operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyReplicationGroupShardConfigurationMessage {
     /// <p>Indicates that the shard reconfiguration process begins immediately. At present, the only permitted value for this parameter is <code>true</code>.</p> <p>Value: true</p>
     pub apply_immediately: bool,
@@ -5210,7 +5210,7 @@ impl ModifyReplicationGroupShardConfigurationMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyReplicationGroupShardConfigurationResult {
     pub replication_group: Option<ReplicationGroup>,
 }
@@ -5257,7 +5257,7 @@ impl ModifyReplicationGroupShardConfigurationResultDeserializer {
     }
 }
 /// <p>Represents a collection of cache nodes in a replication group. One node in the node group is the read/write primary node. All the other nodes are read-only Replica nodes.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct NodeGroup {
     /// <p>The identifier for the node group (shard). A Redis (cluster mode disabled) replication group contains only 1 node group; therefore, the node group ID is 0001. A Redis (cluster mode enabled) replication group contains 1 to 15 node groups numbered 0001 to 0015. </p>
     pub node_group_id: Option<String>,
@@ -5329,7 +5329,7 @@ impl NodeGroupDeserializer {
     }
 }
 /// <p>Node group (shard) configuration options. Each node group (shard) configuration has the following: <code>Slots</code>, <code>PrimaryAvailabilityZone</code>, <code>ReplicaAvailabilityZones</code>, <code>ReplicaCount</code>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct NodeGroupConfiguration {
     /// <p>The Availability Zone where the primary node of this node group (shard) is launched.</p>
     pub primary_availability_zone: Option<String>,
@@ -5488,7 +5488,7 @@ impl NodeGroupListDeserializer {
     }
 }
 /// <p>Represents a single node within a node group (shard).</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct NodeGroupMember {
     /// <p>The ID of the cluster to which the node belongs.</p>
     pub cache_cluster_id: Option<String>,
@@ -5618,7 +5618,7 @@ impl NodeGroupsToRemoveListSerializer {
 }
 
 /// <p>Represents an individual cache node in a snapshot of a cluster.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct NodeSnapshot {
     /// <p>A unique identifier for the source cluster.</p>
     pub cache_cluster_id: Option<String>,
@@ -5793,7 +5793,7 @@ impl NodeTypeListDeserializer {
     }
 }
 /// <p>Describes a notification topic and its status. Notification topics are used for publishing ElastiCache events to subscribers using Amazon Simple Notification Service (SNS).</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct NotificationConfiguration {
     /// <p>The Amazon Resource Name (ARN) that identifies the topic.</p>
     pub topic_arn: Option<String>,
@@ -5846,7 +5846,7 @@ impl NotificationConfigurationDeserializer {
     }
 }
 /// <p>Describes an individual setting that controls some aspect of ElastiCache behavior.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Parameter {
     /// <p>The valid range of values for the parameter.</p>
     pub allowed_values: Option<String>,
@@ -5952,7 +5952,7 @@ impl ParameterDeserializer {
     }
 }
 /// <p>Describes a name-value pair that is used to update the value of a parameter.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ParameterNameValue {
     /// <p>The name of the parameter.</p>
     pub parameter_name: Option<String>,
@@ -6050,7 +6050,7 @@ impl PendingAutomaticFailoverStatusDeserializer {
     }
 }
 /// <p>A group of settings that are applied to the cluster in the future, or that are currently being applied.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PendingModifiedValues {
     /// <p>A list of cache node IDs that are being removed (or will be removed) from the cluster. A node ID is a numeric identifier (0001, 0002, etc.).</p>
     pub cache_node_ids_to_remove: Option<Vec<String>>,
@@ -6136,7 +6136,7 @@ impl PreferredAvailabilityZoneListSerializer {
 }
 
 /// <p>Represents the input of a <code>PurchaseReservedCacheNodesOffering</code> operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PurchaseReservedCacheNodesOfferingMessage {
     /// <p>The number of cache node instances to reserve.</p> <p>Default: <code>1</code> </p>
     pub cache_node_count: Option<i64>,
@@ -6174,7 +6174,7 @@ impl PurchaseReservedCacheNodesOfferingMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PurchaseReservedCacheNodesOfferingResult {
     pub reserved_cache_node: Option<ReservedCacheNode>,
 }
@@ -6221,7 +6221,7 @@ impl PurchaseReservedCacheNodesOfferingResultDeserializer {
     }
 }
 /// <p>Represents the input of a <code>RebootCacheCluster</code> operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RebootCacheClusterMessage {
     /// <p>The cluster identifier. This parameter is stored as a lowercase string.</p>
     pub cache_cluster_id: String,
@@ -6250,7 +6250,7 @@ impl RebootCacheClusterMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RebootCacheClusterResult {
     pub cache_cluster: Option<CacheCluster>,
 }
@@ -6298,7 +6298,7 @@ impl RebootCacheClusterResultDeserializer {
     }
 }
 /// <p>Contains the specific price and frequency of a recurring charges for a reserved cache node, or for a reserved cache node offering.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RecurringCharge {
     /// <p>The monetary amount of the recurring charge.</p>
     pub recurring_charge_amount: Option<f64>,
@@ -6397,7 +6397,7 @@ impl RecurringChargeListDeserializer {
     }
 }
 /// <p>Represents the input of a <code>RemoveTagsFromResource</code> operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RemoveTagsFromResourceMessage {
     /// <p>The Amazon Resource Name (ARN) of the resource from which you want the tags removed, for example <code>arn:aws:elasticache:us-west-2:0123456789:cluster:myCluster</code> or <code>arn:aws:elasticache:us-west-2:0123456789:snapshot:mySnapshot</code>.</p> <p>For more information about ARNs, see <a href="http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html">Amazon Resource Names (ARNs) and AWS Service Namespaces</a>.</p>
     pub resource_name: String,
@@ -6423,7 +6423,7 @@ impl RemoveTagsFromResourceMessageSerializer {
 }
 
 /// <p>Contains all of the attributes of a specific Redis replication group.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ReplicationGroup {
     /// <p>A flag that enables encryption at-rest when set to <code>true</code>.</p> <p>You cannot modify the value of <code>AtRestEncryptionEnabled</code> after the cluster is created. To enable encryption at-rest on a cluster you must set <code>AtRestEncryptionEnabled</code> to <code>true</code> when you create a cluster.</p> <p>Default: <code>false</code> </p>
     pub at_rest_encryption_enabled: Option<bool>,
@@ -6634,7 +6634,7 @@ impl ReplicationGroupListDeserializer {
     }
 }
 /// <p>Represents the output of a <code>DescribeReplicationGroups</code> operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ReplicationGroupMessage {
     /// <p>Provides an identifier to allow retrieval of paginated results.</p>
     pub marker: Option<String>,
@@ -6689,7 +6689,7 @@ impl ReplicationGroupMessageDeserializer {
     }
 }
 /// <p>The settings to be applied to the Redis replication group, either immediately or during the next maintenance window.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ReplicationGroupPendingModifiedValues {
     /// <p><p>Indicates the status of Multi-AZ with automatic failover for this Redis replication group.</p> <p>Amazon ElastiCache for Redis does not support Multi-AZ with automatic failover on:</p> <ul> <li> <p>Redis versions earlier than 2.8.6.</p> </li> <li> <p>Redis (cluster mode disabled): T1 and T2 cache node types.</p> </li> <li> <p>Redis (cluster mode enabled): T1 node types.</p> </li> </ul></p>
     pub automatic_failover_status: Option<String>,
@@ -6756,7 +6756,7 @@ impl ReplicationGroupPendingModifiedValuesDeserializer {
     }
 }
 /// <p>Represents the output of a <code>PurchaseReservedCacheNodesOffering</code> operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ReservedCacheNode {
     /// <p>The number of cache nodes that have been reserved.</p>
     pub cache_node_count: Option<i64>,
@@ -6921,7 +6921,7 @@ impl ReservedCacheNodeListDeserializer {
     }
 }
 /// <p>Represents the output of a <code>DescribeReservedCacheNodes</code> operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ReservedCacheNodeMessage {
     /// <p>Provides an identifier to allow retrieval of paginated results.</p>
     pub marker: Option<String>,
@@ -6976,7 +6976,7 @@ impl ReservedCacheNodeMessageDeserializer {
     }
 }
 /// <p>Describes all of the attributes of a reserved cache node offering.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ReservedCacheNodesOffering {
     /// <p>The cache node type for the reserved cache node.</p> <p>The following node types are supported by ElastiCache. Generally speaking, the current generation types provide more memory and computational power at lower cost when compared to their equivalent previous generation counterparts.</p> <ul> <li> <p>General purpose:</p> <ul> <li> <p>Current generation: </p> <p> <b>T2 node types:</b> <code>cache.t2.micro</code>, <code>cache.t2.small</code>, <code>cache.t2.medium</code> </p> <p> <b>M3 node types:</b> <code>cache.m3.medium</code>, <code>cache.m3.large</code>, <code>cache.m3.xlarge</code>, <code>cache.m3.2xlarge</code> </p> <p> <b>M4 node types:</b> <code>cache.m4.large</code>, <code>cache.m4.xlarge</code>, <code>cache.m4.2xlarge</code>, <code>cache.m4.4xlarge</code>, <code>cache.m4.10xlarge</code> </p> </li> <li> <p>Previous generation: (not recommended)</p> <p> <b>T1 node types:</b> <code>cache.t1.micro</code> </p> <p> <b>M1 node types:</b> <code>cache.m1.small</code>, <code>cache.m1.medium</code>, <code>cache.m1.large</code>, <code>cache.m1.xlarge</code> </p> </li> </ul> </li> <li> <p>Compute optimized:</p> <ul> <li> <p>Previous generation: (not recommended)</p> <p> <b>C1 node types:</b> <code>cache.c1.xlarge</code> </p> </li> </ul> </li> <li> <p>Memory optimized:</p> <ul> <li> <p>Current generation: </p> <p> <b>R3 node types:</b> <code>cache.r3.large</code>, <code>cache.r3.xlarge</code>, <code>cache.r3.2xlarge</code>, <code>cache.r3.4xlarge</code>, <code>cache.r3.8xlarge</code> </p> </li> <li> <p>Previous generation: (not recommended)</p> <p> <b>M2 node types:</b> <code>cache.m2.xlarge</code>, <code>cache.m2.2xlarge</code>, <code>cache.m2.4xlarge</code> </p> </li> </ul> </li> </ul> <p> <b>Notes:</b> </p> <ul> <li> <p>All T2 instances are created in an Amazon Virtual Private Cloud (Amazon VPC).</p> </li> <li> <p>Redis (cluster mode disabled): Redis backup/restore is not supported on T1 and T2 instances. </p> </li> <li> <p>Redis (cluster mode enabled): Backup/restore is not supported on T1 instances.</p> </li> <li> <p>Redis Append-only files (AOF) functionality is not supported for T1 or T2 instances.</p> </li> </ul> <p>For a complete listing of node types and specifications, see <a href="http://aws.amazon.com/elasticache/details">Amazon ElastiCache Product Features and Details</a> and either <a href="http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Memcached.html#ParameterGroups.Memcached.NodeSpecific">Cache Node Type-Specific Parameters for Memcached</a> or <a href="http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Redis.html#ParameterGroups.Redis.NodeSpecific">Cache Node Type-Specific Parameters for Redis</a>.</p>
     pub cache_node_type: Option<String>,
@@ -7114,7 +7114,7 @@ impl ReservedCacheNodesOfferingListDeserializer {
     }
 }
 /// <p>Represents the output of a <code>DescribeReservedCacheNodesOfferings</code> operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ReservedCacheNodesOfferingMessage {
     /// <p>Provides an identifier to allow retrieval of paginated results.</p>
     pub marker: Option<String>,
@@ -7170,7 +7170,7 @@ impl ReservedCacheNodesOfferingMessageDeserializer {
     }
 }
 /// <p>Represents the input of a <code>ResetCacheParameterGroup</code> operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ResetCacheParameterGroupMessage {
     /// <p>The name of the cache parameter group to reset.</p>
     pub cache_parameter_group_name: String,
@@ -7210,7 +7210,7 @@ impl ResetCacheParameterGroupMessageSerializer {
 }
 
 /// <p>A list of <code>PreferredAvailabilityZones</code> objects that specifies the configuration of a node group in the resharded cluster.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ReshardingConfiguration {
     /// <p>A list of preferred availability zones for the nodes in this cluster.</p>
     pub preferred_availability_zones: Option<Vec<String>>,
@@ -7247,7 +7247,7 @@ impl ReshardingConfigurationListSerializer {
 }
 
 /// <p>The status of an online resharding operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ReshardingStatus {
     /// <p>Represents the progress of an online resharding operation.</p>
     pub slot_migration: Option<SlotMigration>,
@@ -7296,7 +7296,7 @@ impl ReshardingStatusDeserializer {
     }
 }
 /// <p>Represents the input of a <code>RevokeCacheSecurityGroupIngress</code> operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RevokeCacheSecurityGroupIngressMessage {
     /// <p>The name of the cache security group to revoke ingress from.</p>
     pub cache_security_group_name: String,
@@ -7330,7 +7330,7 @@ impl RevokeCacheSecurityGroupIngressMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RevokeCacheSecurityGroupIngressResult {
     pub cache_security_group: Option<CacheSecurityGroup>,
 }
@@ -7391,7 +7391,7 @@ impl SecurityGroupIdsListSerializer {
 }
 
 /// <p>Represents a single cache security group and its status.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SecurityGroupMembership {
     /// <p>The identifier of the cache security group.</p>
     pub security_group_id: Option<String>,
@@ -7487,7 +7487,7 @@ impl SecurityGroupMembershipListDeserializer {
     }
 }
 /// <p>Represents the progress of an online resharding operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SlotMigration {
     /// <p>The percentage of the slot migration that is complete.</p>
     pub progress_percentage: Option<f64>,
@@ -7536,7 +7536,7 @@ impl SlotMigrationDeserializer {
     }
 }
 /// <p>Represents a copy of an entire Redis cluster as of the time when the snapshot was taken.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Snapshot {
     /// <p>This parameter is currently disabled.</p>
     pub auto_minor_version_upgrade: Option<bool>,
@@ -7834,7 +7834,7 @@ impl StringDeserializer {
     }
 }
 /// <p>Represents the subnet associated with a cluster. This parameter refers to subnets defined in Amazon Virtual Private Cloud (Amazon VPC) and used with ElastiCache.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Subnet {
     /// <p>The Availability Zone associated with the subnet.</p>
     pub subnet_availability_zone: Option<AvailabilityZone>,
@@ -7958,7 +7958,7 @@ impl TStampDeserializer {
     }
 }
 /// <p>A cost allocation Tag that can be added to an ElastiCache cluster or replication group. Tags are composed of a Key/Value pair. A tag with a null Value is permitted.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Tag {
     /// <p>The key for the tag. May not be null.</p>
     pub key: Option<String>,
@@ -8086,7 +8086,7 @@ impl TagListSerializer {
 }
 
 /// <p>Represents the output from the <code>AddTagsToResource</code>, <code>ListTagsForResource</code>, and <code>RemoveTagsFromResource</code> operations.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct TagListMessage {
     /// <p>A list of cost allocation tags as key-value pairs.</p>
     pub tag_list: Option<Vec<Tag>>,
@@ -8132,7 +8132,7 @@ impl TagListMessageDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct TestFailoverMessage {
     /// <p>The name of the node group (called shard in the console) in this replication group on which automatic failover is to be tested. You may test automatic failover on up to 5 node groups in any rolling 24-hour period.</p>
     pub node_group_id: String,
@@ -8160,7 +8160,7 @@ impl TestFailoverMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct TestFailoverResult {
     pub replication_group: Option<ReplicationGroup>,
 }

--- a/rusoto/services/elasticache/src/generated.rs
+++ b/rusoto/services/elasticache/src/generated.rs
@@ -29,8 +29,9 @@ use hyper::StatusCode;
 use rusoto_core::param::{Params, ServiceParams};
 use rusoto_core::signature::SignedRequest;
 use rusoto_core::xmlerror::*;
-use rusoto_core::xmlutil::{characters, end_element, find_start_element, peek_at_name, skip_tree,
-                           start_element};
+use rusoto_core::xmlutil::{
+    characters, end_element, find_start_element, peek_at_name, skip_tree, start_element,
+};
 use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
 use std::str::FromStr;
 use xml::reader::ParserConfig;

--- a/rusoto/services/elasticbeanstalk/src/generated.rs
+++ b/rusoto/services/elasticbeanstalk/src/generated.rs
@@ -58,7 +58,7 @@ impl ARNDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AbortEnvironmentUpdateMessage {
     /// <p>This specifies the ID of the environment with the in-progress update that you want to cancel.</p>
     pub environment_id: Option<String>,
@@ -147,7 +147,7 @@ impl ActionTypeDeserializer {
     }
 }
 /// <p>Describes the properties of an application.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ApplicationDescription {
     /// <p>The name of the application.</p>
     pub application_name: Option<String>,
@@ -288,7 +288,7 @@ impl ApplicationDescriptionListDeserializer {
     }
 }
 /// <p>Result message containing a single description of an application.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ApplicationDescriptionMessage {
     /// <p> The <a>ApplicationDescription</a> of the application. </p>
     pub application: Option<ApplicationDescription>,
@@ -336,7 +336,7 @@ impl ApplicationDescriptionMessageDeserializer {
     }
 }
 /// <p>Result message containing a list of application descriptions.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ApplicationDescriptionsMessage {
     /// <p>This parameter contains a list of <a>ApplicationDescription</a>.</p>
     pub applications: Option<Vec<ApplicationDescription>>,
@@ -386,7 +386,7 @@ impl ApplicationDescriptionsMessageDeserializer {
     }
 }
 /// <p>Application request metrics for an AWS Elastic Beanstalk environment.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ApplicationMetrics {
     /// <p>The amount of time that the metrics cover (usually 10 seconds). For example, you might have 5 requests (<code>request_count</code>) within the most recent time slice of 10 seconds (<code>duration</code>).</p>
     pub duration: Option<i64>,
@@ -482,7 +482,7 @@ impl ApplicationNamesListSerializer {
 }
 
 /// <p>The resource lifecycle configuration for an application. Defines lifecycle settings for resources that belong to the application, and the service role that Elastic Beanstalk assumes in order to apply lifecycle settings. The version lifecycle configuration defines lifecycle settings for application versions.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ApplicationResourceLifecycleConfig {
     /// <p>The ARN of an IAM service role that Elastic Beanstalk has permission to assume.</p>
     pub service_role: Option<String>,
@@ -564,7 +564,7 @@ impl ApplicationResourceLifecycleConfigSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ApplicationResourceLifecycleDescriptionMessage {
     /// <p>The name of the application.</p>
     pub application_name: Option<String>,
@@ -622,7 +622,7 @@ impl ApplicationResourceLifecycleDescriptionMessageDeserializer {
     }
 }
 /// <p>Describes the properties of an application version.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ApplicationVersionDescription {
     /// <p>The name of the application to which the application version belongs.</p>
     pub application_name: Option<String>,
@@ -774,7 +774,7 @@ impl ApplicationVersionDescriptionListDeserializer {
     }
 }
 /// <p>Result message wrapping a single description of an application version.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ApplicationVersionDescriptionMessage {
     /// <p> The <a>ApplicationVersionDescription</a> of the application version. </p>
     pub application_version: Option<ApplicationVersionDescription>,
@@ -825,7 +825,7 @@ impl ApplicationVersionDescriptionMessageDeserializer {
     }
 }
 /// <p>Result message wrapping a list of application version descriptions.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ApplicationVersionDescriptionsMessage {
     /// <p>List of <code>ApplicationVersionDescription</code> objects sorted in order of creation.</p>
     pub application_versions: Option<Vec<ApplicationVersionDescription>>,
@@ -882,7 +882,7 @@ impl ApplicationVersionDescriptionsMessageDeserializer {
     }
 }
 /// <p>The application version lifecycle settings for an application. Defines the rules that Elastic Beanstalk applies to an application's versions in order to avoid hitting the per-region limit for application versions.</p> <p>When Elastic Beanstalk deletes an application version from its database, you can no longer deploy that version to an environment. The source bundle remains in S3 unless you configure the rule to delete it.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ApplicationVersionLifecycleConfig {
     /// <p>Specify a max age rule to restrict the length of time that application versions are retained for an application.</p>
     pub max_age_rule: Option<MaxAgeRule>,
@@ -980,7 +980,7 @@ impl ApplicationVersionStatusDeserializer {
     }
 }
 /// <p>Request to execute a scheduled managed action immediately.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ApplyEnvironmentManagedActionRequest {
     /// <p>The action ID of the scheduled managed action to execute.</p>
     pub action_id: String,
@@ -1019,7 +1019,7 @@ impl ApplyEnvironmentManagedActionRequestSerializer {
 }
 
 /// <p>The result message containing information about the managed action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ApplyEnvironmentManagedActionResult {
     /// <p>A description of the managed action.</p>
     pub action_description: Option<String>,
@@ -1087,7 +1087,7 @@ impl ApplyEnvironmentManagedActionResultDeserializer {
     }
 }
 /// <p>Describes an Auto Scaling launch configuration.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AutoScalingGroup {
     /// <p>The name of the <code>AutoScalingGroup</code> . </p>
     pub name: Option<String>,
@@ -1287,7 +1287,7 @@ impl BoxedIntDeserializer {
     }
 }
 /// <p>Settings for an AWS CodeBuild build.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct BuildConfiguration {
     /// <p>The name of the artifact of the CodeBuild build. If provided, Elastic Beanstalk stores the build artifact in the S3 location <i>S3-bucket</i>/resources/<i>application-name</i>/codebuild/codebuild-<i>version-label</i>-<i>artifact-name</i>.zip. If not provided, Elastic Beanstalk stores the build artifact in the S3 location <i>S3-bucket</i>/resources/<i>application-name</i>/codebuild/codebuild-<i>version-label</i>.zip. </p>
     pub artifact_name: Option<String>,
@@ -1340,7 +1340,7 @@ impl BuildConfigurationSerializer {
 }
 
 /// <p>The builder used to build the custom platform.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Builder {
     /// <p>The ARN of the builder.</p>
     pub arn: Option<String>,
@@ -1386,7 +1386,7 @@ impl BuilderDeserializer {
     }
 }
 /// <p>CPU utilization metrics for an instance.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CPUUtilization {
     /// <p>Percentage of time that the CPU has spent in the <code>I/O Wait</code> state over the last 10 seconds.</p>
     pub io_wait: Option<f64>,
@@ -1525,7 +1525,7 @@ impl CausesDeserializer {
     }
 }
 /// <p>Results message indicating whether a CNAME is available.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CheckDNSAvailabilityMessage {
     /// <p>The prefix used when this CNAME is reserved.</p>
     pub cname_prefix: String,
@@ -1548,7 +1548,7 @@ impl CheckDNSAvailabilityMessageSerializer {
 }
 
 /// <p>Indicates if the specified CNAME is available.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CheckDNSAvailabilityResultMessage {
     /// <p><p>Indicates if the specified CNAME is available:</p> <ul> <li> <p> <code>true</code> : The CNAME is available.</p> </li> <li> <p> <code>false</code> : The CNAME is not available.</p> </li> </ul></p>
     pub available: Option<bool>,
@@ -1619,7 +1619,7 @@ impl CnameAvailabilityDeserializer {
     }
 }
 /// <p>Request to create or update a group of environments.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ComposeEnvironmentsMessage {
     /// <p>The name of the application to which the specified source bundles belong.</p>
     pub application_name: Option<String>,
@@ -1689,7 +1689,7 @@ impl ConfigurationOptionDefaultValueDeserializer {
     }
 }
 /// <p>Describes the possible values for a configuration option.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ConfigurationOptionDescription {
     /// <p><p>An indication of which action is required if the value for this configuration option changes:</p> <ul> <li> <p> <code>NoInterruption</code> : There is no interruption to the environment or application availability.</p> </li> <li> <p> <code>RestartEnvironment</code> : The environment is entirely restarted, all AWS resources are deleted and recreated, and the environment is unavailable during the process.</p> </li> <li> <p> <code>RestartApplicationServer</code> : The environment is available the entire time. However, a short application outage occurs when the application servers on the running Amazon EC2 instances are restarted.</p> </li> </ul></p>
     pub change_severity: Option<String>,
@@ -1935,7 +1935,7 @@ impl ConfigurationOptionPossibleValuesDeserializer {
     }
 }
 /// <p> A specification identifying an individual configuration option along with its current value. For a list of possible option values, go to <a href="http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/command-options.html">Option Values</a> in the <i>AWS Elastic Beanstalk Developer Guide</i>. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ConfigurationOptionSetting {
     /// <p>A unique namespace identifying the option's associated AWS resource.</p>
     pub namespace: Option<String>,
@@ -2139,7 +2139,7 @@ impl ConfigurationOptionValueTypeDeserializer {
     }
 }
 /// <p>Describes the settings for a specified configuration set.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ConfigurationOptionsDescription {
     /// <p> A list of <a>ConfigurationOptionDescription</a>. </p>
     pub options: Option<Vec<ConfigurationOptionDescription>>,
@@ -2204,7 +2204,7 @@ impl ConfigurationOptionsDescriptionDeserializer {
     }
 }
 /// <p>Describes the settings for a configuration set.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ConfigurationSettingsDescription {
     /// <p>The name of the application associated with this configuration set.</p>
     pub application_name: Option<String>,
@@ -2371,7 +2371,7 @@ impl ConfigurationSettingsDescriptionListDeserializer {
     }
 }
 /// <p>The results from a request to change the configuration settings of an environment.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ConfigurationSettingsDescriptions {
     /// <p> A list of <a>ConfigurationSettingsDescription</a>. </p>
     pub configuration_settings: Option<Vec<ConfigurationSettingsDescription>>,
@@ -2422,7 +2422,7 @@ impl ConfigurationSettingsDescriptionsDeserializer {
     }
 }
 /// <p>Provides a list of validation messages.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ConfigurationSettingsValidationMessages {
     /// <p> A list of <a>ValidationMessage</a>. </p>
     pub messages: Option<Vec<ValidationMessage>>,
@@ -2526,7 +2526,7 @@ impl ConfigurationTemplateNamesListDeserializer {
     }
 }
 /// <p>Request to create an application.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateApplicationMessage {
     /// <p>The name of the application.</p> <p>Constraint: This name must be unique within your account. If the specified name already exists, the action returns an <code>InvalidParameterValue</code> error.</p>
     pub application_name: String,
@@ -2566,7 +2566,7 @@ impl CreateApplicationMessageSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateApplicationVersionMessage {
     /// <p> The name of the application. If no application is found with this name, and <code>AutoCreateApplication</code> is <code>false</code>, returns an <code>InvalidParameterValue</code> error. </p>
     pub application_name: String,
@@ -2646,7 +2646,7 @@ impl CreateApplicationVersionMessageSerializer {
 }
 
 /// <p>Request to create a configuration template.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateConfigurationTemplateMessage {
     /// <p>The name of the application to associate with this configuration template. If no application is found with this name, AWS Elastic Beanstalk returns an <code>InvalidParameterValue</code> error. </p>
     pub application_name: String,
@@ -2725,7 +2725,7 @@ impl CreateConfigurationTemplateMessageSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateEnvironmentMessage {
     /// <p>The name of the application that contains the version to be deployed.</p> <p> If no application is found with this name, <code>CreateEnvironment</code> returns an <code>InvalidParameterValue</code> error. </p>
     pub application_name: String,
@@ -2844,7 +2844,7 @@ impl CreateEnvironmentMessageSerializer {
 }
 
 /// <p>Request to create a new platform version.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreatePlatformVersionRequest {
     /// <p>The name of the builder environment.</p>
     pub environment_name: Option<String>,
@@ -2896,7 +2896,7 @@ impl CreatePlatformVersionRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreatePlatformVersionResult {
     /// <p>The builder used to create the custom platform.</p>
     pub builder: Option<Builder>,
@@ -2950,7 +2950,7 @@ impl CreatePlatformVersionResultDeserializer {
     }
 }
 /// <p>Results of a <a>CreateStorageLocationResult</a> call.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateStorageLocationResultMessage {
     /// <p>The name of the Amazon S3 bucket created.</p>
     pub s3_bucket: Option<String>,
@@ -3011,7 +3011,7 @@ impl CreationDateDeserializer {
     }
 }
 /// <p>A custom AMI available to platforms.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CustomAmi {
     /// <p>THe ID of the image used to create the custom AMI.</p>
     pub image_id: Option<String>,
@@ -3121,7 +3121,7 @@ impl DNSCnameDeserializer {
     }
 }
 /// <p>Request to delete an application.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteApplicationMessage {
     /// <p>The name of the application to delete.</p>
     pub application_name: String,
@@ -3152,7 +3152,7 @@ impl DeleteApplicationMessageSerializer {
 }
 
 /// <p>Request to delete an application version.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteApplicationVersionMessage {
     /// <p>The name of the application to which the version belongs.</p>
     pub application_name: String,
@@ -3189,7 +3189,7 @@ impl DeleteApplicationVersionMessageSerializer {
 }
 
 /// <p>Request to delete a configuration template.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteConfigurationTemplateMessage {
     /// <p>The name of the application to delete the configuration template from.</p>
     pub application_name: String,
@@ -3218,7 +3218,7 @@ impl DeleteConfigurationTemplateMessageSerializer {
 }
 
 /// <p>Request to delete a draft environment configuration.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteEnvironmentConfigurationMessage {
     /// <p>The name of the application the environment is associated with.</p>
     pub application_name: String,
@@ -3246,7 +3246,7 @@ impl DeleteEnvironmentConfigurationMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeletePlatformVersionRequest {
     /// <p>The ARN of the version of the custom platform.</p>
     pub platform_arn: Option<String>,
@@ -3270,7 +3270,7 @@ impl DeletePlatformVersionRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeletePlatformVersionResult {
     /// <p>Detailed information about the version of the custom platform.</p>
     pub platform_summary: Option<PlatformSummary>,
@@ -3318,7 +3318,7 @@ impl DeletePlatformVersionResultDeserializer {
     }
 }
 /// <p>Information about an application version deployment.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Deployment {
     /// <p>The ID of the deployment. This number increases by one each time that you deploy source code or change instance configuration settings.</p>
     pub deployment_id: Option<i64>,
@@ -3398,7 +3398,7 @@ impl DeploymentTimestampDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeAccountAttributesResult {
     /// <p>The Elastic Beanstalk resource quotas associated with the calling AWS account.</p>
     pub resource_quotas: Option<ResourceQuotas>,
@@ -3447,7 +3447,7 @@ impl DescribeAccountAttributesResultDeserializer {
     }
 }
 /// <p>Request to describe application versions.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeApplicationVersionsMessage {
     /// <p>Specify an application name to show only application versions for that application.</p>
     pub application_name: Option<String>,
@@ -3497,7 +3497,7 @@ impl DescribeApplicationVersionsMessageSerializer {
 }
 
 /// <p>Request to describe one or more applications.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeApplicationsMessage {
     /// <p>If specified, AWS Elastic Beanstalk restricts the returned descriptions to only include those with the specified names.</p>
     pub application_names: Option<Vec<String>>,
@@ -3523,7 +3523,7 @@ impl DescribeApplicationsMessageSerializer {
 }
 
 /// <p>Result message containing a list of application version descriptions.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeConfigurationOptionsMessage {
     /// <p>The name of the application associated with the configuration template or environment. Only needed if you want to describe the configuration options associated with either the configuration template or environment.</p>
     pub application_name: Option<String>,
@@ -3589,7 +3589,7 @@ impl DescribeConfigurationOptionsMessageSerializer {
 }
 
 /// <p>Result message containing all of the configuration settings for a specified solution stack or configuration template.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeConfigurationSettingsMessage {
     /// <p>The application for the environment or configuration template.</p>
     pub application_name: String,
@@ -3628,7 +3628,7 @@ impl DescribeConfigurationSettingsMessageSerializer {
 }
 
 /// <p>See the example below to learn how to create a request body.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeEnvironmentHealthRequest {
     /// <p>Specify the response elements to return. To retrieve all attributes, set to <code>All</code>. If no attribute names are specified, returns the name of the environment.</p>
     pub attribute_names: Option<Vec<String>>,
@@ -3670,7 +3670,7 @@ impl DescribeEnvironmentHealthRequestSerializer {
 }
 
 /// <p>Health details for an AWS Elastic Beanstalk environment.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeEnvironmentHealthResult {
     /// <p>Application request metrics for the environment.</p>
     pub application_metrics: Option<ApplicationMetrics>,
@@ -3767,7 +3767,7 @@ impl DescribeEnvironmentHealthResultDeserializer {
     }
 }
 /// <p>Request to list completed and failed managed actions.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeEnvironmentManagedActionHistoryRequest {
     /// <p>The environment ID of the target environment.</p>
     pub environment_id: Option<String>,
@@ -3820,7 +3820,7 @@ impl DescribeEnvironmentManagedActionHistoryRequestSerializer {
 }
 
 /// <p>A result message containing a list of completed and failed managed actions.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeEnvironmentManagedActionHistoryResult {
     /// <p>A list of completed and failed managed actions.</p>
     pub managed_action_history_items: Option<Vec<ManagedActionHistoryItem>>,
@@ -3876,7 +3876,7 @@ impl DescribeEnvironmentManagedActionHistoryResultDeserializer {
     }
 }
 /// <p>Request to list an environment's upcoming and in-progress managed actions.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeEnvironmentManagedActionsRequest {
     /// <p>The environment ID of the target environment.</p>
     pub environment_id: Option<String>,
@@ -3917,7 +3917,7 @@ impl DescribeEnvironmentManagedActionsRequestSerializer {
 }
 
 /// <p>The result message containing a list of managed actions.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeEnvironmentManagedActionsResult {
     /// <p>A list of upcoming and in-progress managed actions.</p>
     pub managed_actions: Option<Vec<ManagedAction>>,
@@ -3966,7 +3966,7 @@ impl DescribeEnvironmentManagedActionsResultDeserializer {
     }
 }
 /// <p>Request to describe the resources in an environment.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeEnvironmentResourcesMessage {
     /// <p>The ID of the environment to retrieve AWS resource usage data.</p> <p> Condition: You must specify either this or an EnvironmentName, or both. If you do not specify either, AWS Elastic Beanstalk returns <code>MissingRequiredParameter</code> error. </p>
     pub environment_id: Option<String>,
@@ -3999,7 +3999,7 @@ impl DescribeEnvironmentResourcesMessageSerializer {
 }
 
 /// <p>Request to describe one or more environments.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeEnvironmentsMessage {
     /// <p>If specified, AWS Elastic Beanstalk restricts the returned descriptions to include only those that are associated with this application.</p>
     pub application_name: Option<String>,
@@ -4082,7 +4082,7 @@ impl DescribeEnvironmentsMessageSerializer {
 }
 
 /// <p>Request to retrieve a list of events for an environment.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeEventsMessage {
     /// <p>If specified, AWS Elastic Beanstalk restricts the returned descriptions to include only those associated with this application.</p>
     pub application_name: Option<String>,
@@ -4195,7 +4195,7 @@ impl DescribeEventsMessageSerializer {
 }
 
 /// <p>Parameters for a call to <code>DescribeInstancesHealth</code>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeInstancesHealthRequest {
     /// <p>Specifies the response elements you wish to receive. To retrieve all attributes, set to <code>All</code>. If no attribute names are specified, returns a list of instances.</p>
     pub attribute_names: Option<Vec<String>>,
@@ -4245,7 +4245,7 @@ impl DescribeInstancesHealthRequestSerializer {
 }
 
 /// <p>Detailed health information about the Amazon EC2 instances in an AWS Elastic Beanstalk environment.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeInstancesHealthResult {
     /// <p>Detailed health information about each instance.</p>
     pub instance_health_list: Option<Vec<SingleInstanceHealth>>,
@@ -4308,7 +4308,7 @@ impl DescribeInstancesHealthResultDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribePlatformVersionRequest {
     /// <p>The ARN of the version of the platform.</p>
     pub platform_arn: Option<String>,
@@ -4332,7 +4332,7 @@ impl DescribePlatformVersionRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribePlatformVersionResult {
     /// <p>Detailed information about the version of the platform.</p>
     pub platform_description: Option<PlatformDescription>,
@@ -4438,7 +4438,7 @@ impl EnvironmentArnDeserializer {
     }
 }
 /// <p>Describes the properties of an environment.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct EnvironmentDescription {
     /// <p>Indicates if there is an in-progress environment configuration update or application version deployment that you can cancel.</p> <p> <code>true:</code> There is an update in progress. </p> <p> <code>false:</code> There are no updates currently in progress. </p>
     pub abortable_operation_in_progress: Option<bool>,
@@ -4674,7 +4674,7 @@ impl EnvironmentDescriptionsListDeserializer {
     }
 }
 /// <p>Result message containing a list of environment descriptions.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct EnvironmentDescriptionsMessage {
     /// <p> Returns an <a>EnvironmentDescription</a> list. </p>
     pub environments: Option<Vec<EnvironmentDescription>>,
@@ -4796,7 +4796,7 @@ impl EnvironmentIdListSerializer {
 }
 
 /// <p>The information retrieved from the Amazon EC2 instances.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct EnvironmentInfoDescription {
     /// <p>The Amazon EC2 Instance ID for this information.</p>
     pub ec_2_instance_id: Option<String>,
@@ -4921,7 +4921,7 @@ impl EnvironmentInfoTypeDeserializer {
     }
 }
 /// <p>A link to another environment, defined in the environment's manifest. Links provide connection information in system properties that can be used to connect to another environment in the same group. See <a href="http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/environment-cfg-manifest.html">Environment Manifest (env.yaml)</a> for details.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct EnvironmentLink {
     /// <p>The name of the linked environment (the dependency).</p>
     pub environment_name: Option<String>,
@@ -5044,7 +5044,7 @@ impl EnvironmentNamesListSerializer {
 }
 
 /// <p>Describes the AWS resources in use by this environment. This data is live.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct EnvironmentResourceDescription {
     /// <p> The <code>AutoScalingGroups</code> used by this environment. </p>
     pub auto_scaling_groups: Option<Vec<AutoScalingGroup>>,
@@ -5139,7 +5139,7 @@ impl EnvironmentResourceDescriptionDeserializer {
     }
 }
 /// <p>Result message containing a list of environment resource descriptions.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct EnvironmentResourceDescriptionsMessage {
     /// <p> A list of <a>EnvironmentResourceDescription</a>. </p>
     pub environment_resources: Option<EnvironmentResourceDescription>,
@@ -5190,7 +5190,7 @@ impl EnvironmentResourceDescriptionsMessageDeserializer {
     }
 }
 /// <p>Describes the AWS resources in use by this environment. This data is not live data.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct EnvironmentResourcesDescription {
     /// <p>Describes the LoadBalancer.</p>
     pub load_balancer: Option<LoadBalancerDescription>,
@@ -5252,7 +5252,7 @@ impl EnvironmentStatusDeserializer {
     }
 }
 /// <p>Describes the properties of an environment tier</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct EnvironmentTier {
     /// <p>The name of this environment tier.</p>
     pub name: Option<String>,
@@ -5353,7 +5353,7 @@ impl EventDateDeserializer {
     }
 }
 /// <p>Describes an event.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct EventDescription {
     /// <p>The application associated with the event.</p>
     pub application_name: Option<String>,
@@ -5501,7 +5501,7 @@ impl EventDescriptionListDeserializer {
     }
 }
 /// <p>Result message wrapping a list of event descriptions.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct EventDescriptionsMessage {
     /// <p> A list of <a>EventDescription</a>. </p>
     pub events: Option<Vec<EventDescription>>,
@@ -5625,7 +5625,7 @@ impl ImageIdDeserializer {
     }
 }
 /// <p>The description of an Amazon EC2 instance.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Instance {
     /// <p>The ID of the Amazon EC2 instance.</p>
     pub id: Option<String>,
@@ -5713,7 +5713,7 @@ impl InstanceHealthListDeserializer {
     }
 }
 /// <p>Represents summary information about the health of an instance. For more information, see <a href="http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/health-enhanced-status.html">Health Colors and Statuses</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct InstanceHealthSummary {
     /// <p> <b>Red.</b> The health agent is reporting a high number of request failures or other issues for an instance or environment.</p>
     pub degraded: Option<i64>,
@@ -5888,7 +5888,7 @@ impl IntegerDeserializer {
     }
 }
 /// <p>Represents the average latency for the slowest X percent of requests over the last 10 seconds.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Latency {
     /// <p>The average latency for the slowest 90 percent of requests over the last 10 seconds.</p>
     pub p10: Option<f64>,
@@ -5970,7 +5970,7 @@ impl LatencyDeserializer {
     }
 }
 /// <p>Describes an Auto Scaling launch configuration.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct LaunchConfiguration {
     /// <p>The name of the launch configuration.</p>
     pub name: Option<String>,
@@ -6072,7 +6072,7 @@ impl LaunchedAtDeserializer {
     }
 }
 /// <p>A list of available AWS Elastic Beanstalk solution stacks.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListAvailableSolutionStacksResultMessage {
     /// <p> A list of available solution stacks and their <a>SolutionStackDescription</a>. </p>
     pub solution_stack_details: Option<Vec<SolutionStackDescription>>,
@@ -6132,7 +6132,7 @@ impl ListAvailableSolutionStacksResultMessageDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListPlatformVersionsRequest {
     /// <p>List only the platforms where the platform member value relates to one of the supplied values.</p>
     pub filters: Option<Vec<PlatformFilter>>,
@@ -6173,7 +6173,7 @@ impl ListPlatformVersionsRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListPlatformVersionsResult {
     /// <p>The starting index into the remaining list of platforms. if this value is not <code>null</code>, you can use it in a subsequent <code>ListPlatformVersion</code> call. </p>
     pub next_token: Option<String>,
@@ -6228,7 +6228,7 @@ impl ListPlatformVersionsResultDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListTagsForResourceMessage {
     /// <p>The Amazon Resource Name (ARN) of the resouce for which a tag list is requested.</p> <p>Must be the ARN of an Elastic Beanstalk environment.</p>
     pub resource_arn: String,
@@ -6251,7 +6251,7 @@ impl ListTagsForResourceMessageSerializer {
 }
 
 /// <p>Describes the properties of a Listener for the LoadBalancer.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Listener {
     /// <p>The port that is used by the Listener.</p>
     pub port: Option<i64>,
@@ -6359,7 +6359,7 @@ impl LoadAverageValueDeserializer {
     }
 }
 /// <p>Describes a LoadBalancer.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct LoadBalancer {
     /// <p>The name of the LoadBalancer.</p>
     pub name: Option<String>,
@@ -6405,7 +6405,7 @@ impl LoadBalancerDeserializer {
     }
 }
 /// <p>Describes the details of a LoadBalancer.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct LoadBalancerDescription {
     /// <p>The domain name of the LoadBalancer.</p>
     pub domain: Option<String>,
@@ -6563,7 +6563,7 @@ impl MaintainerDeserializer {
     }
 }
 /// <p>The record of an upcoming or in-progress managed action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ManagedAction {
     /// <p>A description of the managed action.</p>
     pub action_description: Option<String>,
@@ -6640,7 +6640,7 @@ impl ManagedActionDeserializer {
     }
 }
 /// <p>The record of a completed or failed managed action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ManagedActionHistoryItem {
     /// <p>A description of the managed action.</p>
     pub action_description: Option<String>,
@@ -6826,7 +6826,7 @@ impl ManagedActionsDeserializer {
     }
 }
 /// <p>A lifecycle rule that deletes application versions after the specified number of days.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct MaxAgeRule {
     /// <p>Set to <code>true</code> to delete a version's source bundle from Amazon S3 when Elastic Beanstalk deletes the application version.</p>
     pub delete_source_from_s3: Option<bool>,
@@ -6916,7 +6916,7 @@ impl MaxAgeRuleSerializer {
 }
 
 /// <p>A lifecycle rule that deletes the oldest application version when the maximum count is exceeded.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct MaxCountRule {
     /// <p>Set to <code>true</code> to delete a version's source bundle from Amazon S3 when Elastic Beanstalk deletes the application version.</p>
     pub delete_source_from_s3: Option<bool>,
@@ -7158,7 +7158,7 @@ impl OptionRestrictionMinValueDeserializer {
     }
 }
 /// <p>A regular expression representing a restriction on a string configuration option value.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct OptionRestrictionRegex {
     /// <p>A unique name representing this regular expression.</p>
     pub label: Option<String>,
@@ -7211,7 +7211,7 @@ impl OptionRestrictionRegexDeserializer {
     }
 }
 /// <p>A specification identifying an individual configuration option.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct OptionSpecification {
     /// <p>A unique namespace identifying the option's associated AWS resource.</p>
     pub namespace: Option<String>,
@@ -7291,7 +7291,7 @@ impl PlatformCategoryDeserializer {
     }
 }
 /// <p>Detailed information about a platform.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PlatformDescription {
     /// <p>The custom AMIs supported by the platform.</p>
     pub custom_ami_list: Option<Vec<CustomAmi>>,
@@ -7476,7 +7476,7 @@ impl PlatformDescriptionDeserializer {
     }
 }
 /// <p>Specify criteria to restrict the results when listing custom platforms.</p> <p>The filter is evaluated as the expression:</p> <p> <code>Type</code> <code>Operator</code> <code>Values[i]</code> </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PlatformFilter {
     /// <p>The operator to apply to the <code>Type</code> with each of the <code>Values</code>.</p> <p> Valid Values: <code>=</code> (equal to) | <code>!=</code> (not equal to) | <code>&lt;</code> (less than) | <code>&lt;=</code> (less than or equal to) | <code>&gt;</code> (greater than) | <code>&gt;=</code> (greater than or equal to) | <code>contains</code> | <code>begins_with</code> | <code>ends_with</code> </p>
     pub operator: Option<String>,
@@ -7540,7 +7540,7 @@ impl PlatformFiltersSerializer {
 }
 
 /// <p>A framework supported by the custom platform.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PlatformFramework {
     /// <p>The name of the framework.</p>
     pub name: Option<String>,
@@ -7661,7 +7661,7 @@ impl PlatformOwnerDeserializer {
     }
 }
 /// <p>A programming language supported by the platform.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PlatformProgrammingLanguage {
     /// <p>The name of the programming language.</p>
     pub name: Option<String>,
@@ -7768,7 +7768,7 @@ impl PlatformStatusDeserializer {
     }
 }
 /// <p>Detailed information about a platform.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PlatformSummary {
     /// <p>The operating system used by the platform.</p>
     pub operating_system_name: Option<String>,
@@ -7930,7 +7930,7 @@ impl PlatformVersionDeserializer {
     }
 }
 /// <p>Describes a queue.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Queue {
     /// <p>The name of the queue.</p>
     pub name: Option<String>,
@@ -8021,7 +8021,7 @@ impl QueueListDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RebuildEnvironmentMessage {
     /// <p>The ID of the environment to rebuild.</p> <p> Condition: You must specify either this or an EnvironmentName, or both. If you do not specify either, AWS Elastic Beanstalk returns <code>MissingRequiredParameter</code> error. </p>
     pub environment_id: Option<String>,
@@ -8110,7 +8110,7 @@ impl RequestCountDeserializer {
     }
 }
 /// <p>Request to retrieve logs from an environment and store them in your Elastic Beanstalk storage bucket.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RequestEnvironmentInfoMessage {
     /// <p>The ID of the environment of the requested data.</p> <p>If no such environment is found, <code>RequestEnvironmentInfo</code> returns an <code>InvalidParameterValue</code> error. </p> <p>Condition: You must specify either this or an EnvironmentName, or both. If you do not specify either, AWS Elastic Beanstalk returns <code>MissingRequiredParameter</code> error. </p>
     pub environment_id: Option<String>,
@@ -8205,7 +8205,7 @@ impl ResourceNameDeserializer {
     }
 }
 /// <p>The AWS Elastic Beanstalk quota information for a single resource type in an AWS account. It reflects the resource's limits for this account.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ResourceQuota {
     /// <p>The maximum number of instances of this Elastic Beanstalk resource type that an AWS account can use.</p>
     pub maximum: Option<i64>,
@@ -8252,7 +8252,7 @@ impl ResourceQuotaDeserializer {
     }
 }
 /// <p>A set of per-resource AWS Elastic Beanstalk quotas associated with an AWS account. They reflect Elastic Beanstalk resource limits for this account.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ResourceQuotas {
     /// <p>The quota for applications in the AWS account.</p>
     pub application_quota: Option<ResourceQuota>,
@@ -8333,7 +8333,7 @@ impl ResourceQuotasDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ResourceTagsDescriptionMessage {
     /// <p>The Amazon Resource Name (ARN) of the resouce for which a tag list was requested.</p>
     pub resource_arn: Option<String>,
@@ -8390,7 +8390,7 @@ impl ResourceTagsDescriptionMessageDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RestartAppServerMessage {
     /// <p>The ID of the environment to restart the server for.</p> <p> Condition: You must specify either this or an EnvironmentName, or both. If you do not specify either, AWS Elastic Beanstalk returns <code>MissingRequiredParameter</code> error. </p>
     pub environment_id: Option<String>,
@@ -8423,7 +8423,7 @@ impl RestartAppServerMessageSerializer {
 }
 
 /// <p>Request to download logs retrieved with <a>RequestEnvironmentInfo</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RetrieveEnvironmentInfoMessage {
     /// <p>The ID of the data's environment.</p> <p>If no such environment is found, returns an <code>InvalidParameterValue</code> error.</p> <p>Condition: You must specify either this or an EnvironmentName, or both. If you do not specify either, AWS Elastic Beanstalk returns <code>MissingRequiredParameter</code> error.</p>
     pub environment_id: Option<String>,
@@ -8462,7 +8462,7 @@ impl RetrieveEnvironmentInfoMessageSerializer {
 }
 
 /// <p>Result message containing a description of the requested environment info.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RetrieveEnvironmentInfoResultMessage {
     /// <p> The <a>EnvironmentInfoDescription</a> of the environment. </p>
     pub environment_info: Option<Vec<EnvironmentInfoDescription>>,
@@ -8541,7 +8541,7 @@ impl S3KeyDeserializer {
     }
 }
 /// <p>The bucket and key of an item stored in Amazon S3.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct S3Location {
     /// <p>The Amazon S3 bucket where the data is located.</p>
     pub s3_bucket: Option<String>,
@@ -8632,7 +8632,7 @@ impl SampleTimestampDeserializer {
     }
 }
 /// <p>Detailed health information about an Amazon EC2 instance in your Elastic Beanstalk environment.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SingleInstanceHealth {
     /// <p>Request metrics from your application.</p>
     pub application_metrics: Option<ApplicationMetrics>,
@@ -8742,7 +8742,7 @@ impl SingleInstanceHealthDeserializer {
     }
 }
 /// <p>Describes the solution stack.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SolutionStackDescription {
     /// <p>The permitted file types allowed for a solution stack.</p>
     pub permitted_file_types: Option<Vec<String>>,
@@ -8855,7 +8855,7 @@ impl SolutionStackNameDeserializer {
     }
 }
 /// <p>Location of the source code for an application version.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SourceBuildInformation {
     /// <p><p>The location of the source code, as a formatted string, depending on the value of <code>SourceRepository</code> </p> <ul> <li> <p>For <code>CodeCommit</code>, the format is the repository name and commit ID, separated by a forward slash. For example, <code>my-git-repo/265cfa0cf6af46153527f55d6503ec030551f57a</code>.</p> </li> <li> <p>For <code>S3</code>, the format is the S3 bucket name and object key, separated by a forward slash. For example, <code>my-s3-bucket/Folders/my-source-file</code>.</p> </li> </ul></p>
     pub source_location: String,
@@ -8943,7 +8943,7 @@ impl SourceBuildInformationSerializer {
 }
 
 /// <p>A specification for an environment configuration</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SourceConfiguration {
     /// <p>The name of the application associated with the configuration.</p>
     pub application_name: Option<String>,
@@ -9018,7 +9018,7 @@ impl SourceTypeDeserializer {
     }
 }
 /// <p>Represents the percentage of requests over the last 10 seconds that resulted in each type of status code response. For more information, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html">Status Code Definitions</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct StatusCodes {
     /// <p>The percentage of requests over the last 10 seconds that resulted in a 2xx (200, 201, etc.) status code.</p>
     pub status_2xx: Option<i64>,
@@ -9217,7 +9217,7 @@ impl SupportedTierListDeserializer {
     }
 }
 /// <p>Swaps the CNAMEs of two environments.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SwapEnvironmentCNAMEsMessage {
     /// <p>The ID of the destination environment.</p> <p> Condition: You must specify at least the <code>DestinationEnvironmentID</code> or the <code>DestinationEnvironmentName</code>. You may also specify both. You must specify the <code>SourceEnvironmentId</code> with the <code>DestinationEnvironmentId</code>. </p>
     pub destination_environment_id: Option<String>,
@@ -9266,7 +9266,7 @@ impl SwapEnvironmentCNAMEsMessageSerializer {
 }
 
 /// <p>CPU utilization and load average metrics for an Amazon EC2 instance.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SystemStatus {
     /// <p>CPU utilization metrics for the instance.</p>
     pub cpu_utilization: Option<CPUUtilization>,
@@ -9323,7 +9323,7 @@ impl SystemStatusDeserializer {
     }
 }
 /// <p>Describes a tag applied to a resource in an environment.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Tag {
     /// <p>The key of the tag.</p>
     pub key: Option<String>,
@@ -9503,7 +9503,7 @@ impl TagsSerializer {
 }
 
 /// <p>Request to terminate an environment.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct TerminateEnvironmentMessage {
     /// <p>The ID of the environment to terminate.</p> <p> Condition: You must specify either this or an EnvironmentName, or both. If you do not specify either, AWS Elastic Beanstalk returns <code>MissingRequiredParameter</code> error. </p>
     pub environment_id: Option<String>,
@@ -9580,7 +9580,7 @@ impl TokenDeserializer {
     }
 }
 /// <p>Describes a trigger.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Trigger {
     /// <p>The name of the trigger.</p>
     pub name: Option<String>,
@@ -9666,7 +9666,7 @@ impl TriggerListDeserializer {
     }
 }
 /// <p>Request to update an application.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateApplicationMessage {
     /// <p>The name of the application to update. If no such application is found, <code>UpdateApplication</code> returns an <code>InvalidParameterValue</code> error. </p>
     pub application_name: String,
@@ -9696,7 +9696,7 @@ impl UpdateApplicationMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateApplicationResourceLifecycleMessage {
     /// <p>The name of the application.</p>
     pub application_name: String,
@@ -9726,7 +9726,7 @@ impl UpdateApplicationResourceLifecycleMessageSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateApplicationVersionMessage {
     /// <p>The name of the application associated with this version.</p> <p> If no application is found with this name, <code>UpdateApplication</code> returns an <code>InvalidParameterValue</code> error.</p>
     pub application_name: String,
@@ -9763,7 +9763,7 @@ impl UpdateApplicationVersionMessageSerializer {
 }
 
 /// <p>The result message containing the options for the specified solution stack.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateConfigurationTemplateMessage {
     /// <p>The name of the application associated with the configuration template to update.</p> <p> If no application is found with this name, <code>UpdateConfigurationTemplate</code> returns an <code>InvalidParameterValue</code> error. </p>
     pub application_name: String,
@@ -9832,7 +9832,7 @@ impl UpdateDateDeserializer {
     }
 }
 /// <p>Request to update an environment.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateEnvironmentMessage {
     /// <p>The name of the application with which the environment is associated.</p>
     pub application_name: Option<String>,
@@ -9947,7 +9947,7 @@ impl UpdateEnvironmentMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateTagsForResourceMessage {
     /// <p>The Amazon Resource Name (ARN) of the resouce to be updated.</p> <p>Must be the ARN of an Elastic Beanstalk environment.</p>
     pub resource_arn: String,
@@ -10002,7 +10002,7 @@ impl UserDefinedOptionDeserializer {
     }
 }
 /// <p>A list of validation messages for a specified configuration template.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ValidateConfigurationSettingsMessage {
     /// <p>The name of the application that the configuration template or environment belongs to.</p>
     pub application_name: String,
@@ -10048,7 +10048,7 @@ impl ValidateConfigurationSettingsMessageSerializer {
 }
 
 /// <p>An error or warning for a desired configuration option value.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ValidationMessage {
     /// <p>A message describing the error or warning.</p>
     pub message: Option<String>,

--- a/rusoto/services/elasticbeanstalk/src/generated.rs
+++ b/rusoto/services/elasticbeanstalk/src/generated.rs
@@ -29,8 +29,9 @@ use hyper::StatusCode;
 use rusoto_core::param::{Params, ServiceParams};
 use rusoto_core::signature::SignedRequest;
 use rusoto_core::xmlerror::*;
-use rusoto_core::xmlutil::{characters, end_element, find_start_element, peek_at_name, skip_tree,
-                           start_element};
+use rusoto_core::xmlutil::{
+    characters, end_element, find_start_element, peek_at_name, skip_tree, start_element,
+};
 use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
 use std::str::FromStr;
 use xml::reader::ParserConfig;

--- a/rusoto/services/elastictranscoder/src/generated.rs
+++ b/rusoto/services/elastictranscoder/src/generated.rs
@@ -31,7 +31,7 @@ use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 /// <p>The file to be used as album art. There can be multiple artworks associated with an audio file, to a maximum of 20.</p> <p>To remove artwork or leave the artwork empty, you can either set <code>Artwork</code> to null, or set the <code>Merge Policy</code> to "Replace" and use an empty <code>Artwork</code> array.</p> <p>To pass through existing artwork unchanged, set the <code>Merge Policy</code> to "Prepend", "Append", or "Fallback", and use an empty <code>Artwork</code> array.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Artwork {
     /// <p>The format of album art, if any. Valid formats are <code>.jpg</code> and <code>.png</code>.</p>
     #[serde(rename = "AlbumArtFormat")]
@@ -64,7 +64,7 @@ pub struct Artwork {
 }
 
 /// <p>Options associated with your audio codec.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct AudioCodecOptions {
     /// <p>You can only choose an audio bit depth when you specify <code>flac</code> or <code>pcm</code> for the value of Audio:Codec.</p> <p>The bit depth of a sample is how many bits of information are included in the audio samples. The higher the bit depth, the better the audio, but the larger the file.</p> <p>Valid values are <code>16</code> and <code>24</code>.</p> <p>The most common bit depth is <code>24</code>.</p>
     #[serde(rename = "BitDepth")]
@@ -85,7 +85,7 @@ pub struct AudioCodecOptions {
 }
 
 /// <p>Parameters required for transcoding audio.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct AudioParameters {
     /// <p><p>The method of organizing audio channels and tracks. Use <code>Audio:Channels</code> to specify the number of channels in your output, and <code>Audio:AudioPackingMode</code> to specify the number of tracks and their relation to the channels. If you do not specify an <code>Audio:AudioPackingMode</code>, Elastic Transcoder uses <code>SingleTrack</code>.</p> <p>The following values are valid:</p> <p> <code>SingleTrack</code>, <code>OneChannelPerTrack</code>, and <code>OneChannelPerTrackWithMosTo8Tracks</code> </p> <p>When you specify <code>SingleTrack</code>, Elastic Transcoder creates a single track for your output. The track can have up to eight channels. Use <code>SingleTrack</code> for all non-<code>mxf</code> containers.</p> <p>The outputs of <code>SingleTrack</code> for a specific channel value and inputs are as follows:</p> <ul> <li> <p> <code>0</code> <b> channels with any input:</b> Audio omitted from the output</p> </li> <li> <p> <code>1, 2, or auto </code> <b>channels with no audio input:</b> Audio omitted from the output</p> </li> <li> <p> <code>1 </code> <b>channel with any input with audio:</b> One track with one channel, downmixed if necessary</p> </li> <li> <p> <code>2 </code> <b>channels with one track with one channel:</b> One track with two identical channels</p> </li> <li> <p> <code>2 or auto </code> <b>channels with two tracks with one channel each:</b> One track with two channels</p> </li> <li> <p> <code>2 or auto </code> <b>channels with one track with two channels:</b> One track with two channels</p> </li> <li> <p> <code>2 </code> <b>channels with one track with multiple channels:</b> One track with two channels</p> </li> <li> <p> <code>auto </code> <b>channels with one track with one channel:</b> One track with one channel</p> </li> <li> <p> <code>auto </code> <b>channels with one track with multiple channels:</b> One track with multiple channels</p> </li> </ul> <p>When you specify <code>OneChannelPerTrack</code>, Elastic Transcoder creates a new track for every channel in your output. Your output can have up to eight single-channel tracks.</p> <p>The outputs of <code>OneChannelPerTrack</code> for a specific channel value and inputs are as follows:</p> <ul> <li> <p> <code>0 </code> <b>channels with any input:</b> Audio omitted from the output</p> </li> <li> <p> <code>1, 2, or auto </code> <b>channels with no audio input:</b> Audio omitted from the output</p> </li> <li> <p> <code>1 </code> <b>channel with any input with audio:</b> One track with one channel, downmixed if necessary</p> </li> <li> <p> <code>2 </code> <b>channels with one track with one channel:</b> Two tracks with one identical channel each</p> </li> <li> <p> <code>2 or auto </code> <b>channels with two tracks with one channel each:</b> Two tracks with one channel each</p> </li> <li> <p> <code>2 or auto </code> <b>channels with one track with two channels:</b> Two tracks with one channel each</p> </li> <li> <p> <code>2 </code> <b>channels with one track with multiple channels:</b> Two tracks with one channel each</p> </li> <li> <p> <code>auto </code> <b>channels with one track with one channel:</b> One track with one channel</p> </li> <li> <p> <code>auto </code> <b>channels with one track with multiple channels:</b> Up to eight tracks with one channel each</p> </li> </ul> <p>When you specify <code>OneChannelPerTrackWithMosTo8Tracks</code>, Elastic Transcoder creates eight single-channel tracks for your output. All tracks that do not contain audio data from an input channel are MOS, or Mit Out Sound, tracks.</p> <p>The outputs of <code>OneChannelPerTrackWithMosTo8Tracks</code> for a specific channel value and inputs are as follows:</p> <ul> <li> <p> <code>0 </code> <b>channels with any input:</b> Audio omitted from the output</p> </li> <li> <p> <code>1, 2, or auto </code> <b>channels with no audio input:</b> Audio omitted from the output</p> </li> <li> <p> <code>1 </code> <b>channel with any input with audio:</b> One track with one channel, downmixed if necessary, plus six MOS tracks</p> </li> <li> <p> <code>2 </code> <b>channels with one track with one channel:</b> Two tracks with one identical channel each, plus six MOS tracks</p> </li> <li> <p> <code>2 or auto </code> <b>channels with two tracks with one channel each:</b> Two tracks with one channel each, plus six MOS tracks</p> </li> <li> <p> <code>2 or auto </code> <b>channels with one track with two channels:</b> Two tracks with one channel each, plus six MOS tracks</p> </li> <li> <p> <code>2 </code> <b>channels with one track with multiple channels:</b> Two tracks with one channel each, plus six MOS tracks</p> </li> <li> <p> <code>auto </code> <b>channels with one track with one channel:</b> One track with one channel, plus seven MOS tracks</p> </li> <li> <p> <code>auto </code> <b>channels with one track with multiple channels:</b> Up to eight tracks with one channel each, plus MOS tracks until there are eight tracks in all</p> </li> </ul></p>
     #[serde(rename = "AudioPackingMode")]
@@ -114,7 +114,7 @@ pub struct AudioParameters {
 }
 
 /// <p>The <code>CancelJobRequest</code> structure.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CancelJobRequest {
     /// <p>The identifier of the job that you want to cancel.</p> <p>To get a list of the jobs (including their <code>jobId</code>) that have a status of <code>Submitted</code>, use the <a>ListJobsByStatus</a> API action.</p>
     #[serde(rename = "Id")]
@@ -122,11 +122,11 @@ pub struct CancelJobRequest {
 }
 
 /// <p>The response body contains a JSON object. If the job is successfully canceled, the value of <code>Success</code> is <code>true</code>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CancelJobResponse {}
 
 /// <p>The file format of the output captions. If you leave this value blank, Elastic Transcoder returns an error.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CaptionFormat {
     /// <p>The encryption settings, if any, that you want Elastic Transcoder to apply to your caption formats.</p>
     #[serde(rename = "Encryption")]
@@ -143,7 +143,7 @@ pub struct CaptionFormat {
 }
 
 /// <p>A source file for the input sidecar captions used during the transcoding process.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CaptionSource {
     /// <p>The encryption settings, if any, that Elastic Transcoder needs to decyrpt your caption sources, or that you want Elastic Transcoder to apply to your caption sources.</p>
     #[serde(rename = "Encryption")]
@@ -168,7 +168,7 @@ pub struct CaptionSource {
 }
 
 /// <p>The captions to be created, if any.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Captions {
     /// <p>The array of file formats for the output captions. If you leave this value blank, Elastic Transcoder returns an error.</p>
     #[serde(rename = "CaptionFormats")]
@@ -177,14 +177,14 @@ pub struct Captions {
 }
 
 /// <p>Settings for one clip in a composition. All jobs in a playlist must have the same clip settings.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Clip {
     /// <p>Settings that determine when a clip begins and how long it lasts.</p>
     pub time_span: Option<TimeSpan>,
 }
 
 /// <p>The <code>CreateJobOutput</code> structure.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateJobOutput {
     /// <p>Information about the album art that you want Elastic Transcoder to add to the file during transcoding. You can specify up to twenty album artworks for each output. Settings for each artwork must be defined in the job for the current output.</p>
     #[serde(rename = "AlbumArt")]
@@ -229,7 +229,7 @@ pub struct CreateJobOutput {
 }
 
 /// <p>Information about the master playlist.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateJobPlaylist {
     /// <p>The format of the output playlist. Valid formats include <code>HLSv3</code>, <code>HLSv4</code>, and <code>Smooth</code>.</p>
     #[serde(rename = "Format")]
@@ -254,7 +254,7 @@ pub struct CreateJobPlaylist {
 }
 
 /// <p>The <code>CreateJobRequest</code> structure.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateJobRequest {
     /// <p>A section of the request body that provides information about the file that is being transcoded.</p>
     #[serde(rename = "Input")]
@@ -290,7 +290,7 @@ pub struct CreateJobRequest {
 }
 
 /// <p>The CreateJobResponse structure.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateJobResponse {
     /// <p>A section of the response body that provides information about the job that is created.</p>
     #[serde(rename = "Job")]
@@ -299,7 +299,7 @@ pub struct CreateJobResponse {
 }
 
 /// <p>The <code>CreatePipelineRequest</code> structure.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreatePipelineRequest {
     /// <p>The AWS Key Management Service (AWS KMS) key that you want to use with this pipeline.</p> <p>If you use either <code>S3</code> or <code>S3-AWS-KMS</code> as your <code>Encryption:Mode</code>, you don't need to provide a key with your job because a default key, known as an AWS-KMS key, is created for you automatically. You need to provide an AWS-KMS key only if you want to use a non-default AWS-KMS key, or if you are using an <code>Encryption:Mode</code> of <code>AES-PKCS7</code>, <code>AES-CTR</code>, or <code>AES-GCM</code>.</p>
     #[serde(rename = "AwsKmsKeyArn")]
@@ -333,7 +333,7 @@ pub struct CreatePipelineRequest {
 }
 
 /// <p>When you create a pipeline, Elastic Transcoder returns the values that you specified in the request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreatePipelineResponse {
     /// <p>A section of the response body that provides information about the pipeline that is created.</p>
     #[serde(rename = "Pipeline")]
@@ -346,7 +346,7 @@ pub struct CreatePipelineResponse {
 }
 
 /// <p>The <code>CreatePresetRequest</code> structure.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreatePresetRequest {
     /// <p>A section of the request body that specifies the audio parameters.</p>
     #[serde(rename = "Audio")]
@@ -373,7 +373,7 @@ pub struct CreatePresetRequest {
 }
 
 /// <p>The <code>CreatePresetResponse</code> structure.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreatePresetResponse {
     /// <p>A section of the response body that provides information about the preset that is created.</p>
     #[serde(rename = "Preset")]
@@ -386,7 +386,7 @@ pub struct CreatePresetResponse {
 }
 
 /// <p>The <code>DeletePipelineRequest</code> structure.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeletePipelineRequest {
     /// <p>The identifier of the pipeline that you want to delete.</p>
     #[serde(rename = "Id")]
@@ -394,11 +394,11 @@ pub struct DeletePipelineRequest {
 }
 
 /// <p>The <code>DeletePipelineResponse</code> structure.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeletePipelineResponse {}
 
 /// <p>The <code>DeletePresetRequest</code> structure.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeletePresetRequest {
     /// <p>The identifier of the preset for which you want to get detailed information.</p>
     #[serde(rename = "Id")]
@@ -406,11 +406,11 @@ pub struct DeletePresetRequest {
 }
 
 /// <p>The <code>DeletePresetResponse</code> structure.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeletePresetResponse {}
 
 /// <p>The detected properties of the input file. Elastic Transcoder identifies these values from the input file.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct DetectedProperties {
     /// <p>The detected duration of the input file, in milliseconds.</p>
     #[serde(rename = "DurationMillis")]
@@ -435,7 +435,7 @@ pub struct DetectedProperties {
 }
 
 /// <p>The encryption settings, if any, that are used for decrypting your input files or encrypting your output files. If your input file is encrypted, you must specify the mode that Elastic Transcoder uses to decrypt your file, otherwise you must specify the mode you want Elastic Transcoder to use to encrypt your output files.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Encryption {
     /// <p>The series of random bits created by a random bit generator, unique for every encryption operation, that you used to encrypt your input files or that you want Elastic Transcoder to use to encrypt your output files. The initialization vector must be base64-encoded, and it must be exactly 16 bytes long before being base64-encoded.</p>
     #[serde(rename = "InitializationVector")]
@@ -456,7 +456,7 @@ pub struct Encryption {
 }
 
 /// <p>The HLS content protection settings, if any, that you want Elastic Transcoder to apply to your output files.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct HlsContentProtection {
     /// <p>If Elastic Transcoder is generating your key for you, you must leave this field blank.</p> <p>The series of random bits created by a random bit generator, unique for every encryption operation, that you want Elastic Transcoder to use to encrypt your output files. The initialization vector must be base64-encoded, and it must be exactly 16 bytes before being base64-encoded.</p>
     #[serde(rename = "InitializationVector")]
@@ -485,7 +485,7 @@ pub struct HlsContentProtection {
 }
 
 /// <p>The captions to be created, if any.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct InputCaptions {
     /// <p>Source files for the input sidecar captions used during the transcoding process. To omit all sidecar captions, leave <code>CaptionSources</code> blank.</p>
     #[serde(rename = "CaptionSources")]
@@ -498,7 +498,7 @@ pub struct InputCaptions {
 }
 
 /// <p>A section of the response body that provides information about the job that is created.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Job {
     /// <p>The Amazon Resource Name (ARN) for the job.</p>
     #[serde(rename = "Arn")]
@@ -551,7 +551,7 @@ pub struct Job {
 }
 
 /// <p>The .jpg or .png file associated with an audio file.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct JobAlbumArt {
     /// <p>The file to be used as album art. There can be multiple artworks associated with an audio file, to a maximum of 20. Valid formats are <code>.jpg</code> and <code>.png</code> </p>
     #[serde(rename = "Artwork")]
@@ -564,7 +564,7 @@ pub struct JobAlbumArt {
 }
 
 /// <p>Information about the file that you're transcoding.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct JobInput {
     /// <p> The aspect ratio of the input file. If you want Elastic Transcoder to automatically detect the aspect ratio of the input file, specify <code>auto</code>. If you want to specify the aspect ratio for the output file, enter one of the following values: </p> <p> <code>1:1</code>, <code>4:3</code>, <code>3:2</code>, <code>16:9</code> </p> <p> If you specify a value other than <code>auto</code>, Elastic Transcoder disables automatic detection of the aspect ratio. </p>
     #[serde(rename = "AspectRatio")]
@@ -609,7 +609,7 @@ pub struct JobInput {
 }
 
 /// <p><important> <p>Outputs recommended instead.</p> </important> <p>If you specified one output for a job, information about that output. If you specified multiple outputs for a job, the <code>Output</code> object lists information about the first output. This duplicates the information that is listed for the first output in the <code>Outputs</code> object.</p></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct JobOutput {
     /// <p>The album art to be associated with the output file, if any.</p>
     #[serde(rename = "AlbumArt")]
@@ -694,7 +694,7 @@ pub struct JobOutput {
 }
 
 /// <p>Watermarks can be in .png or .jpg format. If you want to display a watermark that is not rectangular, use the .png format, which supports transparency.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct JobWatermark {
     /// <p>The encryption settings, if any, that you want Elastic Transcoder to apply to your watermarks.</p>
     #[serde(rename = "Encryption")]
@@ -711,7 +711,7 @@ pub struct JobWatermark {
 }
 
 /// <p>The <code>ListJobsByPipelineRequest</code> structure.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListJobsByPipelineRequest {
     /// <p> To list jobs in chronological order by the date and time that they were submitted, enter <code>true</code>. To list jobs in reverse chronological order, enter <code>false</code>. </p>
     #[serde(rename = "Ascending")]
@@ -727,7 +727,7 @@ pub struct ListJobsByPipelineRequest {
 }
 
 /// <p>The <code>ListJobsByPipelineResponse</code> structure.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListJobsByPipelineResponse {
     /// <p>An array of <code>Job</code> objects that are in the specified pipeline.</p>
     #[serde(rename = "Jobs")]
@@ -740,7 +740,7 @@ pub struct ListJobsByPipelineResponse {
 }
 
 /// <p>The <code>ListJobsByStatusRequest</code> structure.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListJobsByStatusRequest {
     /// <p> To list jobs in chronological order by the date and time that they were submitted, enter <code>true</code>. To list jobs in reverse chronological order, enter <code>false</code>. </p>
     #[serde(rename = "Ascending")]
@@ -756,7 +756,7 @@ pub struct ListJobsByStatusRequest {
 }
 
 /// <p> The <code>ListJobsByStatusResponse</code> structure. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListJobsByStatusResponse {
     /// <p>An array of <code>Job</code> objects that have the specified status.</p>
     #[serde(rename = "Jobs")]
@@ -769,7 +769,7 @@ pub struct ListJobsByStatusResponse {
 }
 
 /// <p>The <code>ListPipelineRequest</code> structure.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListPipelinesRequest {
     /// <p>To list pipelines in chronological order by the date and time that they were created, enter <code>true</code>. To list pipelines in reverse chronological order, enter <code>false</code>.</p>
     #[serde(rename = "Ascending")]
@@ -782,7 +782,7 @@ pub struct ListPipelinesRequest {
 }
 
 /// <p>A list of the pipelines associated with the current AWS account.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListPipelinesResponse {
     /// <p>A value that you use to access the second and subsequent pages of results, if any. When the pipelines fit on one page or when you've reached the last page of results, the value of <code>NextPageToken</code> is <code>null</code>.</p>
     #[serde(rename = "NextPageToken")]
@@ -795,7 +795,7 @@ pub struct ListPipelinesResponse {
 }
 
 /// <p>The <code>ListPresetsRequest</code> structure.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListPresetsRequest {
     /// <p>To list presets in chronological order by the date and time that they were created, enter <code>true</code>. To list presets in reverse chronological order, enter <code>false</code>.</p>
     #[serde(rename = "Ascending")]
@@ -808,7 +808,7 @@ pub struct ListPresetsRequest {
 }
 
 /// <p>The <code>ListPresetsResponse</code> structure.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListPresetsResponse {
     /// <p>A value that you use to access the second and subsequent pages of results, if any. When the presets fit on one page or when you've reached the last page of results, the value of <code>NextPageToken</code> is <code>null</code>.</p>
     #[serde(rename = "NextPageToken")]
@@ -821,7 +821,7 @@ pub struct ListPresetsResponse {
 }
 
 /// <p><p>The Amazon Simple Notification Service (Amazon SNS) topic or topics to notify in order to report job status.</p> <important> <p>To receive notifications, you must also subscribe to the new topic in the Amazon SNS console.</p> </important></p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Notifications {
     /// <p>The Amazon SNS topic that you want to notify when Elastic Transcoder has finished processing the job.</p>
     #[serde(rename = "Completed")]
@@ -842,7 +842,7 @@ pub struct Notifications {
 }
 
 /// <p>The <code>Permission</code> structure.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Permission {
     /// <p><p> The permission that you want to give to the AWS user that is listed in Grantee. Valid values include: </p> <ul> <li> <p> <code>READ</code>: The grantee can read the thumbnails and metadata for thumbnails that Elastic Transcoder adds to the Amazon S3 bucket.</p> </li> <li> <p> <code>READ<em>ACP</code>: The grantee can read the object ACL for thumbnails that Elastic Transcoder adds to the Amazon S3 bucket.</p> </li> <li> <p> <code>WRITE</em>ACP</code>: The grantee can write the ACL for the thumbnails that Elastic Transcoder adds to the Amazon S3 bucket.</p> </li> <li> <p> <code>FULL<em>CONTROL</code>: The grantee has READ, READ</em>ACP, and WRITE_ACP permissions for the thumbnails that Elastic Transcoder adds to the Amazon S3 bucket.</p> </li> </ul></p>
     #[serde(rename = "Access")]
@@ -859,7 +859,7 @@ pub struct Permission {
 }
 
 /// <p>The pipeline (queue) that is used to manage jobs.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Pipeline {
     /// <p>The Amazon Resource Name (ARN) for the pipeline.</p>
     #[serde(rename = "Arn")]
@@ -908,7 +908,7 @@ pub struct Pipeline {
 }
 
 /// <p>The <code>PipelineOutputConfig</code> structure.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct PipelineOutputConfig {
     /// <p> The Amazon S3 bucket in which you want Elastic Transcoder to save the transcoded files. Specify this value when all of the following are true:</p> <ul> <li> <p>You want to save transcoded files, thumbnails (if any), and playlists (if any) together in one bucket.</p> </li> <li> <p>You do not want to specify the users or groups who have access to the transcoded files, thumbnails, and playlists.</p> </li> <li> <p>You do not want to specify the permissions that Elastic Transcoder grants to the files.</p> </li> <li> <p>You want to associate the transcoded files and thumbnails with the Amazon S3 Standard storage class.</p> </li> </ul> <p>If you want to save transcoded files and playlists in one bucket and thumbnails in another bucket, specify which users can access the transcoded files or the permissions the users have, or change the Amazon S3 storage class, omit OutputBucket and specify values for <code>ContentConfig</code> and <code>ThumbnailConfig</code> instead. </p>
     #[serde(rename = "Bucket")]
@@ -925,7 +925,7 @@ pub struct PipelineOutputConfig {
 }
 
 /// <p>The PlayReady DRM settings, if any, that you want Elastic Transcoder to apply to the output files associated with this playlist.</p> <p>PlayReady DRM encrypts your media files using <code>AES-CTR</code> encryption.</p> <p>If you use DRM for an <code>HLSv3</code> playlist, your outputs must have a master playlist.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct PlayReadyDrm {
     /// <p>The type of DRM, if any, that you want Elastic Transcoder to apply to the output files associated with this playlist.</p>
     #[serde(rename = "Format")]
@@ -954,7 +954,7 @@ pub struct PlayReadyDrm {
 }
 
 /// <p> Use Only for Fragmented MP4 or MPEG-TS Outputs. If you specify a preset for which the value of Container is <code>fmp4</code> (Fragmented MP4) or <code>ts</code> (MPEG-TS), Playlists contains information about the master playlists that you want Elastic Transcoder to create. We recommend that you create only one master playlist per output format. The maximum number of master playlists in a job is 30. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Playlist {
     /// <p>The format of the output playlist. Valid formats include <code>HLSv3</code>, <code>HLSv4</code>, and <code>Smooth</code>.</p>
     #[serde(rename = "Format")]
@@ -987,7 +987,7 @@ pub struct Playlist {
 }
 
 /// <p>Presets are templates that contain most of the settings for transcoding media files from one format to another. Elastic Transcoder includes some default presets for common formats, for example, several iPod and iPhone versions. You can also create your own presets for formats that aren't included among the default presets. You specify which preset you want to use when you create a job.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Preset {
     /// <p>The Amazon Resource Name (ARN) for the preset.</p>
     #[serde(rename = "Arn")]
@@ -1028,7 +1028,7 @@ pub struct Preset {
 }
 
 /// <p>Settings for the size, location, and opacity of graphics that you want Elastic Transcoder to overlay over videos that are transcoded using this preset. You can specify settings for up to four watermarks. Watermarks appear in the specified size and location, and with the specified opacity for the duration of the transcoded video.</p> <p>Watermarks can be in .png or .jpg format. If you want to display a watermark that is not rectangular, use the .png format, which supports transparency.</p> <p>When you create a job that uses this preset, you specify the .png or .jpg graphics that you want Elastic Transcoder to include in the transcoded videos. You can specify fewer graphics in the job than you specify watermark settings in the preset, which allows you to use the same preset for up to four watermarks that have different dimensions.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct PresetWatermark {
     /// <p><p>The horizontal position of the watermark unless you specify a non-zero value for <code>HorizontalOffset</code>: </p> <ul> <li> <p> <b>Left</b>: The left edge of the watermark is aligned with the left border of the video.</p> </li> <li> <p> <b>Right</b>: The right edge of the watermark is aligned with the right border of the video.</p> </li> <li> <p> <b>Center</b>: The watermark is centered between the left and right borders.</p> </li> </ul></p>
     #[serde(rename = "HorizontalAlign")]
@@ -1073,7 +1073,7 @@ pub struct PresetWatermark {
 }
 
 /// <p>The <code>ReadJobRequest</code> structure.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ReadJobRequest {
     /// <p>The identifier of the job for which you want to get detailed information.</p>
     #[serde(rename = "Id")]
@@ -1081,7 +1081,7 @@ pub struct ReadJobRequest {
 }
 
 /// <p>The <code>ReadJobResponse</code> structure.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ReadJobResponse {
     /// <p>A section of the response body that provides information about the job.</p>
     #[serde(rename = "Job")]
@@ -1090,7 +1090,7 @@ pub struct ReadJobResponse {
 }
 
 /// <p>The <code>ReadPipelineRequest</code> structure.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ReadPipelineRequest {
     /// <p>The identifier of the pipeline to read.</p>
     #[serde(rename = "Id")]
@@ -1098,7 +1098,7 @@ pub struct ReadPipelineRequest {
 }
 
 /// <p>The <code>ReadPipelineResponse</code> structure.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ReadPipelineResponse {
     /// <p>A section of the response body that provides information about the pipeline.</p>
     #[serde(rename = "Pipeline")]
@@ -1111,7 +1111,7 @@ pub struct ReadPipelineResponse {
 }
 
 /// <p>The <code>ReadPresetRequest</code> structure.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ReadPresetRequest {
     /// <p>The identifier of the preset for which you want to get detailed information.</p>
     #[serde(rename = "Id")]
@@ -1119,7 +1119,7 @@ pub struct ReadPresetRequest {
 }
 
 /// <p>The <code>ReadPresetResponse</code> structure.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ReadPresetResponse {
     /// <p>A section of the response body that provides information about the preset.</p>
     #[serde(rename = "Preset")]
@@ -1128,7 +1128,7 @@ pub struct ReadPresetResponse {
 }
 
 /// <p> The <code>TestRoleRequest</code> structure. </p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct TestRoleRequest {
     /// <p>The Amazon S3 bucket that contains media files to be transcoded. The action attempts to read from this bucket.</p>
     #[serde(rename = "InputBucket")]
@@ -1145,7 +1145,7 @@ pub struct TestRoleRequest {
 }
 
 /// <p>The <code>TestRoleResponse</code> structure.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct TestRoleResponse {
     /// <p>If the <code>Success</code> element contains <code>false</code>, this value is an array of one or more error messages that were generated during the test process.</p>
     #[serde(rename = "Messages")]
@@ -1158,7 +1158,7 @@ pub struct TestRoleResponse {
 }
 
 /// <p>Thumbnails for videos.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Thumbnails {
     /// <p><important> <p>To better control resolution and aspect ratio of thumbnails, we recommend that you use the values <code>MaxWidth</code>, <code>MaxHeight</code>, <code>SizingPolicy</code>, and <code>PaddingPolicy</code> instead of <code>Resolution</code> and <code>AspectRatio</code>. The two groups of settings are mutually exclusive. Do not use them together.</p> </important> <p>The aspect ratio of thumbnails. Valid values include:</p> <p> <code>auto</code>, <code>1:1</code>, <code>4:3</code>, <code>3:2</code>, <code>16:9</code> </p> <p>If you specify <code>auto</code>, Elastic Transcoder tries to preserve the aspect ratio of the video in the output file.</p></p>
     #[serde(rename = "AspectRatio")]
@@ -1195,7 +1195,7 @@ pub struct Thumbnails {
 }
 
 /// <p>Settings that determine when a clip begins and how long it lasts.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TimeSpan {
     /// <p>The duration of the clip. The format can be either HH:mm:ss.SSS (maximum value: 23:59:59.999; SSS is thousandths of a second) or sssss.SSS (maximum value: 86399.999). If you don't specify a value, Elastic Transcoder creates an output file from StartTime to the end of the file.</p> <p>If you specify a value longer than the duration of the input file, Elastic Transcoder transcodes the file and returns a warning message.</p>
     #[serde(rename = "Duration")]
@@ -1208,7 +1208,7 @@ pub struct TimeSpan {
 }
 
 /// <p>Details about the timing of a job.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Timing {
     /// <p>The time the job finished transcoding, in epoch milliseconds.</p>
     #[serde(rename = "FinishTimeMillis")]
@@ -1225,7 +1225,7 @@ pub struct Timing {
 }
 
 /// <p>The <code>UpdatePipelineNotificationsRequest</code> structure.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdatePipelineNotificationsRequest {
     /// <p>The identifier of the pipeline for which you want to change notification settings.</p>
     #[serde(rename = "Id")]
@@ -1236,7 +1236,7 @@ pub struct UpdatePipelineNotificationsRequest {
 }
 
 /// <p>The <code>UpdatePipelineNotificationsResponse</code> structure.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdatePipelineNotificationsResponse {
     /// <p>A section of the response body that provides information about the pipeline associated with this notification.</p>
     #[serde(rename = "Pipeline")]
@@ -1245,7 +1245,7 @@ pub struct UpdatePipelineNotificationsResponse {
 }
 
 /// <p>The <code>UpdatePipelineRequest</code> structure.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdatePipelineRequest {
     /// <p>The AWS Key Management Service (AWS KMS) key that you want to use with this pipeline.</p> <p>If you use either <code>S3</code> or <code>S3-AWS-KMS</code> as your <code>Encryption:Mode</code>, you don't need to provide a key with your job because a default key, known as an AWS-KMS key, is created for you automatically. You need to provide an AWS-KMS key only if you want to use a non-default AWS-KMS key, or if you are using an <code>Encryption:Mode</code> of <code>AES-PKCS7</code>, <code>AES-CTR</code>, or <code>AES-GCM</code>.</p>
     #[serde(rename = "AwsKmsKeyArn")]
@@ -1281,7 +1281,7 @@ pub struct UpdatePipelineRequest {
 }
 
 /// <p>When you update a pipeline, Elastic Transcoder returns the values that you specified in the request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdatePipelineResponse {
     /// <p>The pipeline updated by this <code>UpdatePipelineResponse</code> call.</p>
     #[serde(rename = "Pipeline")]
@@ -1294,7 +1294,7 @@ pub struct UpdatePipelineResponse {
 }
 
 /// <p>The <code>UpdatePipelineStatusRequest</code> structure.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdatePipelineStatusRequest {
     /// <p>The identifier of the pipeline to update.</p>
     #[serde(rename = "Id")]
@@ -1305,7 +1305,7 @@ pub struct UpdatePipelineStatusRequest {
 }
 
 /// <p>When you update status for a pipeline, Elastic Transcoder returns the values that you specified in the request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdatePipelineStatusResponse {
     /// <p>A section of the response body that provides information about the pipeline.</p>
     #[serde(rename = "Pipeline")]
@@ -1314,7 +1314,7 @@ pub struct UpdatePipelineStatusResponse {
 }
 
 /// <p>The <code>VideoParameters</code> structure.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct VideoParameters {
     /// <p><important> <p>To better control resolution and aspect ratio of output videos, we recommend that you use the values <code>MaxWidth</code>, <code>MaxHeight</code>, <code>SizingPolicy</code>, <code>PaddingPolicy</code>, and <code>DisplayAspectRatio</code> instead of <code>Resolution</code> and <code>AspectRatio</code>. The two groups of settings are mutually exclusive. Do not use them together.</p> </important> <p>The display aspect ratio of the video in the output file. Valid values include:</p> <p> <code>auto</code>, <code>1:1</code>, <code>4:3</code>, <code>3:2</code>, <code>16:9</code> </p> <p>If you specify <code>auto</code>, Elastic Transcoder tries to preserve the aspect ratio of the input file.</p> <p>If you specify an aspect ratio for the output file that differs from aspect ratio of the input file, Elastic Transcoder adds pillarboxing (black bars on the sides) or letterboxing (black bars on the top and bottom) to maintain the aspect ratio of the active region of the video.</p></p>
     #[serde(rename = "AspectRatio")]
@@ -1379,7 +1379,7 @@ pub struct VideoParameters {
 }
 
 /// <p>Elastic Transcoder returns a warning if the resources used by your pipeline are not in the same region as the pipeline.</p> <p>Using resources in the same region, such as your Amazon S3 buckets, Amazon SNS notification topics, and AWS KMS key, reduces processing time and prevents cross-regional charges.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Warning {
     /// <p>The code of the cross-regional warning.</p>
     #[serde(rename = "Code")]

--- a/rusoto/services/elastictranscoder/src/generated.rs
+++ b/rusoto/services/elastictranscoder/src/generated.rs
@@ -1418,7 +1418,8 @@ impl CancelJobError {
     pub fn from_body(body: &str) -> CancelJobError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1518,7 +1519,8 @@ impl CreateJobError {
     pub fn from_body(body: &str) -> CreateJobError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1618,7 +1620,8 @@ impl CreatePipelineError {
     pub fn from_body(body: &str) -> CreatePipelineError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1718,7 +1721,8 @@ impl CreatePresetError {
     pub fn from_body(body: &str) -> CreatePresetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1816,7 +1820,8 @@ impl DeletePipelineError {
     pub fn from_body(body: &str) -> DeletePipelineError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1916,7 +1921,8 @@ impl DeletePresetError {
     pub fn from_body(body: &str) -> DeletePresetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2012,7 +2018,8 @@ impl ListJobsByPipelineError {
     pub fn from_body(body: &str) -> ListJobsByPipelineError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2110,7 +2117,8 @@ impl ListJobsByStatusError {
     pub fn from_body(body: &str) -> ListJobsByStatusError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2204,7 +2212,8 @@ impl ListPipelinesError {
     pub fn from_body(body: &str) -> ListPipelinesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2294,7 +2303,8 @@ impl ListPresetsError {
     pub fn from_body(body: &str) -> ListPresetsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2386,7 +2396,8 @@ impl ReadJobError {
     pub fn from_body(body: &str) -> ReadJobError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2480,7 +2491,8 @@ impl ReadPipelineError {
     pub fn from_body(body: &str) -> ReadPipelineError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2576,7 +2588,8 @@ impl ReadPresetError {
     pub fn from_body(body: &str) -> ReadPresetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2670,7 +2683,8 @@ impl TestRoleError {
     pub fn from_body(body: &str) -> TestRoleError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2766,7 +2780,8 @@ impl UpdatePipelineError {
     pub fn from_body(body: &str) -> UpdatePipelineError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2868,7 +2883,8 @@ impl UpdatePipelineNotificationsError {
     pub fn from_body(body: &str) -> UpdatePipelineNotificationsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2978,7 +2994,8 @@ impl UpdatePipelineStatusError {
     pub fn from_body(body: &str) -> UpdatePipelineStatusError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/elb/src/generated.rs
+++ b/rusoto/services/elb/src/generated.rs
@@ -44,7 +44,7 @@ enum DeserializerNext {
     Element(String),
 }
 /// <p>Information about the <code>AccessLog</code> attribute.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AccessLog {
     /// <p>The interval for publishing the access logs. You can specify an interval of either 5 minutes or 60 minutes.</p> <p>Default: 60 minutes</p>
     pub emit_interval: Option<i64>,
@@ -219,7 +219,7 @@ impl AccessPointPortDeserializer {
     }
 }
 /// <p>Contains the parameters for EnableAvailabilityZonesForLoadBalancer.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AddAvailabilityZonesInput {
     /// <p>The Availability Zones. These must be in the same region as the load balancer.</p>
     pub availability_zones: Vec<String>,
@@ -249,7 +249,7 @@ impl AddAvailabilityZonesInputSerializer {
 }
 
 /// <p>Contains the output of EnableAvailabilityZonesForLoadBalancer.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AddAvailabilityZonesOutput {
     /// <p>The updated list of Availability Zones for the load balancer.</p>
     pub availability_zones: Option<Vec<String>>,
@@ -297,7 +297,7 @@ impl AddAvailabilityZonesOutputDeserializer {
     }
 }
 /// <p>Contains the parameters for AddTags.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AddTagsInput {
     /// <p>The name of the load balancer. You can specify one load balancer only.</p>
     pub load_balancer_names: Vec<String>,
@@ -324,7 +324,7 @@ impl AddTagsInputSerializer {
 }
 
 /// <p>Contains the output of AddTags.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AddTagsOutput {}
 
 struct AddTagsOutputDeserializer;
@@ -344,7 +344,7 @@ impl AddTagsOutputDeserializer {
     }
 }
 /// <p>This data type is reserved.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AdditionalAttribute {
     /// <p>This parameter is reserved.</p>
     pub key: Option<String>,
@@ -548,7 +548,7 @@ impl AppCookieStickinessPoliciesDeserializer {
     }
 }
 /// <p>Information about a policy for application-controlled session stickiness.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AppCookieStickinessPolicy {
     /// <p>The name of the application cookie used for stickiness.</p>
     pub cookie_name: Option<String>,
@@ -605,7 +605,7 @@ impl AppCookieStickinessPolicyDeserializer {
     }
 }
 /// <p>Contains the parameters for ApplySecurityGroupsToLoadBalancer.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ApplySecurityGroupsToLoadBalancerInput {
     /// <p>The name of the load balancer.</p>
     pub load_balancer_name: String,
@@ -635,7 +635,7 @@ impl ApplySecurityGroupsToLoadBalancerInputSerializer {
 }
 
 /// <p>Contains the output of ApplySecurityGroupsToLoadBalancer.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ApplySecurityGroupsToLoadBalancerOutput {
     /// <p>The IDs of the security groups associated with the load balancer.</p>
     pub security_groups: Option<Vec<String>>,
@@ -684,7 +684,7 @@ impl ApplySecurityGroupsToLoadBalancerOutputDeserializer {
     }
 }
 /// <p>Contains the parameters for AttachLoaBalancerToSubnets.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AttachLoadBalancerToSubnetsInput {
     /// <p>The name of the load balancer.</p>
     pub load_balancer_name: String,
@@ -710,7 +710,7 @@ impl AttachLoadBalancerToSubnetsInputSerializer {
 }
 
 /// <p>Contains the output of AttachLoadBalancerToSubnets.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AttachLoadBalancerToSubnetsOutput {
     /// <p>The IDs of the subnets attached to the load balancer.</p>
     pub subnets: Option<Vec<String>>,
@@ -867,7 +867,7 @@ impl AvailabilityZonesSerializer {
 }
 
 /// <p>Information about the configuration of an EC2 instance.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct BackendServerDescription {
     /// <p>The port on which the EC2 instance is listening.</p>
     pub instance_port: Option<i64>,
@@ -980,7 +980,7 @@ impl CardinalityDeserializer {
     }
 }
 /// <p>Contains the parameters for ConfigureHealthCheck.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ConfigureHealthCheckInput {
     /// <p>The configuration information.</p>
     pub health_check: HealthCheck,
@@ -1010,7 +1010,7 @@ impl ConfigureHealthCheckInputSerializer {
 }
 
 /// <p>Contains the output of ConfigureHealthCheck.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ConfigureHealthCheckOutput {
     /// <p>The updated health check.</p>
     pub health_check: Option<HealthCheck>,
@@ -1059,7 +1059,7 @@ impl ConfigureHealthCheckOutputDeserializer {
     }
 }
 /// <p>Information about the <code>ConnectionDraining</code> attribute.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ConnectionDraining {
     /// <p>Specifies whether connection draining is enabled for the load balancer.</p>
     pub enabled: bool,
@@ -1165,7 +1165,7 @@ impl ConnectionDrainingTimeoutDeserializer {
     }
 }
 /// <p>Information about the <code>ConnectionSettings</code> attribute.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ConnectionSettings {
     /// <p>The time, in seconds, that the connection is allowed to be idle (no data has been sent over the connection) before it is closed by the load balancer.</p>
     pub idle_timeout: i64,
@@ -1257,7 +1257,7 @@ impl CookieNameDeserializer {
     }
 }
 /// <p>Contains the parameters for CreateLoadBalancer.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateAccessPointInput {
     /// <p>One or more Availability Zones from the same region as the load balancer.</p> <p>You must specify at least one Availability Zone.</p> <p>You can add more Availability Zones after you create the load balancer using <a>EnableAvailabilityZonesForLoadBalancer</a>.</p>
     pub availability_zones: Option<Vec<String>>,
@@ -1323,7 +1323,7 @@ impl CreateAccessPointInputSerializer {
 }
 
 /// <p>Contains the output for CreateLoadBalancer.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateAccessPointOutput {
     /// <p>The DNS name of the load balancer.</p>
     pub dns_name: Option<String>,
@@ -1370,7 +1370,7 @@ impl CreateAccessPointOutputDeserializer {
     }
 }
 /// <p>Contains the parameters for CreateAppCookieStickinessPolicy.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateAppCookieStickinessPolicyInput {
     /// <p>The name of the application cookie used for stickiness.</p>
     pub cookie_name: String,
@@ -1405,7 +1405,7 @@ impl CreateAppCookieStickinessPolicyInputSerializer {
 }
 
 /// <p>Contains the output for CreateAppCookieStickinessPolicy.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateAppCookieStickinessPolicyOutput {}
 
 struct CreateAppCookieStickinessPolicyOutputDeserializer;
@@ -1425,7 +1425,7 @@ impl CreateAppCookieStickinessPolicyOutputDeserializer {
     }
 }
 /// <p>Contains the parameters for CreateLBCookieStickinessPolicy.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateLBCookieStickinessPolicyInput {
     /// <p>The time period, in seconds, after which the cookie should be considered stale. If you do not specify this parameter, the default value is 0, which indicates that the sticky session should last for the duration of the browser session.</p>
     pub cookie_expiration_period: Option<i64>,
@@ -1462,7 +1462,7 @@ impl CreateLBCookieStickinessPolicyInputSerializer {
 }
 
 /// <p>Contains the output for CreateLBCookieStickinessPolicy.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateLBCookieStickinessPolicyOutput {}
 
 struct CreateLBCookieStickinessPolicyOutputDeserializer;
@@ -1482,7 +1482,7 @@ impl CreateLBCookieStickinessPolicyOutputDeserializer {
     }
 }
 /// <p>Contains the parameters for CreateLoadBalancerListeners.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateLoadBalancerListenerInput {
     /// <p>The listeners.</p>
     pub listeners: Vec<Listener>,
@@ -1512,7 +1512,7 @@ impl CreateLoadBalancerListenerInputSerializer {
 }
 
 /// <p>Contains the parameters for CreateLoadBalancerListener.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateLoadBalancerListenerOutput {}
 
 struct CreateLoadBalancerListenerOutputDeserializer;
@@ -1532,7 +1532,7 @@ impl CreateLoadBalancerListenerOutputDeserializer {
     }
 }
 /// <p>Contains the parameters for CreateLoadBalancerPolicy.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateLoadBalancerPolicyInput {
     /// <p>The name of the load balancer.</p>
     pub load_balancer_name: String,
@@ -1576,7 +1576,7 @@ impl CreateLoadBalancerPolicyInputSerializer {
 }
 
 /// <p>Contains the output of CreateLoadBalancerPolicy.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateLoadBalancerPolicyOutput {}
 
 struct CreateLoadBalancerPolicyOutputDeserializer;
@@ -1610,7 +1610,7 @@ impl CreatedTimeDeserializer {
     }
 }
 /// <p>Information about the <code>CrossZoneLoadBalancing</code> attribute.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CrossZoneLoadBalancing {
     /// <p>Specifies whether cross-zone load balancing is enabled for the load balancer.</p>
     pub enabled: bool,
@@ -1717,7 +1717,7 @@ impl DefaultValueDeserializer {
     }
 }
 /// <p>Contains the parameters for DeleteLoadBalancer.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteAccessPointInput {
     /// <p>The name of the load balancer.</p>
     pub load_balancer_name: String,
@@ -1740,7 +1740,7 @@ impl DeleteAccessPointInputSerializer {
 }
 
 /// <p>Contains the output of DeleteLoadBalancer.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteAccessPointOutput {}
 
 struct DeleteAccessPointOutputDeserializer;
@@ -1760,7 +1760,7 @@ impl DeleteAccessPointOutputDeserializer {
     }
 }
 /// <p>Contains the parameters for DeleteLoadBalancerListeners.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteLoadBalancerListenerInput {
     /// <p>The name of the load balancer.</p>
     pub load_balancer_name: String,
@@ -1790,7 +1790,7 @@ impl DeleteLoadBalancerListenerInputSerializer {
 }
 
 /// <p>Contains the output of DeleteLoadBalancerListeners.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteLoadBalancerListenerOutput {}
 
 struct DeleteLoadBalancerListenerOutputDeserializer;
@@ -1810,7 +1810,7 @@ impl DeleteLoadBalancerListenerOutputDeserializer {
     }
 }
 /// <p>Contains the parameters for DeleteLoadBalancerPolicy.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteLoadBalancerPolicyInput {
     /// <p>The name of the load balancer.</p>
     pub load_balancer_name: String,
@@ -1839,7 +1839,7 @@ impl DeleteLoadBalancerPolicyInputSerializer {
 }
 
 /// <p>Contains the output of DeleteLoadBalancerPolicy.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteLoadBalancerPolicyOutput {}
 
 struct DeleteLoadBalancerPolicyOutputDeserializer;
@@ -1859,7 +1859,7 @@ impl DeleteLoadBalancerPolicyOutputDeserializer {
     }
 }
 /// <p>Contains the parameters for DeregisterInstancesFromLoadBalancer.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeregisterEndPointsInput {
     /// <p>The IDs of the instances.</p>
     pub instances: Vec<Instance>,
@@ -1889,7 +1889,7 @@ impl DeregisterEndPointsInputSerializer {
 }
 
 /// <p>Contains the output of DeregisterInstancesFromLoadBalancer.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeregisterEndPointsOutput {
     /// <p>The remaining instances registered with the load balancer.</p>
     pub instances: Option<Vec<Instance>>,
@@ -1936,7 +1936,7 @@ impl DeregisterEndPointsOutputDeserializer {
     }
 }
 /// <p>Contains the parameters for DescribeLoadBalancers.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeAccessPointsInput {
     /// <p>The names of the load balancers.</p>
     pub load_balancer_names: Option<Vec<String>>,
@@ -1978,7 +1978,7 @@ impl DescribeAccessPointsInputSerializer {
 }
 
 /// <p>Contains the parameters for DescribeLoadBalancers.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeAccessPointsOutput {
     /// <p>Information about the load balancers.</p>
     pub load_balancer_descriptions: Option<Vec<LoadBalancerDescription>>,
@@ -2033,7 +2033,7 @@ impl DescribeAccessPointsOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeAccountLimitsInput {
     /// <p>The marker for the next set of results. (You received this marker from a previous call.)</p>
     pub marker: Option<String>,
@@ -2065,7 +2065,7 @@ impl DescribeAccountLimitsInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeAccountLimitsOutput {
     /// <p>Information about the limits.</p>
     pub limits: Option<Vec<Limit>>,
@@ -2117,7 +2117,7 @@ impl DescribeAccountLimitsOutputDeserializer {
     }
 }
 /// <p>Contains the parameters for DescribeInstanceHealth.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeEndPointStateInput {
     /// <p>The IDs of the instances.</p>
     pub instances: Option<Vec<Instance>>,
@@ -2149,7 +2149,7 @@ impl DescribeEndPointStateInputSerializer {
 }
 
 /// <p>Contains the output for DescribeInstanceHealth.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeEndPointStateOutput {
     /// <p>Information about the health of the instances.</p>
     pub instance_states: Option<Vec<InstanceState>>,
@@ -2198,7 +2198,7 @@ impl DescribeEndPointStateOutputDeserializer {
     }
 }
 /// <p>Contains the parameters for DescribeLoadBalancerAttributes.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeLoadBalancerAttributesInput {
     /// <p>The name of the load balancer.</p>
     pub load_balancer_name: String,
@@ -2221,7 +2221,7 @@ impl DescribeLoadBalancerAttributesInputSerializer {
 }
 
 /// <p>Contains the output of DescribeLoadBalancerAttributes.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeLoadBalancerAttributesOutput {
     /// <p>Information about the load balancer attributes.</p>
     pub load_balancer_attributes: Option<LoadBalancerAttributes>,
@@ -2271,7 +2271,7 @@ impl DescribeLoadBalancerAttributesOutputDeserializer {
     }
 }
 /// <p>Contains the parameters for DescribeLoadBalancerPolicies.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeLoadBalancerPoliciesInput {
     /// <p>The name of the load balancer.</p>
     pub load_balancer_name: Option<String>,
@@ -2305,7 +2305,7 @@ impl DescribeLoadBalancerPoliciesInputSerializer {
 }
 
 /// <p>Contains the output of DescribeLoadBalancerPolicies.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeLoadBalancerPoliciesOutput {
     /// <p>Information about the policies.</p>
     pub policy_descriptions: Option<Vec<PolicyDescription>>,
@@ -2355,7 +2355,7 @@ impl DescribeLoadBalancerPoliciesOutputDeserializer {
     }
 }
 /// <p>Contains the parameters for DescribeLoadBalancerPolicyTypes.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeLoadBalancerPolicyTypesInput {
     /// <p>The names of the policy types. If no names are specified, describes all policy types defined by Elastic Load Balancing.</p>
     pub policy_type_names: Option<Vec<String>>,
@@ -2381,7 +2381,7 @@ impl DescribeLoadBalancerPolicyTypesInputSerializer {
 }
 
 /// <p>Contains the output of DescribeLoadBalancerPolicyTypes.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeLoadBalancerPolicyTypesOutput {
     /// <p>Information about the policy types.</p>
     pub policy_type_descriptions: Option<Vec<PolicyTypeDescription>>,
@@ -2431,7 +2431,7 @@ impl DescribeLoadBalancerPolicyTypesOutputDeserializer {
     }
 }
 /// <p>Contains the parameters for DescribeTags.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeTagsInput {
     /// <p>The names of the load balancers.</p>
     pub load_balancer_names: Vec<String>,
@@ -2455,7 +2455,7 @@ impl DescribeTagsInputSerializer {
 }
 
 /// <p>Contains the output for DescribeTags.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeTagsOutput {
     /// <p>Information about the tags.</p>
     pub tag_descriptions: Option<Vec<TagDescription>>,
@@ -2517,7 +2517,7 @@ impl DescriptionDeserializer {
     }
 }
 /// <p>Contains the parameters for DetachLoadBalancerFromSubnets.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DetachLoadBalancerFromSubnetsInput {
     /// <p>The name of the load balancer.</p>
     pub load_balancer_name: String,
@@ -2543,7 +2543,7 @@ impl DetachLoadBalancerFromSubnetsInputSerializer {
 }
 
 /// <p>Contains the output of DetachLoadBalancerFromSubnets.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DetachLoadBalancerFromSubnetsOutput {
     /// <p>The IDs of the remaining subnets for the load balancer.</p>
     pub subnets: Option<Vec<String>>,
@@ -2590,7 +2590,7 @@ impl DetachLoadBalancerFromSubnetsOutputDeserializer {
     }
 }
 /// <p>Information about a health check.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct HealthCheck {
     /// <p>The number of consecutive health checks successes required before moving the instance to the <code>Healthy</code> state.</p>
     pub healthy_threshold: i64,
@@ -2771,7 +2771,7 @@ impl IdleTimeoutDeserializer {
     }
 }
 /// <p>The ID of an EC2 instance.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Instance {
     /// <p>The instance ID.</p>
     pub instance_id: Option<String>,
@@ -2867,7 +2867,7 @@ impl InstancePortDeserializer {
     }
 }
 /// <p>Information about the state of an EC2 instance.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct InstanceState {
     /// <p><p>A description of the instance state. This string can contain one or more of the following messages.</p> <ul> <li> <p> <code>N/A</code> </p> </li> <li> <p> <code>A transient error occurred. Please try again later.</code> </p> </li> <li> <p> <code>Instance has failed at least the UnhealthyThreshold number of health checks consecutively.</code> </p> </li> <li> <p> <code>Instance has not passed the configured HealthyThreshold number of health checks consecutively.</code> </p> </li> <li> <p> <code>Instance registration is still in progress.</code> </p> </li> <li> <p> <code>Instance is in the EC2 Availability Zone for which LoadBalancer is not configured to route traffic to.</code> </p> </li> <li> <p> <code>Instance is not currently registered with the LoadBalancer.</code> </p> </li> <li> <p> <code>Instance deregistration currently in progress.</code> </p> </li> <li> <p> <code>Disable Availability Zone is currently in progress.</code> </p> </li> <li> <p> <code>Instance is in pending state.</code> </p> </li> <li> <p> <code>Instance is in stopped state.</code> </p> </li> <li> <p> <code>Instance is in terminated state.</code> </p> </li> </ul></p>
     pub description: Option<String>,
@@ -3073,7 +3073,7 @@ impl LBCookieStickinessPoliciesDeserializer {
     }
 }
 /// <p>Information about a policy for duration-based session stickiness.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct LBCookieStickinessPolicy {
     /// <p>The time period, in seconds, after which the cookie should be considered stale. If this parameter is not specified, the stickiness session lasts for the duration of the browser session.</p>
     pub cookie_expiration_period: Option<i64>,
@@ -3131,7 +3131,7 @@ impl LBCookieStickinessPolicyDeserializer {
     }
 }
 /// <p>Information about an Elastic Load Balancing resource limit for your AWS account.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Limit {
     /// <p>The maximum value of the limit.</p>
     pub max: Option<String>,
@@ -3222,7 +3222,7 @@ impl LimitsDeserializer {
     }
 }
 /// <p>Information about a listener.</p> <p>For information about the protocols and the ports supported by Elastic Load Balancing, see <a href="http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-listener-config.html">Listeners for Your Classic Load Balancer</a> in the <i>Classic Load Balancer Guide</i>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Listener {
     /// <p>The port on which the instance is listening.</p>
     pub instance_port: i64,
@@ -3334,7 +3334,7 @@ impl ListenerSerializer {
 }
 
 /// <p>The policies enabled for a listener.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListenerDescription {
     /// <p>The listener.</p>
     pub listener: Option<Listener>,
@@ -3443,7 +3443,7 @@ impl ListenersSerializer {
 }
 
 /// <p>The attributes for a load balancer.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct LoadBalancerAttributes {
     /// <p>If enabled, the load balancer captures detailed information of all requests and delivers the information to the Amazon S3 bucket that you specify.</p> <p>For more information, see <a href="http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/enable-access-logs.html">Enable Access Logs</a> in the <i>Classic Load Balancer Guide</i>.</p>
     pub access_log: Option<AccessLog>,
@@ -3574,7 +3574,7 @@ impl LoadBalancerAttributesSerializer {
 }
 
 /// <p>Information about a load balancer.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct LoadBalancerDescription {
     /// <p>The Availability Zones for the load balancer.</p>
     pub availability_zones: Option<Vec<String>>,
@@ -3837,7 +3837,7 @@ impl MaxDeserializer {
     }
 }
 /// <p>Contains the parameters for ModifyLoadBalancerAttributes.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyLoadBalancerAttributesInput {
     /// <p>The attributes for the load balancer.</p>
     pub load_balancer_attributes: LoadBalancerAttributes,
@@ -3867,7 +3867,7 @@ impl ModifyLoadBalancerAttributesInputSerializer {
 }
 
 /// <p>Contains the output of ModifyLoadBalancerAttributes.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyLoadBalancerAttributesOutput {
     /// <p>Information about the load balancer attributes.</p>
     pub load_balancer_attributes: Option<LoadBalancerAttributes>,
@@ -3938,7 +3938,7 @@ impl NameDeserializer {
     }
 }
 /// <p>The policies for a load balancer.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Policies {
     /// <p>The stickiness policies created using <a>CreateAppCookieStickinessPolicy</a>.</p>
     pub app_cookie_stickiness_policies: Option<Vec<AppCookieStickinessPolicy>>,
@@ -4005,7 +4005,7 @@ impl PoliciesDeserializer {
     }
 }
 /// <p>Information about a policy attribute.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PolicyAttribute {
     /// <p>The name of the attribute.</p>
     pub attribute_name: Option<String>,
@@ -4038,7 +4038,7 @@ impl PolicyAttributeSerializer {
 }
 
 /// <p>Information about a policy attribute.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PolicyAttributeDescription {
     /// <p>The name of the attribute.</p>
     pub attribute_name: Option<String>,
@@ -4137,7 +4137,7 @@ impl PolicyAttributeDescriptionsDeserializer {
     }
 }
 /// <p>Information about a policy attribute type.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PolicyAttributeTypeDescription {
     /// <p>The name of the attribute.</p>
     pub attribute_name: Option<String>,
@@ -4274,7 +4274,7 @@ impl PolicyAttributesSerializer {
 }
 
 /// <p>Information about a policy.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PolicyDescription {
     /// <p>The policy attributes.</p>
     pub policy_attribute_descriptions: Option<Vec<PolicyAttributeDescription>>,
@@ -4448,7 +4448,7 @@ impl PolicyNamesSerializer {
 }
 
 /// <p>Information about a policy type.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PolicyTypeDescription {
     /// <p>A description of the policy type.</p>
     pub description: Option<String>,
@@ -4622,7 +4622,7 @@ impl ReasonCodeDeserializer {
     }
 }
 /// <p>Contains the parameters for RegisterInstancesWithLoadBalancer.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RegisterEndPointsInput {
     /// <p>The IDs of the instances.</p>
     pub instances: Vec<Instance>,
@@ -4652,7 +4652,7 @@ impl RegisterEndPointsInputSerializer {
 }
 
 /// <p>Contains the output of RegisterInstancesWithLoadBalancer.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RegisterEndPointsOutput {
     /// <p>The updated list of instances for the load balancer.</p>
     pub instances: Option<Vec<Instance>>,
@@ -4699,7 +4699,7 @@ impl RegisterEndPointsOutputDeserializer {
     }
 }
 /// <p>Contains the parameters for DisableAvailabilityZonesForLoadBalancer.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RemoveAvailabilityZonesInput {
     /// <p>The Availability Zones.</p>
     pub availability_zones: Vec<String>,
@@ -4729,7 +4729,7 @@ impl RemoveAvailabilityZonesInputSerializer {
 }
 
 /// <p>Contains the output for DisableAvailabilityZonesForLoadBalancer.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RemoveAvailabilityZonesOutput {
     /// <p>The remaining Availability Zones for the load balancer.</p>
     pub availability_zones: Option<Vec<String>>,
@@ -4777,7 +4777,7 @@ impl RemoveAvailabilityZonesOutputDeserializer {
     }
 }
 /// <p>Contains the parameters for RemoveTags.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RemoveTagsInput {
     /// <p>The name of the load balancer. You can specify a maximum of one load balancer name.</p>
     pub load_balancer_names: Vec<String>,
@@ -4804,7 +4804,7 @@ impl RemoveTagsInputSerializer {
 }
 
 /// <p>Contains the output of RemoveTags.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RemoveTagsOutput {}
 
 struct RemoveTagsOutputDeserializer;
@@ -4948,7 +4948,7 @@ impl SecurityGroupsSerializer {
 }
 
 /// <p>Contains the parameters for SetLoadBalancerListenerSSLCertificate.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SetLoadBalancerListenerSSLCertificateInput {
     /// <p>The name of the load balancer.</p>
     pub load_balancer_name: String,
@@ -4987,7 +4987,7 @@ impl SetLoadBalancerListenerSSLCertificateInputSerializer {
 }
 
 /// <p>Contains the output of SetLoadBalancerListenerSSLCertificate.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SetLoadBalancerListenerSSLCertificateOutput {}
 
 struct SetLoadBalancerListenerSSLCertificateOutputDeserializer;
@@ -5007,7 +5007,7 @@ impl SetLoadBalancerListenerSSLCertificateOutputDeserializer {
     }
 }
 /// <p>Contains the parameters for SetLoadBalancerPoliciesForBackendServer.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SetLoadBalancerPoliciesForBackendServerInput {
     /// <p>The port number associated with the EC2 instance.</p>
     pub instance_port: i64,
@@ -5047,7 +5047,7 @@ impl SetLoadBalancerPoliciesForBackendServerInputSerializer {
 }
 
 /// <p>Contains the output of SetLoadBalancerPoliciesForBackendServer.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SetLoadBalancerPoliciesForBackendServerOutput {}
 
 struct SetLoadBalancerPoliciesForBackendServerOutputDeserializer;
@@ -5067,7 +5067,7 @@ impl SetLoadBalancerPoliciesForBackendServerOutputDeserializer {
     }
 }
 /// <p>Contains the parameters for SetLoadBalancePoliciesOfListener.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SetLoadBalancerPoliciesOfListenerInput {
     /// <p>The name of the load balancer.</p>
     pub load_balancer_name: String,
@@ -5103,7 +5103,7 @@ impl SetLoadBalancerPoliciesOfListenerInputSerializer {
 }
 
 /// <p>Contains the output of SetLoadBalancePoliciesOfListener.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SetLoadBalancerPoliciesOfListenerOutput {}
 
 struct SetLoadBalancerPoliciesOfListenerOutputDeserializer;
@@ -5123,7 +5123,7 @@ impl SetLoadBalancerPoliciesOfListenerOutputDeserializer {
     }
 }
 /// <p>Information about a source security group.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SourceSecurityGroup {
     /// <p>The name of the security group.</p>
     pub group_name: Option<String>,
@@ -5259,7 +5259,7 @@ impl SubnetsSerializer {
 }
 
 /// <p>Information about a tag.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Tag {
     /// <p>The key of the tag.</p>
     pub key: String,
@@ -5333,7 +5333,7 @@ impl TagSerializer {
 }
 
 /// <p>The tags associated with a load balancer.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct TagDescription {
     /// <p>The name of the load balancer.</p>
     pub load_balancer_name: Option<String>,
@@ -5454,7 +5454,7 @@ impl TagKeyListSerializer {
 }
 
 /// <p>The key of a tag.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct TagKeyOnly {
     /// <p>The name of the key.</p>
     pub key: Option<String>,

--- a/rusoto/services/elb/src/generated.rs
+++ b/rusoto/services/elb/src/generated.rs
@@ -29,8 +29,9 @@ use hyper::StatusCode;
 use rusoto_core::param::{Params, ServiceParams};
 use rusoto_core::signature::SignedRequest;
 use rusoto_core::xmlerror::*;
-use rusoto_core::xmlutil::{characters, end_element, find_start_element, peek_at_name, skip_tree,
-                           start_element};
+use rusoto_core::xmlutil::{
+    characters, end_element, find_start_element, peek_at_name, skip_tree, start_element,
+};
 use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
 use std::str::FromStr;
 use xml::reader::ParserConfig;

--- a/rusoto/services/elbv2/src/generated.rs
+++ b/rusoto/services/elbv2/src/generated.rs
@@ -44,7 +44,7 @@ enum DeserializerNext {
     Element(String),
 }
 /// <p>Information about an action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Action {
     /// <p>The Amazon Resource Name (ARN) of the target group.</p>
     pub target_group_arn: String,
@@ -184,7 +184,7 @@ impl ActionsSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AddListenerCertificatesInput {
     /// <p>The certificate to add. You can specify one certificate per call.</p>
     pub certificates: Vec<Certificate>,
@@ -213,7 +213,7 @@ impl AddListenerCertificatesInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AddListenerCertificatesOutput {
     /// <p>Information about the certificates.</p>
     pub certificates: Option<Vec<Certificate>>,
@@ -261,7 +261,7 @@ impl AddListenerCertificatesOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AddTagsInput {
     /// <p>The Amazon Resource Name (ARN) of the resource.</p>
     pub resource_arns: Vec<String>,
@@ -287,7 +287,7 @@ impl AddTagsInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AddTagsOutput {}
 
 struct AddTagsOutputDeserializer;
@@ -321,7 +321,7 @@ impl AllocationIdDeserializer {
     }
 }
 /// <p>Information about an Availability Zone.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AvailabilityZone {
     /// <p>[Network Load Balancers] The static IP address.</p>
     pub load_balancer_addresses: Option<Vec<LoadBalancerAddress>>,
@@ -439,7 +439,7 @@ impl CanonicalHostedZoneIdDeserializer {
     }
 }
 /// <p>Information about an SSL server certificate.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Certificate {
     /// <p>The Amazon Resource Name (ARN) of the certificate.</p>
     pub certificate_arn: Option<String>,
@@ -585,7 +585,7 @@ impl CertificateListSerializer {
 }
 
 /// <p>Information about a cipher used in a policy.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Cipher {
     /// <p>The name of the cipher.</p>
     pub name: Option<String>,
@@ -719,7 +719,7 @@ impl ConditionFieldNameDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateListenerInput {
     /// <p>[HTTPS listeners] The SSL server certificate. You must provide exactly one certificate.</p>
     pub certificates: Option<Vec<Certificate>>,
@@ -777,7 +777,7 @@ impl CreateListenerInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateListenerOutput {
     /// <p>Information about the listener.</p>
     pub listeners: Option<Vec<Listener>>,
@@ -823,7 +823,7 @@ impl CreateListenerOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateLoadBalancerInput {
     /// <p>[Application Load Balancers] The type of IP addresses used by the subnets for your load balancer. The possible values are <code>ipv4</code> (for IPv4 addresses) and <code>dualstack</code> (for IPv4 and IPv6 addresses). Internal load balancers must use <code>ipv4</code>.</p>
     pub ip_address_type: Option<String>,
@@ -897,7 +897,7 @@ impl CreateLoadBalancerInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateLoadBalancerOutput {
     /// <p>Information about the load balancer.</p>
     pub load_balancers: Option<Vec<LoadBalancer>>,
@@ -945,7 +945,7 @@ impl CreateLoadBalancerOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateRuleInput {
     /// <p>An action. Each action has the type <code>forward</code> and specifies a target group.</p>
     pub actions: Vec<Action>,
@@ -983,7 +983,7 @@ impl CreateRuleInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateRuleOutput {
     /// <p>Information about the rule.</p>
     pub rules: Option<Vec<Rule>>,
@@ -1028,7 +1028,7 @@ impl CreateRuleOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateTargetGroupInput {
     /// <p>The approximate amount of time, in seconds, between health checks of an individual target. For Application Load Balancers, the range is 5 to 300 seconds. For Network Load Balancers, the supported values are 10 or 30 seconds. The default is 30 seconds.</p>
     pub health_check_interval_seconds: Option<i64>,
@@ -1137,7 +1137,7 @@ impl CreateTargetGroupInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateTargetGroupOutput {
     /// <p>Information about the target group.</p>
     pub target_groups: Option<Vec<TargetGroup>>,
@@ -1227,7 +1227,7 @@ impl DefaultDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteListenerInput {
     /// <p>The Amazon Resource Name (ARN) of the listener.</p>
     pub listener_arn: String,
@@ -1249,7 +1249,7 @@ impl DeleteListenerInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteListenerOutput {}
 
 struct DeleteListenerOutputDeserializer;
@@ -1268,7 +1268,7 @@ impl DeleteListenerOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteLoadBalancerInput {
     /// <p>The Amazon Resource Name (ARN) of the load balancer.</p>
     pub load_balancer_arn: String,
@@ -1290,7 +1290,7 @@ impl DeleteLoadBalancerInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteLoadBalancerOutput {}
 
 struct DeleteLoadBalancerOutputDeserializer;
@@ -1309,7 +1309,7 @@ impl DeleteLoadBalancerOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteRuleInput {
     /// <p>The Amazon Resource Name (ARN) of the rule.</p>
     pub rule_arn: String,
@@ -1331,7 +1331,7 @@ impl DeleteRuleInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteRuleOutput {}
 
 struct DeleteRuleOutputDeserializer;
@@ -1350,7 +1350,7 @@ impl DeleteRuleOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteTargetGroupInput {
     /// <p>The Amazon Resource Name (ARN) of the target group.</p>
     pub target_group_arn: String,
@@ -1372,7 +1372,7 @@ impl DeleteTargetGroupInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteTargetGroupOutput {}
 
 struct DeleteTargetGroupOutputDeserializer;
@@ -1391,7 +1391,7 @@ impl DeleteTargetGroupOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeregisterTargetsInput {
     /// <p>The Amazon Resource Name (ARN) of the target group.</p>
     pub target_group_arn: String,
@@ -1420,7 +1420,7 @@ impl DeregisterTargetsInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeregisterTargetsOutput {}
 
 struct DeregisterTargetsOutputDeserializer;
@@ -1439,7 +1439,7 @@ impl DeregisterTargetsOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeAccountLimitsInput {
     /// <p>The marker for the next set of results. (You received this marker from a previous call.)</p>
     pub marker: Option<String>,
@@ -1471,7 +1471,7 @@ impl DescribeAccountLimitsInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeAccountLimitsOutput {
     /// <p>Information about the limits.</p>
     pub limits: Option<Vec<Limit>>,
@@ -1522,7 +1522,7 @@ impl DescribeAccountLimitsOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeListenerCertificatesInput {
     /// <p>The Amazon Resource Names (ARN) of the listener.</p>
     pub listener_arn: String,
@@ -1560,7 +1560,7 @@ impl DescribeListenerCertificatesInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeListenerCertificatesOutput {
     /// <p>Information about the certificates.</p>
     pub certificates: Option<Vec<Certificate>>,
@@ -1614,7 +1614,7 @@ impl DescribeListenerCertificatesOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeListenersInput {
     /// <p>The Amazon Resource Names (ARN) of the listeners.</p>
     pub listener_arns: Option<Vec<String>>,
@@ -1663,7 +1663,7 @@ impl DescribeListenersInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeListenersOutput {
     /// <p>Information about the listeners.</p>
     pub listeners: Option<Vec<Listener>>,
@@ -1715,7 +1715,7 @@ impl DescribeListenersOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeLoadBalancerAttributesInput {
     /// <p>The Amazon Resource Name (ARN) of the load balancer.</p>
     pub load_balancer_arn: String,
@@ -1737,7 +1737,7 @@ impl DescribeLoadBalancerAttributesInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeLoadBalancerAttributesOutput {
     /// <p>Information about the load balancer attributes.</p>
     pub attributes: Option<Vec<LoadBalancerAttribute>>,
@@ -1784,7 +1784,7 @@ impl DescribeLoadBalancerAttributesOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeLoadBalancersInput {
     /// <p>The Amazon Resource Names (ARN) of the load balancers. You can specify up to 20 load balancers in a single call.</p>
     pub load_balancer_arns: Option<Vec<String>>,
@@ -1834,7 +1834,7 @@ impl DescribeLoadBalancersInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeLoadBalancersOutput {
     /// <p>Information about the load balancers.</p>
     pub load_balancers: Option<Vec<LoadBalancer>>,
@@ -1888,7 +1888,7 @@ impl DescribeLoadBalancersOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeRulesInput {
     /// <p>The Amazon Resource Name (ARN) of the listener.</p>
     pub listener_arn: Option<String>,
@@ -1937,7 +1937,7 @@ impl DescribeRulesInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeRulesOutput {
     /// <p>The marker to use when requesting the next set of results. If there are no additional results, the string is empty.</p>
     pub next_marker: Option<String>,
@@ -1988,7 +1988,7 @@ impl DescribeRulesOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeSSLPoliciesInput {
     /// <p>The marker for the next set of results. (You received this marker from a previous call.)</p>
     pub marker: Option<String>,
@@ -2029,7 +2029,7 @@ impl DescribeSSLPoliciesInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeSSLPoliciesOutput {
     /// <p>The marker to use when requesting the next set of results. If there are no additional results, the string is empty.</p>
     pub next_marker: Option<String>,
@@ -2083,7 +2083,7 @@ impl DescribeSSLPoliciesOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeTagsInput {
     /// <p>The Amazon Resource Names (ARN) of the resources.</p>
     pub resource_arns: Vec<String>,
@@ -2106,7 +2106,7 @@ impl DescribeTagsInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeTagsOutput {
     /// <p>Information about the tags.</p>
     pub tag_descriptions: Option<Vec<TagDescription>>,
@@ -2153,7 +2153,7 @@ impl DescribeTagsOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeTargetGroupAttributesInput {
     /// <p>The Amazon Resource Name (ARN) of the target group.</p>
     pub target_group_arn: String,
@@ -2175,7 +2175,7 @@ impl DescribeTargetGroupAttributesInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeTargetGroupAttributesOutput {
     /// <p>Information about the target group attributes</p>
     pub attributes: Option<Vec<TargetGroupAttribute>>,
@@ -2222,7 +2222,7 @@ impl DescribeTargetGroupAttributesOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeTargetGroupsInput {
     /// <p>The Amazon Resource Name (ARN) of the load balancer.</p>
     pub load_balancer_arn: Option<String>,
@@ -2280,7 +2280,7 @@ impl DescribeTargetGroupsInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeTargetGroupsOutput {
     /// <p>The marker to use when requesting the next set of results. If there are no additional results, the string is empty.</p>
     pub next_marker: Option<String>,
@@ -2334,7 +2334,7 @@ impl DescribeTargetGroupsOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeTargetHealthInput {
     /// <p>The Amazon Resource Name (ARN) of the target group.</p>
     pub target_group_arn: String,
@@ -2365,7 +2365,7 @@ impl DescribeTargetHealthInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeTargetHealthOutput {
     /// <p>Information about the health of the targets.</p>
     pub target_health_descriptions: Option<Vec<TargetHealthDescription>>,
@@ -2541,7 +2541,7 @@ impl IsDefaultDeserializer {
     }
 }
 /// <p>Information about an Elastic Load Balancing resource limit for your AWS account.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Limit {
     /// <p>The maximum value of the limit.</p>
     pub max: Option<String>,
@@ -2684,7 +2684,7 @@ impl ListOfStringSerializer {
 }
 
 /// <p>Information about a listener.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Listener {
     /// <p>The SSL server certificate. You must provide a certificate if the protocol is HTTPS.</p>
     pub certificates: Option<Vec<Certificate>>,
@@ -2842,7 +2842,7 @@ impl ListenersDeserializer {
     }
 }
 /// <p>Information about a load balancer.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct LoadBalancer {
     /// <p>The Availability Zones for the load balancer.</p>
     pub availability_zones: Option<Vec<AvailabilityZone>>,
@@ -2969,7 +2969,7 @@ impl LoadBalancerDeserializer {
     }
 }
 /// <p>Information about a static IP address for a load balancer.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct LoadBalancerAddress {
     /// <p>[Network Load Balancers] The allocation ID of the Elastic IP address.</p>
     pub allocation_id: Option<String>,
@@ -3134,7 +3134,7 @@ impl LoadBalancerArnsSerializer {
 }
 
 /// <p>Information about a load balancer attribute.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct LoadBalancerAttribute {
     /// <p><p>The name of the attribute.</p> <ul> <li> <p> <code>access<em>logs.s3.enabled</code> - [Application Load Balancers] Indicates whether access logs stored in Amazon S3 are enabled. The value is <code>true</code> or <code>false</code>.</p> </li> <li> <p> <code>access</em>logs.s3.bucket</code> - [Application Load Balancers] The name of the S3 bucket for the access logs. This attribute is required if access logs in Amazon S3 are enabled. The bucket must exist in the same region as the load balancer and have a bucket policy that grants Elastic Load Balancing permission to write to the bucket.</p> </li> <li> <p> <code>access<em>logs.s3.prefix</code> - [Application Load Balancers] The prefix for the location in the S3 bucket. If you don&#39;t specify a prefix, the access logs are stored in the root of the bucket.</p> </li> <li> <p> <code>deletion</em>protection.enabled</code> - Indicates whether deletion protection is enabled. The value is <code>true</code> or <code>false</code>.</p> </li> <li> <p> <code>idle<em>timeout.timeout</em>seconds</code> - [Application Load Balancers] The idle timeout value, in seconds. The valid range is 1-4000. The default is 60 seconds.</p> </li> <li> <p> <code>load<em>balancing.cross</em>zone.enabled</code> - [Network Load Balancers] Indicates whether cross-zone load balancing is enabled. The value is <code>true</code> or <code>false</code>. The default is <code>false</code>.</p> </li> <li> <p> <code>routing.http2.enabled</code> - [Application Load Balancers] Indicates whether HTTP/2 is enabled. The value is <code>true</code> or <code>false</code>. The default is <code>true</code>.</p> </li> </ul></p>
     pub key: Option<String>,
@@ -3336,7 +3336,7 @@ impl LoadBalancerSchemeEnumDeserializer {
     }
 }
 /// <p>Information about the state of the load balancer.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct LoadBalancerState {
     /// <p>The state code. The initial state of the load balancer is <code>provisioning</code>. After the load balancer is fully set up and ready to route traffic, its state is <code>active</code>. If the load balancer could not be set up, its state is <code>failed</code>.</p>
     pub code: Option<String>,
@@ -3472,7 +3472,7 @@ impl MarkerDeserializer {
     }
 }
 /// <p>Information to use when checking for a successful response from a target.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Matcher {
     /// <p>The HTTP codes.</p> <p>For Application Load Balancers, you can specify values between 200 and 499, and the default value is 200. You can specify multiple values (for example, "200,202") or a range of values (for example, "200-299").</p> <p>For Network Load Balancers, this is 200 to 399.</p>
     pub http_code: String,
@@ -3548,7 +3548,7 @@ impl MaxDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyListenerInput {
     /// <p>The default SSL server certificate.</p>
     pub certificates: Option<Vec<Certificate>>,
@@ -3612,7 +3612,7 @@ impl ModifyListenerInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyListenerOutput {
     /// <p>Information about the modified listeners.</p>
     pub listeners: Option<Vec<Listener>>,
@@ -3658,7 +3658,7 @@ impl ModifyListenerOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyLoadBalancerAttributesInput {
     /// <p>The load balancer attributes.</p>
     pub attributes: Vec<LoadBalancerAttribute>,
@@ -3687,7 +3687,7 @@ impl ModifyLoadBalancerAttributesInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyLoadBalancerAttributesOutput {
     /// <p>Information about the load balancer attributes.</p>
     pub attributes: Option<Vec<LoadBalancerAttribute>>,
@@ -3734,7 +3734,7 @@ impl ModifyLoadBalancerAttributesOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyRuleInput {
     /// <p>The actions. The target group must use the HTTP or HTTPS protocol.</p>
     pub actions: Option<Vec<Action>>,
@@ -3770,7 +3770,7 @@ impl ModifyRuleInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyRuleOutput {
     /// <p>Information about the rule.</p>
     pub rules: Option<Vec<Rule>>,
@@ -3815,7 +3815,7 @@ impl ModifyRuleOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyTargetGroupAttributesInput {
     /// <p>The attributes.</p>
     pub attributes: Vec<TargetGroupAttribute>,
@@ -3844,7 +3844,7 @@ impl ModifyTargetGroupAttributesInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyTargetGroupAttributesOutput {
     /// <p>Information about the attributes.</p>
     pub attributes: Option<Vec<TargetGroupAttribute>>,
@@ -3891,7 +3891,7 @@ impl ModifyTargetGroupAttributesOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyTargetGroupInput {
     /// <p>The approximate amount of time, in seconds, between health checks of an individual target. For Application Load Balancers, the range is 5 to 300 seconds. For Network Load Balancers, the supported values are 10 or 30 seconds.</p>
     pub health_check_interval_seconds: Option<i64>,
@@ -3974,7 +3974,7 @@ impl ModifyTargetGroupInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyTargetGroupOutput {
     /// <p>Information about the target group.</p>
     pub target_groups: Option<Vec<TargetGroup>>,
@@ -4078,7 +4078,7 @@ impl ProtocolEnumDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RegisterTargetsInput {
     /// <p>The Amazon Resource Name (ARN) of the target group.</p>
     pub target_group_arn: String,
@@ -4107,7 +4107,7 @@ impl RegisterTargetsInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RegisterTargetsOutput {}
 
 struct RegisterTargetsOutputDeserializer;
@@ -4126,7 +4126,7 @@ impl RegisterTargetsOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RemoveListenerCertificatesInput {
     /// <p>The certificate to remove. You can specify one certificate per call.</p>
     pub certificates: Vec<Certificate>,
@@ -4155,7 +4155,7 @@ impl RemoveListenerCertificatesInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RemoveListenerCertificatesOutput {}
 
 struct RemoveListenerCertificatesOutputDeserializer;
@@ -4174,7 +4174,7 @@ impl RemoveListenerCertificatesOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RemoveTagsInput {
     /// <p>The Amazon Resource Name (ARN) of the resource.</p>
     pub resource_arns: Vec<String>,
@@ -4200,7 +4200,7 @@ impl RemoveTagsInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RemoveTagsOutput {}
 
 struct RemoveTagsOutputDeserializer;
@@ -4246,7 +4246,7 @@ impl ResourceArnsSerializer {
 }
 
 /// <p>Information about a rule.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Rule {
     /// <p>The actions.</p>
     pub actions: Option<Vec<Action>>,
@@ -4345,7 +4345,7 @@ impl RuleArnsSerializer {
 }
 
 /// <p>Information about a condition for a rule.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RuleCondition {
     /// <p>The name of the field. The possible values are <code>host-header</code> and <code>path-pattern</code>.</p>
     pub field: Option<String>,
@@ -4490,7 +4490,7 @@ impl RulePriorityListSerializer {
 }
 
 /// <p>Information about the priorities for the rules for a listener.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RulePriorityPair {
     /// <p>The rule priority.</p>
     pub priority: Option<i64>,
@@ -4630,7 +4630,7 @@ impl SecurityGroupsSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SetIpAddressTypeInput {
     /// <p>The IP address type. The possible values are <code>ipv4</code> (for IPv4 addresses) and <code>dualstack</code> (for IPv4 and IPv6 addresses). Internal load balancers must use <code>ipv4</code>.</p>
     pub ip_address_type: String,
@@ -4658,7 +4658,7 @@ impl SetIpAddressTypeInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SetIpAddressTypeOutput {
     /// <p>The IP address type.</p>
     pub ip_address_type: Option<String>,
@@ -4706,7 +4706,7 @@ impl SetIpAddressTypeOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SetRulePrioritiesInput {
     /// <p>The rule priorities.</p>
     pub rule_priorities: Vec<RulePriorityPair>,
@@ -4729,7 +4729,7 @@ impl SetRulePrioritiesInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SetRulePrioritiesOutput {
     /// <p>Information about the rules.</p>
     pub rules: Option<Vec<Rule>>,
@@ -4774,7 +4774,7 @@ impl SetRulePrioritiesOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SetSecurityGroupsInput {
     /// <p>The Amazon Resource Name (ARN) of the load balancer.</p>
     pub load_balancer_arn: String,
@@ -4803,7 +4803,7 @@ impl SetSecurityGroupsInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SetSecurityGroupsOutput {
     /// <p>The IDs of the security groups associated with the load balancer.</p>
     pub security_group_ids: Option<Vec<String>>,
@@ -4850,7 +4850,7 @@ impl SetSecurityGroupsOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SetSubnetsInput {
     /// <p>The Amazon Resource Name (ARN) of the load balancer.</p>
     pub load_balancer_arn: String,
@@ -4884,7 +4884,7 @@ impl SetSubnetsInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SetSubnetsOutput {
     /// <p>Information about the subnet and Availability Zone.</p>
     pub availability_zones: Option<Vec<AvailabilityZone>>,
@@ -4972,7 +4972,7 @@ impl SslPoliciesDeserializer {
     }
 }
 /// <p>Information about a policy used for SSL negotiation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SslPolicy {
     /// <p>The ciphers.</p>
     pub ciphers: Option<Vec<Cipher>>,
@@ -5169,7 +5169,7 @@ impl SubnetIdDeserializer {
     }
 }
 /// <p>Information about a subnet mapping.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SubnetMapping {
     /// <p>[Network Load Balancers] The allocation ID of the Elastic IP address.</p>
     pub allocation_id: Option<String>,
@@ -5224,7 +5224,7 @@ impl SubnetsSerializer {
 }
 
 /// <p>Information about a tag.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Tag {
     /// <p>The key of the tag.</p>
     pub key: String,
@@ -5298,7 +5298,7 @@ impl TagSerializer {
 }
 
 /// <p>The tags associated with a resource.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct TagDescription {
     /// <p>The Amazon Resource Name (ARN) of the resource.</p>
     pub resource_arn: Option<String>,
@@ -5486,7 +5486,7 @@ impl TagValueDeserializer {
     }
 }
 /// <p>Information about a target.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct TargetDescription {
     /// <p>An Availability Zone or <code>all</code>. This determines whether the target receives traffic from the load balancer nodes in the specified Availability Zone or from all enabled Availability Zones for the load balancer.</p> <p>This parameter is not supported if the target type of the target group is <code>instance</code>. If the IP address is in a subnet of the VPC for the target group, the Availability Zone is automatically detected and this parameter is optional. If the IP address is outside the VPC, this parameter is required.</p> <p>With an Application Load Balancer, if the IP address is outside the VPC for the target group, the only supported value is <code>all</code>.</p>
     pub availability_zone: Option<String>,
@@ -5582,7 +5582,7 @@ impl TargetDescriptionsSerializer {
 }
 
 /// <p>Information about a target group.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct TargetGroup {
     /// <p>The approximate amount of time, in seconds, between health checks of an individual target.</p>
     pub health_check_interval_seconds: Option<i64>,
@@ -5760,7 +5760,7 @@ impl TargetGroupArnsSerializer {
 }
 
 /// <p>Information about a target group attribute.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct TargetGroupAttribute {
     /// <p><p>The name of the attribute.</p> <ul> <li> <p> <code>deregistration<em>delay.timeout</em>seconds</code> - The amount time for Elastic Load Balancing to wait before changing the state of a deregistering target from <code>draining</code> to <code>unused</code>. The range is 0-3600 seconds. The default value is 300 seconds.</p> </li> <li> <p> <code>proxy<em>protocol</em>v2.enabled</code> - [Network Load Balancers] Indicates whether Proxy Protocol version 2 is enabled.</p> </li> <li> <p> <code>stickiness.enabled</code> - [Application Load Balancers] Indicates whether sticky sessions are enabled. The value is <code>true</code> or <code>false</code>.</p> </li> <li> <p> <code>stickiness.type</code> - [Application Load Balancers] The type of sticky sessions. The possible value is <code>lb<em>cookie</code>.</p> </li> <li> <p> <code>stickiness.lb</em>cookie.duration_seconds</code> - [Application Load Balancers] The time period, in seconds, during which requests from a client should be routed to the same target. After this time period expires, the load balancer-generated cookie is considered stale. The range is 1 second to 1 week (604800 seconds). The default value is 1 day (86400 seconds).</p> </li> </ul></p>
     pub key: Option<String>,
@@ -5988,7 +5988,7 @@ impl TargetGroupsDeserializer {
     }
 }
 /// <p>Information about the current health of a target.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct TargetHealth {
     /// <p>A description of the target health that provides additional details. If the state is <code>healthy</code>, a description is not provided.</p>
     pub description: Option<String>,
@@ -6051,7 +6051,7 @@ impl TargetHealthDeserializer {
     }
 }
 /// <p>Information about the health of a target.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct TargetHealthDescription {
     /// <p>The port to use to connect with the target.</p>
     pub health_check_port: Option<String>,

--- a/rusoto/services/elbv2/src/generated.rs
+++ b/rusoto/services/elbv2/src/generated.rs
@@ -29,8 +29,9 @@ use hyper::StatusCode;
 use rusoto_core::param::{Params, ServiceParams};
 use rusoto_core::signature::SignedRequest;
 use rusoto_core::xmlerror::*;
-use rusoto_core::xmlutil::{characters, end_element, find_start_element, peek_at_name, skip_tree,
-                           start_element};
+use rusoto_core::xmlutil::{
+    characters, end_element, find_start_element, peek_at_name, skip_tree, start_element,
+};
 use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
 use std::str::FromStr;
 use xml::reader::ParserConfig;

--- a/rusoto/services/emr/src/generated.rs
+++ b/rusoto/services/emr/src/generated.rs
@@ -30,7 +30,7 @@ use rusoto_core::signature::SignedRequest;
 use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AddInstanceFleetInput {
     /// <p>The unique identifier of the cluster.</p>
     #[serde(rename = "ClusterId")]
@@ -40,7 +40,7 @@ pub struct AddInstanceFleetInput {
     pub instance_fleet: InstanceFleetConfig,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AddInstanceFleetOutput {
     /// <p>The unique identifier of the cluster.</p>
     #[serde(rename = "ClusterId")]
@@ -53,7 +53,7 @@ pub struct AddInstanceFleetOutput {
 }
 
 /// <p>Input to an AddInstanceGroups call.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AddInstanceGroupsInput {
     /// <p>Instance groups to add.</p>
     #[serde(rename = "InstanceGroups")]
@@ -64,7 +64,7 @@ pub struct AddInstanceGroupsInput {
 }
 
 /// <p>Output from an AddInstanceGroups call.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AddInstanceGroupsOutput {
     /// <p>Instance group IDs of the newly created instance groups.</p>
     #[serde(rename = "InstanceGroupIds")]
@@ -77,7 +77,7 @@ pub struct AddInstanceGroupsOutput {
 }
 
 /// <p> The input argument to the <a>AddJobFlowSteps</a> operation. </p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AddJobFlowStepsInput {
     /// <p>A string that uniquely identifies the job flow. This identifier is returned by <a>RunJobFlow</a> and can also be obtained from <a>ListClusters</a>. </p>
     #[serde(rename = "JobFlowId")]
@@ -88,7 +88,7 @@ pub struct AddJobFlowStepsInput {
 }
 
 /// <p> The output for the <a>AddJobFlowSteps</a> operation. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AddJobFlowStepsOutput {
     /// <p>The identifiers of the list of steps added to the job flow.</p>
     #[serde(rename = "StepIds")]
@@ -97,7 +97,7 @@ pub struct AddJobFlowStepsOutput {
 }
 
 /// <p>This input identifies a cluster and a list of tags to attach.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AddTagsInput {
     /// <p>The Amazon EMR resource identifier to which tags will be added. This value must be a cluster identifier.</p>
     #[serde(rename = "ResourceId")]
@@ -108,11 +108,11 @@ pub struct AddTagsInput {
 }
 
 /// <p>This output indicates the result of adding tags to a resource.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AddTagsOutput {}
 
 /// <p><p>An application is any Amazon or third-party software that you can add to the cluster. This structure contains a list of strings that indicates the software to use with the cluster and accepts a user argument list. Amazon EMR accepts and forwards the argument list to the corresponding installation script as bootstrap action argument. For more information, see <a href="http://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-mapr.html">Using the MapR Distribution for Hadoop</a>. Currently supported values are:</p> <ul> <li> <p>&quot;mapr-m3&quot; - launch the cluster using MapR M3 Edition.</p> </li> <li> <p>&quot;mapr-m5&quot; - launch the cluster using MapR M5 Edition.</p> </li> <li> <p>&quot;mapr&quot; with the user arguments specifying &quot;--edition,m3&quot; or &quot;--edition,m5&quot; - launch the cluster using MapR M3 or M5 Edition, respectively.</p> </li> </ul> <note> <p>In Amazon EMR releases 4.x and later, the only accepted parameter is the application name. To pass arguments to applications, you supply a configuration for each application.</p> </note></p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Application {
     /// <p>This option is for advanced users only. This is meta information about third-party applications that third-party vendors use for testing purposes.</p>
     #[serde(rename = "AdditionalInfo")]
@@ -133,7 +133,7 @@ pub struct Application {
 }
 
 /// <p>An automatic scaling policy for a core instance group or task instance group in an Amazon EMR cluster. An automatic scaling policy defines how an instance group dynamically adds and terminates EC2 instances in response to the value of a CloudWatch metric. See <a>PutAutoScalingPolicy</a>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AutoScalingPolicy {
     /// <p>The upper and lower EC2 instance limits for an automatic scaling policy. Automatic scaling activity will not cause an instance group to grow above or below these limits.</p>
     #[serde(rename = "Constraints")]
@@ -144,7 +144,7 @@ pub struct AutoScalingPolicy {
 }
 
 /// <p>An automatic scaling policy for a core instance group or task instance group in an Amazon EMR cluster. The automatic scaling policy defines how an instance group dynamically adds and terminates EC2 instances in response to the value of a CloudWatch metric. See <a>PutAutoScalingPolicy</a>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AutoScalingPolicyDescription {
     /// <p>The upper and lower EC2 instance limits for an automatic scaling policy. Automatic scaling activity will not cause an instance group to grow above or below these limits.</p>
     #[serde(rename = "Constraints")]
@@ -161,7 +161,7 @@ pub struct AutoScalingPolicyDescription {
 }
 
 /// <p>The reason for an <a>AutoScalingPolicyStatus</a> change.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AutoScalingPolicyStateChangeReason {
     /// <p>The code indicating the reason for the change in status.<code>USER_REQUEST</code> indicates that the scaling policy status was changed by a user. <code>PROVISION_FAILURE</code> indicates that the status change was because the policy failed to provision. <code>CLEANUP_FAILURE</code> indicates an error.</p>
     #[serde(rename = "Code")]
@@ -174,7 +174,7 @@ pub struct AutoScalingPolicyStateChangeReason {
 }
 
 /// <p>The status of an automatic scaling policy. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AutoScalingPolicyStatus {
     /// <p>Indicates the status of the automatic scaling policy.</p>
     #[serde(rename = "State")]
@@ -187,7 +187,7 @@ pub struct AutoScalingPolicyStatus {
 }
 
 /// <p>Configuration of a bootstrap action.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct BootstrapActionConfig {
     /// <p>The name of the bootstrap action.</p>
     #[serde(rename = "Name")]
@@ -198,7 +198,7 @@ pub struct BootstrapActionConfig {
 }
 
 /// <p>Reports the configuration of a bootstrap action in a cluster (job flow).</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BootstrapActionDetail {
     /// <p>A description of the bootstrap action.</p>
     #[serde(rename = "BootstrapActionConfig")]
@@ -207,7 +207,7 @@ pub struct BootstrapActionDetail {
 }
 
 /// <p>Specification of the status of a CancelSteps request. Available only in Amazon EMR version 4.8.0 and later, excluding version 5.0.0.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CancelStepsInfo {
     /// <p>The reason for the failure if the CancelSteps request fails.</p>
     #[serde(rename = "Reason")]
@@ -224,7 +224,7 @@ pub struct CancelStepsInfo {
 }
 
 /// <p>The input argument to the <a>CancelSteps</a> operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CancelStepsInput {
     /// <p>The <code>ClusterID</code> for which specified steps will be canceled. Use <a>RunJobFlow</a> and <a>ListClusters</a> to get ClusterIDs. </p>
     #[serde(rename = "ClusterId")]
@@ -237,7 +237,7 @@ pub struct CancelStepsInput {
 }
 
 /// <p> The output for the <a>CancelSteps</a> operation. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CancelStepsOutput {
     /// <p>A list of <a>CancelStepsInfo</a>, which shows the status of specified cancel requests for each <code>StepID</code> specified.</p>
     #[serde(rename = "CancelStepsInfoList")]
@@ -246,7 +246,7 @@ pub struct CancelStepsOutput {
 }
 
 /// <p>The definition of a CloudWatch metric alarm, which determines when an automatic scaling activity is triggered. When the defined alarm conditions are satisfied, scaling activity begins.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CloudWatchAlarmDefinition {
     /// <p>Determines how the metric specified by <code>MetricName</code> is compared to the value specified by <code>Threshold</code>.</p>
     #[serde(rename = "ComparisonOperator")]
@@ -283,7 +283,7 @@ pub struct CloudWatchAlarmDefinition {
 }
 
 /// <p>The detailed description of the cluster.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Cluster {
     /// <p>The applications installed on this cluster.</p>
     #[serde(rename = "Applications")]
@@ -388,7 +388,7 @@ pub struct Cluster {
 }
 
 /// <p>The reason that the cluster changed to its current state.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ClusterStateChangeReason {
     /// <p>The programmatic code for the state change reason.</p>
     #[serde(rename = "Code")]
@@ -401,7 +401,7 @@ pub struct ClusterStateChangeReason {
 }
 
 /// <p>The detailed status of the cluster.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ClusterStatus {
     /// <p>The current state of the cluster.</p>
     #[serde(rename = "State")]
@@ -418,7 +418,7 @@ pub struct ClusterStatus {
 }
 
 /// <p>The summary description of the cluster.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ClusterSummary {
     /// <p>The unique identifier for the cluster.</p>
     #[serde(rename = "Id")]
@@ -439,7 +439,7 @@ pub struct ClusterSummary {
 }
 
 /// <p>Represents the timeline of the cluster's lifecycle.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ClusterTimeline {
     /// <p>The creation date and time of the cluster.</p>
     #[serde(rename = "CreationDateTime")]
@@ -456,7 +456,7 @@ pub struct ClusterTimeline {
 }
 
 /// <p>An entity describing an executable that runs on a cluster.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Command {
     /// <p>Arguments for Amazon EMR to pass to the command for execution.</p>
     #[serde(rename = "Args")]
@@ -473,7 +473,7 @@ pub struct Command {
 }
 
 /// <p><note> <p>Amazon EMR releases 4.x or later.</p> </note> <p>An optional configuration specification to be used when provisioning cluster instances, which can include configurations for applications and software bundled with Amazon EMR. A configuration consists of a classification, properties, and optional nested configurations. A classification refers to an application-specific configuration file. Properties are the settings you want to change in that file. For more information, see <a href="http://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-configure-apps.html">Configuring Applications</a>.</p></p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Configuration {
     /// <p>The classification within a configuration.</p>
     #[serde(rename = "Classification")]
@@ -489,7 +489,7 @@ pub struct Configuration {
     pub properties: Option<::std::collections::HashMap<String, String>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateSecurityConfigurationInput {
     /// <p>The name of the security configuration.</p>
     #[serde(rename = "Name")]
@@ -499,7 +499,7 @@ pub struct CreateSecurityConfigurationInput {
     pub security_configuration: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateSecurityConfigurationOutput {
     /// <p>The date and time the security configuration was created.</p>
     #[serde(rename = "CreationDateTime")]
@@ -509,18 +509,18 @@ pub struct CreateSecurityConfigurationOutput {
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteSecurityConfigurationInput {
     /// <p>The name of the security configuration.</p>
     #[serde(rename = "Name")]
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteSecurityConfigurationOutput {}
 
 /// <p>This input determines which cluster to describe.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeClusterInput {
     /// <p>The identifier of the cluster to describe.</p>
     #[serde(rename = "ClusterId")]
@@ -528,7 +528,7 @@ pub struct DescribeClusterInput {
 }
 
 /// <p>This output contains the description of the cluster.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeClusterOutput {
     /// <p>This output contains the details for the requested cluster.</p>
     #[serde(rename = "Cluster")]
@@ -537,7 +537,7 @@ pub struct DescribeClusterOutput {
 }
 
 /// <p> The input for the <a>DescribeJobFlows</a> operation. </p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeJobFlowsInput {
     /// <p>Return only job flows created after this date and time.</p>
     #[serde(rename = "CreatedAfter")]
@@ -558,7 +558,7 @@ pub struct DescribeJobFlowsInput {
 }
 
 /// <p> The output for the <a>DescribeJobFlows</a> operation. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeJobFlowsOutput {
     /// <p>A list of job flows matching the parameters supplied.</p>
     #[serde(rename = "JobFlows")]
@@ -566,14 +566,14 @@ pub struct DescribeJobFlowsOutput {
     pub job_flows: Option<Vec<JobFlowDetail>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeSecurityConfigurationInput {
     /// <p>The name of the security configuration.</p>
     #[serde(rename = "Name")]
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeSecurityConfigurationOutput {
     /// <p>The date and time the security configuration was created</p>
     #[serde(rename = "CreationDateTime")]
@@ -590,7 +590,7 @@ pub struct DescribeSecurityConfigurationOutput {
 }
 
 /// <p>This input determines which step to describe.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeStepInput {
     /// <p>The identifier of the cluster with steps to describe.</p>
     #[serde(rename = "ClusterId")]
@@ -601,7 +601,7 @@ pub struct DescribeStepInput {
 }
 
 /// <p>This output contains the description of the cluster step.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeStepOutput {
     /// <p>The step details for the requested step identifier.</p>
     #[serde(rename = "Step")]
@@ -610,7 +610,7 @@ pub struct DescribeStepOutput {
 }
 
 /// <p>Configuration of requested EBS block device associated with the instance group.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct EbsBlockDevice {
     /// <p>The device name that is exposed to the instance, such as /dev/sdh.</p>
     #[serde(rename = "Device")]
@@ -623,7 +623,7 @@ pub struct EbsBlockDevice {
 }
 
 /// <p>Configuration of requested EBS block device associated with the instance group with count of volumes that will be associated to every instance.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct EbsBlockDeviceConfig {
     /// <p>EBS volume specifications such as volume type, IOPS, and size (GiB) that will be requested for the EBS volume attached to an EC2 instance in the cluster.</p>
     #[serde(rename = "VolumeSpecification")]
@@ -635,7 +635,7 @@ pub struct EbsBlockDeviceConfig {
 }
 
 /// <p>The Amazon EBS configuration of a cluster instance.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct EbsConfiguration {
     /// <p>An array of Amazon EBS volume specifications attached to a cluster instance.</p>
     #[serde(rename = "EbsBlockDeviceConfigs")]
@@ -648,7 +648,7 @@ pub struct EbsConfiguration {
 }
 
 /// <p>EBS block device that's attached to an EC2 instance.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct EbsVolume {
     /// <p>The device name that is exposed to the instance, such as /dev/sdh.</p>
     #[serde(rename = "Device")]
@@ -661,7 +661,7 @@ pub struct EbsVolume {
 }
 
 /// <p>Provides information about the EC2 instances in a cluster grouped by category. For example, key name, subnet ID, IAM instance profile, and so on.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Ec2InstanceAttributes {
     /// <p>A list of additional Amazon EC2 security group IDs for the master node.</p>
     #[serde(rename = "AdditionalMasterSecurityGroups")]
@@ -710,7 +710,7 @@ pub struct Ec2InstanceAttributes {
 }
 
 /// <p>The details of the step failure. The service attempts to detect the root cause for many common failures.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct FailureDetails {
     /// <p>The path to the log file where the step failure root cause was originally recorded.</p>
     #[serde(rename = "LogFile")]
@@ -727,7 +727,7 @@ pub struct FailureDetails {
 }
 
 /// <p>A job flow step consisting of a JAR file whose main function will be executed. The main function submits a job for Hadoop to execute and waits for the job to finish or fail.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct HadoopJarStepConfig {
     /// <p>A list of command line arguments passed to the JAR file's main function when executed.</p>
     #[serde(rename = "Args")]
@@ -747,7 +747,7 @@ pub struct HadoopJarStepConfig {
 }
 
 /// <p>A cluster step consisting of a JAR file whose main function will be executed. The main function submits a job for Hadoop to execute and waits for the job to finish or fail.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct HadoopStepConfig {
     /// <p>The list of command line arguments to pass to the JAR file's main function for execution.</p>
     #[serde(rename = "Args")]
@@ -768,7 +768,7 @@ pub struct HadoopStepConfig {
 }
 
 /// <p>Represents an EC2 instance provisioned as part of cluster.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Instance {
     /// <p>The list of EBS volumes that are attached to this instance.</p>
     #[serde(rename = "EbsVolumes")]
@@ -821,7 +821,7 @@ pub struct Instance {
 }
 
 /// <p><p>Describes an instance fleet, which is a group of EC2 instances that host a particular node type (master, core, or task) in an Amazon EMR cluster. Instance fleets can consist of a mix of instance types and On-Demand and Spot instances, which are provisioned to meet a defined target capacity. </p> <note> <p>The instance fleet configuration is available only in Amazon EMR versions 4.8.0 and later, excluding 5.0.x versions.</p> </note></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct InstanceFleet {
     /// <p>The unique identifier of the instance fleet.</p>
     #[serde(rename = "Id")]
@@ -866,7 +866,7 @@ pub struct InstanceFleet {
 }
 
 /// <p><p>The configuration that defines an instance fleet.</p> <note> <p>The instance fleet configuration is available only in Amazon EMR versions 4.8.0 and later, excluding 5.0.x versions.</p> </note></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct InstanceFleetConfig {
     /// <p>The node type that the instance fleet hosts. Valid values are MASTER,CORE,and TASK.</p>
     #[serde(rename = "InstanceFleetType")]
@@ -894,7 +894,7 @@ pub struct InstanceFleetConfig {
 }
 
 /// <p><p>Configuration parameters for an instance fleet modification request.</p> <note> <p>The instance fleet configuration is available only in Amazon EMR versions 4.8.0 and later, excluding 5.0.x versions.</p> </note></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct InstanceFleetModifyConfig {
     /// <p>A unique identifier for the instance fleet.</p>
     #[serde(rename = "InstanceFleetId")]
@@ -910,7 +910,7 @@ pub struct InstanceFleetModifyConfig {
 }
 
 /// <p><p>The launch specification for Spot instances in the fleet, which determines the defined duration and provisioning timeout behavior.</p> <note> <p>The instance fleet configuration is available only in Amazon EMR versions 4.8.0 and later, excluding 5.0.x versions.</p> </note></p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct InstanceFleetProvisioningSpecifications {
     /// <p>The launch specification for Spot instances in the fleet, which determines the defined duration and provisioning timeout behavior.</p>
     #[serde(rename = "SpotSpecification")]
@@ -918,7 +918,7 @@ pub struct InstanceFleetProvisioningSpecifications {
 }
 
 /// <p><p>Provides status change reason details for the instance fleet.</p> <note> <p>The instance fleet configuration is available only in Amazon EMR versions 4.8.0 and later, excluding 5.0.x versions.</p> </note></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct InstanceFleetStateChangeReason {
     /// <p>A code corresponding to the reason the state change occurred.</p>
     #[serde(rename = "Code")]
@@ -931,7 +931,7 @@ pub struct InstanceFleetStateChangeReason {
 }
 
 /// <p><p>The status of the instance fleet.</p> <note> <p>The instance fleet configuration is available only in Amazon EMR versions 4.8.0 and later, excluding 5.0.x versions.</p> </note></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct InstanceFleetStatus {
     /// <p><p>A code representing the instance fleet status.</p> <ul> <li> <p> <code>PROVISIONING</code>—The instance fleet is provisioning EC2 resources and is not yet ready to run jobs.</p> </li> <li> <p> <code>BOOTSTRAPPING</code>—EC2 instances and other resources have been provisioned and the bootstrap actions specified for the instances are underway.</p> </li> <li> <p> <code>RUNNING</code>—EC2 instances and other resources are running. They are either executing jobs or waiting to execute jobs.</p> </li> <li> <p> <code>RESIZING</code>—A resize operation is underway. EC2 instances are either being added or removed.</p> </li> <li> <p> <code>SUSPENDED</code>—A resize operation could not complete. Existing EC2 instances are running, but instances can&#39;t be added or removed.</p> </li> <li> <p> <code>TERMINATING</code>—The instance fleet is terminating EC2 instances.</p> </li> <li> <p> <code>TERMINATED</code>—The instance fleet is no longer active, and all EC2 instances have been terminated.</p> </li> </ul></p>
     #[serde(rename = "State")]
@@ -948,7 +948,7 @@ pub struct InstanceFleetStatus {
 }
 
 /// <p><p>Provides historical timestamps for the instance fleet, including the time of creation, the time it became ready to run jobs, and the time of termination.</p> <note> <p>The instance fleet configuration is available only in Amazon EMR versions 4.8.0 and later, excluding 5.0.x versions.</p> </note></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct InstanceFleetTimeline {
     /// <p>The time and date the instance fleet was created.</p>
     #[serde(rename = "CreationDateTime")]
@@ -965,7 +965,7 @@ pub struct InstanceFleetTimeline {
 }
 
 /// <p>This entity represents an instance group, which is a group of instances that have common purpose. For example, CORE instance group is used for HDFS.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct InstanceGroup {
     /// <p>An automatic scaling policy for a core instance group or task instance group in an Amazon EMR cluster. The automatic scaling policy defines how an instance group dynamically adds and terminates EC2 instances in response to the value of a CloudWatch metric. See PutAutoScalingPolicy.</p>
     #[serde(rename = "AutoScalingPolicy")]
@@ -1026,7 +1026,7 @@ pub struct InstanceGroup {
 }
 
 /// <p>Configuration defining a new instance group.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct InstanceGroupConfig {
     /// <p>An automatic scaling policy for a core instance group or task instance group in an Amazon EMR cluster. The automatic scaling policy defines how an instance group dynamically adds and terminates EC2 instances in response to the value of a CloudWatch metric. See <a>PutAutoScalingPolicy</a>.</p>
     #[serde(rename = "AutoScalingPolicy")]
@@ -1064,7 +1064,7 @@ pub struct InstanceGroupConfig {
 }
 
 /// <p>Detailed information about an instance group.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct InstanceGroupDetail {
     /// <p>Bid price for EC2 Instances when launching nodes as Spot Instances, expressed in USD.</p>
     #[serde(rename = "BidPrice")]
@@ -1118,7 +1118,7 @@ pub struct InstanceGroupDetail {
 }
 
 /// <p>Modify an instance group size.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct InstanceGroupModifyConfig {
     /// <p>The EC2 InstanceIds to terminate. After you terminate the instances, the instance group will not return to its original requested size.</p>
     #[serde(rename = "EC2InstanceIdsToTerminate")]
@@ -1138,7 +1138,7 @@ pub struct InstanceGroupModifyConfig {
 }
 
 /// <p>The status change reason details for the instance group.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct InstanceGroupStateChangeReason {
     /// <p>The programmable code for the state change reason.</p>
     #[serde(rename = "Code")]
@@ -1151,7 +1151,7 @@ pub struct InstanceGroupStateChangeReason {
 }
 
 /// <p>The details of the instance group status.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct InstanceGroupStatus {
     /// <p>The current state of the instance group.</p>
     #[serde(rename = "State")]
@@ -1168,7 +1168,7 @@ pub struct InstanceGroupStatus {
 }
 
 /// <p>The timeline of the instance group lifecycle.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct InstanceGroupTimeline {
     /// <p>The creation date and time of the instance group.</p>
     #[serde(rename = "CreationDateTime")]
@@ -1185,7 +1185,7 @@ pub struct InstanceGroupTimeline {
 }
 
 /// <p>Custom policy for requesting termination protection or termination of specific instances when shrinking an instance group.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct InstanceResizePolicy {
     /// <p>Decommissioning timeout override for the specific list of instances to be terminated.</p>
     #[serde(rename = "InstanceTerminationTimeout")]
@@ -1202,7 +1202,7 @@ pub struct InstanceResizePolicy {
 }
 
 /// <p>The details of the status change reason for the instance.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct InstanceStateChangeReason {
     /// <p>The programmable code for the state change reason.</p>
     #[serde(rename = "Code")]
@@ -1215,7 +1215,7 @@ pub struct InstanceStateChangeReason {
 }
 
 /// <p>The instance status details.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct InstanceStatus {
     /// <p>The current state of the instance.</p>
     #[serde(rename = "State")]
@@ -1232,7 +1232,7 @@ pub struct InstanceStatus {
 }
 
 /// <p>The timeline of the instance lifecycle.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct InstanceTimeline {
     /// <p>The creation date and time of the instance.</p>
     #[serde(rename = "CreationDateTime")]
@@ -1249,7 +1249,7 @@ pub struct InstanceTimeline {
 }
 
 /// <p><p>An instance type configuration for each instance type in an instance fleet, which determines the EC2 instances Amazon EMR attempts to provision to fulfill On-Demand and Spot target capacities. There can be a maximum of 5 instance type configurations in a fleet.</p> <note> <p>The instance fleet configuration is available only in Amazon EMR versions 4.8.0 and later, excluding 5.0.x versions.</p> </note></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct InstanceTypeConfig {
     /// <p>The bid price for each EC2 Spot instance type as defined by <code>InstanceType</code>. Expressed in USD. If neither <code>BidPrice</code> nor <code>BidPriceAsPercentageOfOnDemandPrice</code> is provided, <code>BidPriceAsPercentageOfOnDemandPrice</code> defaults to 100%. </p>
     #[serde(rename = "BidPrice")]
@@ -1277,7 +1277,7 @@ pub struct InstanceTypeConfig {
 }
 
 /// <p><p>The configuration specification for each instance type in an instance fleet.</p> <note> <p>The instance fleet configuration is available only in Amazon EMR versions 4.8.0 and later, excluding 5.0.x versions.</p> </note></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct InstanceTypeSpecification {
     /// <p>The bid price for each EC2 Spot instance type as defined by <code>InstanceType</code>. Expressed in USD.</p>
     #[serde(rename = "BidPrice")]
@@ -1310,7 +1310,7 @@ pub struct InstanceTypeSpecification {
 }
 
 /// <p>A description of a cluster (job flow).</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct JobFlowDetail {
     /// <p>Used only for version 2.x and 3.x of Amazon EMR. The version of the AMI used to initialize Amazon EC2 instances in the job flow. For a list of AMI versions supported by Amazon EMR, see <a href="http://docs.aws.amazon.com/emr/latest/DeveloperGuide/emr-dg.pdf#nameddest=ami-versions-supported">AMI Versions Supported in EMR</a> in the <i>Amazon EMR Developer Guide.</i> </p>
     #[serde(rename = "AmiVersion")]
@@ -1367,7 +1367,7 @@ pub struct JobFlowDetail {
 }
 
 /// <p>Describes the status of the cluster (job flow).</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct JobFlowExecutionStatusDetail {
     /// <p>The creation date and time of the job flow.</p>
     #[serde(rename = "CreationDateTime")]
@@ -1394,7 +1394,7 @@ pub struct JobFlowExecutionStatusDetail {
 }
 
 /// <p>A description of the Amazon EC2 instance on which the cluster (job flow) runs. A valid JobFlowInstancesConfig must contain either InstanceGroups or InstanceFleets, which is the recommended configuration. They cannot be used together. You may also have MasterInstanceType, SlaveInstanceType, and InstanceCount (all three must be present), but we don't recommend this configuration.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct JobFlowInstancesConfig {
     /// <p>A list of additional Amazon EC2 security group IDs for the master node.</p>
     #[serde(rename = "AdditionalMasterSecurityGroups")]
@@ -1467,7 +1467,7 @@ pub struct JobFlowInstancesConfig {
 }
 
 /// <p>Specify the type of Amazon EC2 instances that the cluster (job flow) runs on.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct JobFlowInstancesDetail {
     /// <p>The name of an Amazon EC2 key pair that can be used to ssh to the master node.</p>
     #[serde(rename = "Ec2KeyName")]
@@ -1521,7 +1521,7 @@ pub struct JobFlowInstancesDetail {
 }
 
 /// <p>Attributes for Kerberos configuration when Kerberos authentication is enabled using a security configuration. For more information see <a href="http://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-kerberos.html">Use Kerberos Authentication</a> in the <i>EMR Management Guide</i>.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct KerberosAttributes {
     /// <p>The Active Directory password for <code>ADDomainJoinUser</code>.</p>
     #[serde(rename = "ADDomainJoinPassword")]
@@ -1544,7 +1544,7 @@ pub struct KerberosAttributes {
 }
 
 /// <p>A key value pair.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct KeyValue {
     /// <p>The unique identifier of a key value pair.</p>
     #[serde(rename = "Key")]
@@ -1557,7 +1557,7 @@ pub struct KeyValue {
 }
 
 /// <p>This input determines which bootstrap actions to retrieve.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListBootstrapActionsInput {
     /// <p>The cluster identifier for the bootstrap actions to list.</p>
     #[serde(rename = "ClusterId")]
@@ -1569,7 +1569,7 @@ pub struct ListBootstrapActionsInput {
 }
 
 /// <p>This output contains the bootstrap actions detail.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListBootstrapActionsOutput {
     /// <p>The bootstrap actions associated with the cluster.</p>
     #[serde(rename = "BootstrapActions")]
@@ -1582,7 +1582,7 @@ pub struct ListBootstrapActionsOutput {
 }
 
 /// <p>This input determines how the ListClusters action filters the list of clusters that it returns.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListClustersInput {
     /// <p>The cluster state filters to apply when listing clusters.</p>
     #[serde(rename = "ClusterStates")]
@@ -1603,7 +1603,7 @@ pub struct ListClustersInput {
 }
 
 /// <p>This contains a ClusterSummaryList with the cluster details; for example, the cluster IDs, names, and status.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListClustersOutput {
     /// <p>The list of clusters for the account based on the given filters.</p>
     #[serde(rename = "Clusters")]
@@ -1615,7 +1615,7 @@ pub struct ListClustersOutput {
     pub marker: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListInstanceFleetsInput {
     /// <p>The unique identifier of the cluster.</p>
     #[serde(rename = "ClusterId")]
@@ -1626,7 +1626,7 @@ pub struct ListInstanceFleetsInput {
     pub marker: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListInstanceFleetsOutput {
     /// <p>The list of instance fleets for the cluster and given filters.</p>
     #[serde(rename = "InstanceFleets")]
@@ -1639,7 +1639,7 @@ pub struct ListInstanceFleetsOutput {
 }
 
 /// <p>This input determines which instance groups to retrieve.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListInstanceGroupsInput {
     /// <p>The identifier of the cluster for which to list the instance groups.</p>
     #[serde(rename = "ClusterId")]
@@ -1651,7 +1651,7 @@ pub struct ListInstanceGroupsInput {
 }
 
 /// <p>This input determines which instance groups to retrieve.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListInstanceGroupsOutput {
     /// <p>The list of instance groups for the cluster and given filters.</p>
     #[serde(rename = "InstanceGroups")]
@@ -1664,7 +1664,7 @@ pub struct ListInstanceGroupsOutput {
 }
 
 /// <p>This input determines which instances to list.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListInstancesInput {
     /// <p>The identifier of the cluster for which to list the instances.</p>
     #[serde(rename = "ClusterId")]
@@ -1696,7 +1696,7 @@ pub struct ListInstancesInput {
 }
 
 /// <p>This output contains the list of instances.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListInstancesOutput {
     /// <p>The list of instances for the cluster and given filters.</p>
     #[serde(rename = "Instances")]
@@ -1708,7 +1708,7 @@ pub struct ListInstancesOutput {
     pub marker: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListSecurityConfigurationsInput {
     /// <p>The pagination token that indicates the set of results to retrieve.</p>
     #[serde(rename = "Marker")]
@@ -1716,7 +1716,7 @@ pub struct ListSecurityConfigurationsInput {
     pub marker: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListSecurityConfigurationsOutput {
     /// <p>A pagination token that indicates the next set of results to retrieve. Include the marker in the next ListSecurityConfiguration call to retrieve the next page of results, if required.</p>
     #[serde(rename = "Marker")]
@@ -1729,7 +1729,7 @@ pub struct ListSecurityConfigurationsOutput {
 }
 
 /// <p>This input determines which steps to list.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListStepsInput {
     /// <p>The identifier of the cluster for which to list the steps.</p>
     #[serde(rename = "ClusterId")]
@@ -1749,7 +1749,7 @@ pub struct ListStepsInput {
 }
 
 /// <p>This output contains the list of steps returned in reverse order. This means that the last step is the first element in the list.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListStepsOutput {
     /// <p>The pagination token that indicates the next set of results to retrieve.</p>
     #[serde(rename = "Marker")]
@@ -1762,7 +1762,7 @@ pub struct ListStepsOutput {
 }
 
 /// <p>A CloudWatch dimension, which is specified using a <code>Key</code> (known as a <code>Name</code> in CloudWatch), <code>Value</code> pair. By default, Amazon EMR uses one dimension whose <code>Key</code> is <code>JobFlowID</code> and <code>Value</code> is a variable representing the cluster ID, which is <code>${emr.clusterId}</code>. This enables the rule to bootstrap when the cluster ID becomes available.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct MetricDimension {
     /// <p>The dimension name.</p>
     #[serde(rename = "Key")]
@@ -1774,7 +1774,7 @@ pub struct MetricDimension {
     pub value: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ModifyInstanceFleetInput {
     /// <p>The unique identifier of the cluster.</p>
     #[serde(rename = "ClusterId")]
@@ -1785,7 +1785,7 @@ pub struct ModifyInstanceFleetInput {
 }
 
 /// <p>Change the size of some instance groups.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ModifyInstanceGroupsInput {
     /// <p>The ID of the cluster to which the instance group belongs.</p>
     #[serde(rename = "ClusterId")]
@@ -1798,7 +1798,7 @@ pub struct ModifyInstanceGroupsInput {
 }
 
 /// <p>The Amazon EC2 Availability Zone configuration of the cluster (job flow).</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct PlacementType {
     /// <p>The Amazon EC2 Availability Zone for the cluster. <code>AvailabilityZone</code> is used for uniform instance groups, while <code>AvailabilityZones</code> (plural) is used for instance fleets.</p>
     #[serde(rename = "AvailabilityZone")]
@@ -1810,7 +1810,7 @@ pub struct PlacementType {
     pub availability_zones: Option<Vec<String>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PutAutoScalingPolicyInput {
     /// <p>Specifies the definition of the automatic scaling policy.</p>
     #[serde(rename = "AutoScalingPolicy")]
@@ -1823,7 +1823,7 @@ pub struct PutAutoScalingPolicyInput {
     pub instance_group_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PutAutoScalingPolicyOutput {
     /// <p>The automatic scaling policy definition.</p>
     #[serde(rename = "AutoScalingPolicy")]
@@ -1839,7 +1839,7 @@ pub struct PutAutoScalingPolicyOutput {
     pub instance_group_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RemoveAutoScalingPolicyInput {
     /// <p>Specifies the ID of a cluster. The instance group to which the automatic scaling policy is applied is within this cluster.</p>
     #[serde(rename = "ClusterId")]
@@ -1849,11 +1849,11 @@ pub struct RemoveAutoScalingPolicyInput {
     pub instance_group_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RemoveAutoScalingPolicyOutput {}
 
 /// <p>This input identifies a cluster and a list of tags to remove.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RemoveTagsInput {
     /// <p>The Amazon EMR resource identifier from which tags will be removed. This value must be a cluster identifier.</p>
     #[serde(rename = "ResourceId")]
@@ -1864,11 +1864,11 @@ pub struct RemoveTagsInput {
 }
 
 /// <p>This output indicates the result of removing tags from a resource.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RemoveTagsOutput {}
 
 /// <p> Input to the <a>RunJobFlow</a> operation. </p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RunJobFlowInput {
     /// <p>A JSON string for selecting additional features.</p>
     #[serde(rename = "AdditionalInfo")]
@@ -1963,7 +1963,7 @@ pub struct RunJobFlowInput {
 }
 
 /// <p> The result of the <a>RunJobFlow</a> operation. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RunJobFlowOutput {
     /// <p>An unique identifier for the job flow.</p>
     #[serde(rename = "JobFlowId")]
@@ -1972,7 +1972,7 @@ pub struct RunJobFlowOutput {
 }
 
 /// <p>The type of adjustment the automatic scaling activity makes when triggered, and the periodicity of the adjustment.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ScalingAction {
     /// <p>Not available for instance groups. Instance groups use the market type specified for the group.</p>
     #[serde(rename = "Market")]
@@ -1984,7 +1984,7 @@ pub struct ScalingAction {
 }
 
 /// <p>The upper and lower EC2 instance limits for an automatic scaling policy. Automatic scaling activities triggered by automatic scaling rules will not cause an instance group to grow above or below these limits.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ScalingConstraints {
     /// <p>The upper boundary of EC2 instances in an instance group beyond which scaling activities are not allowed to grow. Scale-out activities will not add instances beyond this boundary.</p>
     #[serde(rename = "MaxCapacity")]
@@ -1995,7 +1995,7 @@ pub struct ScalingConstraints {
 }
 
 /// <p>A scale-in or scale-out rule that defines scaling activity, including the CloudWatch metric alarm that triggers activity, how EC2 instances are added or removed, and the periodicity of adjustments. The automatic scaling policy for an instance group can comprise one or more automatic scaling rules.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ScalingRule {
     /// <p>The conditions that trigger an automatic scaling activity.</p>
     #[serde(rename = "Action")]
@@ -2013,7 +2013,7 @@ pub struct ScalingRule {
 }
 
 /// <p>The conditions that trigger an automatic scaling activity.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ScalingTrigger {
     /// <p>The definition of a CloudWatch metric alarm. When the defined alarm conditions are met along with other trigger parameters, scaling activity begins.</p>
     #[serde(rename = "CloudWatchAlarmDefinition")]
@@ -2021,7 +2021,7 @@ pub struct ScalingTrigger {
 }
 
 /// <p>Configuration of the script to run during a bootstrap action.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ScriptBootstrapActionConfig {
     /// <p>A list of command line arguments to pass to the bootstrap action script.</p>
     #[serde(rename = "Args")]
@@ -2033,7 +2033,7 @@ pub struct ScriptBootstrapActionConfig {
 }
 
 /// <p>The creation date and time, and name, of a security configuration.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SecurityConfigurationSummary {
     /// <p>The date and time the security configuration was created.</p>
     #[serde(rename = "CreationDateTime")]
@@ -2046,7 +2046,7 @@ pub struct SecurityConfigurationSummary {
 }
 
 /// <p> The input argument to the <a>TerminationProtection</a> operation. </p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SetTerminationProtectionInput {
     /// <p> A list of strings that uniquely identify the clusters to protect. This identifier is returned by <a>RunJobFlow</a> and can also be obtained from <a>DescribeJobFlows</a> . </p>
     #[serde(rename = "JobFlowIds")]
@@ -2057,7 +2057,7 @@ pub struct SetTerminationProtectionInput {
 }
 
 /// <p>The input to the SetVisibleToAllUsers action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SetVisibleToAllUsersInput {
     /// <p>Identifiers of the job flows to receive the new visibility setting.</p>
     #[serde(rename = "JobFlowIds")]
@@ -2068,7 +2068,7 @@ pub struct SetVisibleToAllUsersInput {
 }
 
 /// <p>Policy for customizing shrink operations. Allows configuration of decommissioning timeout and targeted instance shrinking.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ShrinkPolicy {
     /// <p>The desired timeout for decommissioning an instance. Overrides the default YARN decommissioning timeout.</p>
     #[serde(rename = "DecommissionTimeout")]
@@ -2081,7 +2081,7 @@ pub struct ShrinkPolicy {
 }
 
 /// <p>An automatic scaling configuration, which describes how the policy adds or removes instances, the cooldown period, and the number of EC2 instances that will be added each time the CloudWatch metric alarm condition is satisfied.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SimpleScalingPolicyConfiguration {
     /// <p>The way in which EC2 instances are added (if <code>ScalingAdjustment</code> is a positive number) or terminated (if <code>ScalingAdjustment</code> is a negative number) each time the scaling activity is triggered. <code>CHANGE_IN_CAPACITY</code> is the default. <code>CHANGE_IN_CAPACITY</code> indicates that the EC2 instance count increments or decrements by <code>ScalingAdjustment</code>, which should be expressed as an integer. <code>PERCENT_CHANGE_IN_CAPACITY</code> indicates the instance count increments or decrements by the percentage specified by <code>ScalingAdjustment</code>, which should be expressed as an integer. For example, 20 indicates an increase in 20% increments of cluster capacity. <code>EXACT_CAPACITY</code> indicates the scaling activity results in an instance group with the number of EC2 instances specified by <code>ScalingAdjustment</code>, which should be expressed as a positive integer.</p>
     #[serde(rename = "AdjustmentType")]
@@ -2097,7 +2097,7 @@ pub struct SimpleScalingPolicyConfiguration {
 }
 
 /// <p><p>The launch specification for Spot instances in the instance fleet, which determines the defined duration and provisioning timeout behavior.</p> <note> <p>The instance fleet configuration is available only in Amazon EMR versions 4.8.0 and later, excluding 5.0.x versions.</p> </note></p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SpotProvisioningSpecification {
     /// <p>The defined duration for Spot instances (also known as Spot blocks) in minutes. When specified, the Spot instance does not terminate before the defined duration expires, and defined duration pricing for Spot instances applies. Valid values are 60, 120, 180, 240, 300, or 360. The duration period starts as soon as a Spot instance receives its instance ID. At the end of the duration, Amazon EC2 marks the Spot instance for termination and provides a Spot instance termination notice, which gives the instance a two-minute warning before it terminates. </p>
     #[serde(rename = "BlockDurationMinutes")]
@@ -2112,7 +2112,7 @@ pub struct SpotProvisioningSpecification {
 }
 
 /// <p>This represents a step in a cluster.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Step {
     /// <p>This specifies what action to take when the cluster step fails. Possible values are TERMINATE_CLUSTER, CANCEL_AND_WAIT, and CONTINUE.</p>
     #[serde(rename = "ActionOnFailure")]
@@ -2137,7 +2137,7 @@ pub struct Step {
 }
 
 /// <p>Specification of a cluster (job flow) step.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct StepConfig {
     /// <p>The action to take if the step fails.</p>
     #[serde(rename = "ActionOnFailure")]
@@ -2152,7 +2152,7 @@ pub struct StepConfig {
 }
 
 /// <p>Combines the execution state and configuration of a step.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StepDetail {
     /// <p>The description of the step status.</p>
     #[serde(rename = "ExecutionStatusDetail")]
@@ -2163,7 +2163,7 @@ pub struct StepDetail {
 }
 
 /// <p>The execution state of a step.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StepExecutionStatusDetail {
     /// <p>The creation date and time of the step.</p>
     #[serde(rename = "CreationDateTime")]
@@ -2186,7 +2186,7 @@ pub struct StepExecutionStatusDetail {
 }
 
 /// <p>The details of the step state change reason.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StepStateChangeReason {
     /// <p>The programmable code for the state change reason. Note: Currently, the service provides no code for the state change.</p>
     #[serde(rename = "Code")]
@@ -2199,7 +2199,7 @@ pub struct StepStateChangeReason {
 }
 
 /// <p>The execution status details of the cluster step.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StepStatus {
     /// <p>The details for the step failure including reason, message, and log file path where the root cause was identified.</p>
     #[serde(rename = "FailureDetails")]
@@ -2220,7 +2220,7 @@ pub struct StepStatus {
 }
 
 /// <p>The summary of the cluster step.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StepSummary {
     /// <p>This specifies what action to take when the cluster step fails. Possible values are TERMINATE_CLUSTER, CANCEL_AND_WAIT, and CONTINUE.</p>
     #[serde(rename = "ActionOnFailure")]
@@ -2245,7 +2245,7 @@ pub struct StepSummary {
 }
 
 /// <p>The timeline of the cluster step lifecycle.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StepTimeline {
     /// <p>The date and time when the cluster step was created.</p>
     #[serde(rename = "CreationDateTime")]
@@ -2262,7 +2262,7 @@ pub struct StepTimeline {
 }
 
 /// <p>The list of supported product configurations which allow user-supplied arguments. EMR accepts these arguments and forwards them to the corresponding installation script as bootstrap action arguments.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SupportedProductConfig {
     /// <p>The list of user-supplied arguments.</p>
     #[serde(rename = "Args")]
@@ -2275,7 +2275,7 @@ pub struct SupportedProductConfig {
 }
 
 /// <p>A key/value pair containing user-defined metadata that you can associate with an Amazon EMR resource. Tags make it easier to associate clusters in various ways, such as grouping clusters to track your Amazon EMR resource allocation costs. For more information, see <a href="http://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-plan-tags.html">Tag Clusters</a>. </p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Tag {
     /// <p>A user-defined key, which is the minimum required information for a valid tag. For more information, see <a href="http://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-plan-tags.html">Tag </a>. </p>
     #[serde(rename = "Key")]
@@ -2288,7 +2288,7 @@ pub struct Tag {
 }
 
 /// <p> Input to the <a>TerminateJobFlows</a> operation. </p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct TerminateJobFlowsInput {
     /// <p>A list of job flows to be shutdown.</p>
     #[serde(rename = "JobFlowIds")]
@@ -2296,7 +2296,7 @@ pub struct TerminateJobFlowsInput {
 }
 
 /// <p>EBS volume specifications such as volume type, IOPS, and size (GiB) that will be requested for the EBS volume attached to an EC2 instance in the cluster.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct VolumeSpecification {
     /// <p>The number of I/O operations per second (IOPS) that the volume supports.</p>
     #[serde(rename = "Iops")]

--- a/rusoto/services/emr/src/generated.rs
+++ b/rusoto/services/emr/src/generated.rs
@@ -2331,7 +2331,8 @@ impl AddInstanceFleetError {
     pub fn from_body(body: &str) -> AddInstanceFleetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2413,7 +2414,8 @@ impl AddInstanceGroupsError {
     pub fn from_body(body: &str) -> AddInstanceGroupsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2493,7 +2495,8 @@ impl AddJobFlowStepsError {
     pub fn from_body(body: &str) -> AddJobFlowStepsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2573,7 +2576,8 @@ impl AddTagsError {
     pub fn from_body(body: &str) -> AddTagsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2655,7 +2659,8 @@ impl CancelStepsError {
     pub fn from_body(body: &str) -> CancelStepsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2739,7 +2744,8 @@ impl CreateSecurityConfigurationError {
     pub fn from_body(body: &str) -> CreateSecurityConfigurationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2825,7 +2831,8 @@ impl DeleteSecurityConfigurationError {
     pub fn from_body(body: &str) -> DeleteSecurityConfigurationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2911,7 +2918,8 @@ impl DescribeClusterError {
     pub fn from_body(body: &str) -> DescribeClusterError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2993,7 +3001,8 @@ impl DescribeJobFlowsError {
     pub fn from_body(body: &str) -> DescribeJobFlowsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3073,7 +3082,8 @@ impl DescribeSecurityConfigurationError {
     pub fn from_body(body: &str) -> DescribeSecurityConfigurationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3163,7 +3173,8 @@ impl DescribeStepError {
     pub fn from_body(body: &str) -> DescribeStepError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3247,7 +3258,8 @@ impl ListBootstrapActionsError {
     pub fn from_body(body: &str) -> ListBootstrapActionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3333,7 +3345,8 @@ impl ListClustersError {
     pub fn from_body(body: &str) -> ListClustersError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3417,7 +3430,8 @@ impl ListInstanceFleetsError {
     pub fn from_body(body: &str) -> ListInstanceFleetsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3503,7 +3517,8 @@ impl ListInstanceGroupsError {
     pub fn from_body(body: &str) -> ListInstanceGroupsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3589,7 +3604,8 @@ impl ListInstancesError {
     pub fn from_body(body: &str) -> ListInstancesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3673,7 +3689,8 @@ impl ListSecurityConfigurationsError {
     pub fn from_body(body: &str) -> ListSecurityConfigurationsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3759,7 +3776,8 @@ impl ListStepsError {
     pub fn from_body(body: &str) -> ListStepsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3841,7 +3859,8 @@ impl ModifyInstanceFleetError {
     pub fn from_body(body: &str) -> ModifyInstanceFleetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3925,7 +3944,8 @@ impl ModifyInstanceGroupsError {
     pub fn from_body(body: &str) -> ModifyInstanceGroupsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4003,7 +4023,8 @@ impl PutAutoScalingPolicyError {
     pub fn from_body(body: &str) -> PutAutoScalingPolicyError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4077,7 +4098,8 @@ impl RemoveAutoScalingPolicyError {
     pub fn from_body(body: &str) -> RemoveAutoScalingPolicyError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4155,7 +4177,8 @@ impl RemoveTagsError {
     pub fn from_body(body: &str) -> RemoveTagsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4235,7 +4258,8 @@ impl RunJobFlowError {
     pub fn from_body(body: &str) -> RunJobFlowError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4311,7 +4335,8 @@ impl SetTerminationProtectionError {
     pub fn from_body(body: &str) -> SetTerminationProtectionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4391,7 +4416,8 @@ impl SetVisibleToAllUsersError {
     pub fn from_body(body: &str) -> SetVisibleToAllUsersError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4471,7 +4497,8 @@ impl TerminateJobFlowsError {
     pub fn from_body(body: &str) -> TerminateJobFlowsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/events/src/generated.rs
+++ b/rusoto/services/events/src/generated.rs
@@ -601,7 +601,8 @@ impl DeleteRuleError {
     pub fn from_body(body: &str) -> DeleteRuleError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -681,7 +682,8 @@ impl DescribeEventBusError {
     pub fn from_body(body: &str) -> DescribeEventBusError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -765,7 +767,8 @@ impl DescribeRuleError {
     pub fn from_body(body: &str) -> DescribeRuleError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -849,7 +852,8 @@ impl DisableRuleError {
     pub fn from_body(body: &str) -> DisableRuleError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -937,7 +941,8 @@ impl EnableRuleError {
     pub fn from_body(body: &str) -> EnableRuleError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1019,7 +1024,8 @@ impl ListRuleNamesByTargetError {
     pub fn from_body(body: &str) -> ListRuleNamesByTargetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1099,7 +1105,8 @@ impl ListRulesError {
     pub fn from_body(body: &str) -> ListRulesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1175,7 +1182,8 @@ impl ListTargetsByRuleError {
     pub fn from_body(body: &str) -> ListTargetsByRuleError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1259,7 +1267,8 @@ impl PutEventsError {
     pub fn from_body(body: &str) -> PutEventsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1339,7 +1348,8 @@ impl PutPermissionError {
     pub fn from_body(body: &str) -> PutPermissionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1435,7 +1445,8 @@ impl PutRuleError {
     pub fn from_body(body: &str) -> PutRuleError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1527,7 +1538,8 @@ impl PutTargetsError {
     pub fn from_body(body: &str) -> PutTargetsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1617,7 +1629,8 @@ impl RemovePermissionError {
     pub fn from_body(body: &str) -> RemovePermissionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1707,7 +1720,8 @@ impl RemoveTargetsError {
     pub fn from_body(body: &str) -> RemoveTargetsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1795,7 +1809,8 @@ impl TestEventPatternError {
     pub fn from_body(body: &str) -> TestEventPatternError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/events/src/generated.rs
+++ b/rusoto/services/events/src/generated.rs
@@ -31,7 +31,7 @@ use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 /// <p>The array properties for the submitted job, such as the size of the array. The array size can be between 2 and 10,000. If you specify array properties for a job, it becomes an array job. This parameter is used only if the target is an AWS Batch job.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct BatchArrayProperties {
     /// <p>The size of the array, if this is an array batch job. Valid values are integers between 2 and 10,000.</p>
     #[serde(rename = "Size")]
@@ -40,7 +40,7 @@ pub struct BatchArrayProperties {
 }
 
 /// <p>The custom parameters to be used when the target is an AWS Batch job.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct BatchParameters {
     /// <p>The array properties for the submitted job, such as the size of the array. The array size can be between 2 and 10,000. If you specify array properties for a job, it becomes an array job. This parameter is used only if the target is an AWS Batch job.</p>
     #[serde(rename = "ArrayProperties")]
@@ -59,7 +59,7 @@ pub struct BatchParameters {
 }
 
 /// <p>The retry strategy to use for failed jobs, if the target is an AWS Batch job. If you specify a retry strategy here, it overrides the retry strategy defined in the job definition.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct BatchRetryStrategy {
     /// <p>The number of times to attempt to retry, if the job fails. Valid values are 1 to 10.</p>
     #[serde(rename = "Attempts")]
@@ -67,17 +67,17 @@ pub struct BatchRetryStrategy {
     pub attempts: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteRuleRequest {
     /// <p>The name of the rule.</p>
     #[serde(rename = "Name")]
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeEventBusRequest {}
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeEventBusResponse {
     /// <p>The Amazon Resource Name (ARN) of the account permitted to write events to the current account.</p>
     #[serde(rename = "Arn")]
@@ -93,14 +93,14 @@ pub struct DescribeEventBusResponse {
     pub policy: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeRuleRequest {
     /// <p>The name of the rule.</p>
     #[serde(rename = "Name")]
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeRuleResponse {
     /// <p>The Amazon Resource Name (ARN) of the rule.</p>
     #[serde(rename = "Arn")]
@@ -132,7 +132,7 @@ pub struct DescribeRuleResponse {
     pub state: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DisableRuleRequest {
     /// <p>The name of the rule.</p>
     #[serde(rename = "Name")]
@@ -140,7 +140,7 @@ pub struct DisableRuleRequest {
 }
 
 /// <p>The custom parameters to be used when the target is an Amazon ECS cluster.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct EcsParameters {
     /// <p>The number of tasks to create based on the <code>TaskDefinition</code>. The default is one.</p>
     #[serde(rename = "TaskCount")]
@@ -151,7 +151,7 @@ pub struct EcsParameters {
     pub task_definition_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct EnableRuleRequest {
     /// <p>The name of the rule.</p>
     #[serde(rename = "Name")]
@@ -159,7 +159,7 @@ pub struct EnableRuleRequest {
 }
 
 /// <p>Contains the parameters needed for you to provide custom input to a target based on one or more pieces of data extracted from the event.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct InputTransformer {
     /// <p>Map of JSON paths to be extracted from the event. These are key-value pairs, where each value is a JSON path. You must use JSON dot notation, not bracket notation.</p>
     #[serde(rename = "InputPathsMap")]
@@ -171,14 +171,14 @@ pub struct InputTransformer {
 }
 
 /// <p>This object enables you to specify a JSON path to extract from the event and use as the partition key for the Amazon Kinesis stream, so that you can control the shard to which the event goes. If you do not include this parameter, the default is to use the <code>eventId</code> as the partition key.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct KinesisParameters {
     /// <p>The JSON path to be extracted from the event and used as the partition key. For more information, see <a href="http://docs.aws.amazon.com/streams/latest/dev/key-concepts.html#partition-key">Amazon Kinesis Streams Key Concepts</a> in the <i>Amazon Kinesis Streams Developer Guide</i>.</p>
     #[serde(rename = "PartitionKeyPath")]
     pub partition_key_path: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListRuleNamesByTargetRequest {
     /// <p>The maximum number of results to return.</p>
     #[serde(rename = "Limit")]
@@ -193,7 +193,7 @@ pub struct ListRuleNamesByTargetRequest {
     pub target_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListRuleNamesByTargetResponse {
     /// <p>Indicates whether there are additional results to retrieve. If there are no more results, the value is null.</p>
     #[serde(rename = "NextToken")]
@@ -205,7 +205,7 @@ pub struct ListRuleNamesByTargetResponse {
     pub rule_names: Option<Vec<String>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListRulesRequest {
     /// <p>The maximum number of results to return.</p>
     #[serde(rename = "Limit")]
@@ -221,7 +221,7 @@ pub struct ListRulesRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListRulesResponse {
     /// <p>Indicates whether there are additional results to retrieve. If there are no more results, the value is null.</p>
     #[serde(rename = "NextToken")]
@@ -233,7 +233,7 @@ pub struct ListRulesResponse {
     pub rules: Option<Vec<Rule>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListTargetsByRuleRequest {
     /// <p>The maximum number of results to return.</p>
     #[serde(rename = "Limit")]
@@ -248,7 +248,7 @@ pub struct ListTargetsByRuleRequest {
     pub rule: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListTargetsByRuleResponse {
     /// <p>Indicates whether there are additional results to retrieve. If there are no more results, the value is null.</p>
     #[serde(rename = "NextToken")]
@@ -260,7 +260,7 @@ pub struct ListTargetsByRuleResponse {
     pub targets: Option<Vec<Target>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PutEventsRequest {
     /// <p>The entry that defines an event in your system. You can specify several parameters for the entry such as the source and type of the event, resources associated with the event, and so on.</p>
     #[serde(rename = "Entries")]
@@ -268,7 +268,7 @@ pub struct PutEventsRequest {
 }
 
 /// <p>Represents an event to be submitted.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PutEventsRequestEntry {
     /// <p>A valid JSON string. There is no other schema imposed. The JSON string may contain fields and nested subobjects.</p>
     #[serde(rename = "Detail")]
@@ -292,7 +292,7 @@ pub struct PutEventsRequestEntry {
     pub time: Option<f64>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PutEventsResponse {
     /// <p>The successfully and unsuccessfully ingested events results. If the ingestion was successful, the entry has the event ID in it. Otherwise, you can use the error code and error message to identify the problem with the entry.</p>
     #[serde(rename = "Entries")]
@@ -305,7 +305,7 @@ pub struct PutEventsResponse {
 }
 
 /// <p>Represents an event that failed to be submitted.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PutEventsResultEntry {
     /// <p>The error code that indicates why the event submission failed.</p>
     #[serde(rename = "ErrorCode")]
@@ -321,7 +321,7 @@ pub struct PutEventsResultEntry {
     pub event_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PutPermissionRequest {
     /// <p>The action that you are enabling the other account to perform. Currently, this must be <code>events:PutEvents</code>.</p>
     #[serde(rename = "Action")]
@@ -334,7 +334,7 @@ pub struct PutPermissionRequest {
     pub statement_id: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PutRuleRequest {
     /// <p>A description of the rule.</p>
     #[serde(rename = "Description")]
@@ -361,7 +361,7 @@ pub struct PutRuleRequest {
     pub state: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PutRuleResponse {
     /// <p>The Amazon Resource Name (ARN) of the rule.</p>
     #[serde(rename = "RuleArn")]
@@ -369,7 +369,7 @@ pub struct PutRuleResponse {
     pub rule_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PutTargetsRequest {
     /// <p>The name of the rule.</p>
     #[serde(rename = "Rule")]
@@ -379,7 +379,7 @@ pub struct PutTargetsRequest {
     pub targets: Vec<Target>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PutTargetsResponse {
     /// <p>The failed target entries.</p>
     #[serde(rename = "FailedEntries")]
@@ -392,7 +392,7 @@ pub struct PutTargetsResponse {
 }
 
 /// <p>Represents a target that failed to be added to a rule.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PutTargetsResultEntry {
     /// <p>The error code that indicates why the target addition failed. If the value is <code>ConcurrentModificationException</code>, too many requests were made at the same time.</p>
     #[serde(rename = "ErrorCode")]
@@ -408,14 +408,14 @@ pub struct PutTargetsResultEntry {
     pub target_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RemovePermissionRequest {
     /// <p>The statement ID corresponding to the account that is no longer allowed to put events to the default event bus.</p>
     #[serde(rename = "StatementId")]
     pub statement_id: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RemoveTargetsRequest {
     /// <p>The IDs of the targets to remove from the rule.</p>
     #[serde(rename = "Ids")]
@@ -425,7 +425,7 @@ pub struct RemoveTargetsRequest {
     pub rule: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RemoveTargetsResponse {
     /// <p>The failed target entries.</p>
     #[serde(rename = "FailedEntries")]
@@ -438,7 +438,7 @@ pub struct RemoveTargetsResponse {
 }
 
 /// <p>Represents a target that failed to be removed from a rule.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RemoveTargetsResultEntry {
     /// <p>The error code that indicates why the target removal failed. If the value is <code>ConcurrentModificationException</code>, too many requests were made at the same time.</p>
     #[serde(rename = "ErrorCode")]
@@ -455,7 +455,7 @@ pub struct RemoveTargetsResultEntry {
 }
 
 /// <p>Contains information about a rule in Amazon CloudWatch Events.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Rule {
     /// <p>The Amazon Resource Name (ARN) of the rule.</p>
     #[serde(rename = "Arn")]
@@ -488,7 +488,7 @@ pub struct Rule {
 }
 
 /// <p>This parameter contains the criteria (either InstanceIds or a tag) used to specify which EC2 instances are to be sent the command. </p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RunCommandParameters {
     /// <p>Currently, we support including only one RunCommandTarget block, which specifies either an array of InstanceIds or a tag.</p>
     #[serde(rename = "RunCommandTargets")]
@@ -496,7 +496,7 @@ pub struct RunCommandParameters {
 }
 
 /// <p>Information about the EC2 instances that are to be sent the command, specified as key-value pairs. Each <code>RunCommandTarget</code> block can include only one key, but this key may specify multiple values.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RunCommandTarget {
     /// <p>Can be either <code>tag:</code> <i>tag-key</i> or <code>InstanceIds</code>.</p>
     #[serde(rename = "Key")]
@@ -507,7 +507,7 @@ pub struct RunCommandTarget {
 }
 
 /// <p>This structure includes the custom parameter to be used when the target is an SQS FIFO queue.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SqsParameters {
     /// <p>The FIFO message group ID to use as the target.</p>
     #[serde(rename = "MessageGroupId")]
@@ -516,7 +516,7 @@ pub struct SqsParameters {
 }
 
 /// <p>Targets are the resources to be invoked when a rule is triggered. Target types include EC2 instances, AWS Lambda functions, Amazon Kinesis streams, Amazon ECS tasks, AWS Step Functions state machines, Run Command, and built-in targets.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Target {
     /// <p>The Amazon Resource Name (ARN) of the target.</p>
     #[serde(rename = "Arn")]
@@ -562,7 +562,7 @@ pub struct Target {
     pub sqs_parameters: Option<SqsParameters>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct TestEventPatternRequest {
     /// <p>The event, in JSON format, to test against the event pattern.</p>
     #[serde(rename = "Event")]
@@ -572,7 +572,7 @@ pub struct TestEventPatternRequest {
     pub event_pattern: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct TestEventPatternResponse {
     /// <p>Indicates whether the event matches the event pattern.</p>
     #[serde(rename = "Result")]

--- a/rusoto/services/firehose/src/generated.rs
+++ b/rusoto/services/firehose/src/generated.rs
@@ -31,7 +31,7 @@ use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 /// <p>Describes hints for the buffering to perform before delivering data to the destination. Please note that these options are treated as hints, and therefore Kinesis Firehose may choose to use different values when it is optimal.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct BufferingHints {
     /// <p>Buffer incoming data for the specified period of time, in seconds, before delivering it to the destination. The default value is 300.</p>
     #[serde(rename = "IntervalInSeconds")]
@@ -44,7 +44,7 @@ pub struct BufferingHints {
 }
 
 /// <p>Describes the Amazon CloudWatch logging options for your delivery stream.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CloudWatchLoggingOptions {
     /// <p>Enables or disables CloudWatch logging.</p>
     #[serde(rename = "Enabled")]
@@ -61,7 +61,7 @@ pub struct CloudWatchLoggingOptions {
 }
 
 /// <p>Describes a <code>COPY</code> command for Amazon Redshift.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CopyCommand {
     /// <p>Optional parameters to use with the Amazon Redshift <code>COPY</code> command. For more information, see the "Optional Parameters" section of <a href="http://docs.aws.amazon.com/redshift/latest/dg/r_COPY.html">Amazon Redshift COPY command</a>. Some possible examples that would apply to Kinesis Firehose are as follows:</p> <p> <code>delimiter '\t' lzop;</code> - fields are delimited with "\t" (TAB character) and compressed using lzop.</p> <p> <code>delimiter '|'</code> - fields are delimited with "|" (this is the default delimiter).</p> <p> <code>delimiter '|' escape</code> - the delimiter should be escaped.</p> <p> <code>fixedwidth 'venueid:3,venuename:25,venuecity:12,venuestate:2,venueseats:6'</code> - fields are fixed width in the source, with each width specified after every column in the table.</p> <p> <code>JSON 's3://mybucket/jsonpaths.txt'</code> - data is in JSON format, and the path specified is the format of the data.</p> <p>For more examples, see <a href="http://docs.aws.amazon.com/redshift/latest/dg/r_COPY_command_examples.html">Amazon Redshift COPY command examples</a>.</p>
     #[serde(rename = "CopyOptions")]
@@ -76,7 +76,7 @@ pub struct CopyCommand {
     pub data_table_name: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateDeliveryStreamInput {
     /// <p>The name of the delivery stream. This name must be unique per AWS account in the same region. If the delivery streams are in different accounts or different regions, you can have multiple delivery streams with the same name.</p>
     #[serde(rename = "DeliveryStreamName")]
@@ -107,7 +107,7 @@ pub struct CreateDeliveryStreamInput {
     pub splunk_destination_configuration: Option<SplunkDestinationConfiguration>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateDeliveryStreamOutput {
     /// <p>The ARN of the delivery stream.</p>
     #[serde(rename = "DeliveryStreamARN")]
@@ -115,18 +115,18 @@ pub struct CreateDeliveryStreamOutput {
     pub delivery_stream_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteDeliveryStreamInput {
     /// <p>The name of the delivery stream.</p>
     #[serde(rename = "DeliveryStreamName")]
     pub delivery_stream_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteDeliveryStreamOutput {}
 
 /// <p>Contains information about a delivery stream.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeliveryStreamDescription {
     /// <p>The date and time that the delivery stream was created.</p>
     #[serde(rename = "CreateTimestamp")]
@@ -163,7 +163,7 @@ pub struct DeliveryStreamDescription {
     pub version_id: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeDeliveryStreamInput {
     /// <p>The name of the delivery stream.</p>
     #[serde(rename = "DeliveryStreamName")]
@@ -178,7 +178,7 @@ pub struct DescribeDeliveryStreamInput {
     pub limit: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeDeliveryStreamOutput {
     /// <p>Information about the delivery stream.</p>
     #[serde(rename = "DeliveryStreamDescription")]
@@ -186,7 +186,7 @@ pub struct DescribeDeliveryStreamOutput {
 }
 
 /// <p>Describes the destination for a delivery stream.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DestinationDescription {
     /// <p>The ID of the destination.</p>
     #[serde(rename = "DestinationId")]
@@ -214,7 +214,7 @@ pub struct DestinationDescription {
 }
 
 /// <p>Describes the buffering to perform before delivering data to the Amazon ES destination.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ElasticsearchBufferingHints {
     /// <p>Buffer incoming data for the specified period of time, in seconds, before delivering it to the destination. The default value is 300 (5 minutes).</p>
     #[serde(rename = "IntervalInSeconds")]
@@ -227,7 +227,7 @@ pub struct ElasticsearchBufferingHints {
 }
 
 /// <p>Describes the configuration of a destination in Amazon ES.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ElasticsearchDestinationConfiguration {
     /// <p>The buffering options. If no value is specified, the default values for <b>ElasticsearchBufferingHints</b> are used.</p>
     #[serde(rename = "BufferingHints")]
@@ -271,7 +271,7 @@ pub struct ElasticsearchDestinationConfiguration {
 }
 
 /// <p>The destination description in Amazon ES.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ElasticsearchDestinationDescription {
     /// <p>The buffering options.</p>
     #[serde(rename = "BufferingHints")]
@@ -320,7 +320,7 @@ pub struct ElasticsearchDestinationDescription {
 }
 
 /// <p>Describes an update for a destination in Amazon ES.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ElasticsearchDestinationUpdate {
     /// <p>The buffering options. If no value is specified, <b>ElasticsearchBufferingHints</b> object default values are used. </p>
     #[serde(rename = "BufferingHints")]
@@ -365,7 +365,7 @@ pub struct ElasticsearchDestinationUpdate {
 }
 
 /// <p>Configures retry behavior in case Kinesis Firehose is unable to deliver documents to Amazon ES.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ElasticsearchRetryOptions {
     /// <p>After an initial failure to deliver to Amazon ES, the total amount of time during which Kinesis Firehose re-attempts delivery (including the first attempt). After this time has elapsed, the failed documents are written to Amazon S3. Default value is 300 seconds (5 minutes). A value of 0 (zero) results in no retries.</p>
     #[serde(rename = "DurationInSeconds")]
@@ -374,7 +374,7 @@ pub struct ElasticsearchRetryOptions {
 }
 
 /// <p>Describes the encryption for a destination in Amazon S3.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct EncryptionConfiguration {
     /// <p>The encryption key.</p>
     #[serde(rename = "KMSEncryptionConfig")]
@@ -387,7 +387,7 @@ pub struct EncryptionConfiguration {
 }
 
 /// <p>Describes the configuration of a destination in Amazon S3.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ExtendedS3DestinationConfiguration {
     /// <p>The ARN of the S3 bucket.</p>
     #[serde(rename = "BucketARN")]
@@ -430,7 +430,7 @@ pub struct ExtendedS3DestinationConfiguration {
 }
 
 /// <p>Describes a destination in Amazon S3.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ExtendedS3DestinationDescription {
     /// <p>The ARN of the S3 bucket.</p>
     #[serde(rename = "BucketARN")]
@@ -470,7 +470,7 @@ pub struct ExtendedS3DestinationDescription {
 }
 
 /// <p>Describes an update for a destination in Amazon S3.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ExtendedS3DestinationUpdate {
     /// <p>The ARN of the S3 bucket.</p>
     #[serde(rename = "BucketARN")]
@@ -515,7 +515,7 @@ pub struct ExtendedS3DestinationUpdate {
 }
 
 /// <p>Describes an encryption key for a destination in Amazon S3.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct KMSEncryptionConfig {
     /// <p>The ARN of the encryption key. Must belong to the same region as the destination Amazon S3 bucket.</p>
     #[serde(rename = "AWSKMSKeyARN")]
@@ -523,7 +523,7 @@ pub struct KMSEncryptionConfig {
 }
 
 /// <p>The stream and role ARNs for a Kinesis stream used as the source for a delivery stream.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct KinesisStreamSourceConfiguration {
     /// <p>The ARN of the source Kinesis stream.</p>
     #[serde(rename = "KinesisStreamARN")]
@@ -534,7 +534,7 @@ pub struct KinesisStreamSourceConfiguration {
 }
 
 /// <p>Details about a Kinesis stream used as the source for a Kinesis Firehose delivery stream.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct KinesisStreamSourceDescription {
     /// <p>Kinesis Firehose starts retrieving records from the Kinesis stream starting with this time stamp.</p>
     #[serde(rename = "DeliveryStartTimestamp")]
@@ -550,7 +550,7 @@ pub struct KinesisStreamSourceDescription {
     pub role_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListDeliveryStreamsInput {
     /// <p>The delivery stream type. This can be one of the following values:</p> <ul> <li> <p> <code>DirectPut</code>: Provider applications access the delivery stream directly.</p> </li> <li> <p> <code>KinesisStreamAsSource</code>: The delivery stream uses a Kinesis stream as a source.</p> </li> </ul> <p>This parameter is optional. If this parameter is omitted, delivery streams of all types are returned.</p>
     #[serde(rename = "DeliveryStreamType")]
@@ -566,7 +566,7 @@ pub struct ListDeliveryStreamsInput {
     pub limit: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListDeliveryStreamsOutput {
     /// <p>The names of the delivery streams.</p>
     #[serde(rename = "DeliveryStreamNames")]
@@ -577,7 +577,7 @@ pub struct ListDeliveryStreamsOutput {
 }
 
 /// <p>Describes a data processing configuration.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ProcessingConfiguration {
     /// <p>Enables or disables data processing.</p>
     #[serde(rename = "Enabled")]
@@ -590,7 +590,7 @@ pub struct ProcessingConfiguration {
 }
 
 /// <p>Describes a data processor.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Processor {
     /// <p>The processor parameters.</p>
     #[serde(rename = "Parameters")]
@@ -602,7 +602,7 @@ pub struct Processor {
 }
 
 /// <p>Describes the processor parameter.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ProcessorParameter {
     /// <p>The name of the parameter.</p>
     #[serde(rename = "ParameterName")]
@@ -612,7 +612,7 @@ pub struct ProcessorParameter {
     pub parameter_value: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PutRecordBatchInput {
     /// <p>The name of the delivery stream.</p>
     #[serde(rename = "DeliveryStreamName")]
@@ -622,7 +622,7 @@ pub struct PutRecordBatchInput {
     pub records: Vec<Record>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PutRecordBatchOutput {
     /// <p>The number of records that might have failed processing.</p>
     #[serde(rename = "FailedPutCount")]
@@ -633,7 +633,7 @@ pub struct PutRecordBatchOutput {
 }
 
 /// <p>Contains the result for an individual record from a <a>PutRecordBatch</a> request. If the record is successfully added to your delivery stream, it receives a record ID. If the record fails to be added to your delivery stream, the result includes an error code and an error message.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PutRecordBatchResponseEntry {
     /// <p>The error code for an individual record result.</p>
     #[serde(rename = "ErrorCode")]
@@ -649,7 +649,7 @@ pub struct PutRecordBatchResponseEntry {
     pub record_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PutRecordInput {
     /// <p>The name of the delivery stream.</p>
     #[serde(rename = "DeliveryStreamName")]
@@ -659,7 +659,7 @@ pub struct PutRecordInput {
     pub record: Record,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PutRecordOutput {
     /// <p>The ID of the record.</p>
     #[serde(rename = "RecordId")]
@@ -667,7 +667,7 @@ pub struct PutRecordOutput {
 }
 
 /// <p>The unit of data in a delivery stream.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct Record {
     /// <p>The data blob, which is base64-encoded when the blob is serialized. The maximum size of the data blob, before base64-encoding, is 1,000 KB.</p>
     #[serde(rename = "Data")]
@@ -680,7 +680,7 @@ pub struct Record {
 }
 
 /// <p>Describes the configuration of a destination in Amazon Redshift.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RedshiftDestinationConfiguration {
     /// <p>The CloudWatch logging options for your delivery stream.</p>
     #[serde(rename = "CloudWatchLoggingOptions")]
@@ -723,7 +723,7 @@ pub struct RedshiftDestinationConfiguration {
 }
 
 /// <p>Describes a destination in Amazon Redshift.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RedshiftDestinationDescription {
     /// <p>The CloudWatch logging options for your delivery stream.</p>
     #[serde(rename = "CloudWatchLoggingOptions")]
@@ -763,7 +763,7 @@ pub struct RedshiftDestinationDescription {
 }
 
 /// <p>Describes an update for a destination in Amazon Redshift.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RedshiftDestinationUpdate {
     /// <p>The CloudWatch logging options for your delivery stream.</p>
     #[serde(rename = "CloudWatchLoggingOptions")]
@@ -812,7 +812,7 @@ pub struct RedshiftDestinationUpdate {
 }
 
 /// <p>Configures retry behavior in case Kinesis Firehose is unable to deliver documents to Amazon Redshift.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RedshiftRetryOptions {
     /// <p>The length of time during which Kinesis Firehose retries delivery after a failure, starting from the initial request and including the first attempt. The default value is 3600 seconds (60 minutes). Kinesis Firehose does not retry if the value of <code>DurationInSeconds</code> is 0 (zero) or if the first delivery attempt takes longer than the current value.</p>
     #[serde(rename = "DurationInSeconds")]
@@ -821,7 +821,7 @@ pub struct RedshiftRetryOptions {
 }
 
 /// <p>Describes the configuration of a destination in Amazon S3.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct S3DestinationConfiguration {
     /// <p>The ARN of the S3 bucket.</p>
     #[serde(rename = "BucketARN")]
@@ -852,7 +852,7 @@ pub struct S3DestinationConfiguration {
 }
 
 /// <p>Describes a destination in Amazon S3.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct S3DestinationDescription {
     /// <p>The ARN of the S3 bucket.</p>
     #[serde(rename = "BucketARN")]
@@ -880,7 +880,7 @@ pub struct S3DestinationDescription {
 }
 
 /// <p>Describes an update for a destination in Amazon S3.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct S3DestinationUpdate {
     /// <p>The ARN of the S3 bucket.</p>
     #[serde(rename = "BucketARN")]
@@ -913,7 +913,7 @@ pub struct S3DestinationUpdate {
 }
 
 /// <p>Details about a Kinesis stream used as the source for a Kinesis Firehose delivery stream.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SourceDescription {
     /// <p>The <a>KinesisStreamSourceDescription</a> value for the source Kinesis stream.</p>
     #[serde(rename = "KinesisStreamSourceDescription")]
@@ -922,7 +922,7 @@ pub struct SourceDescription {
 }
 
 /// <p>Describes the configuration of a destination in Splunk.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SplunkDestinationConfiguration {
     /// <p>The CloudWatch logging options for your delivery stream.</p>
     #[serde(rename = "CloudWatchLoggingOptions")]
@@ -959,7 +959,7 @@ pub struct SplunkDestinationConfiguration {
 }
 
 /// <p>Describes a destination in Splunk.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SplunkDestinationDescription {
     /// <p>The CloudWatch logging options for your delivery stream.</p>
     #[serde(rename = "CloudWatchLoggingOptions")]
@@ -1000,7 +1000,7 @@ pub struct SplunkDestinationDescription {
 }
 
 /// <p>Describes an update for a destination in Splunk.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SplunkDestinationUpdate {
     /// <p>The CloudWatch logging options for your delivery stream.</p>
     #[serde(rename = "CloudWatchLoggingOptions")]
@@ -1041,7 +1041,7 @@ pub struct SplunkDestinationUpdate {
 }
 
 /// <p>Configures retry behavior in case Kinesis Firehose is unable to deliver documents to Splunk or if it doesn't receive an acknowledgment from Splunk.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SplunkRetryOptions {
     /// <p>The total amount of time that Kinesis Firehose spends on retries. This duration starts after the initial attempt to send data to Splunk fails and doesn't include the periods during which Kinesis Firehose waits for acknowledgment from Splunk after each attempt.</p>
     #[serde(rename = "DurationInSeconds")]
@@ -1049,7 +1049,7 @@ pub struct SplunkRetryOptions {
     pub duration_in_seconds: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateDestinationInput {
     /// <p>Obtain this value from the <b>VersionId</b> result of <a>DeliveryStreamDescription</a>. This value is required, and helps the service to perform conditional operations. For example, if there is an interleaving update and this value is null, then the update destination fails. After the update is successful, the <b>VersionId</b> value is updated. The service then performs a merge of the old configuration with the new configuration.</p>
     #[serde(rename = "CurrentDeliveryStreamVersionId")]
@@ -1078,7 +1078,7 @@ pub struct UpdateDestinationInput {
     pub splunk_destination_update: Option<SplunkDestinationUpdate>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateDestinationOutput {}
 
 /// Errors returned by CreateDeliveryStream

--- a/rusoto/services/firehose/src/generated.rs
+++ b/rusoto/services/firehose/src/generated.rs
@@ -1104,7 +1104,8 @@ impl CreateDeliveryStreamError {
     pub fn from_body(body: &str) -> CreateDeliveryStreamError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1194,7 +1195,8 @@ impl DeleteDeliveryStreamError {
     pub fn from_body(body: &str) -> DeleteDeliveryStreamError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1278,7 +1280,8 @@ impl DescribeDeliveryStreamError {
     pub fn from_body(body: &str) -> DescribeDeliveryStreamError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1356,7 +1359,8 @@ impl ListDeliveryStreamsError {
     pub fn from_body(body: &str) -> ListDeliveryStreamsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1436,7 +1440,8 @@ impl PutRecordError {
     pub fn from_body(body: &str) -> PutRecordError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1524,7 +1529,8 @@ impl PutRecordBatchError {
     pub fn from_body(body: &str) -> PutRecordBatchError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1616,7 +1622,8 @@ impl UpdateDestinationError {
     pub fn from_body(body: &str) -> UpdateDestinationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/gamelift/src/generated.rs
+++ b/rusoto/services/gamelift/src/generated.rs
@@ -2813,7 +2813,8 @@ impl AcceptMatchError {
     pub fn from_body(body: &str) -> AcceptMatchError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2909,7 +2910,8 @@ impl CreateAliasError {
     pub fn from_body(body: &str) -> CreateAliasError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3007,7 +3009,8 @@ impl CreateBuildError {
     pub fn from_body(body: &str) -> CreateBuildError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3105,7 +3108,8 @@ impl CreateFleetError {
     pub fn from_body(body: &str) -> CreateFleetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3217,7 +3221,8 @@ impl CreateGameSessionError {
     pub fn from_body(body: &str) -> CreateGameSessionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3341,7 +3346,8 @@ impl CreateGameSessionQueueError {
     pub fn from_body(body: &str) -> CreateGameSessionQueueError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3441,7 +3447,8 @@ impl CreateMatchmakingConfigurationError {
     pub fn from_body(body: &str) -> CreateMatchmakingConfigurationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3547,7 +3554,8 @@ impl CreateMatchmakingRuleSetError {
     pub fn from_body(body: &str) -> CreateMatchmakingRuleSetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3649,7 +3657,8 @@ impl CreatePlayerSessionError {
     pub fn from_body(body: &str) -> CreatePlayerSessionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3769,7 +3778,8 @@ impl CreatePlayerSessionsError {
     pub fn from_body(body: &str) -> CreatePlayerSessionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3883,7 +3893,8 @@ impl CreateVpcPeeringAuthorizationError {
     pub fn from_body(body: &str) -> CreateVpcPeeringAuthorizationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3985,7 +3996,8 @@ impl CreateVpcPeeringConnectionError {
     pub fn from_body(body: &str) -> CreateVpcPeeringConnectionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4083,7 +4095,8 @@ impl DeleteAliasError {
     pub fn from_body(body: &str) -> DeleteAliasError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4177,7 +4190,8 @@ impl DeleteBuildError {
     pub fn from_body(body: &str) -> DeleteBuildError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4273,7 +4287,8 @@ impl DeleteFleetError {
     pub fn from_body(body: &str) -> DeleteFleetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4371,7 +4386,8 @@ impl DeleteGameSessionQueueError {
     pub fn from_body(body: &str) -> DeleteGameSessionQueueError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4469,7 +4485,8 @@ impl DeleteMatchmakingConfigurationError {
     pub fn from_body(body: &str) -> DeleteMatchmakingConfigurationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4573,7 +4590,8 @@ impl DeleteScalingPolicyError {
     pub fn from_body(body: &str) -> DeleteScalingPolicyError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4671,7 +4689,8 @@ impl DeleteVpcPeeringAuthorizationError {
     pub fn from_body(body: &str) -> DeleteVpcPeeringAuthorizationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4773,7 +4792,8 @@ impl DeleteVpcPeeringConnectionError {
     pub fn from_body(body: &str) -> DeleteVpcPeeringConnectionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4871,7 +4891,8 @@ impl DescribeAliasError {
     pub fn from_body(body: &str) -> DescribeAliasError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4967,7 +4988,8 @@ impl DescribeBuildError {
     pub fn from_body(body: &str) -> DescribeBuildError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5061,7 +5083,8 @@ impl DescribeEC2InstanceLimitsError {
     pub fn from_body(body: &str) -> DescribeEC2InstanceLimitsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5155,7 +5178,8 @@ impl DescribeFleetAttributesError {
     pub fn from_body(body: &str) -> DescribeFleetAttributesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5253,7 +5277,8 @@ impl DescribeFleetCapacityError {
     pub fn from_body(body: &str) -> DescribeFleetCapacityError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5351,7 +5376,8 @@ impl DescribeFleetEventsError {
     pub fn from_body(body: &str) -> DescribeFleetEventsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5449,7 +5475,8 @@ impl DescribeFleetPortSettingsError {
     pub fn from_body(body: &str) -> DescribeFleetPortSettingsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5547,7 +5574,8 @@ impl DescribeFleetUtilizationError {
     pub fn from_body(body: &str) -> DescribeFleetUtilizationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5647,7 +5675,8 @@ impl DescribeGameSessionDetailsError {
     pub fn from_body(body: &str) -> DescribeGameSessionDetailsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5751,7 +5780,8 @@ impl DescribeGameSessionPlacementError {
     pub fn from_body(body: &str) -> DescribeGameSessionPlacementError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5851,7 +5881,8 @@ impl DescribeGameSessionQueuesError {
     pub fn from_body(body: &str) -> DescribeGameSessionQueuesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5951,7 +5982,8 @@ impl DescribeGameSessionsError {
     pub fn from_body(body: &str) -> DescribeGameSessionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6055,7 +6087,8 @@ impl DescribeInstancesError {
     pub fn from_body(body: &str) -> DescribeInstancesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6151,7 +6184,8 @@ impl DescribeMatchmakingError {
     pub fn from_body(body: &str) -> DescribeMatchmakingError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6243,7 +6277,8 @@ impl DescribeMatchmakingConfigurationsError {
     pub fn from_body(body: &str) -> DescribeMatchmakingConfigurationsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6343,7 +6378,8 @@ impl DescribeMatchmakingRuleSetsError {
     pub fn from_body(body: &str) -> DescribeMatchmakingRuleSetsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6445,7 +6481,8 @@ impl DescribePlayerSessionsError {
     pub fn from_body(body: &str) -> DescribePlayerSessionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6543,7 +6580,8 @@ impl DescribeRuntimeConfigurationError {
     pub fn from_body(body: &str) -> DescribeRuntimeConfigurationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6643,7 +6681,8 @@ impl DescribeScalingPoliciesError {
     pub fn from_body(body: &str) -> DescribeScalingPoliciesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6739,7 +6778,8 @@ impl DescribeVpcPeeringAuthorizationsError {
     pub fn from_body(body: &str) -> DescribeVpcPeeringAuthorizationsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6837,7 +6877,8 @@ impl DescribeVpcPeeringConnectionsError {
     pub fn from_body(body: &str) -> DescribeVpcPeeringConnectionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6939,7 +6980,8 @@ impl GetGameSessionLogUrlError {
     pub fn from_body(body: &str) -> GetGameSessionLogUrlError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7037,7 +7079,8 @@ impl GetInstanceAccessError {
     pub fn from_body(body: &str) -> GetInstanceAccessError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7133,7 +7176,8 @@ impl ListAliasesError {
     pub fn from_body(body: &str) -> ListAliasesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7223,7 +7267,8 @@ impl ListBuildsError {
     pub fn from_body(body: &str) -> ListBuildsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7313,7 +7358,8 @@ impl ListFleetsError {
     pub fn from_body(body: &str) -> ListFleetsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7405,7 +7451,8 @@ impl PutScalingPolicyError {
     pub fn from_body(body: &str) -> PutScalingPolicyError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7501,7 +7548,8 @@ impl RequestUploadCredentialsError {
     pub fn from_body(body: &str) -> RequestUploadCredentialsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7601,7 +7649,8 @@ impl ResolveAliasError {
     pub fn from_body(body: &str) -> ResolveAliasError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7701,7 +7750,8 @@ impl SearchGameSessionsError {
     pub fn from_body(body: &str) -> SearchGameSessionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7805,7 +7855,8 @@ impl StartGameSessionPlacementError {
     pub fn from_body(body: &str) -> StartGameSessionPlacementError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7903,7 +7954,8 @@ impl StartMatchBackfillError {
     pub fn from_body(body: &str) -> StartMatchBackfillError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8001,7 +8053,8 @@ impl StartMatchmakingError {
     pub fn from_body(body: &str) -> StartMatchmakingError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8097,7 +8150,8 @@ impl StopGameSessionPlacementError {
     pub fn from_body(body: &str) -> StopGameSessionPlacementError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8195,7 +8249,8 @@ impl StopMatchmakingError {
     pub fn from_body(body: &str) -> StopMatchmakingError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8291,7 +8346,8 @@ impl UpdateAliasError {
     pub fn from_body(body: &str) -> UpdateAliasError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8385,7 +8441,8 @@ impl UpdateBuildError {
     pub fn from_body(body: &str) -> UpdateBuildError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8485,7 +8542,8 @@ impl UpdateFleetAttributesError {
     pub fn from_body(body: &str) -> UpdateFleetAttributesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8601,7 +8659,8 @@ impl UpdateFleetCapacityError {
     pub fn from_body(body: &str) -> UpdateFleetCapacityError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8717,7 +8776,8 @@ impl UpdateFleetPortSettingsError {
     pub fn from_body(body: &str) -> UpdateFleetPortSettingsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8833,7 +8893,8 @@ impl UpdateGameSessionError {
     pub fn from_body(body: &str) -> UpdateGameSessionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8941,7 +9002,8 @@ impl UpdateGameSessionQueueError {
     pub fn from_body(body: &str) -> UpdateGameSessionQueueError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9039,7 +9101,8 @@ impl UpdateMatchmakingConfigurationError {
     pub fn from_body(body: &str) -> UpdateMatchmakingConfigurationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9145,7 +9208,8 @@ impl UpdateRuntimeConfigurationError {
     pub fn from_body(body: &str) -> UpdateRuntimeConfigurationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9247,7 +9311,8 @@ impl ValidateMatchmakingRuleSetError {
     pub fn from_body(body: &str) -> ValidateMatchmakingRuleSetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/gamelift/src/generated.rs
+++ b/rusoto/services/gamelift/src/generated.rs
@@ -31,7 +31,7 @@ use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 /// <p>Represents the input for a request action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AcceptMatchInput {
     /// <p>Player response to the proposed match.</p>
     #[serde(rename = "AcceptanceType")]
@@ -44,11 +44,11 @@ pub struct AcceptMatchInput {
     pub ticket_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AcceptMatchOutput {}
 
 /// <p><p>Properties describing a fleet alias.</p> <p>Alias-related operations include:</p> <ul> <li> <p> <a>CreateAlias</a> </p> </li> <li> <p> <a>ListAliases</a> </p> </li> <li> <p> <a>DescribeAlias</a> </p> </li> <li> <p> <a>UpdateAlias</a> </p> </li> <li> <p> <a>DeleteAlias</a> </p> </li> <li> <p> <a>ResolveAlias</a> </p> </li> </ul></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Alias {
     /// <p>Unique identifier for an alias; alias ARNs are unique across all regions.</p>
     #[serde(rename = "AliasArn")]
@@ -81,7 +81,7 @@ pub struct Alias {
 }
 
 /// <p>Values for use in <a>Player</a> attribute key:value pairs. This object lets you specify an attribute value using any of the valid data types: string, number, string array or data map. Each <code>AttributeValue</code> object can use only one of the available properties.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct AttributeValue {
     /// <p>For number values, expressed as double.</p>
     #[serde(rename = "N")]
@@ -102,7 +102,7 @@ pub struct AttributeValue {
 }
 
 /// <p>Temporary access credentials used for uploading game build files to Amazon GameLift. They are valid for a limited time. If they expire before you upload your game build, get a new set by calling <a>RequestUploadCredentials</a>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AwsCredentials {
     /// <p>Temporary key allowing access to the Amazon GameLift S3 account.</p>
     #[serde(rename = "AccessKeyId")]
@@ -119,7 +119,7 @@ pub struct AwsCredentials {
 }
 
 /// <p><p>Properties describing a game build.</p> <p>Build-related operations include:</p> <ul> <li> <p> <a>CreateBuild</a> </p> </li> <li> <p> <a>ListBuilds</a> </p> </li> <li> <p> <a>DescribeBuild</a> </p> </li> <li> <p> <a>UpdateBuild</a> </p> </li> <li> <p> <a>DeleteBuild</a> </p> </li> </ul></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Build {
     /// <p>Unique identifier for a build.</p>
     #[serde(rename = "BuildId")]
@@ -152,7 +152,7 @@ pub struct Build {
 }
 
 /// <p>Represents the input for a request action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateAliasInput {
     /// <p>Human-readable description of an alias.</p>
     #[serde(rename = "Description")]
@@ -167,7 +167,7 @@ pub struct CreateAliasInput {
 }
 
 /// <p>Represents the returned data in response to a request action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateAliasOutput {
     /// <p>Object that describes the newly created alias record.</p>
     #[serde(rename = "Alias")]
@@ -176,7 +176,7 @@ pub struct CreateAliasOutput {
 }
 
 /// <p>Represents the input for a request action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateBuildInput {
     /// <p>Descriptive label that is associated with a build. Build names do not need to be unique. You can use <a>UpdateBuild</a> to change this value later. </p>
     #[serde(rename = "Name")]
@@ -197,7 +197,7 @@ pub struct CreateBuildInput {
 }
 
 /// <p>Represents the returned data in response to a request action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateBuildOutput {
     /// <p>The newly created build record, including a unique build ID and status. </p>
     #[serde(rename = "Build")]
@@ -214,7 +214,7 @@ pub struct CreateBuildOutput {
 }
 
 /// <p>Represents the input for a request action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateFleetInput {
     /// <p>Unique identifier for a build to be deployed on the new fleet. The build must have been successfully uploaded to Amazon GameLift and be in a <code>READY</code> status. This fleet setting cannot be changed once the fleet is created.</p>
     #[serde(rename = "BuildId")]
@@ -276,7 +276,7 @@ pub struct CreateFleetInput {
 }
 
 /// <p>Represents the returned data in response to a request action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateFleetOutput {
     /// <p>Properties for the newly created fleet.</p>
     #[serde(rename = "FleetAttributes")]
@@ -285,7 +285,7 @@ pub struct CreateFleetOutput {
 }
 
 /// <p>Represents the input for a request action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateGameSessionInput {
     /// <p>Unique identifier for an alias associated with the fleet to create a game session in. Each request must reference either a fleet ID or alias ID, but not both.</p>
     #[serde(rename = "AliasId")]
@@ -325,7 +325,7 @@ pub struct CreateGameSessionInput {
 }
 
 /// <p>Represents the returned data in response to a request action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateGameSessionOutput {
     /// <p>Object that describes the newly created game session record.</p>
     #[serde(rename = "GameSession")]
@@ -334,7 +334,7 @@ pub struct CreateGameSessionOutput {
 }
 
 /// <p>Represents the input for a request action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateGameSessionQueueInput {
     /// <p>List of fleets that can be used to fulfill game session placement requests in the queue. Fleets are identified by either a fleet ARN or a fleet alias ARN. Destinations are listed in default preference order.</p>
     #[serde(rename = "Destinations")]
@@ -354,7 +354,7 @@ pub struct CreateGameSessionQueueInput {
 }
 
 /// <p>Represents the returned data in response to a request action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateGameSessionQueueOutput {
     /// <p>Object that describes the newly created game session queue.</p>
     #[serde(rename = "GameSessionQueue")]
@@ -363,7 +363,7 @@ pub struct CreateGameSessionQueueOutput {
 }
 
 /// <p>Represents the input for a request action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateMatchmakingConfigurationInput {
     /// <p>Flag that determines whether or not a match that was created with this configuration must be accepted by the matched players. To require acceptance, set to TRUE.</p>
     #[serde(rename = "AcceptanceRequired")]
@@ -411,7 +411,7 @@ pub struct CreateMatchmakingConfigurationInput {
 }
 
 /// <p>Represents the returned data in response to a request action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateMatchmakingConfigurationOutput {
     /// <p>Object that describes the newly created matchmaking configuration.</p>
     #[serde(rename = "Configuration")]
@@ -420,7 +420,7 @@ pub struct CreateMatchmakingConfigurationOutput {
 }
 
 /// <p>Represents the input for a request action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateMatchmakingRuleSetInput {
     /// <p>Unique identifier for a matchmaking rule set. This name is used to identify the rule set associated with a matchmaking configuration.</p>
     #[serde(rename = "Name")]
@@ -431,7 +431,7 @@ pub struct CreateMatchmakingRuleSetInput {
 }
 
 /// <p>Represents the returned data in response to a request action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateMatchmakingRuleSetOutput {
     /// <p>Object that describes the newly created matchmaking rule set.</p>
     #[serde(rename = "RuleSet")]
@@ -439,7 +439,7 @@ pub struct CreateMatchmakingRuleSetOutput {
 }
 
 /// <p>Represents the input for a request action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreatePlayerSessionInput {
     /// <p>Unique identifier for the game session to add a player to.</p>
     #[serde(rename = "GameSessionId")]
@@ -454,7 +454,7 @@ pub struct CreatePlayerSessionInput {
 }
 
 /// <p>Represents the returned data in response to a request action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreatePlayerSessionOutput {
     /// <p>Object that describes the newly created player session record.</p>
     #[serde(rename = "PlayerSession")]
@@ -463,7 +463,7 @@ pub struct CreatePlayerSessionOutput {
 }
 
 /// <p>Represents the input for a request action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreatePlayerSessionsInput {
     /// <p>Unique identifier for the game session to add players to.</p>
     #[serde(rename = "GameSessionId")]
@@ -478,7 +478,7 @@ pub struct CreatePlayerSessionsInput {
 }
 
 /// <p>Represents the returned data in response to a request action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreatePlayerSessionsOutput {
     /// <p>Collection of player session objects created for the added players.</p>
     #[serde(rename = "PlayerSessions")]
@@ -487,7 +487,7 @@ pub struct CreatePlayerSessionsOutput {
 }
 
 /// <p>Represents the input for a request action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateVpcPeeringAuthorizationInput {
     /// <p>Unique identifier for the AWS account that you use to manage your Amazon GameLift fleet. You can find your Account ID in the AWS Management Console under account settings.</p>
     #[serde(rename = "GameLiftAwsAccountId")]
@@ -498,7 +498,7 @@ pub struct CreateVpcPeeringAuthorizationInput {
 }
 
 /// <p>Represents the returned data in response to a request action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateVpcPeeringAuthorizationOutput {
     /// <p>Details on the requested VPC peering authorization, including expiration.</p>
     #[serde(rename = "VpcPeeringAuthorization")]
@@ -507,7 +507,7 @@ pub struct CreateVpcPeeringAuthorizationOutput {
 }
 
 /// <p>Represents the input for a request action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateVpcPeeringConnectionInput {
     /// <p>Unique identifier for a fleet. This tells Amazon GameLift which GameLift VPC to peer with. </p>
     #[serde(rename = "FleetId")]
@@ -520,11 +520,11 @@ pub struct CreateVpcPeeringConnectionInput {
     pub peer_vpc_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateVpcPeeringConnectionOutput {}
 
 /// <p>Represents the input for a request action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteAliasInput {
     /// <p>Unique identifier for a fleet alias. Specify the alias you want to delete.</p>
     #[serde(rename = "AliasId")]
@@ -532,7 +532,7 @@ pub struct DeleteAliasInput {
 }
 
 /// <p>Represents the input for a request action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteBuildInput {
     /// <p>Unique identifier for a build to delete.</p>
     #[serde(rename = "BuildId")]
@@ -540,7 +540,7 @@ pub struct DeleteBuildInput {
 }
 
 /// <p>Represents the input for a request action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteFleetInput {
     /// <p>Unique identifier for a fleet to be deleted.</p>
     #[serde(rename = "FleetId")]
@@ -548,29 +548,29 @@ pub struct DeleteFleetInput {
 }
 
 /// <p>Represents the input for a request action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteGameSessionQueueInput {
     /// <p>Descriptive label that is associated with game session queue. Queue names must be unique within each region.</p>
     #[serde(rename = "Name")]
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteGameSessionQueueOutput {}
 
 /// <p>Represents the input for a request action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteMatchmakingConfigurationInput {
     /// <p>Unique identifier for a matchmaking configuration</p>
     #[serde(rename = "Name")]
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteMatchmakingConfigurationOutput {}
 
 /// <p>Represents the input for a request action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteScalingPolicyInput {
     /// <p>Unique identifier for a fleet to be deleted.</p>
     #[serde(rename = "FleetId")]
@@ -581,7 +581,7 @@ pub struct DeleteScalingPolicyInput {
 }
 
 /// <p>Represents the input for a request action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteVpcPeeringAuthorizationInput {
     /// <p>Unique identifier for the AWS account that you use to manage your Amazon GameLift fleet. You can find your Account ID in the AWS Management Console under account settings.</p>
     #[serde(rename = "GameLiftAwsAccountId")]
@@ -591,11 +591,11 @@ pub struct DeleteVpcPeeringAuthorizationInput {
     pub peer_vpc_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteVpcPeeringAuthorizationOutput {}
 
 /// <p>Represents the input for a request action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteVpcPeeringConnectionInput {
     /// <p>Unique identifier for a fleet. This value must match the fleet ID referenced in the VPC peering connection record.</p>
     #[serde(rename = "FleetId")]
@@ -605,11 +605,11 @@ pub struct DeleteVpcPeeringConnectionInput {
     pub vpc_peering_connection_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteVpcPeeringConnectionOutput {}
 
 /// <p>Represents the input for a request action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeAliasInput {
     /// <p>Unique identifier for a fleet alias. Specify the alias you want to retrieve.</p>
     #[serde(rename = "AliasId")]
@@ -617,7 +617,7 @@ pub struct DescribeAliasInput {
 }
 
 /// <p>Represents the returned data in response to a request action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeAliasOutput {
     /// <p>Object that contains the requested alias.</p>
     #[serde(rename = "Alias")]
@@ -626,7 +626,7 @@ pub struct DescribeAliasOutput {
 }
 
 /// <p>Represents the input for a request action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeBuildInput {
     /// <p>Unique identifier for a build to retrieve properties for.</p>
     #[serde(rename = "BuildId")]
@@ -634,7 +634,7 @@ pub struct DescribeBuildInput {
 }
 
 /// <p>Represents the returned data in response to a request action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeBuildOutput {
     /// <p>Set of properties describing the requested build.</p>
     #[serde(rename = "Build")]
@@ -643,7 +643,7 @@ pub struct DescribeBuildOutput {
 }
 
 /// <p>Represents the input for a request action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeEC2InstanceLimitsInput {
     /// <p>Name of an EC2 instance type that is supported in Amazon GameLift. A fleet instance type determines the computing resources of each instance in the fleet, including CPU, memory, storage, and networking capacity. Amazon GameLift supports the following EC2 instance types. See <a href="http://aws.amazon.com/ec2/instance-types/">Amazon EC2 Instance Types</a> for detailed descriptions. Leave this parameter blank to retrieve limits for all types.</p>
     #[serde(rename = "EC2InstanceType")]
@@ -652,7 +652,7 @@ pub struct DescribeEC2InstanceLimitsInput {
 }
 
 /// <p>Represents the returned data in response to a request action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeEC2InstanceLimitsOutput {
     /// <p>Object that contains the maximum number of instances for the specified instance type.</p>
     #[serde(rename = "EC2InstanceLimits")]
@@ -661,7 +661,7 @@ pub struct DescribeEC2InstanceLimitsOutput {
 }
 
 /// <p>Represents the input for a request action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeFleetAttributesInput {
     /// <p>Unique identifier for a fleet(s) to retrieve attributes for. To request attributes for all fleets, leave this parameter empty.</p>
     #[serde(rename = "FleetIds")]
@@ -678,7 +678,7 @@ pub struct DescribeFleetAttributesInput {
 }
 
 /// <p>Represents the returned data in response to a request action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeFleetAttributesOutput {
     /// <p>Collection of objects containing attribute metadata for each requested fleet ID.</p>
     #[serde(rename = "FleetAttributes")]
@@ -691,7 +691,7 @@ pub struct DescribeFleetAttributesOutput {
 }
 
 /// <p>Represents the input for a request action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeFleetCapacityInput {
     /// <p>Unique identifier for a fleet(s) to retrieve capacity information for. To request capacity information for all fleets, leave this parameter empty.</p>
     #[serde(rename = "FleetIds")]
@@ -708,7 +708,7 @@ pub struct DescribeFleetCapacityInput {
 }
 
 /// <p>Represents the returned data in response to a request action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeFleetCapacityOutput {
     /// <p>Collection of objects containing capacity information for each requested fleet ID. Leave this parameter empty to retrieve capacity information for all fleets.</p>
     #[serde(rename = "FleetCapacity")]
@@ -721,7 +721,7 @@ pub struct DescribeFleetCapacityOutput {
 }
 
 /// <p>Represents the input for a request action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeFleetEventsInput {
     /// <p>Most recent date to retrieve event logs for. If no end time is specified, this call returns entries from the specified start time up to the present. Format is a number expressed in Unix time as milliseconds (ex: "1469498468.057").</p>
     #[serde(rename = "EndTime")]
@@ -745,7 +745,7 @@ pub struct DescribeFleetEventsInput {
 }
 
 /// <p>Represents the returned data in response to a request action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeFleetEventsOutput {
     /// <p>Collection of objects containing event log entries for the specified fleet.</p>
     #[serde(rename = "Events")]
@@ -758,7 +758,7 @@ pub struct DescribeFleetEventsOutput {
 }
 
 /// <p>Represents the input for a request action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeFleetPortSettingsInput {
     /// <p>Unique identifier for a fleet to retrieve port settings for.</p>
     #[serde(rename = "FleetId")]
@@ -766,7 +766,7 @@ pub struct DescribeFleetPortSettingsInput {
 }
 
 /// <p>Represents the returned data in response to a request action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeFleetPortSettingsOutput {
     /// <p>Object that contains port settings for the requested fleet ID.</p>
     #[serde(rename = "InboundPermissions")]
@@ -775,7 +775,7 @@ pub struct DescribeFleetPortSettingsOutput {
 }
 
 /// <p>Represents the input for a request action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeFleetUtilizationInput {
     /// <p>Unique identifier for a fleet(s) to retrieve utilization data for. To request utilization data for all fleets, leave this parameter empty.</p>
     #[serde(rename = "FleetIds")]
@@ -792,7 +792,7 @@ pub struct DescribeFleetUtilizationInput {
 }
 
 /// <p>Represents the returned data in response to a request action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeFleetUtilizationOutput {
     /// <p>Collection of objects containing utilization information for each requested fleet ID.</p>
     #[serde(rename = "FleetUtilization")]
@@ -805,7 +805,7 @@ pub struct DescribeFleetUtilizationOutput {
 }
 
 /// <p>Represents the input for a request action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeGameSessionDetailsInput {
     /// <p>Unique identifier for an alias associated with the fleet to retrieve all game sessions for.</p>
     #[serde(rename = "AliasId")]
@@ -834,7 +834,7 @@ pub struct DescribeGameSessionDetailsInput {
 }
 
 /// <p>Represents the returned data in response to a request action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeGameSessionDetailsOutput {
     /// <p>Collection of objects containing game session properties and the protection policy currently in force for each session matching the request.</p>
     #[serde(rename = "GameSessionDetails")]
@@ -847,7 +847,7 @@ pub struct DescribeGameSessionDetailsOutput {
 }
 
 /// <p>Represents the input for a request action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeGameSessionPlacementInput {
     /// <p>Unique identifier for a game session placement to retrieve.</p>
     #[serde(rename = "PlacementId")]
@@ -855,7 +855,7 @@ pub struct DescribeGameSessionPlacementInput {
 }
 
 /// <p>Represents the returned data in response to a request action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeGameSessionPlacementOutput {
     /// <p>Object that describes the requested game session placement.</p>
     #[serde(rename = "GameSessionPlacement")]
@@ -864,7 +864,7 @@ pub struct DescribeGameSessionPlacementOutput {
 }
 
 /// <p>Represents the input for a request action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeGameSessionQueuesInput {
     /// <p>Maximum number of results to return. Use this parameter with <code>NextToken</code> to get results as a set of sequential pages.</p>
     #[serde(rename = "Limit")]
@@ -881,7 +881,7 @@ pub struct DescribeGameSessionQueuesInput {
 }
 
 /// <p>Represents the returned data in response to a request action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeGameSessionQueuesOutput {
     /// <p>Collection of objects that describes the requested game session queues.</p>
     #[serde(rename = "GameSessionQueues")]
@@ -894,7 +894,7 @@ pub struct DescribeGameSessionQueuesOutput {
 }
 
 /// <p>Represents the input for a request action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeGameSessionsInput {
     /// <p>Unique identifier for an alias associated with the fleet to retrieve all game sessions for. </p>
     #[serde(rename = "AliasId")]
@@ -923,7 +923,7 @@ pub struct DescribeGameSessionsInput {
 }
 
 /// <p>Represents the returned data in response to a request action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeGameSessionsOutput {
     /// <p>Collection of objects containing game session properties for each session matching the request.</p>
     #[serde(rename = "GameSessions")]
@@ -936,7 +936,7 @@ pub struct DescribeGameSessionsOutput {
 }
 
 /// <p>Represents the input for a request action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeInstancesInput {
     /// <p>Unique identifier for a fleet to retrieve instance information for.</p>
     #[serde(rename = "FleetId")]
@@ -956,7 +956,7 @@ pub struct DescribeInstancesInput {
 }
 
 /// <p>Represents the returned data in response to a request action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeInstancesOutput {
     /// <p>Collection of objects containing properties for each instance returned.</p>
     #[serde(rename = "Instances")]
@@ -969,7 +969,7 @@ pub struct DescribeInstancesOutput {
 }
 
 /// <p>Represents the input for a request action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeMatchmakingConfigurationsInput {
     /// <p>Maximum number of results to return. Use this parameter with <code>NextToken</code> to get results as a set of sequential pages. This parameter is limited to 10.</p>
     #[serde(rename = "Limit")]
@@ -990,7 +990,7 @@ pub struct DescribeMatchmakingConfigurationsInput {
 }
 
 /// <p>Represents the returned data in response to a request action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeMatchmakingConfigurationsOutput {
     /// <p>Collection of requested matchmaking configuration objects.</p>
     #[serde(rename = "Configurations")]
@@ -1003,7 +1003,7 @@ pub struct DescribeMatchmakingConfigurationsOutput {
 }
 
 /// <p>Represents the input for a request action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeMatchmakingInput {
     /// <p>Unique identifier for a matchmaking ticket. You can include up to 10 ID values. </p>
     #[serde(rename = "TicketIds")]
@@ -1011,7 +1011,7 @@ pub struct DescribeMatchmakingInput {
 }
 
 /// <p>Represents the returned data in response to a request action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeMatchmakingOutput {
     /// <p>Collection of existing matchmaking ticket objects matching the request.</p>
     #[serde(rename = "TicketList")]
@@ -1020,7 +1020,7 @@ pub struct DescribeMatchmakingOutput {
 }
 
 /// <p>Represents the input for a request action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeMatchmakingRuleSetsInput {
     /// <p>Maximum number of results to return. Use this parameter with <code>NextToken</code> to get results as a set of sequential pages.</p>
     #[serde(rename = "Limit")]
@@ -1037,7 +1037,7 @@ pub struct DescribeMatchmakingRuleSetsInput {
 }
 
 /// <p>Represents the returned data in response to a request action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeMatchmakingRuleSetsOutput {
     /// <p>Token that indicates where to resume retrieving results on the next call to this action. If no token is returned, these results represent the end of the list.</p>
     #[serde(rename = "NextToken")]
@@ -1049,7 +1049,7 @@ pub struct DescribeMatchmakingRuleSetsOutput {
 }
 
 /// <p>Represents the input for a request action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribePlayerSessionsInput {
     /// <p>Unique identifier for the game session to retrieve player sessions for.</p>
     #[serde(rename = "GameSessionId")]
@@ -1078,7 +1078,7 @@ pub struct DescribePlayerSessionsInput {
 }
 
 /// <p>Represents the returned data in response to a request action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribePlayerSessionsOutput {
     /// <p>Token that indicates where to resume retrieving results on the next call to this action. If no token is returned, these results represent the end of the list.</p>
     #[serde(rename = "NextToken")]
@@ -1091,7 +1091,7 @@ pub struct DescribePlayerSessionsOutput {
 }
 
 /// <p>Represents the input for a request action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeRuntimeConfigurationInput {
     /// <p>Unique identifier for a fleet to get the run-time configuration for.</p>
     #[serde(rename = "FleetId")]
@@ -1099,7 +1099,7 @@ pub struct DescribeRuntimeConfigurationInput {
 }
 
 /// <p>Represents the returned data in response to a request action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeRuntimeConfigurationOutput {
     /// <p>Instructions describing how server processes should be launched and maintained on each instance in the fleet.</p>
     #[serde(rename = "RuntimeConfiguration")]
@@ -1108,7 +1108,7 @@ pub struct DescribeRuntimeConfigurationOutput {
 }
 
 /// <p>Represents the input for a request action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeScalingPoliciesInput {
     /// <p>Unique identifier for a fleet to retrieve scaling policies for.</p>
     #[serde(rename = "FleetId")]
@@ -1128,7 +1128,7 @@ pub struct DescribeScalingPoliciesInput {
 }
 
 /// <p>Represents the returned data in response to a request action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeScalingPoliciesOutput {
     /// <p>Token that indicates where to resume retrieving results on the next call to this action. If no token is returned, these results represent the end of the list.</p>
     #[serde(rename = "NextToken")]
@@ -1140,10 +1140,10 @@ pub struct DescribeScalingPoliciesOutput {
     pub scaling_policies: Option<Vec<ScalingPolicy>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeVpcPeeringAuthorizationsInput {}
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeVpcPeeringAuthorizationsOutput {
     /// <p>Collection of objects that describe all valid VPC peering operations for the current AWS account.</p>
     #[serde(rename = "VpcPeeringAuthorizations")]
@@ -1152,7 +1152,7 @@ pub struct DescribeVpcPeeringAuthorizationsOutput {
 }
 
 /// <p>Represents the input for a request action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeVpcPeeringConnectionsInput {
     /// <p>Unique identifier for a fleet.</p>
     #[serde(rename = "FleetId")]
@@ -1161,7 +1161,7 @@ pub struct DescribeVpcPeeringConnectionsInput {
 }
 
 /// <p>Represents the returned data in response to a request action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeVpcPeeringConnectionsOutput {
     /// <p>Collection of VPC peering connection records that match the request.</p>
     #[serde(rename = "VpcPeeringConnections")]
@@ -1170,7 +1170,7 @@ pub struct DescribeVpcPeeringConnectionsOutput {
 }
 
 /// <p>Player information for use when creating player sessions using a game session placement request with <a>StartGameSessionPlacement</a>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DesiredPlayerSession {
     /// <p>Developer-defined information related to a player. Amazon GameLift does not use this data, so it can be formatted as needed for use in the game.</p>
     #[serde(rename = "PlayerData")]
@@ -1183,7 +1183,7 @@ pub struct DesiredPlayerSession {
 }
 
 /// <p><p>Current status of fleet capacity. The number of active instances should match or be in the process of matching the number of desired instances. Pending and terminating counts are non-zero only if fleet capacity is adjusting to an <a>UpdateFleetCapacity</a> request, or if access to resources is temporarily affected.</p> <p>Fleet-related operations include:</p> <ul> <li> <p> <a>CreateFleet</a> </p> </li> <li> <p> <a>ListFleets</a> </p> </li> <li> <p>Describe fleets:</p> <ul> <li> <p> <a>DescribeFleetAttributes</a> </p> </li> <li> <p> <a>DescribeFleetPortSettings</a> </p> </li> <li> <p> <a>DescribeFleetUtilization</a> </p> </li> <li> <p> <a>DescribeRuntimeConfiguration</a> </p> </li> <li> <p> <a>DescribeFleetEvents</a> </p> </li> </ul> </li> <li> <p>Update fleets:</p> <ul> <li> <p> <a>UpdateFleetAttributes</a> </p> </li> <li> <p> <a>UpdateFleetCapacity</a> </p> </li> <li> <p> <a>UpdateFleetPortSettings</a> </p> </li> <li> <p> <a>UpdateRuntimeConfiguration</a> </p> </li> </ul> </li> <li> <p>Manage fleet capacity:</p> <ul> <li> <p> <a>DescribeFleetCapacity</a> </p> </li> <li> <p> <a>UpdateFleetCapacity</a> </p> </li> <li> <p> <a>PutScalingPolicy</a> (automatic scaling)</p> </li> <li> <p> <a>DescribeScalingPolicies</a> (automatic scaling)</p> </li> <li> <p> <a>DeleteScalingPolicy</a> (automatic scaling)</p> </li> <li> <p> <a>DescribeEC2InstanceLimits</a> </p> </li> </ul> </li> <li> <p> <a>DeleteFleet</a> </p> </li> </ul></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct EC2InstanceCounts {
     /// <p>Actual number of active instances in the fleet.</p>
     #[serde(rename = "ACTIVE")]
@@ -1216,7 +1216,7 @@ pub struct EC2InstanceCounts {
 }
 
 /// <p>Maximum number of instances allowed based on the Amazon Elastic Compute Cloud (Amazon EC2) instance type. Instance limits can be retrieved by calling <a>DescribeEC2InstanceLimits</a>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct EC2InstanceLimit {
     /// <p>Number of instances of the specified type that are currently in use by this AWS account.</p>
     #[serde(rename = "CurrentInstances")]
@@ -1233,7 +1233,7 @@ pub struct EC2InstanceLimit {
 }
 
 /// <p>Log entry describing an event that involves Amazon GameLift resources (such as a fleet). In addition to tracking activity, event codes and messages can provide additional information for troubleshooting and debugging problems.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Event {
     /// <p><p>Type of event being logged. The following events are currently in use:</p> <p> <b>Fleet creation events:</b> </p> <ul> <li> <p>FLEET<em>CREATED -- A fleet record was successfully created with a status of <code>NEW</code>. Event messaging includes the fleet ID.</p> </li> <li> <p>FLEET</em>STATE<em>DOWNLOADING -- Fleet status changed from <code>NEW</code> to <code>DOWNLOADING</code>. The compressed build has started downloading to a fleet instance for installation.</p> </li> <li> <p> FLEET</em>BINARY<em>DOWNLOAD</em>FAILED -- The build failed to download to the fleet instance.</p> </li> <li> <p>FLEET<em>CREATION</em>EXTRACTING<em>BUILD – The game server build was successfully downloaded to an instance, and the build files are now being extracted from the uploaded build and saved to an instance. Failure at this stage prevents a fleet from moving to <code>ACTIVE</code> status. Logs for this stage display a list of the files that are extracted and saved on the instance. Access the logs by using the URL in <i>PreSignedLogUrl</i>.</p> </li> <li> <p>FLEET</em>CREATION<em>RUNNING</em>INSTALLER – The game server build files were successfully extracted, and the Amazon GameLift is now running the build&#39;s install script (if one is included). Failure in this stage prevents a fleet from moving to <code>ACTIVE</code> status. Logs for this stage list the installation steps and whether or not the install completed successfully. Access the logs by using the URL in <i>PreSignedLogUrl</i>. </p> </li> <li> <p>FLEET<em>CREATION</em>VALIDATING<em>RUNTIME</em>CONFIG -- The build process was successful, and the Amazon GameLift is now verifying that the game server launch paths, which are specified in the fleet&#39;s run-time configuration, exist. If any listed launch path exists, Amazon GameLift tries to launch a game server process and waits for the process to report ready. Failures in this stage prevent a fleet from moving to <code>ACTIVE</code> status. Logs for this stage list the launch paths in the run-time configuration and indicate whether each is found. Access the logs by using the URL in <i>PreSignedLogUrl</i>. </p> </li> <li> <p>FLEET<em>STATE</em>VALIDATING -- Fleet status changed from <code>DOWNLOADING</code> to <code>VALIDATING</code>.</p> </li> <li> <p> FLEET<em>VALIDATION</em>LAUNCH<em>PATH</em>NOT<em>FOUND -- Validation of the run-time configuration failed because the executable specified in a launch path does not exist on the instance.</p> </li> <li> <p>FLEET</em>STATE<em>BUILDING -- Fleet status changed from <code>VALIDATING</code> to <code>BUILDING</code>.</p> </li> <li> <p>FLEET</em>VALIDATION<em>EXECUTABLE</em>RUNTIME<em>FAILURE -- Validation of the run-time configuration failed because the executable specified in a launch path failed to run on the fleet instance.</p> </li> <li> <p>FLEET</em>STATE<em>ACTIVATING -- Fleet status changed from <code>BUILDING</code> to <code>ACTIVATING</code>. </p> </li> <li> <p> FLEET</em>ACTIVATION<em>FAILED - The fleet failed to successfully complete one of the steps in the fleet activation process. This event code indicates that the game build was successfully downloaded to a fleet instance, built, and validated, but was not able to start a server process. A possible reason for failure is that the game server is not reporting &quot;process ready&quot; to the Amazon GameLift service.</p> </li> <li> <p>FLEET</em>STATE<em>ACTIVE -- The fleet&#39;s status changed from <code>ACTIVATING</code> to <code>ACTIVE</code>. The fleet is now ready to host game sessions.</p> </li> </ul> <p> <b>VPC peering events:</b> </p> <ul> <li> <p>FLEET</em>VPC<em>PEERING</em>SUCCEEDED -- A VPC peering connection has been established between the VPC for an Amazon GameLift fleet and a VPC in your AWS account.</p> </li> <li> <p>FLEET<em>VPC</em>PEERING<em>FAILED -- A requested VPC peering connection has failed. Event details and status information (see <a>DescribeVpcPeeringConnections</a>) provide additional detail. A common reason for peering failure is that the two VPCs have overlapping CIDR blocks of IPv4 addresses. To resolve this, change the CIDR block for the VPC in your AWS account. For more information on VPC peering failures, see <a href="http://docs.aws.amazon.com/AmazonVPC/latest/PeeringGuide/invalid-peering-configurations.html">http://docs.aws.amazon.com/AmazonVPC/latest/PeeringGuide/invalid-peering-configurations.html</a> </p> </li> <li> <p>FLEET</em>VPC<em>PEERING</em>DELETED -- A VPC peering connection has been successfully deleted.</p> </li> </ul> <p> <b>Spot instance events:</b> </p> <ul> <li> <p> INSTANCE<em>INTERRUPTED -- A spot instance was interrupted by EC2 with a two-minute notification.</p> </li> </ul> <p> <b>Other fleet events:</b> </p> <ul> <li> <p>FLEET</em>SCALING<em>EVENT -- A change was made to the fleet&#39;s capacity settings (desired instances, minimum/maximum scaling limits). Event messaging includes the new capacity settings.</p> </li> <li> <p>FLEET</em>NEW<em>GAME</em>SESSION<em>PROTECTION</em>POLICY<em>UPDATED -- A change was made to the fleet&#39;s game session protection policy setting. Event messaging includes both the old and new policy setting. </p> </li> <li> <p>FLEET</em>DELETED -- A request to delete a fleet was initiated.</p> </li> <li> <p> GENERIC_EVENT -- An unspecified event has occurred.</p> </li> </ul></p>
     #[serde(rename = "EventCode")]
@@ -1262,7 +1262,7 @@ pub struct Event {
 }
 
 /// <p><p>General properties describing a fleet.</p> <p>Fleet-related operations include:</p> <ul> <li> <p> <a>CreateFleet</a> </p> </li> <li> <p> <a>ListFleets</a> </p> </li> <li> <p>Describe fleets:</p> <ul> <li> <p> <a>DescribeFleetAttributes</a> </p> </li> <li> <p> <a>DescribeFleetPortSettings</a> </p> </li> <li> <p> <a>DescribeFleetUtilization</a> </p> </li> <li> <p> <a>DescribeRuntimeConfiguration</a> </p> </li> <li> <p> <a>DescribeFleetEvents</a> </p> </li> </ul> </li> <li> <p>Update fleets:</p> <ul> <li> <p> <a>UpdateFleetAttributes</a> </p> </li> <li> <p> <a>UpdateFleetCapacity</a> </p> </li> <li> <p> <a>UpdateFleetPortSettings</a> </p> </li> <li> <p> <a>UpdateRuntimeConfiguration</a> </p> </li> </ul> </li> <li> <p>Manage fleet capacity:</p> <ul> <li> <p> <a>DescribeFleetCapacity</a> </p> </li> <li> <p> <a>UpdateFleetCapacity</a> </p> </li> <li> <p> <a>PutScalingPolicy</a> (automatic scaling)</p> </li> <li> <p> <a>DescribeScalingPolicies</a> (automatic scaling)</p> </li> <li> <p> <a>DeleteScalingPolicy</a> (automatic scaling)</p> </li> <li> <p> <a>DescribeEC2InstanceLimits</a> </p> </li> </ul> </li> <li> <p> <a>DeleteFleet</a> </p> </li> </ul></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct FleetAttributes {
     /// <p>Unique identifier for a build.</p>
     #[serde(rename = "BuildId")]
@@ -1335,7 +1335,7 @@ pub struct FleetAttributes {
 }
 
 /// <p><p>Information about the fleet&#39;s capacity. Fleet capacity is measured in EC2 instances. By default, new fleets have a capacity of one instance, but can be updated as needed. The maximum number of instances for a fleet is determined by the fleet&#39;s instance type.</p> <p>Fleet-related operations include:</p> <ul> <li> <p> <a>CreateFleet</a> </p> </li> <li> <p> <a>ListFleets</a> </p> </li> <li> <p>Describe fleets:</p> <ul> <li> <p> <a>DescribeFleetAttributes</a> </p> </li> <li> <p> <a>DescribeFleetPortSettings</a> </p> </li> <li> <p> <a>DescribeFleetUtilization</a> </p> </li> <li> <p> <a>DescribeRuntimeConfiguration</a> </p> </li> <li> <p> <a>DescribeFleetEvents</a> </p> </li> </ul> </li> <li> <p>Update fleets:</p> <ul> <li> <p> <a>UpdateFleetAttributes</a> </p> </li> <li> <p> <a>UpdateFleetCapacity</a> </p> </li> <li> <p> <a>UpdateFleetPortSettings</a> </p> </li> <li> <p> <a>UpdateRuntimeConfiguration</a> </p> </li> </ul> </li> <li> <p>Manage fleet capacity:</p> <ul> <li> <p> <a>DescribeFleetCapacity</a> </p> </li> <li> <p> <a>UpdateFleetCapacity</a> </p> </li> <li> <p> <a>PutScalingPolicy</a> (automatic scaling)</p> </li> <li> <p> <a>DescribeScalingPolicies</a> (automatic scaling)</p> </li> <li> <p> <a>DeleteScalingPolicy</a> (automatic scaling)</p> </li> <li> <p> <a>DescribeEC2InstanceLimits</a> </p> </li> </ul> </li> <li> <p> <a>DeleteFleet</a> </p> </li> </ul></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct FleetCapacity {
     /// <p>Unique identifier for a fleet.</p>
     #[serde(rename = "FleetId")]
@@ -1352,7 +1352,7 @@ pub struct FleetCapacity {
 }
 
 /// <p><p>Current status of fleet utilization, including the number of game and player sessions being hosted.</p> <p>Fleet-related operations include:</p> <ul> <li> <p> <a>CreateFleet</a> </p> </li> <li> <p> <a>ListFleets</a> </p> </li> <li> <p>Describe fleets:</p> <ul> <li> <p> <a>DescribeFleetAttributes</a> </p> </li> <li> <p> <a>DescribeFleetPortSettings</a> </p> </li> <li> <p> <a>DescribeFleetUtilization</a> </p> </li> <li> <p> <a>DescribeRuntimeConfiguration</a> </p> </li> <li> <p> <a>DescribeFleetEvents</a> </p> </li> </ul> </li> <li> <p>Update fleets:</p> <ul> <li> <p> <a>UpdateFleetAttributes</a> </p> </li> <li> <p> <a>UpdateFleetCapacity</a> </p> </li> <li> <p> <a>UpdateFleetPortSettings</a> </p> </li> <li> <p> <a>UpdateRuntimeConfiguration</a> </p> </li> </ul> </li> <li> <p>Manage fleet capacity:</p> <ul> <li> <p> <a>DescribeFleetCapacity</a> </p> </li> <li> <p> <a>UpdateFleetCapacity</a> </p> </li> <li> <p> <a>PutScalingPolicy</a> (automatic scaling)</p> </li> <li> <p> <a>DescribeScalingPolicies</a> (automatic scaling)</p> </li> <li> <p> <a>DeleteScalingPolicy</a> (automatic scaling)</p> </li> <li> <p> <a>DescribeEC2InstanceLimits</a> </p> </li> </ul> </li> <li> <p> <a>DeleteFleet</a> </p> </li> </ul></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct FleetUtilization {
     /// <p>Number of active game sessions currently being hosted on all instances in the fleet.</p>
     #[serde(rename = "ActiveGameSessionCount")]
@@ -1377,7 +1377,7 @@ pub struct FleetUtilization {
 }
 
 /// <p>Set of key-value pairs that contain information about a game session. When included in a game session request, these properties communicate details to be used when setting up the new game session, such as to specify a game mode, level, or map. Game properties are passed to the game server process when initiating a new game session; the server process uses the properties as appropriate. For more information, see the <a href="http://docs.aws.amazon.com/gamelift/latest/developerguide/gamelift-sdk-client-api.html#gamelift-sdk-client-api-create"> Amazon GameLift Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct GameProperty {
     /// <p>Game property identifier.</p>
     #[serde(rename = "Key")]
@@ -1388,7 +1388,7 @@ pub struct GameProperty {
 }
 
 /// <p><p>Properties describing a game session.</p> <p>A game session in ACTIVE status can host players. When a game session ends, its status is set to <code>TERMINATED</code>. </p> <p>Once the session ends, the game session object is retained for 30 days. This means you can reuse idempotency token values after this time. Game session logs are retained for 14 days.</p> <p>Game-session-related operations include:</p> <ul> <li> <p> <a>CreateGameSession</a> </p> </li> <li> <p> <a>DescribeGameSessions</a> </p> </li> <li> <p> <a>DescribeGameSessionDetails</a> </p> </li> <li> <p> <a>SearchGameSessions</a> </p> </li> <li> <p> <a>UpdateGameSession</a> </p> </li> <li> <p> <a>GetGameSessionLogUrl</a> </p> </li> <li> <p>Game session placements</p> <ul> <li> <p> <a>StartGameSessionPlacement</a> </p> </li> <li> <p> <a>DescribeGameSessionPlacement</a> </p> </li> <li> <p> <a>StopGameSessionPlacement</a> </p> </li> </ul> </li> </ul></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GameSession {
     /// <p>Time stamp indicating when this data object was created. Format is a number expressed in Unix time as milliseconds (for example "1469498468.057").</p>
     #[serde(rename = "CreationTime")]
@@ -1457,7 +1457,7 @@ pub struct GameSession {
 }
 
 /// <p>Connection information for the new game session that is created with matchmaking. (with <a>StartMatchmaking</a>). Once a match is set, the FlexMatch engine places the match and creates a new game session for it. This information, including the game session endpoint and player sessions for each player in the original matchmaking request, is added to the <a>MatchmakingTicket</a>, which can be retrieved by calling <a>DescribeMatchmaking</a>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GameSessionConnectionInfo {
     /// <p>Amazon Resource Name (<a href="http://docs.aws.amazon.com/AmazonS3/latest/dev/s3-arn-format.html">ARN</a>) that is assigned to a game session and uniquely identifies it.</p>
     #[serde(rename = "GameSessionArn")]
@@ -1478,7 +1478,7 @@ pub struct GameSessionConnectionInfo {
 }
 
 /// <p>A game session's properties plus the protection policy currently in force.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GameSessionDetail {
     /// <p>Object that describes a game session.</p>
     #[serde(rename = "GameSession")]
@@ -1491,7 +1491,7 @@ pub struct GameSessionDetail {
 }
 
 /// <p><p>Object that describes a <a>StartGameSessionPlacement</a> request. This object includes the full details of the original request plus the current status and start/end time stamps.</p> <p>Game session placement-related operations include:</p> <ul> <li> <p> <a>StartGameSessionPlacement</a> </p> </li> <li> <p> <a>DescribeGameSessionPlacement</a> </p> </li> <li> <p> <a>StopGameSessionPlacement</a> </p> </li> </ul></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GameSessionPlacement {
     /// <p>Time stamp indicating when this request was completed, canceled, or timed out.</p>
     #[serde(rename = "EndTime")]
@@ -1564,7 +1564,7 @@ pub struct GameSessionPlacement {
 }
 
 /// <p><p>Configuration of a queue that is used to process game session placement requests. The queue configuration identifies several game features:</p> <ul> <li> <p>The destinations where a new game session can potentially be hosted. Amazon GameLift tries these destinations in an order based on either the queue&#39;s default order or player latency information, if provided in a placement request. With latency information, Amazon GameLift can place game sessions where the majority of players are reporting the lowest possible latency. </p> </li> <li> <p>The length of time that placement requests can wait in the queue before timing out. </p> </li> <li> <p>A set of optional latency policies that protect individual players from high latencies, preventing game sessions from being placed where any individual player is reporting latency higher than a policy&#39;s maximum.</p> </li> </ul> <p>Queue-related operations include:</p> <ul> <li> <p> <a>CreateGameSessionQueue</a> </p> </li> <li> <p> <a>DescribeGameSessionQueues</a> </p> </li> <li> <p> <a>UpdateGameSessionQueue</a> </p> </li> <li> <p> <a>DeleteGameSessionQueue</a> </p> </li> </ul></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GameSessionQueue {
     /// <p>List of fleets that can be used to fulfill game session placement requests in the queue. Fleets are identified by either a fleet ARN or a fleet alias ARN. Destinations are listed in default preference order.</p>
     #[serde(rename = "Destinations")]
@@ -1589,7 +1589,7 @@ pub struct GameSessionQueue {
 }
 
 /// <p><p>Fleet designated in a game session queue. Requests for new game sessions in the queue are fulfilled by starting a new game session on any destination configured for a queue. </p> <p>Queue-related operations include:</p> <ul> <li> <p> <a>CreateGameSessionQueue</a> </p> </li> <li> <p> <a>DescribeGameSessionQueues</a> </p> </li> <li> <p> <a>UpdateGameSessionQueue</a> </p> </li> <li> <p> <a>DeleteGameSessionQueue</a> </p> </li> </ul></p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct GameSessionQueueDestination {
     /// <p>Amazon Resource Name (ARN) assigned to fleet or fleet alias. ARNs, which include a fleet ID or alias ID and a region name, provide a unique identifier across all regions. </p>
     #[serde(rename = "DestinationArn")]
@@ -1598,7 +1598,7 @@ pub struct GameSessionQueueDestination {
 }
 
 /// <p>Represents the input for a request action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetGameSessionLogUrlInput {
     /// <p>Unique identifier for the game session to get logs for.</p>
     #[serde(rename = "GameSessionId")]
@@ -1606,7 +1606,7 @@ pub struct GetGameSessionLogUrlInput {
 }
 
 /// <p>Represents the returned data in response to a request action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetGameSessionLogUrlOutput {
     /// <p>Location of the requested game session logs, available for download.</p>
     #[serde(rename = "PreSignedUrl")]
@@ -1615,7 +1615,7 @@ pub struct GetGameSessionLogUrlOutput {
 }
 
 /// <p>Represents the input for a request action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetInstanceAccessInput {
     /// <p>Unique identifier for a fleet that contains the instance you want access to. The fleet can be in any of the following statuses: <code>ACTIVATING</code>, <code>ACTIVE</code>, or <code>ERROR</code>. Fleets with an <code>ERROR</code> status may be accessible for a short time before they are deleted.</p>
     #[serde(rename = "FleetId")]
@@ -1626,7 +1626,7 @@ pub struct GetInstanceAccessInput {
 }
 
 /// <p>Represents the returned data in response to a request action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetInstanceAccessOutput {
     /// <p>Object that contains connection information for a fleet instance, including IP address and access credentials.</p>
     #[serde(rename = "InstanceAccess")]
@@ -1635,7 +1635,7 @@ pub struct GetInstanceAccessOutput {
 }
 
 /// <p>Properties that describe an instance of a virtual computing resource that hosts one or more game servers. A fleet may contain zero or more instances.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Instance {
     /// <p>Time stamp indicating when this data object was created. Format is a number expressed in Unix time as milliseconds (for example "1469498468.057").</p>
     #[serde(rename = "CreationTime")]
@@ -1668,7 +1668,7 @@ pub struct Instance {
 }
 
 /// <p>Information required to remotely connect to a fleet instance. Access is requested by calling <a>GetInstanceAccess</a>. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct InstanceAccess {
     /// <p>Credentials required to access the instance.</p>
     #[serde(rename = "Credentials")]
@@ -1693,7 +1693,7 @@ pub struct InstanceAccess {
 }
 
 /// <p>Set of credentials required to remotely access a fleet instance. Access credentials are requested by calling <a>GetInstanceAccess</a> and returned in an <a>InstanceAccess</a> object.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct InstanceCredentials {
     /// <p>Secret string. For Windows instances, the secret is a password for use with Windows Remote Desktop. For Linux instances, it is a private key (which must be saved as a <code>.pem</code> file) for use with SSH.</p>
     #[serde(rename = "Secret")]
@@ -1706,7 +1706,7 @@ pub struct InstanceCredentials {
 }
 
 /// <p>A range of IP addresses and port settings that allow inbound traffic to connect to server processes on Amazon GameLift. Each game session hosted on a fleet is assigned a unique combination of IP address and port number, which must fall into the fleet's allowed ranges. This combination is included in the <a>GameSession</a> object. </p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct IpPermission {
     /// <p>Starting value for a range of allowed port numbers.</p>
     #[serde(rename = "FromPort")]
@@ -1723,7 +1723,7 @@ pub struct IpPermission {
 }
 
 /// <p>Represents the input for a request action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListAliasesInput {
     /// <p>Maximum number of results to return. Use this parameter with <code>NextToken</code> to get results as a set of sequential pages.</p>
     #[serde(rename = "Limit")]
@@ -1744,7 +1744,7 @@ pub struct ListAliasesInput {
 }
 
 /// <p>Represents the returned data in response to a request action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListAliasesOutput {
     /// <p>Collection of alias records that match the list request.</p>
     #[serde(rename = "Aliases")]
@@ -1757,7 +1757,7 @@ pub struct ListAliasesOutput {
 }
 
 /// <p>Represents the input for a request action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListBuildsInput {
     /// <p>Maximum number of results to return. Use this parameter with <code>NextToken</code> to get results as a set of sequential pages.</p>
     #[serde(rename = "Limit")]
@@ -1774,7 +1774,7 @@ pub struct ListBuildsInput {
 }
 
 /// <p>Represents the returned data in response to a request action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListBuildsOutput {
     /// <p>Collection of build records that match the request.</p>
     #[serde(rename = "Builds")]
@@ -1787,7 +1787,7 @@ pub struct ListBuildsOutput {
 }
 
 /// <p>Represents the input for a request action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListFleetsInput {
     /// <p>Unique identifier for a build to return fleets for. Use this parameter to return only fleets using the specified build. To retrieve all fleets, leave this parameter empty.</p>
     #[serde(rename = "BuildId")]
@@ -1804,7 +1804,7 @@ pub struct ListFleetsInput {
 }
 
 /// <p>Represents the returned data in response to a request action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListFleetsOutput {
     /// <p>Set of fleet IDs matching the list request. You can retrieve additional information about all returned fleets by passing this result set to a call to <a>DescribeFleetAttributes</a>, <a>DescribeFleetCapacity</a>, or <a>DescribeFleetUtilization</a>.</p>
     #[serde(rename = "FleetIds")]
@@ -1817,7 +1817,7 @@ pub struct ListFleetsOutput {
 }
 
 /// <p>Represents a new player session that is created as a result of a successful FlexMatch match. A successful match automatically creates new player sessions for every player ID in the original matchmaking request. </p> <p>When players connect to the match's game session, they must include both player ID and player session ID in order to claim their assigned player slot.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct MatchedPlayerSession {
     /// <p>Unique identifier for a player </p>
     #[serde(rename = "PlayerId")]
@@ -1830,7 +1830,7 @@ pub struct MatchedPlayerSession {
 }
 
 /// <p>Guidelines for use with FlexMatch to match players into games. All matchmaking requests must specify a matchmaking configuration.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct MatchmakingConfiguration {
     /// <p>Flag that determines whether or not a match that was created with this configuration must be accepted by the matched players. To require acceptance, set to TRUE.</p>
     #[serde(rename = "AcceptanceRequired")]
@@ -1887,7 +1887,7 @@ pub struct MatchmakingConfiguration {
 }
 
 /// <p><p>Set of rule statements, used with FlexMatch, that determine how to build a certain kind of player match. Each rule set describes a type of group to be created and defines the parameters for acceptable player matches. Rule sets are used in <a>MatchmakingConfiguration</a> objects.</p> <p>A rule set may define the following elements for a match. For detailed information and examples showing how to construct a rule set, see <a href="http://docs.aws.amazon.com/gamelift/latest/developerguide/match-rulesets.html">Build a FlexMatch Rule Set</a>. </p> <ul> <li> <p>Teams -- Required. A rule set must define one or multiple teams for the match and set minimum and maximum team sizes. For example, a rule set might describe a 4x4 match that requires all eight slots to be filled. </p> </li> <li> <p>Player attributes -- Optional. These attributes specify a set of player characteristics to evaluate when looking for a match. Matchmaking requests that use a rule set with player attributes must provide the corresponding attribute values. For example, an attribute might specify a player&#39;s skill or level.</p> </li> <li> <p>Rules -- Optional. Rules define how to evaluate potential players for a match based on player attributes. A rule might specify minimum requirements for individual players, teams, or entire matches. For example, a rule might require each player to meet a certain skill level, each team to have at least one player in a certain role, or the match to have a minimum average skill level. or may describe an entire group--such as all teams must be evenly matched or have at least one player in a certain role. </p> </li> <li> <p>Expansions -- Optional. Expansions allow you to relax the rules after a period of time when no acceptable matches are found. This feature lets you balance getting players into games in a reasonable amount of time instead of making them wait indefinitely for the best possible match. For example, you might use an expansion to increase the maximum skill variance between players after 30 seconds.</p> </li> </ul></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct MatchmakingRuleSet {
     /// <p>Time stamp indicating when this data object was created. Format is a number expressed in Unix time as milliseconds (for example "1469498468.057").</p>
     #[serde(rename = "CreationTime")]
@@ -1903,7 +1903,7 @@ pub struct MatchmakingRuleSet {
 }
 
 /// <p>Ticket generated to track the progress of a matchmaking request. Each ticket is uniquely identified by a ticket ID, supplied by the requester, when creating a matchmaking request with <a>StartMatchmaking</a>. Tickets can be retrieved by calling <a>DescribeMatchmaking</a> with the ticket ID.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct MatchmakingTicket {
     /// <p>Name of the <a>MatchmakingConfiguration</a> that is used with this ticket. Matchmaking configurations determine how players are grouped into a match and how a new game session is created for the match.</p>
     #[serde(rename = "ConfigurationName")]
@@ -1948,7 +1948,7 @@ pub struct MatchmakingTicket {
 }
 
 /// <p><p>Information about a player session that was created as part of a <a>StartGameSessionPlacement</a> request. This object contains only the player ID and player session ID. To retrieve full details on a player session, call <a>DescribePlayerSessions</a> with the player session ID.</p> <p>Player-session-related operations include:</p> <ul> <li> <p> <a>CreatePlayerSession</a> </p> </li> <li> <p> <a>CreatePlayerSessions</a> </p> </li> <li> <p> <a>DescribePlayerSessions</a> </p> </li> <li> <p>Game session placements</p> <ul> <li> <p> <a>StartGameSessionPlacement</a> </p> </li> <li> <p> <a>DescribeGameSessionPlacement</a> </p> </li> <li> <p> <a>StopGameSessionPlacement</a> </p> </li> </ul> </li> </ul></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PlacedPlayerSession {
     /// <p>Unique identifier for a player that is associated with this player session.</p>
     #[serde(rename = "PlayerId")]
@@ -1961,7 +1961,7 @@ pub struct PlacedPlayerSession {
 }
 
 /// <p>Represents a player in matchmaking. When starting a matchmaking request, a player has a player ID, attributes, and may have latency data. Team information is added after a match has been successfully completed.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Player {
     /// <p>Set of values, expressed in milliseconds, indicating the amount of latency that a player experiences when connected to AWS regions. If this property is present, FlexMatch considers placing the match only in regions for which latency is reported. </p> <p>If a matchmaker has a rule that evaluates player latency, players must report latency in order to be matched. If no latency is reported in this scenario, FlexMatch assumes that no regions are available to the player and the ticket is not matchable. </p>
     #[serde(rename = "LatencyInMs")]
@@ -1982,7 +1982,7 @@ pub struct Player {
 }
 
 /// <p>Regional latency information for a player, used when requesting a new game session with <a>StartGameSessionPlacement</a>. This value indicates the amount of time lag that exists when the player is connected to a fleet in the specified region. The relative difference between a player's latency values for multiple regions are used to determine which fleets are best suited to place a new game session for the player. </p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct PlayerLatency {
     /// <p>Amount of time that represents the time lag experienced by the player when connected to the specified region.</p>
     #[serde(rename = "LatencyInMilliseconds")]
@@ -1999,7 +1999,7 @@ pub struct PlayerLatency {
 }
 
 /// <p><p>Queue setting that determines the highest latency allowed for individual players when placing a game session. When a latency policy is in force, a game session cannot be placed at any destination in a region where a player is reporting latency higher than the cap. Latency policies are only enforced when the placement request contains player latency information.</p> <p>Queue-related operations include:</p> <ul> <li> <p> <a>CreateGameSessionQueue</a> </p> </li> <li> <p> <a>DescribeGameSessionQueues</a> </p> </li> <li> <p> <a>UpdateGameSessionQueue</a> </p> </li> <li> <p> <a>DeleteGameSessionQueue</a> </p> </li> </ul></p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct PlayerLatencyPolicy {
     /// <p>The maximum latency value that is allowed for any player, in milliseconds. All policies must have a value set for this property.</p>
     #[serde(rename = "MaximumIndividualPlayerLatencyMilliseconds")]
@@ -2012,7 +2012,7 @@ pub struct PlayerLatencyPolicy {
 }
 
 /// <p><p>Properties describing a player session. Player session objects are created either by creating a player session for a specific game session, or as part of a game session placement. A player session represents either a player reservation for a game session (status <code>RESERVED</code>) or actual player activity in a game session (status <code>ACTIVE</code>). A player session object (including player data) is automatically passed to a game session when the player connects to the game session and is validated.</p> <p>When a player disconnects, the player session status changes to <code>COMPLETED</code>. Once the session ends, the player session object is retained for 30 days and then removed.</p> <p>Player-session-related operations include:</p> <ul> <li> <p> <a>CreatePlayerSession</a> </p> </li> <li> <p> <a>CreatePlayerSessions</a> </p> </li> <li> <p> <a>DescribePlayerSessions</a> </p> </li> <li> <p>Game session placements</p> <ul> <li> <p> <a>StartGameSessionPlacement</a> </p> </li> <li> <p> <a>DescribeGameSessionPlacement</a> </p> </li> <li> <p> <a>StopGameSessionPlacement</a> </p> </li> </ul> </li> </ul></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PlayerSession {
     /// <p>Time stamp indicating when this data object was created. Format is a number expressed in Unix time as milliseconds (for example "1469498468.057").</p>
     #[serde(rename = "CreationTime")]
@@ -2057,7 +2057,7 @@ pub struct PlayerSession {
 }
 
 /// <p>Represents the input for a request action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PutScalingPolicyInput {
     /// <p>Comparison operator to use when measuring the metric against the threshold value.</p>
     #[serde(rename = "ComparisonOperator")]
@@ -2086,7 +2086,7 @@ pub struct PutScalingPolicyInput {
 }
 
 /// <p>Represents the returned data in response to a request action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PutScalingPolicyOutput {
     /// <p>Descriptive label that is associated with a scaling policy. Policy names do not need to be unique.</p>
     #[serde(rename = "Name")]
@@ -2095,7 +2095,7 @@ pub struct PutScalingPolicyOutput {
 }
 
 /// <p>Represents the input for a request action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RequestUploadCredentialsInput {
     /// <p>Unique identifier for a build to get credentials for.</p>
     #[serde(rename = "BuildId")]
@@ -2103,7 +2103,7 @@ pub struct RequestUploadCredentialsInput {
 }
 
 /// <p>Represents the returned data in response to a request action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RequestUploadCredentialsOutput {
     /// <p>Amazon S3 path and key, identifying where the game build files are stored.</p>
     #[serde(rename = "StorageLocation")]
@@ -2116,7 +2116,7 @@ pub struct RequestUploadCredentialsOutput {
 }
 
 /// <p>Represents the input for a request action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ResolveAliasInput {
     /// <p>Unique identifier for the alias you want to resolve.</p>
     #[serde(rename = "AliasId")]
@@ -2124,7 +2124,7 @@ pub struct ResolveAliasInput {
 }
 
 /// <p>Represents the returned data in response to a request action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ResolveAliasOutput {
     /// <p>Fleet identifier that is associated with the requested alias.</p>
     #[serde(rename = "FleetId")]
@@ -2133,7 +2133,7 @@ pub struct ResolveAliasOutput {
 }
 
 /// <p>Policy that limits the number of game sessions a player can create on the same fleet. This optional policy gives game owners control over how players can consume available game server resources. A resource creation policy makes the following statement: "An individual player can create a maximum number of new game sessions within a specified time period".</p> <p>The policy is evaluated when a player tries to create a new game session. For example, with a policy of 10 new game sessions and a time period of 60 minutes, on receiving a <code>CreateGameSession</code> request, Amazon GameLift checks that the player (identified by <code>CreatorId</code>) has created fewer than 10 game sessions in the past 60 minutes.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ResourceCreationLimitPolicy {
     /// <p>Maximum number of game sessions that an individual can create during the policy period. </p>
     #[serde(rename = "NewGameSessionsPerCreator")]
@@ -2146,7 +2146,7 @@ pub struct ResourceCreationLimitPolicy {
 }
 
 /// <p><p>Routing configuration for a fleet alias.</p> <p>Fleet-related operations include:</p> <ul> <li> <p> <a>CreateFleet</a> </p> </li> <li> <p> <a>ListFleets</a> </p> </li> <li> <p>Describe fleets:</p> <ul> <li> <p> <a>DescribeFleetAttributes</a> </p> </li> <li> <p> <a>DescribeFleetPortSettings</a> </p> </li> <li> <p> <a>DescribeFleetUtilization</a> </p> </li> <li> <p> <a>DescribeRuntimeConfiguration</a> </p> </li> <li> <p> <a>DescribeFleetEvents</a> </p> </li> </ul> </li> <li> <p>Update fleets:</p> <ul> <li> <p> <a>UpdateFleetAttributes</a> </p> </li> <li> <p> <a>UpdateFleetCapacity</a> </p> </li> <li> <p> <a>UpdateFleetPortSettings</a> </p> </li> <li> <p> <a>UpdateRuntimeConfiguration</a> </p> </li> </ul> </li> <li> <p>Manage fleet capacity:</p> <ul> <li> <p> <a>DescribeFleetCapacity</a> </p> </li> <li> <p> <a>UpdateFleetCapacity</a> </p> </li> <li> <p> <a>PutScalingPolicy</a> (automatic scaling)</p> </li> <li> <p> <a>DescribeScalingPolicies</a> (automatic scaling)</p> </li> <li> <p> <a>DeleteScalingPolicy</a> (automatic scaling)</p> </li> <li> <p> <a>DescribeEC2InstanceLimits</a> </p> </li> </ul> </li> <li> <p> <a>DeleteFleet</a> </p> </li> </ul></p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RoutingStrategy {
     /// <p>Unique identifier for a fleet that the alias points to.</p>
     #[serde(rename = "FleetId")]
@@ -2163,7 +2163,7 @@ pub struct RoutingStrategy {
 }
 
 /// <p><p>A collection of server process configurations that describe what processes to run on each instance in a fleet. All fleets must have a run-time configuration. Each instance in the fleet launches the server processes specified in the run-time configuration and launches new ones as existing processes end. Each instance regularly checks for an updated run-time configuration and follows the new instructions. </p> <p>The run-time configuration enables the instances in a fleet to run multiple processes simultaneously. Potential scenarios are as follows: (1) Run multiple processes of a single game server executable to maximize usage of your hosting resources. (2) Run one or more processes of different build executables, such as your game server executable and a related program, or two or more different versions of a game server. (3) Run multiple processes of a single game server but with different launch parameters, for example to run one process on each instance in debug mode.</p> <p>A Amazon GameLift instance is limited to 50 processes running simultaneously. A run-time configuration must specify fewer than this limit. To calculate the total number of processes specified in a run-time configuration, add the values of the <code>ConcurrentExecutions</code> parameter for each <code> <a>ServerProcess</a> </code> object in the run-time configuration.</p> <p>Fleet-related operations include:</p> <ul> <li> <p> <a>CreateFleet</a> </p> </li> <li> <p> <a>ListFleets</a> </p> </li> <li> <p>Describe fleets:</p> <ul> <li> <p> <a>DescribeFleetAttributes</a> </p> </li> <li> <p> <a>DescribeFleetPortSettings</a> </p> </li> <li> <p> <a>DescribeFleetUtilization</a> </p> </li> <li> <p> <a>DescribeRuntimeConfiguration</a> </p> </li> <li> <p> <a>DescribeFleetEvents</a> </p> </li> </ul> </li> <li> <p>Update fleets:</p> <ul> <li> <p> <a>UpdateFleetAttributes</a> </p> </li> <li> <p> <a>UpdateFleetCapacity</a> </p> </li> <li> <p> <a>UpdateFleetPortSettings</a> </p> </li> <li> <p> <a>UpdateRuntimeConfiguration</a> </p> </li> </ul> </li> <li> <p>Manage fleet capacity:</p> <ul> <li> <p> <a>DescribeFleetCapacity</a> </p> </li> <li> <p> <a>UpdateFleetCapacity</a> </p> </li> <li> <p> <a>PutScalingPolicy</a> (automatic scaling)</p> </li> <li> <p> <a>DescribeScalingPolicies</a> (automatic scaling)</p> </li> <li> <p> <a>DeleteScalingPolicy</a> (automatic scaling)</p> </li> <li> <p> <a>DescribeEC2InstanceLimits</a> </p> </li> </ul> </li> <li> <p> <a>DeleteFleet</a> </p> </li> </ul></p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RuntimeConfiguration {
     /// <p>Maximum amount of time (in seconds) that a game session can remain in status <code>ACTIVATING</code>. If the game session is not active before the timeout, activation is terminated and the game session status is changed to <code>TERMINATED</code>.</p>
     #[serde(rename = "GameSessionActivationTimeoutSeconds")]
@@ -2180,7 +2180,7 @@ pub struct RuntimeConfiguration {
 }
 
 /// <p>Location in Amazon Simple Storage Service (Amazon S3) where build files can be stored for access by Amazon GameLift. This location is specified in a <a>CreateBuild</a> request. For more details, see the <a href="http://docs.aws.amazon.com/gamelift/latest/developerguide/gamelift-build-cli-uploading.html#gamelift-build-cli-uploading-create-build">Create a Build with Files in Amazon S3</a>.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct S3Location {
     /// <p>Amazon S3 bucket identifier. This is the name of your S3 bucket.</p>
     #[serde(rename = "Bucket")]
@@ -2197,7 +2197,7 @@ pub struct S3Location {
 }
 
 /// <p><p>Rule that controls how a fleet is scaled. Scaling policies are uniquely identified by the combination of name and fleet ID.</p> <p>Fleet-related operations include:</p> <ul> <li> <p> <a>CreateFleet</a> </p> </li> <li> <p> <a>ListFleets</a> </p> </li> <li> <p>Describe fleets:</p> <ul> <li> <p> <a>DescribeFleetAttributes</a> </p> </li> <li> <p> <a>DescribeFleetPortSettings</a> </p> </li> <li> <p> <a>DescribeFleetUtilization</a> </p> </li> <li> <p> <a>DescribeRuntimeConfiguration</a> </p> </li> <li> <p> <a>DescribeFleetEvents</a> </p> </li> </ul> </li> <li> <p>Update fleets:</p> <ul> <li> <p> <a>UpdateFleetAttributes</a> </p> </li> <li> <p> <a>UpdateFleetCapacity</a> </p> </li> <li> <p> <a>UpdateFleetPortSettings</a> </p> </li> <li> <p> <a>UpdateRuntimeConfiguration</a> </p> </li> </ul> </li> <li> <p>Manage fleet capacity:</p> <ul> <li> <p> <a>DescribeFleetCapacity</a> </p> </li> <li> <p> <a>UpdateFleetCapacity</a> </p> </li> <li> <p> <a>PutScalingPolicy</a> (automatic scaling)</p> </li> <li> <p> <a>DescribeScalingPolicies</a> (automatic scaling)</p> </li> <li> <p> <a>DeleteScalingPolicy</a> (automatic scaling)</p> </li> <li> <p> <a>DescribeEC2InstanceLimits</a> </p> </li> </ul> </li> <li> <p> <a>DeleteFleet</a> </p> </li> </ul></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ScalingPolicy {
     /// <p>Comparison operator to use when measuring a metric against the threshold value.</p>
     #[serde(rename = "ComparisonOperator")]
@@ -2238,7 +2238,7 @@ pub struct ScalingPolicy {
 }
 
 /// <p>Represents the input for a request action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SearchGameSessionsInput {
     /// <p>Unique identifier for an alias associated with the fleet to search for active game sessions. Each request must reference either a fleet ID or alias ID, but not both.</p>
     #[serde(rename = "AliasId")]
@@ -2267,7 +2267,7 @@ pub struct SearchGameSessionsInput {
 }
 
 /// <p>Represents the returned data in response to a request action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SearchGameSessionsOutput {
     /// <p>Collection of objects containing game session properties for each session matching the request.</p>
     #[serde(rename = "GameSessions")]
@@ -2280,7 +2280,7 @@ pub struct SearchGameSessionsOutput {
 }
 
 /// <p>A set of instructions for launching server processes on each instance in a fleet. Each instruction set identifies the location of the server executable, optional launch parameters, and the number of server processes with this configuration to maintain concurrently on the instance. Server process configurations make up a fleet's <code> <a>RuntimeConfiguration</a> </code>.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ServerProcess {
     /// <p>Number of server processes using this configuration to run concurrently on an instance.</p>
     #[serde(rename = "ConcurrentExecutions")]
@@ -2295,7 +2295,7 @@ pub struct ServerProcess {
 }
 
 /// <p>Represents the input for a request action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StartGameSessionPlacementInput {
     /// <p>Set of information on each player to create a player session for.</p>
     #[serde(rename = "DesiredPlayerSessions")]
@@ -2329,7 +2329,7 @@ pub struct StartGameSessionPlacementInput {
 }
 
 /// <p>Represents the returned data in response to a request action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StartGameSessionPlacementOutput {
     /// <p>Object that describes the newly created game session placement. This object includes all the information provided in the request, as well as start/end time stamps and placement status. </p>
     #[serde(rename = "GameSessionPlacement")]
@@ -2338,7 +2338,7 @@ pub struct StartGameSessionPlacementOutput {
 }
 
 /// <p>Represents the input for a request action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StartMatchBackfillInput {
     /// <p>Name of the matchmaker to use for this request. The name of the matchmaker that was used with the original game session is listed in the <a>GameSession</a> object, <code>MatchmakerData</code> property. This property contains a matchmaking configuration ARN value, which includes the matchmaker name. (In the ARN value "arn:aws:gamelift:us-west-2:111122223333:matchmakingconfiguration/MM-4v4", the matchmaking configuration name is "MM-4v4".) Use only the name for this parameter.</p>
     #[serde(rename = "ConfigurationName")]
@@ -2356,7 +2356,7 @@ pub struct StartMatchBackfillInput {
 }
 
 /// <p>Represents the returned data in response to a request action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StartMatchBackfillOutput {
     /// <p>Ticket representing the backfill matchmaking request. This object includes the information in the request, ticket status, and match results as generated during the matchmaking process.</p>
     #[serde(rename = "MatchmakingTicket")]
@@ -2365,7 +2365,7 @@ pub struct StartMatchBackfillOutput {
 }
 
 /// <p>Represents the input for a request action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StartMatchmakingInput {
     /// <p>Name of the matchmaking configuration to use for this request. Matchmaking configurations must exist in the same region as this request.</p>
     #[serde(rename = "ConfigurationName")]
@@ -2380,7 +2380,7 @@ pub struct StartMatchmakingInput {
 }
 
 /// <p>Represents the returned data in response to a request action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StartMatchmakingOutput {
     /// <p>Ticket representing the matchmaking request. This object include the information included in the request, ticket status, and match results as generated during the matchmaking process.</p>
     #[serde(rename = "MatchmakingTicket")]
@@ -2389,7 +2389,7 @@ pub struct StartMatchmakingOutput {
 }
 
 /// <p>Represents the input for a request action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StopGameSessionPlacementInput {
     /// <p>Unique identifier for a game session placement to cancel.</p>
     #[serde(rename = "PlacementId")]
@@ -2397,7 +2397,7 @@ pub struct StopGameSessionPlacementInput {
 }
 
 /// <p>Represents the returned data in response to a request action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StopGameSessionPlacementOutput {
     /// <p>Object that describes the canceled game session placement, with <code>CANCELLED</code> status and an end time stamp. </p>
     #[serde(rename = "GameSessionPlacement")]
@@ -2406,18 +2406,18 @@ pub struct StopGameSessionPlacementOutput {
 }
 
 /// <p>Represents the input for a request action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StopMatchmakingInput {
     /// <p>Unique identifier for a matchmaking ticket.</p>
     #[serde(rename = "TicketId")]
     pub ticket_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StopMatchmakingOutput {}
 
 /// <p>Represents the input for a request action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateAliasInput {
     /// <p>Unique identifier for a fleet alias. Specify the alias you want to update.</p>
     #[serde(rename = "AliasId")]
@@ -2437,7 +2437,7 @@ pub struct UpdateAliasInput {
 }
 
 /// <p>Represents the returned data in response to a request action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateAliasOutput {
     /// <p>Object that contains the updated alias configuration.</p>
     #[serde(rename = "Alias")]
@@ -2446,7 +2446,7 @@ pub struct UpdateAliasOutput {
 }
 
 /// <p>Represents the input for a request action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateBuildInput {
     /// <p>Unique identifier for a build to update.</p>
     #[serde(rename = "BuildId")]
@@ -2462,7 +2462,7 @@ pub struct UpdateBuildInput {
 }
 
 /// <p>Represents the returned data in response to a request action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateBuildOutput {
     /// <p>Object that contains the updated build record.</p>
     #[serde(rename = "Build")]
@@ -2471,7 +2471,7 @@ pub struct UpdateBuildOutput {
 }
 
 /// <p>Represents the input for a request action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateFleetAttributesInput {
     /// <p>Human-readable description of a fleet.</p>
     #[serde(rename = "Description")]
@@ -2499,7 +2499,7 @@ pub struct UpdateFleetAttributesInput {
 }
 
 /// <p>Represents the returned data in response to a request action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateFleetAttributesOutput {
     /// <p>Unique identifier for a fleet that was updated.</p>
     #[serde(rename = "FleetId")]
@@ -2508,7 +2508,7 @@ pub struct UpdateFleetAttributesOutput {
 }
 
 /// <p>Represents the input for a request action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateFleetCapacityInput {
     /// <p>Number of EC2 instances you want this fleet to host.</p>
     #[serde(rename = "DesiredInstances")]
@@ -2528,7 +2528,7 @@ pub struct UpdateFleetCapacityInput {
 }
 
 /// <p>Represents the returned data in response to a request action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateFleetCapacityOutput {
     /// <p>Unique identifier for a fleet that was updated.</p>
     #[serde(rename = "FleetId")]
@@ -2537,7 +2537,7 @@ pub struct UpdateFleetCapacityOutput {
 }
 
 /// <p>Represents the input for a request action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateFleetPortSettingsInput {
     /// <p>Unique identifier for a fleet to update port settings for.</p>
     #[serde(rename = "FleetId")]
@@ -2553,7 +2553,7 @@ pub struct UpdateFleetPortSettingsInput {
 }
 
 /// <p>Represents the returned data in response to a request action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateFleetPortSettingsOutput {
     /// <p>Unique identifier for a fleet that was updated.</p>
     #[serde(rename = "FleetId")]
@@ -2562,7 +2562,7 @@ pub struct UpdateFleetPortSettingsOutput {
 }
 
 /// <p>Represents the input for a request action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateGameSessionInput {
     /// <p>Unique identifier for the game session to update.</p>
     #[serde(rename = "GameSessionId")]
@@ -2586,7 +2586,7 @@ pub struct UpdateGameSessionInput {
 }
 
 /// <p>Represents the returned data in response to a request action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateGameSessionOutput {
     /// <p>Object that contains the updated game session metadata.</p>
     #[serde(rename = "GameSession")]
@@ -2595,7 +2595,7 @@ pub struct UpdateGameSessionOutput {
 }
 
 /// <p>Represents the input for a request action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateGameSessionQueueInput {
     /// <p>List of fleets that can be used to fulfill game session placement requests in the queue. Fleets are identified by either a fleet ARN or a fleet alias ARN. Destinations are listed in default preference order. When updating this list, provide a complete list of destinations.</p>
     #[serde(rename = "Destinations")]
@@ -2615,7 +2615,7 @@ pub struct UpdateGameSessionQueueInput {
 }
 
 /// <p>Represents the returned data in response to a request action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateGameSessionQueueOutput {
     /// <p>Object that describes the newly updated game session queue.</p>
     #[serde(rename = "GameSessionQueue")]
@@ -2624,7 +2624,7 @@ pub struct UpdateGameSessionQueueOutput {
 }
 
 /// <p>Represents the input for a request action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateMatchmakingConfigurationInput {
     /// <p>Flag that determines whether or not a match that was created with this configuration must be accepted by the matched players. To require acceptance, set to TRUE.</p>
     #[serde(rename = "AcceptanceRequired")]
@@ -2676,7 +2676,7 @@ pub struct UpdateMatchmakingConfigurationInput {
 }
 
 /// <p>Represents the returned data in response to a request action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateMatchmakingConfigurationOutput {
     /// <p>Object that describes the updated matchmaking configuration.</p>
     #[serde(rename = "Configuration")]
@@ -2685,7 +2685,7 @@ pub struct UpdateMatchmakingConfigurationOutput {
 }
 
 /// <p>Represents the input for a request action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateRuntimeConfigurationInput {
     /// <p>Unique identifier for a fleet to update run-time configuration for.</p>
     #[serde(rename = "FleetId")]
@@ -2696,7 +2696,7 @@ pub struct UpdateRuntimeConfigurationInput {
 }
 
 /// <p>Represents the returned data in response to a request action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateRuntimeConfigurationOutput {
     /// <p>The run-time configuration currently in force. If the update was successful, this object matches the one in the request.</p>
     #[serde(rename = "RuntimeConfiguration")]
@@ -2705,7 +2705,7 @@ pub struct UpdateRuntimeConfigurationOutput {
 }
 
 /// <p>Represents the input for a request action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ValidateMatchmakingRuleSetInput {
     /// <p>Collection of matchmaking rules to validate, formatted as a JSON string.</p>
     #[serde(rename = "RuleSetBody")]
@@ -2713,7 +2713,7 @@ pub struct ValidateMatchmakingRuleSetInput {
 }
 
 /// <p>Represents the returned data in response to a request action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ValidateMatchmakingRuleSetOutput {
     /// <p>Response indicating whether or not the rule set is valid.</p>
     #[serde(rename = "Valid")]
@@ -2722,7 +2722,7 @@ pub struct ValidateMatchmakingRuleSetOutput {
 }
 
 /// <p><p>Represents an authorization for a VPC peering connection between the VPC for an Amazon GameLift fleet and another VPC on an account you have access to. This authorization must exist and be valid for the peering connection to be established. Authorizations are valid for 24 hours after they are issued.</p> <p>VPC peering connection operations include:</p> <ul> <li> <p> <a>CreateVpcPeeringAuthorization</a> </p> </li> <li> <p> <a>DescribeVpcPeeringAuthorizations</a> </p> </li> <li> <p> <a>DeleteVpcPeeringAuthorization</a> </p> </li> <li> <p> <a>CreateVpcPeeringConnection</a> </p> </li> <li> <p> <a>DescribeVpcPeeringConnections</a> </p> </li> <li> <p> <a>DeleteVpcPeeringConnection</a> </p> </li> </ul></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct VpcPeeringAuthorization {
     /// <p>Time stamp indicating when this authorization was issued. Format is a number expressed in Unix time as milliseconds (for example "1469498468.057").</p>
     #[serde(rename = "CreationTime")]
@@ -2747,7 +2747,7 @@ pub struct VpcPeeringAuthorization {
 }
 
 /// <p><p>Represents a peering connection between a VPC on one of your AWS accounts and the VPC for your Amazon GameLift fleets. This record may be for an active peering connection or a pending connection that has not yet been established.</p> <p>VPC peering connection operations include:</p> <ul> <li> <p> <a>CreateVpcPeeringAuthorization</a> </p> </li> <li> <p> <a>DescribeVpcPeeringAuthorizations</a> </p> </li> <li> <p> <a>DeleteVpcPeeringAuthorization</a> </p> </li> <li> <p> <a>CreateVpcPeeringConnection</a> </p> </li> <li> <p> <a>DescribeVpcPeeringConnections</a> </p> </li> <li> <p> <a>DeleteVpcPeeringConnection</a> </p> </li> </ul></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct VpcPeeringConnection {
     /// <p>Unique identifier for a fleet. This ID determines the ID of the Amazon GameLift VPC for your fleet.</p>
     #[serde(rename = "FleetId")]
@@ -2776,7 +2776,7 @@ pub struct VpcPeeringConnection {
 }
 
 /// <p>Represents status information for a VPC peering connection. Status is associated with a <a>VpcPeeringConnection</a> object. Status codes and messages are provided from EC2 (see <a href="http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_VpcPeeringConnectionStateReason.html">VpcPeeringConnectionStateReason</a>). Connection status information is also communicated as a fleet <a>Event</a>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct VpcPeeringConnectionStatus {
     /// <p>Code indicating the status of a VPC peering connection.</p>
     #[serde(rename = "Code")]

--- a/rusoto/services/glacier/src/generated.rs
+++ b/rusoto/services/glacier/src/generated.rs
@@ -31,7 +31,7 @@ use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 /// <p>Provides options to abort a multipart upload identified by the upload ID.</p> <p>For information about the underlying REST API, see <a href="http://docs.aws.amazon.com/amazonglacier/latest/dev/api-multipart-abort-upload.html">Abort Multipart Upload</a>. For conceptual information, see <a href="http://docs.aws.amazon.com/amazonglacier/latest/dev/working-with-archives.html">Working with Archives in Amazon Glacier</a>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AbortMultipartUploadInput {
     /// <p>The <code>AccountId</code> value is the AWS account ID of the account that owns the vault. You can either specify an AWS account ID or optionally a single '<code>-</code>' (hyphen), in which case Amazon Glacier uses the AWS account ID associated with the credentials used to sign the request. If you use an account ID, do not include any hyphens ('-') in the ID.</p>
     #[serde(rename = "accountId")]
@@ -45,7 +45,7 @@ pub struct AbortMultipartUploadInput {
 }
 
 /// <p>The input values for <code>AbortVaultLock</code>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AbortVaultLockInput {
     /// <p>The <code>AccountId</code> value is the AWS account ID. This value must match the AWS account ID associated with the credentials used to sign the request. You can either specify an AWS account ID or optionally a single '<code>-</code>' (hyphen), in which case Amazon Glacier uses the AWS account ID associated with the credentials used to sign the request. If you specify your account ID, do not include any hyphens ('-') in the ID.</p>
     #[serde(rename = "accountId")]
@@ -56,7 +56,7 @@ pub struct AbortVaultLockInput {
 }
 
 /// <p>The input values for <code>AddTagsToVault</code>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AddTagsToVaultInput {
     /// <p>The tags to add to the vault. Each tag is composed of a key and a value. The value can be an empty string.</p>
     #[serde(rename = "Tags")]
@@ -71,7 +71,7 @@ pub struct AddTagsToVaultInput {
 }
 
 /// <p>Contains the Amazon Glacier response to your request.</p> <p>For information about the underlying REST API, see <a href="http://docs.aws.amazon.com/amazonglacier/latest/dev/api-archive-post.html">Upload Archive</a>. For conceptual information, see <a href="http://docs.aws.amazon.com/amazonglacier/latest/dev/working-with-archives.html">Working with Archives in Amazon Glacier</a>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ArchiveCreationOutput {
     /// <p>The ID of the archive. This value is also included as part of the location.</p>
     #[serde(rename = "archiveId")]
@@ -88,7 +88,7 @@ pub struct ArchiveCreationOutput {
 }
 
 /// <p>Contains information about the comma-separated value (CSV) file to select from.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CSVInput {
     /// <p>A single character used to indicate that a row should be ignored when the character is present at the start of that row.</p>
     #[serde(rename = "Comments")]
@@ -117,7 +117,7 @@ pub struct CSVInput {
 }
 
 /// <p>Contains information about the comma-separated value (CSV) file that the job results are stored in.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CSVOutput {
     /// <p>A value used to separate individual fields from each other within a record.</p>
     #[serde(rename = "FieldDelimiter")]
@@ -142,7 +142,7 @@ pub struct CSVOutput {
 }
 
 /// <p>Provides options to complete a multipart upload operation. This informs Amazon Glacier that all the archive parts have been uploaded and Amazon Glacier can now assemble the archive from the uploaded parts. After assembling and saving the archive to the vault, Amazon Glacier returns the URI path of the newly created archive resource.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CompleteMultipartUploadInput {
     /// <p>The <code>AccountId</code> value is the AWS account ID of the account that owns the vault. You can either specify an AWS account ID or optionally a single '<code>-</code>' (hyphen), in which case Amazon Glacier uses the AWS account ID associated with the credentials used to sign the request. If you use an account ID, do not include any hyphens ('-') in the ID.</p>
     #[serde(rename = "accountId")]
@@ -164,7 +164,7 @@ pub struct CompleteMultipartUploadInput {
 }
 
 /// <p>The input values for <code>CompleteVaultLock</code>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CompleteVaultLockInput {
     /// <p>The <code>AccountId</code> value is the AWS account ID. This value must match the AWS account ID associated with the credentials used to sign the request. You can either specify an AWS account ID or optionally a single '<code>-</code>' (hyphen), in which case Amazon Glacier uses the AWS account ID associated with the credentials used to sign the request. If you specify your account ID, do not include any hyphens ('-') in the ID.</p>
     #[serde(rename = "accountId")]
@@ -178,7 +178,7 @@ pub struct CompleteVaultLockInput {
 }
 
 /// <p>Provides options to create a vault.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateVaultInput {
     /// <p>The <code>AccountId</code> value is the AWS account ID. This value must match the AWS account ID associated with the credentials used to sign the request. You can either specify an AWS account ID or optionally a single '<code>-</code>' (hyphen), in which case Amazon Glacier uses the AWS account ID associated with the credentials used to sign the request. If you specify your account ID, do not include any hyphens ('-') in the ID.</p>
     #[serde(rename = "accountId")]
@@ -189,7 +189,7 @@ pub struct CreateVaultInput {
 }
 
 /// <p>Contains the Amazon Glacier response to your request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateVaultOutput {
     /// <p>The URI of the vault that was created.</p>
     #[serde(rename = "location")]
@@ -198,7 +198,7 @@ pub struct CreateVaultOutput {
 }
 
 /// <p>Data retrieval policy.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct DataRetrievalPolicy {
     /// <p>The policy rule. Although this is a list type, currently there must be only one rule, which contains a Strategy field and optionally a BytesPerHour field.</p>
     #[serde(rename = "Rules")]
@@ -207,7 +207,7 @@ pub struct DataRetrievalPolicy {
 }
 
 /// <p>Data retrieval policy rule.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct DataRetrievalRule {
     /// <p>The maximum number of bytes that can be retrieved in an hour.</p> <p>This field is required only if the value of the Strategy field is <code>BytesPerHour</code>. Your PUT operation will be rejected if the Strategy field is not set to <code>BytesPerHour</code> and you set this field.</p>
     #[serde(rename = "BytesPerHour")]
@@ -220,7 +220,7 @@ pub struct DataRetrievalRule {
 }
 
 /// <p>Provides options for deleting an archive from an Amazon Glacier vault.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteArchiveInput {
     /// <p>The <code>AccountId</code> value is the AWS account ID of the account that owns the vault. You can either specify an AWS account ID or optionally a single '<code>-</code>' (hyphen), in which case Amazon Glacier uses the AWS account ID associated with the credentials used to sign the request. If you use an account ID, do not include any hyphens ('-') in the ID.</p>
     #[serde(rename = "accountId")]
@@ -234,7 +234,7 @@ pub struct DeleteArchiveInput {
 }
 
 /// <p>DeleteVaultAccessPolicy input.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteVaultAccessPolicyInput {
     /// <p>The <code>AccountId</code> value is the AWS account ID of the account that owns the vault. You can either specify an AWS account ID or optionally a single '<code>-</code>' (hyphen), in which case Amazon Glacier uses the AWS account ID associated with the credentials used to sign the request. If you use an account ID, do not include any hyphens ('-') in the ID. </p>
     #[serde(rename = "accountId")]
@@ -245,7 +245,7 @@ pub struct DeleteVaultAccessPolicyInput {
 }
 
 /// <p>Provides options for deleting a vault from Amazon Glacier.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteVaultInput {
     /// <p>The <code>AccountId</code> value is the AWS account ID of the account that owns the vault. You can either specify an AWS account ID or optionally a single '<code>-</code>' (hyphen), in which case Amazon Glacier uses the AWS account ID associated with the credentials used to sign the request. If you use an account ID, do not include any hyphens ('-') in the ID.</p>
     #[serde(rename = "accountId")]
@@ -256,7 +256,7 @@ pub struct DeleteVaultInput {
 }
 
 /// <p>Provides options for deleting a vault notification configuration from an Amazon Glacier vault.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteVaultNotificationsInput {
     /// <p>The <code>AccountId</code> value is the AWS account ID of the account that owns the vault. You can either specify an AWS account ID or optionally a single '<code>-</code>' (hyphen), in which case Amazon Glacier uses the AWS account ID associated with the credentials used to sign the request. If you use an account ID, do not include any hyphens ('-') in the ID. </p>
     #[serde(rename = "accountId")]
@@ -267,7 +267,7 @@ pub struct DeleteVaultNotificationsInput {
 }
 
 /// <p>Provides options for retrieving a job description.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeJobInput {
     /// <p>The <code>AccountId</code> value is the AWS account ID of the account that owns the vault. You can either specify an AWS account ID or optionally a single '<code>-</code>' (hyphen), in which case Amazon Glacier uses the AWS account ID associated with the credentials used to sign the request. If you use an account ID, do not include any hyphens ('-') in the ID. </p>
     #[serde(rename = "accountId")]
@@ -281,7 +281,7 @@ pub struct DescribeJobInput {
 }
 
 /// <p>Provides options for retrieving metadata for a specific vault in Amazon Glacier.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeVaultInput {
     /// <p>The <code>AccountId</code> value is the AWS account ID of the account that owns the vault. You can either specify an AWS account ID or optionally a single '<code>-</code>' (hyphen), in which case Amazon Glacier uses the AWS account ID associated with the credentials used to sign the request. If you use an account ID, do not include any hyphens ('-') in the ID. </p>
     #[serde(rename = "accountId")]
@@ -292,7 +292,7 @@ pub struct DescribeVaultInput {
 }
 
 /// <p>Contains the Amazon Glacier response to your request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeVaultOutput {
     /// <p>The Universal Coordinated Time (UTC) date when the vault was created. This value should be a string in the ISO 8601 date format, for example <code>2012-03-20T17:03:43.221Z</code>.</p>
     #[serde(rename = "CreationDate")]
@@ -321,7 +321,7 @@ pub struct DescribeVaultOutput {
 }
 
 /// <p>Contains information about the encryption used to store the job results in Amazon S3. </p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Encryption {
     /// <p>The server-side encryption algorithm used when storing job results in Amazon S3, for example <code>AES256</code> or <code>aws:kms</code>.</p>
     #[serde(rename = "EncryptionType")]
@@ -338,7 +338,7 @@ pub struct Encryption {
 }
 
 /// <p>Input for GetDataRetrievalPolicy.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetDataRetrievalPolicyInput {
     /// <p>The <code>AccountId</code> value is the AWS account ID. This value must match the AWS account ID associated with the credentials used to sign the request. You can either specify an AWS account ID or optionally a single '<code>-</code>' (hyphen), in which case Amazon Glacier uses the AWS account ID associated with the credentials used to sign the request. If you specify your account ID, do not include any hyphens ('-') in the ID. </p>
     #[serde(rename = "accountId")]
@@ -346,7 +346,7 @@ pub struct GetDataRetrievalPolicyInput {
 }
 
 /// <p>Contains the Amazon Glacier response to the <code>GetDataRetrievalPolicy</code> request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetDataRetrievalPolicyOutput {
     /// <p>Contains the returned data retrieval policy in JSON format.</p>
     #[serde(rename = "Policy")]
@@ -355,7 +355,7 @@ pub struct GetDataRetrievalPolicyOutput {
 }
 
 /// <p>Provides options for downloading output of an Amazon Glacier job.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetJobOutputInput {
     /// <p>The <code>AccountId</code> value is the AWS account ID of the account that owns the vault. You can either specify an AWS account ID or optionally a single '<code>-</code>' (hyphen), in which case Amazon Glacier uses the AWS account ID associated with the credentials used to sign the request. If you use an account ID, do not include any hyphens ('-') in the ID.</p>
     #[serde(rename = "accountId")]
@@ -373,7 +373,7 @@ pub struct GetJobOutputInput {
 }
 
 /// <p>Contains the Amazon Glacier response to your request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetJobOutputOutput {
     /// <p>Indicates the range units accepted. For more information, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html">RFC2616</a>. </p>
     pub accept_ranges: Option<String>,
@@ -392,7 +392,7 @@ pub struct GetJobOutputOutput {
 }
 
 /// <p>Input for GetVaultAccessPolicy.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetVaultAccessPolicyInput {
     /// <p>The <code>AccountId</code> value is the AWS account ID of the account that owns the vault. You can either specify an AWS account ID or optionally a single '<code>-</code>' (hyphen), in which case Amazon Glacier uses the AWS account ID associated with the credentials used to sign the request. If you use an account ID, do not include any hyphens ('-') in the ID.</p>
     #[serde(rename = "accountId")]
@@ -403,7 +403,7 @@ pub struct GetVaultAccessPolicyInput {
 }
 
 /// <p>Output for GetVaultAccessPolicy.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetVaultAccessPolicyOutput {
     /// <p>Contains the returned vault access policy as a JSON string.</p>
     #[serde(rename = "policy")]
@@ -412,7 +412,7 @@ pub struct GetVaultAccessPolicyOutput {
 }
 
 /// <p>The input values for <code>GetVaultLock</code>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetVaultLockInput {
     /// <p>The <code>AccountId</code> value is the AWS account ID of the account that owns the vault. You can either specify an AWS account ID or optionally a single '<code>-</code>' (hyphen), in which case Amazon Glacier uses the AWS account ID associated with the credentials used to sign the request. If you use an account ID, do not include any hyphens ('-') in the ID.</p>
     #[serde(rename = "accountId")]
@@ -423,7 +423,7 @@ pub struct GetVaultLockInput {
 }
 
 /// <p>Contains the Amazon Glacier response to your request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetVaultLockOutput {
     /// <p>The UTC date and time at which the vault lock was put into the <code>InProgress</code> state.</p>
     #[serde(rename = "CreationDate")]
@@ -444,7 +444,7 @@ pub struct GetVaultLockOutput {
 }
 
 /// <p>Provides options for retrieving the notification configuration set on an Amazon Glacier vault.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetVaultNotificationsInput {
     /// <p>The <code>AccountId</code> value is the AWS account ID of the account that owns the vault. You can either specify an AWS account ID or optionally a single '<code>-</code>' (hyphen), in which case Amazon Glacier uses the AWS account ID associated with the credentials used to sign the request. If you use an account ID, do not include any hyphens ('-') in the ID.</p>
     #[serde(rename = "accountId")]
@@ -455,7 +455,7 @@ pub struct GetVaultNotificationsInput {
 }
 
 /// <p>Contains the Amazon Glacier response to your request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetVaultNotificationsOutput {
     /// <p>Returns the notification configuration set on the vault.</p>
     #[serde(rename = "vaultNotificationConfig")]
@@ -464,7 +464,7 @@ pub struct GetVaultNotificationsOutput {
 }
 
 /// <p>Contains the description of an Amazon Glacier job.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GlacierJobDescription {
     /// <p>The job type. This value is either <code>ArchiveRetrieval</code>, <code>InventoryRetrieval</code>, or <code>Select</code>. </p>
     #[serde(rename = "Action")]
@@ -553,7 +553,7 @@ pub struct GlacierJobDescription {
 }
 
 /// <p>Contains information about a grant.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Grant {
     /// <p>The grantee.</p>
     #[serde(rename = "Grantee")]
@@ -566,7 +566,7 @@ pub struct Grant {
 }
 
 /// <p>Contains information about the grantee.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Grantee {
     /// <p>Screen name of the grantee.</p>
     #[serde(rename = "DisplayName")]
@@ -590,7 +590,7 @@ pub struct Grantee {
 }
 
 /// <p>Provides options for initiating an Amazon Glacier job.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct InitiateJobInput {
     /// <p>The <code>AccountId</code> value is the AWS account ID of the account that owns the vault. You can either specify an AWS account ID or optionally a single '<code>-</code>' (hyphen), in which case Amazon Glacier uses the AWS account ID associated with the credentials used to sign the request. If you use an account ID, do not include any hyphens ('-') in the ID.</p>
     #[serde(rename = "accountId")]
@@ -605,7 +605,7 @@ pub struct InitiateJobInput {
 }
 
 /// <p>Contains the Amazon Glacier response to your request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct InitiateJobOutput {
     /// <p>The ID of the job.</p>
     #[serde(rename = "jobId")]
@@ -622,7 +622,7 @@ pub struct InitiateJobOutput {
 }
 
 /// <p>Provides options for initiating a multipart upload to an Amazon Glacier vault.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct InitiateMultipartUploadInput {
     /// <p>The <code>AccountId</code> value is the AWS account ID of the account that owns the vault. You can either specify an AWS account ID or optionally a single '<code>-</code>' (hyphen), in which case Amazon Glacier uses the AWS account ID associated with the credentials used to sign the request. If you use an account ID, do not include any hyphens ('-') in the ID. </p>
     #[serde(rename = "accountId")]
@@ -641,7 +641,7 @@ pub struct InitiateMultipartUploadInput {
 }
 
 /// <p>The Amazon Glacier response to your request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct InitiateMultipartUploadOutput {
     /// <p>The relative URI path of the multipart upload ID Amazon Glacier created.</p>
     #[serde(rename = "location")]
@@ -654,7 +654,7 @@ pub struct InitiateMultipartUploadOutput {
 }
 
 /// <p>The input values for <code>InitiateVaultLock</code>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct InitiateVaultLockInput {
     /// <p>The <code>AccountId</code> value is the AWS account ID. This value must match the AWS account ID associated with the credentials used to sign the request. You can either specify an AWS account ID or optionally a single '<code>-</code>' (hyphen), in which case Amazon Glacier uses the AWS account ID associated with the credentials used to sign the request. If you specify your account ID, do not include any hyphens ('-') in the ID.</p>
     #[serde(rename = "accountId")]
@@ -669,7 +669,7 @@ pub struct InitiateVaultLockInput {
 }
 
 /// <p>Contains the Amazon Glacier response to your request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct InitiateVaultLockOutput {
     /// <p>The lock ID, which is used to complete the vault locking process.</p>
     #[serde(rename = "lockId")]
@@ -678,7 +678,7 @@ pub struct InitiateVaultLockOutput {
 }
 
 /// <p>Describes how the archive is serialized.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct InputSerialization {
     /// <p>Describes the serialization of a CSV-encoded object.</p>
     #[serde(rename = "csv")]
@@ -687,7 +687,7 @@ pub struct InputSerialization {
 }
 
 /// <p>Describes the options for a range inventory retrieval job.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct InventoryRetrievalJobDescription {
     /// <p>The end of the date range in UTC for vault inventory retrieval that includes archives created before this date. This value should be a string in the ISO 8601 date format, for example <code>2013-03-20T17:03:43Z</code>.</p>
     #[serde(rename = "EndDate")]
@@ -712,7 +712,7 @@ pub struct InventoryRetrievalJobDescription {
 }
 
 /// <p>Provides options for specifying a range inventory retrieval job.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct InventoryRetrievalJobInput {
     /// <p>The end of the date range in UTC for vault inventory retrieval that includes archives created before this date. This value should be a string in the ISO 8601 date format, for example <code>2013-03-20T17:03:43Z</code>.</p>
     #[serde(rename = "EndDate")]
@@ -733,7 +733,7 @@ pub struct InventoryRetrievalJobInput {
 }
 
 /// <p>Provides options for defining a job.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct JobParameters {
     /// <p>The ID of the archive that you want to retrieve. This field is required only if <code>Type</code> is set to <code>select</code> or <code>archive-retrieval</code>code&gt;. An error occurs if you specify this request parameter for an inventory retrieval job request. </p>
     #[serde(rename = "ArchiveId")]
@@ -778,7 +778,7 @@ pub struct JobParameters {
 }
 
 /// <p>Provides options for retrieving a job list for an Amazon Glacier vault.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListJobsInput {
     /// <p>The <code>AccountId</code> value is the AWS account ID of the account that owns the vault. You can either specify an AWS account ID or optionally a single '<code>-</code>' (hyphen), in which case Amazon Glacier uses the AWS account ID associated with the credentials used to sign the request. If you use an account ID, do not include any hyphens ('-') in the ID. </p>
     #[serde(rename = "accountId")]
@@ -805,7 +805,7 @@ pub struct ListJobsInput {
 }
 
 /// <p>Contains the Amazon Glacier response to your request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListJobsOutput {
     /// <p>A list of job objects. Each job object contains metadata describing the job.</p>
     #[serde(rename = "JobList")]
@@ -818,7 +818,7 @@ pub struct ListJobsOutput {
 }
 
 /// <p>Provides options for retrieving list of in-progress multipart uploads for an Amazon Glacier vault.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListMultipartUploadsInput {
     /// <p>The <code>AccountId</code> value is the AWS account ID of the account that owns the vault. You can either specify an AWS account ID or optionally a single '<code>-</code>' (hyphen), in which case Amazon Glacier uses the AWS account ID associated with the credentials used to sign the request. If you use an account ID, do not include any hyphens ('-') in the ID. </p>
     #[serde(rename = "accountId")]
@@ -837,7 +837,7 @@ pub struct ListMultipartUploadsInput {
 }
 
 /// <p>Contains the Amazon Glacier response to your request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListMultipartUploadsOutput {
     /// <p>An opaque string that represents where to continue pagination of the results. You use the marker in a new List Multipart Uploads request to obtain more uploads in the list. If there are no more uploads, this value is <code>null</code>.</p>
     #[serde(rename = "Marker")]
@@ -850,7 +850,7 @@ pub struct ListMultipartUploadsOutput {
 }
 
 /// <p>Provides options for retrieving a list of parts of an archive that have been uploaded in a specific multipart upload.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListPartsInput {
     /// <p>The <code>AccountId</code> value is the AWS account ID of the account that owns the vault. You can either specify an AWS account ID or optionally a single '<code>-</code>' (hyphen), in which case Amazon Glacier uses the AWS account ID associated with the credentials used to sign the request. If you use an account ID, do not include any hyphens ('-') in the ID. </p>
     #[serde(rename = "accountId")]
@@ -872,7 +872,7 @@ pub struct ListPartsInput {
 }
 
 /// <p>Contains the Amazon Glacier response to your request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListPartsOutput {
     /// <p>The description of the archive that was specified in the Initiate Multipart Upload request.</p>
     #[serde(rename = "ArchiveDescription")]
@@ -904,14 +904,14 @@ pub struct ListPartsOutput {
     pub vault_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListProvisionedCapacityInput {
     /// <p>The AWS account ID of the account that owns the vault. You can either specify an AWS account ID or optionally a single '-' (hyphen), in which case Amazon Glacier uses the AWS account ID associated with the credentials used to sign the request. If you use an account ID, don't include any hyphens ('-') in the ID. </p>
     #[serde(rename = "accountId")]
     pub account_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListProvisionedCapacityOutput {
     /// <p>The response body contains the following JSON fields.</p>
     #[serde(rename = "ProvisionedCapacityList")]
@@ -920,7 +920,7 @@ pub struct ListProvisionedCapacityOutput {
 }
 
 /// <p>The input value for <code>ListTagsForVaultInput</code>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListTagsForVaultInput {
     /// <p>The <code>AccountId</code> value is the AWS account ID of the account that owns the vault. You can either specify an AWS account ID or optionally a single '<code>-</code>' (hyphen), in which case Amazon Glacier uses the AWS account ID associated with the credentials used to sign the request. If you use an account ID, do not include any hyphens ('-') in the ID.</p>
     #[serde(rename = "accountId")]
@@ -931,7 +931,7 @@ pub struct ListTagsForVaultInput {
 }
 
 /// <p>Contains the Amazon Glacier response to your request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListTagsForVaultOutput {
     /// <p>The tags attached to the vault. Each tag is composed of a key and a value.</p>
     #[serde(rename = "Tags")]
@@ -940,7 +940,7 @@ pub struct ListTagsForVaultOutput {
 }
 
 /// <p>Provides options to retrieve the vault list owned by the calling user's account. The list provides metadata information for each vault.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListVaultsInput {
     /// <p>The <code>AccountId</code> value is the AWS account ID. This value must match the AWS account ID associated with the credentials used to sign the request. You can either specify an AWS account ID or optionally a single '<code>-</code>' (hyphen), in which case Amazon Glacier uses the AWS account ID associated with the credentials used to sign the request. If you specify your account ID, do not include any hyphens ('-') in the ID.</p>
     #[serde(rename = "accountId")]
@@ -956,7 +956,7 @@ pub struct ListVaultsInput {
 }
 
 /// <p>Contains the Amazon Glacier response to your request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListVaultsOutput {
     /// <p>The vault ARN at which to continue pagination of the results. You use the marker in another List Vaults request to obtain more vaults in the list.</p>
     #[serde(rename = "Marker")]
@@ -969,7 +969,7 @@ pub struct ListVaultsOutput {
 }
 
 /// <p>Contains information about the location where the select job results are stored.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct OutputLocation {
     /// <p>Describes an S3 location that will receive the results of the job request.</p>
     #[serde(rename = "S3")]
@@ -978,7 +978,7 @@ pub struct OutputLocation {
 }
 
 /// <p>Describes how the select output is serialized.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct OutputSerialization {
     /// <p>Describes the serialization of CSV-encoded query results.</p>
     #[serde(rename = "csv")]
@@ -987,7 +987,7 @@ pub struct OutputSerialization {
 }
 
 /// <p>A list of the part sizes of the multipart upload.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PartListElement {
     /// <p>The byte range of a part, inclusive of the upper value of the range.</p>
     #[serde(rename = "RangeInBytes")]
@@ -1000,7 +1000,7 @@ pub struct PartListElement {
 }
 
 /// <p>The definition for a provisioned capacity unit.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ProvisionedCapacityDescription {
     /// <p>The ID that identifies the provisioned capacity unit.</p>
     #[serde(rename = "CapacityId")]
@@ -1016,14 +1016,14 @@ pub struct ProvisionedCapacityDescription {
     pub start_date: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PurchaseProvisionedCapacityInput {
     /// <p>The AWS account ID of the account that owns the vault. You can either specify an AWS account ID or optionally a single '-' (hyphen), in which case Amazon Glacier uses the AWS account ID associated with the credentials used to sign the request. If you use an account ID, don't include any hyphens ('-') in the ID. </p>
     #[serde(rename = "accountId")]
     pub account_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PurchaseProvisionedCapacityOutput {
     /// <p>The ID that identifies the provisioned capacity unit.</p>
     #[serde(rename = "capacityId")]
@@ -1032,7 +1032,7 @@ pub struct PurchaseProvisionedCapacityOutput {
 }
 
 /// <p>The input value for <code>RemoveTagsFromVaultInput</code>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RemoveTagsFromVaultInput {
     /// <p>A list of tag keys. Each corresponding tag is removed from the vault.</p>
     #[serde(rename = "TagKeys")]
@@ -1047,7 +1047,7 @@ pub struct RemoveTagsFromVaultInput {
 }
 
 /// <p>Contains information about the location in Amazon S3 where the select job results are stored.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct S3Location {
     /// <p>A list of grants that control access to the staged results.</p>
     #[serde(rename = "AccessControlList")]
@@ -1084,7 +1084,7 @@ pub struct S3Location {
 }
 
 /// <p>Contains information about the parameters used for a select.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SelectParameters {
     /// <p>The expression that is used to select the object.</p>
     #[serde(rename = "Expression")]
@@ -1105,7 +1105,7 @@ pub struct SelectParameters {
 }
 
 /// <p>SetDataRetrievalPolicy input.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SetDataRetrievalPolicyInput {
     /// <p>The data retrieval policy in JSON format.</p>
     #[serde(rename = "Policy")]
@@ -1117,7 +1117,7 @@ pub struct SetDataRetrievalPolicyInput {
 }
 
 /// <p>SetVaultAccessPolicy input.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SetVaultAccessPolicyInput {
     /// <p>The <code>AccountId</code> value is the AWS account ID of the account that owns the vault. You can either specify an AWS account ID or optionally a single '<code>-</code>' (hyphen), in which case Amazon Glacier uses the AWS account ID associated with the credentials used to sign the request. If you use an account ID, do not include any hyphens ('-') in the ID.</p>
     #[serde(rename = "accountId")]
@@ -1132,7 +1132,7 @@ pub struct SetVaultAccessPolicyInput {
 }
 
 /// <p>Provides options to configure notifications that will be sent when specific events happen to a vault.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SetVaultNotificationsInput {
     /// <p>The <code>AccountId</code> value is the AWS account ID of the account that owns the vault. You can either specify an AWS account ID or optionally a single '<code>-</code>' (hyphen), in which case Amazon Glacier uses the AWS account ID associated with the credentials used to sign the request. If you use an account ID, do not include any hyphens ('-') in the ID.</p>
     #[serde(rename = "accountId")]
@@ -1147,7 +1147,7 @@ pub struct SetVaultNotificationsInput {
 }
 
 /// <p>Provides options to add an archive to a vault.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UploadArchiveInput {
     /// <p>The <code>AccountId</code> value is the AWS account ID of the account that owns the vault. You can either specify an AWS account ID or optionally a single '<code>-</code>' (hyphen), in which case Amazon Glacier uses the AWS account ID associated with the credentials used to sign the request. If you use an account ID, do not include any hyphens ('-') in the ID. </p>
     #[serde(rename = "accountId")]
@@ -1174,7 +1174,7 @@ pub struct UploadArchiveInput {
 }
 
 /// <p>A list of in-progress multipart uploads for a vault.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UploadListElement {
     /// <p>The description of the archive that was specified in the Initiate Multipart Upload request.</p>
     #[serde(rename = "ArchiveDescription")]
@@ -1199,7 +1199,7 @@ pub struct UploadListElement {
 }
 
 /// <p>Provides options to upload a part of an archive in a multipart upload operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UploadMultipartPartInput {
     /// <p>The <code>AccountId</code> value is the AWS account ID of the account that owns the vault. You can either specify an AWS account ID or optionally a single '<code>-</code>' (hyphen), in which case Amazon Glacier uses the AWS account ID associated with the credentials used to sign the request. If you use an account ID, do not include any hyphens ('-') in the ID. </p>
     #[serde(rename = "accountId")]
@@ -1229,7 +1229,7 @@ pub struct UploadMultipartPartInput {
 }
 
 /// <p>Contains the Amazon Glacier response to your request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UploadMultipartPartOutput {
     /// <p>The SHA256 tree hash that Amazon Glacier computed for the uploaded part.</p>
     #[serde(rename = "checksum")]
@@ -1238,7 +1238,7 @@ pub struct UploadMultipartPartOutput {
 }
 
 /// <p>Contains the vault access policy.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct VaultAccessPolicy {
     /// <p>The vault access policy.</p>
     #[serde(rename = "Policy")]
@@ -1247,7 +1247,7 @@ pub struct VaultAccessPolicy {
 }
 
 /// <p>Contains the vault lock policy.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct VaultLockPolicy {
     /// <p>The vault lock policy.</p>
     #[serde(rename = "Policy")]
@@ -1256,7 +1256,7 @@ pub struct VaultLockPolicy {
 }
 
 /// <p>Represents a vault's notification configuration.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct VaultNotificationConfig {
     /// <p>A list of one or more events for which Amazon Glacier will send a notification to the specified Amazon SNS topic.</p>
     #[serde(rename = "Events")]

--- a/rusoto/services/glacier/src/generated.rs
+++ b/rusoto/services/glacier/src/generated.rs
@@ -1293,7 +1293,8 @@ impl AbortMultipartUploadError {
     pub fn from_body(body: &str) -> AbortMultipartUploadError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1395,7 +1396,8 @@ impl AbortVaultLockError {
     pub fn from_body(body: &str) -> AbortVaultLockError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1493,7 +1495,8 @@ impl AddTagsToVaultError {
     pub fn from_body(body: &str) -> AddTagsToVaultError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1593,7 +1596,8 @@ impl CompleteMultipartUploadError {
     pub fn from_body(body: &str) -> CompleteMultipartUploadError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1697,7 +1701,8 @@ impl CompleteVaultLockError {
     pub fn from_body(body: &str) -> CompleteVaultLockError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1795,7 +1800,8 @@ impl CreateVaultError {
     pub fn from_body(body: &str) -> CreateVaultError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1891,7 +1897,8 @@ impl DeleteArchiveError {
     pub fn from_body(body: &str) -> DeleteArchiveError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1987,7 +1994,8 @@ impl DeleteVaultError {
     pub fn from_body(body: &str) -> DeleteVaultError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2083,7 +2091,8 @@ impl DeleteVaultAccessPolicyError {
     pub fn from_body(body: &str) -> DeleteVaultAccessPolicyError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2187,7 +2196,8 @@ impl DeleteVaultNotificationsError {
     pub fn from_body(body: &str) -> DeleteVaultNotificationsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2291,7 +2301,8 @@ impl DescribeJobError {
     pub fn from_body(body: &str) -> DescribeJobError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2387,7 +2398,8 @@ impl DescribeVaultError {
     pub fn from_body(body: &str) -> DescribeVaultError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2481,7 +2493,8 @@ impl GetDataRetrievalPolicyError {
     pub fn from_body(body: &str) -> GetDataRetrievalPolicyError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2579,7 +2592,8 @@ impl GetJobOutputError {
     pub fn from_body(body: &str) -> GetJobOutputError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2675,7 +2689,8 @@ impl GetVaultAccessPolicyError {
     pub fn from_body(body: &str) -> GetVaultAccessPolicyError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2777,7 +2792,8 @@ impl GetVaultLockError {
     pub fn from_body(body: &str) -> GetVaultLockError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2873,7 +2889,8 @@ impl GetVaultNotificationsError {
     pub fn from_body(body: &str) -> GetVaultNotificationsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2979,7 +2996,8 @@ impl InitiateJobError {
     pub fn from_body(body: &str) -> InitiateJobError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3083,7 +3101,8 @@ impl InitiateMultipartUploadError {
     pub fn from_body(body: &str) -> InitiateMultipartUploadError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3187,7 +3206,8 @@ impl InitiateVaultLockError {
     pub fn from_body(body: &str) -> InitiateVaultLockError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3285,7 +3305,8 @@ impl ListJobsError {
     pub fn from_body(body: &str) -> ListJobsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3379,7 +3400,8 @@ impl ListMultipartUploadsError {
     pub fn from_body(body: &str) -> ListMultipartUploadsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3481,7 +3503,8 @@ impl ListPartsError {
     pub fn from_body(body: &str) -> ListPartsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3573,7 +3596,8 @@ impl ListProvisionedCapacityError {
     pub fn from_body(body: &str) -> ListProvisionedCapacityError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3673,7 +3697,8 @@ impl ListTagsForVaultError {
     pub fn from_body(body: &str) -> ListTagsForVaultError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3769,7 +3794,8 @@ impl ListVaultsError {
     pub fn from_body(body: &str) -> ListVaultsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3863,7 +3889,8 @@ impl PurchaseProvisionedCapacityError {
     pub fn from_body(body: &str) -> PurchaseProvisionedCapacityError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3967,7 +3994,8 @@ impl RemoveTagsFromVaultError {
     pub fn from_body(body: &str) -> RemoveTagsFromVaultError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4063,7 +4091,8 @@ impl SetDataRetrievalPolicyError {
     pub fn from_body(body: &str) -> SetDataRetrievalPolicyError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4161,7 +4190,8 @@ impl SetVaultAccessPolicyError {
     pub fn from_body(body: &str) -> SetVaultAccessPolicyError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4263,7 +4293,8 @@ impl SetVaultNotificationsError {
     pub fn from_body(body: &str) -> SetVaultNotificationsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4367,7 +4398,8 @@ impl UploadArchiveError {
     pub fn from_body(body: &str) -> UploadArchiveError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4469,7 +4501,8 @@ impl UploadMultipartPartError {
     pub fn from_body(body: &str) -> UploadMultipartPartError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/glue/src/generated.rs
+++ b/rusoto/services/glue/src/generated.rs
@@ -31,7 +31,7 @@ use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 /// <p>Defines an action to be initiated by a trigger.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Action {
     /// <p>Arguments to be passed to the job.</p> <p>You can specify arguments here that your own job-execution script consumes, as well as arguments that AWS Glue itself consumes.</p> <p>For information about how to specify and consume your own Job arguments, see the <a href="http://docs.aws.amazon.com/glue/latest/dg/aws-glue-programming-python-calling.html">Calling AWS Glue APIs in Python</a> topic in the developer guide.</p> <p>For information about the key-value pairs that AWS Glue consumes to set up your job, see the <a href="http://docs.aws.amazon.com/glue/latest/dg/aws-glue-programming-python-glue-arguments.html">Special Parameters Used by AWS Glue</a> topic in the developer guide.</p>
     #[serde(rename = "Arguments")]
@@ -43,7 +43,7 @@ pub struct Action {
     pub job_name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct BatchCreatePartitionRequest {
     /// <p>The ID of the catalog in which the partion is to be created. Currently, this should be the AWS account ID.</p>
     #[serde(rename = "CatalogId")]
@@ -60,7 +60,7 @@ pub struct BatchCreatePartitionRequest {
     pub table_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BatchCreatePartitionResponse {
     /// <p>Errors encountered when trying to create the requested partitions.</p>
     #[serde(rename = "Errors")]
@@ -68,7 +68,7 @@ pub struct BatchCreatePartitionResponse {
     pub errors: Option<Vec<PartitionError>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct BatchDeleteConnectionRequest {
     /// <p>The ID of the Data Catalog in which the connections reside. If none is supplied, the AWS account ID is used by default.</p>
     #[serde(rename = "CatalogId")]
@@ -79,7 +79,7 @@ pub struct BatchDeleteConnectionRequest {
     pub connection_name_list: Vec<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BatchDeleteConnectionResponse {
     /// <p>A map of the names of connections that were not successfully deleted to error details.</p>
     #[serde(rename = "Errors")]
@@ -91,7 +91,7 @@ pub struct BatchDeleteConnectionResponse {
     pub succeeded: Option<Vec<String>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct BatchDeletePartitionRequest {
     /// <p>The ID of the Data Catalog where the partition to be deleted resides. If none is supplied, the AWS account ID is used by default.</p>
     #[serde(rename = "CatalogId")]
@@ -108,7 +108,7 @@ pub struct BatchDeletePartitionRequest {
     pub table_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BatchDeletePartitionResponse {
     /// <p>Errors encountered when trying to delete the requested partitions.</p>
     #[serde(rename = "Errors")]
@@ -116,7 +116,7 @@ pub struct BatchDeletePartitionResponse {
     pub errors: Option<Vec<PartitionError>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct BatchDeleteTableRequest {
     /// <p>The ID of the Data Catalog where the table resides. If none is supplied, the AWS account ID is used by default.</p>
     #[serde(rename = "CatalogId")]
@@ -130,7 +130,7 @@ pub struct BatchDeleteTableRequest {
     pub tables_to_delete: Vec<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BatchDeleteTableResponse {
     /// <p>A list of errors encountered in attempting to delete the specified tables.</p>
     #[serde(rename = "Errors")]
@@ -138,7 +138,7 @@ pub struct BatchDeleteTableResponse {
     pub errors: Option<Vec<TableError>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct BatchDeleteTableVersionRequest {
     /// <p>The ID of the Data Catalog where the tables reside. If none is supplied, the AWS account ID is used by default.</p>
     #[serde(rename = "CatalogId")]
@@ -155,7 +155,7 @@ pub struct BatchDeleteTableVersionRequest {
     pub version_ids: Vec<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BatchDeleteTableVersionResponse {
     /// <p>A list of errors encountered while trying to delete the specified table versions.</p>
     #[serde(rename = "Errors")]
@@ -163,7 +163,7 @@ pub struct BatchDeleteTableVersionResponse {
     pub errors: Option<Vec<TableVersionError>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct BatchGetPartitionRequest {
     /// <p>The ID of the Data Catalog where the partitions in question reside. If none is supplied, the AWS account ID is used by default.</p>
     #[serde(rename = "CatalogId")]
@@ -180,7 +180,7 @@ pub struct BatchGetPartitionRequest {
     pub table_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BatchGetPartitionResponse {
     /// <p>A list of the requested partitions.</p>
     #[serde(rename = "Partitions")]
@@ -193,7 +193,7 @@ pub struct BatchGetPartitionResponse {
 }
 
 /// <p>Records an error that occurred when attempting to stop a specified JobRun.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BatchStopJobRunError {
     /// <p>Specifies details about the error that was encountered.</p>
     #[serde(rename = "ErrorDetail")]
@@ -209,7 +209,7 @@ pub struct BatchStopJobRunError {
     pub job_run_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct BatchStopJobRunRequest {
     /// <p>The name of the Job in question.</p>
     #[serde(rename = "JobName")]
@@ -219,7 +219,7 @@ pub struct BatchStopJobRunRequest {
     pub job_run_ids: Vec<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BatchStopJobRunResponse {
     /// <p>A list of the errors that were encountered in tryng to stop JobRuns, including the JobRunId for which each error was encountered and details about the error.</p>
     #[serde(rename = "Errors")]
@@ -232,7 +232,7 @@ pub struct BatchStopJobRunResponse {
 }
 
 /// <p>Records a successful request to stop a specified JobRun.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BatchStopJobRunSuccessfulSubmission {
     /// <p>The Name of the Job in question.</p>
     #[serde(rename = "JobName")]
@@ -245,7 +245,7 @@ pub struct BatchStopJobRunSuccessfulSubmission {
 }
 
 /// <p>Specifies a table definition in the Data Catalog.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CatalogEntry {
     /// <p>The database in which the table metadata resides.</p>
     #[serde(rename = "DatabaseName")]
@@ -256,7 +256,7 @@ pub struct CatalogEntry {
 }
 
 /// <p>A structure containing migration status information.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CatalogImportStatus {
     /// <p>True if the migration has completed, or False otherwise.</p>
     #[serde(rename = "ImportCompleted")]
@@ -273,7 +273,7 @@ pub struct CatalogImportStatus {
 }
 
 /// <p>Classifiers are written in Python and triggered during a crawl task. You can write your own classifiers to best categorize your data sources and specify the appropriate schemas to use for them. A classifier checks whether a given file is in a format it can handle, and if it is, the classifier creates a schema in the form of a <code>StructType</code> object that matches that data format.</p> <p>A classifier can be a <code>grok</code> classifier, an XML classifier, or a JSON classifier, asspecified in one of the fields in the <code>Classifier</code> object.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Classifier {
     /// <p>A <code>GrokClassifier</code> object.</p>
     #[serde(rename = "GrokClassifier")]
@@ -290,7 +290,7 @@ pub struct Classifier {
 }
 
 /// <p>Represents a directional edge in a directed acyclic graph (DAG).</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CodeGenEdge {
     /// <p>The ID of the node at which the edge starts.</p>
     #[serde(rename = "Source")]
@@ -305,7 +305,7 @@ pub struct CodeGenEdge {
 }
 
 /// <p>Represents a node in a directed acyclic graph (DAG)</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CodeGenNode {
     /// <p>Properties of the node, in the form of name-value pairs.</p>
     #[serde(rename = "Args")]
@@ -323,7 +323,7 @@ pub struct CodeGenNode {
 }
 
 /// <p>An argument or property of a node.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CodeGenNodeArg {
     /// <p>The name of the argument or property.</p>
     #[serde(rename = "Name")]
@@ -338,7 +338,7 @@ pub struct CodeGenNodeArg {
 }
 
 /// <p>A column in a <code>Table</code>.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Column {
     /// <p>Free-form text comment.</p>
     #[serde(rename = "Comment")]
@@ -354,7 +354,7 @@ pub struct Column {
 }
 
 /// <p>Defines a condition under which a trigger fires.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Condition {
     /// <p>The name of the Job to whose JobRuns this condition applies and on which this trigger waits.</p>
     #[serde(rename = "JobName")]
@@ -371,7 +371,7 @@ pub struct Condition {
 }
 
 /// <p>Defines a connection to a data source.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Connection {
     /// <p>A list of key-value pairs used as parameters for this connection.</p>
     #[serde(rename = "ConnectionProperties")]
@@ -412,7 +412,7 @@ pub struct Connection {
 }
 
 /// <p>A structure used to specify a connection to create or update.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ConnectionInput {
     /// <p>A list of key-value pairs used as parameters for this connection.</p>
     #[serde(rename = "ConnectionProperties")]
@@ -438,7 +438,7 @@ pub struct ConnectionInput {
 }
 
 /// <p>Specifies the connections used by a job.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ConnectionsList {
     /// <p>A list of connections used by the job.</p>
     #[serde(rename = "Connections")]
@@ -447,7 +447,7 @@ pub struct ConnectionsList {
 }
 
 /// <p>Specifies a crawler program that examines a data source and uses classifiers to try to determine its schema. If successful, the crawler records metadata concerning the data source in the AWS Glue Data Catalog.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Crawler {
     /// <p>A list of custom classifiers associated with the crawler.</p>
     #[serde(rename = "Classifiers")]
@@ -516,7 +516,7 @@ pub struct Crawler {
 }
 
 /// <p>Metrics for a specified crawler.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CrawlerMetrics {
     /// <p>The name of the crawler.</p>
     #[serde(rename = "CrawlerName")]
@@ -553,7 +553,7 @@ pub struct CrawlerMetrics {
 }
 
 /// <p>Specifies data stores to crawl.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CrawlerTargets {
     /// <p>Specifies JDBC targets.</p>
     #[serde(rename = "JdbcTargets")]
@@ -565,7 +565,7 @@ pub struct CrawlerTargets {
     pub s3_targets: Option<Vec<S3Target>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateClassifierRequest {
     /// <p>A <code>GrokClassifier</code> object specifying the classifier to create.</p>
     #[serde(rename = "GrokClassifier")]
@@ -581,10 +581,10 @@ pub struct CreateClassifierRequest {
     pub xml_classifier: Option<CreateXMLClassifierRequest>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateClassifierResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateConnectionRequest {
     /// <p>The ID of the Data Catalog in which to create the connection. If none is supplied, the AWS account ID is used by default.</p>
     #[serde(rename = "CatalogId")]
@@ -595,10 +595,10 @@ pub struct CreateConnectionRequest {
     pub connection_input: ConnectionInput,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateConnectionResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateCrawlerRequest {
     /// <p>A list of custom classifiers that the user has registered. By default, all AWS classifiers are included in a crawl, but these custom classifiers always override the default classifiers for a given classification.</p>
     #[serde(rename = "Classifiers")]
@@ -638,10 +638,10 @@ pub struct CreateCrawlerRequest {
     pub targets: CrawlerTargets,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateCrawlerResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateDatabaseRequest {
     /// <p>The ID of the Data Catalog in which to create the database. If none is supplied, the AWS account ID is used by default.</p>
     #[serde(rename = "CatalogId")]
@@ -652,10 +652,10 @@ pub struct CreateDatabaseRequest {
     pub database_input: DatabaseInput,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateDatabaseResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateDevEndpointRequest {
     /// <p>The name to be assigned to the new DevEndpoint.</p>
     #[serde(rename = "EndpointName")]
@@ -689,7 +689,7 @@ pub struct CreateDevEndpointRequest {
     pub subnet_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateDevEndpointResponse {
     /// <p>The AWS availability zone where this DevEndpoint is located.</p>
     #[serde(rename = "AvailabilityZone")]
@@ -750,7 +750,7 @@ pub struct CreateDevEndpointResponse {
 }
 
 /// <p>Specifies a <code>grok</code> classifier for <code>CreateClassifier</code> to create.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateGrokClassifierRequest {
     /// <p>An identifier of the data format that the classifier matches, such as Twitter, JSON, Omniture logs, Amazon CloudWatch Logs, and so on.</p>
     #[serde(rename = "Classification")]
@@ -767,7 +767,7 @@ pub struct CreateGrokClassifierRequest {
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateJobRequest {
     /// <p>The number of AWS Glue data processing units (DPUs) to allocate to this Job. From 2 to 100 DPUs can be allocated; the default is 10. A DPU is a relative measure of processing power that consists of 4 vCPUs of compute capacity and 16 GB of memory. For more information, see the <a href="https://aws.amazon.com/glue/pricing/">AWS Glue pricing page</a>.</p>
     #[serde(rename = "AllocatedCapacity")]
@@ -808,7 +808,7 @@ pub struct CreateJobRequest {
     pub role: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateJobResponse {
     /// <p>The unique name that was provided.</p>
     #[serde(rename = "Name")]
@@ -817,7 +817,7 @@ pub struct CreateJobResponse {
 }
 
 /// <p>Specifies a JSON classifier for <code>CreateClassifier</code> to create.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateJsonClassifierRequest {
     /// <p>A <code>JsonPath</code> string defining the JSON data for the classifier to classify. AWS Glue supports a subset of JsonPath, as described in <a href="https://docs.aws.amazon.com/glue/latest/dg/custom-classifier.html#custom-classifier-json">Writing JsonPath Custom Classifiers</a>.</p>
     #[serde(rename = "JsonPath")]
@@ -827,7 +827,7 @@ pub struct CreateJsonClassifierRequest {
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreatePartitionRequest {
     /// <p>The ID of the catalog in which the partion is to be created. Currently, this should be the AWS account ID.</p>
     #[serde(rename = "CatalogId")]
@@ -844,10 +844,10 @@ pub struct CreatePartitionRequest {
     pub table_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreatePartitionResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateScriptRequest {
     /// <p>A list of the edges in the DAG.</p>
     #[serde(rename = "DagEdges")]
@@ -863,7 +863,7 @@ pub struct CreateScriptRequest {
     pub language: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateScriptResponse {
     /// <p>The Python script generated from the DAG.</p>
     #[serde(rename = "PythonScript")]
@@ -875,7 +875,7 @@ pub struct CreateScriptResponse {
     pub scala_code: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateTableRequest {
     /// <p>The ID of the Data Catalog in which to create the <code>Table</code>. If none is supplied, the AWS account ID is used by default.</p>
     #[serde(rename = "CatalogId")]
@@ -889,10 +889,10 @@ pub struct CreateTableRequest {
     pub table_input: TableInput,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateTableResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateTriggerRequest {
     /// <p>The actions initiated by this trigger when it fires.</p>
     #[serde(rename = "Actions")]
@@ -917,7 +917,7 @@ pub struct CreateTriggerRequest {
     pub type_: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateTriggerResponse {
     /// <p>The name of the trigger.</p>
     #[serde(rename = "Name")]
@@ -925,7 +925,7 @@ pub struct CreateTriggerResponse {
     pub name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateUserDefinedFunctionRequest {
     /// <p>The ID of the Data Catalog in which to create the function. If none is supplied, the AWS account ID is used by default.</p>
     #[serde(rename = "CatalogId")]
@@ -939,11 +939,11 @@ pub struct CreateUserDefinedFunctionRequest {
     pub function_input: UserDefinedFunctionInput,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateUserDefinedFunctionResponse {}
 
 /// <p>Specifies an XML classifier for <code>CreateClassifier</code> to create.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateXMLClassifierRequest {
     /// <p>An identifier of the data format that the classifier matches.</p>
     #[serde(rename = "Classification")]
@@ -958,7 +958,7 @@ pub struct CreateXMLClassifierRequest {
 }
 
 /// <p>The <code>Database</code> object represents a logical grouping of tables that may reside in a Hive metastore or an RDBMS.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Database {
     /// <p>The time at which the metadata database was created in the catalog.</p>
     #[serde(rename = "CreateTime")]
@@ -982,7 +982,7 @@ pub struct Database {
 }
 
 /// <p>The structure used to create or update a database.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DatabaseInput {
     /// <p>Description of the database</p>
     #[serde(rename = "Description")]
@@ -1001,17 +1001,17 @@ pub struct DatabaseInput {
     pub parameters: Option<::std::collections::HashMap<String, String>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteClassifierRequest {
     /// <p>Name of the classifier to remove.</p>
     #[serde(rename = "Name")]
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteClassifierResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteConnectionRequest {
     /// <p>The ID of the Data Catalog in which the connection resides. If none is supplied, the AWS account ID is used by default.</p>
     #[serde(rename = "CatalogId")]
@@ -1022,20 +1022,20 @@ pub struct DeleteConnectionRequest {
     pub connection_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteConnectionResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteCrawlerRequest {
     /// <p>Name of the crawler to remove.</p>
     #[serde(rename = "Name")]
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteCrawlerResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteDatabaseRequest {
     /// <p>The ID of the Data Catalog in which the database resides. If none is supplied, the AWS account ID is used by default.</p>
     #[serde(rename = "CatalogId")]
@@ -1046,27 +1046,27 @@ pub struct DeleteDatabaseRequest {
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteDatabaseResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteDevEndpointRequest {
     /// <p>The name of the DevEndpoint.</p>
     #[serde(rename = "EndpointName")]
     pub endpoint_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteDevEndpointResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteJobRequest {
     /// <p>The name of the job to delete.</p>
     #[serde(rename = "JobName")]
     pub job_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteJobResponse {
     /// <p>The name of the job that was deleted.</p>
     #[serde(rename = "JobName")]
@@ -1074,7 +1074,7 @@ pub struct DeleteJobResponse {
     pub job_name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeletePartitionRequest {
     /// <p>The ID of the Data Catalog where the partition to be deleted resides. If none is supplied, the AWS account ID is used by default.</p>
     #[serde(rename = "CatalogId")]
@@ -1091,10 +1091,10 @@ pub struct DeletePartitionRequest {
     pub table_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeletePartitionResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteTableRequest {
     /// <p>The ID of the Data Catalog where the table resides. If none is supplied, the AWS account ID is used by default.</p>
     #[serde(rename = "CatalogId")]
@@ -1108,10 +1108,10 @@ pub struct DeleteTableRequest {
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteTableResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteTableVersionRequest {
     /// <p>The ID of the Data Catalog where the tables reside. If none is supplied, the AWS account ID is used by default.</p>
     #[serde(rename = "CatalogId")]
@@ -1128,17 +1128,17 @@ pub struct DeleteTableVersionRequest {
     pub version_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteTableVersionResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteTriggerRequest {
     /// <p>The name of the trigger to delete.</p>
     #[serde(rename = "Name")]
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteTriggerResponse {
     /// <p>The name of the trigger that was deleted.</p>
     #[serde(rename = "Name")]
@@ -1146,7 +1146,7 @@ pub struct DeleteTriggerResponse {
     pub name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteUserDefinedFunctionRequest {
     /// <p>The ID of the Data Catalog where the function to be deleted is located. If none is supplied, the AWS account ID is used by default.</p>
     #[serde(rename = "CatalogId")]
@@ -1160,11 +1160,11 @@ pub struct DeleteUserDefinedFunctionRequest {
     pub function_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteUserDefinedFunctionResponse {}
 
 /// <p>A development endpoint where a developer can remotely debug ETL scripts.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DevEndpoint {
     /// <p>The AWS availability zone where this DevEndpoint is located.</p>
     #[serde(rename = "AvailabilityZone")]
@@ -1245,7 +1245,7 @@ pub struct DevEndpoint {
 }
 
 /// <p>Custom libraries to be loaded into a DevEndpoint.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DevEndpointCustomLibraries {
     /// <p>Path to one or more Java Jars in an S3 bucket that should be loaded in your DevEndpoint.</p> <p>Please note that only pure Java/Scala libraries can currently be used on a DevEndpoint.</p>
     #[serde(rename = "ExtraJarsS3Path")]
@@ -1258,7 +1258,7 @@ pub struct DevEndpointCustomLibraries {
 }
 
 /// <p>Contains details about an error.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ErrorDetail {
     /// <p>The code associated with this error.</p>
     #[serde(rename = "ErrorCode")]
@@ -1271,7 +1271,7 @@ pub struct ErrorDetail {
 }
 
 /// <p>An execution property of a job.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ExecutionProperty {
     /// <p>The maximum number of concurrent runs allowed for a job. The default is 1. An error is returned when this threshold is reached. The maximum value you can specify is controlled by a service limit.</p>
     #[serde(rename = "MaxConcurrentRuns")]
@@ -1279,7 +1279,7 @@ pub struct ExecutionProperty {
     pub max_concurrent_runs: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetCatalogImportStatusRequest {
     /// <p>The ID of the catalog to migrate. Currently, this should be the AWS account ID.</p>
     #[serde(rename = "CatalogId")]
@@ -1287,7 +1287,7 @@ pub struct GetCatalogImportStatusRequest {
     pub catalog_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetCatalogImportStatusResponse {
     /// <p>The status of the specified catalog migration.</p>
     #[serde(rename = "ImportStatus")]
@@ -1295,14 +1295,14 @@ pub struct GetCatalogImportStatusResponse {
     pub import_status: Option<CatalogImportStatus>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetClassifierRequest {
     /// <p>Name of the classifier to retrieve.</p>
     #[serde(rename = "Name")]
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetClassifierResponse {
     /// <p>The requested classifier.</p>
     #[serde(rename = "Classifier")]
@@ -1310,7 +1310,7 @@ pub struct GetClassifierResponse {
     pub classifier: Option<Classifier>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetClassifiersRequest {
     /// <p>Size of the list to return (optional).</p>
     #[serde(rename = "MaxResults")]
@@ -1322,7 +1322,7 @@ pub struct GetClassifiersRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetClassifiersResponse {
     /// <p>The requested list of classifier objects.</p>
     #[serde(rename = "Classifiers")]
@@ -1334,7 +1334,7 @@ pub struct GetClassifiersResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetConnectionRequest {
     /// <p>The ID of the Data Catalog in which the connection resides. If none is supplied, the AWS account ID is used by default.</p>
     #[serde(rename = "CatalogId")]
@@ -1345,7 +1345,7 @@ pub struct GetConnectionRequest {
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetConnectionResponse {
     /// <p>The requested connection definition.</p>
     #[serde(rename = "Connection")]
@@ -1354,7 +1354,7 @@ pub struct GetConnectionResponse {
 }
 
 /// <p>Filters the connection definitions returned by the <code>GetConnections</code> API.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetConnectionsFilter {
     /// <p>The type of connections to return. Currently, only JDBC is supported; SFTP is not supported.</p>
     #[serde(rename = "ConnectionType")]
@@ -1366,7 +1366,7 @@ pub struct GetConnectionsFilter {
     pub match_criteria: Option<Vec<String>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetConnectionsRequest {
     /// <p>The ID of the Data Catalog in which the connections reside. If none is supplied, the AWS account ID is used by default.</p>
     #[serde(rename = "CatalogId")]
@@ -1386,7 +1386,7 @@ pub struct GetConnectionsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetConnectionsResponse {
     /// <p>A list of requested connection definitions.</p>
     #[serde(rename = "ConnectionList")]
@@ -1398,7 +1398,7 @@ pub struct GetConnectionsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetCrawlerMetricsRequest {
     /// <p>A list of the names of crawlers about which to retrieve metrics.</p>
     #[serde(rename = "CrawlerNameList")]
@@ -1414,7 +1414,7 @@ pub struct GetCrawlerMetricsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetCrawlerMetricsResponse {
     /// <p>A list of metrics for the specified crawler.</p>
     #[serde(rename = "CrawlerMetricsList")]
@@ -1426,14 +1426,14 @@ pub struct GetCrawlerMetricsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetCrawlerRequest {
     /// <p>Name of the crawler to retrieve metadata for.</p>
     #[serde(rename = "Name")]
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetCrawlerResponse {
     /// <p>The metadata for the specified crawler.</p>
     #[serde(rename = "Crawler")]
@@ -1441,7 +1441,7 @@ pub struct GetCrawlerResponse {
     pub crawler: Option<Crawler>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetCrawlersRequest {
     /// <p>The number of crawlers to return on each call.</p>
     #[serde(rename = "MaxResults")]
@@ -1453,7 +1453,7 @@ pub struct GetCrawlersRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetCrawlersResponse {
     /// <p>A list of crawler metadata.</p>
     #[serde(rename = "Crawlers")]
@@ -1465,7 +1465,7 @@ pub struct GetCrawlersResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetDatabaseRequest {
     /// <p>The ID of the Data Catalog in which the database resides. If none is supplied, the AWS account ID is used by default.</p>
     #[serde(rename = "CatalogId")]
@@ -1476,7 +1476,7 @@ pub struct GetDatabaseRequest {
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetDatabaseResponse {
     /// <p>The definition of the specified database in the catalog.</p>
     #[serde(rename = "Database")]
@@ -1484,7 +1484,7 @@ pub struct GetDatabaseResponse {
     pub database: Option<Database>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetDatabasesRequest {
     /// <p>The ID of the Data Catalog from which to retrieve <code>Databases</code>. If none is supplied, the AWS account ID is used by default.</p>
     #[serde(rename = "CatalogId")]
@@ -1500,7 +1500,7 @@ pub struct GetDatabasesRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetDatabasesResponse {
     /// <p>A list of <code>Database</code> objects from the specified catalog.</p>
     #[serde(rename = "DatabaseList")]
@@ -1511,7 +1511,7 @@ pub struct GetDatabasesResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetDataflowGraphRequest {
     /// <p>The Python script to transform.</p>
     #[serde(rename = "PythonScript")]
@@ -1519,7 +1519,7 @@ pub struct GetDataflowGraphRequest {
     pub python_script: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetDataflowGraphResponse {
     /// <p>A list of the edges in the resulting DAG.</p>
     #[serde(rename = "DagEdges")]
@@ -1531,14 +1531,14 @@ pub struct GetDataflowGraphResponse {
     pub dag_nodes: Option<Vec<CodeGenNode>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetDevEndpointRequest {
     /// <p>Name of the DevEndpoint for which to retrieve information.</p>
     #[serde(rename = "EndpointName")]
     pub endpoint_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetDevEndpointResponse {
     /// <p>A DevEndpoint definition.</p>
     #[serde(rename = "DevEndpoint")]
@@ -1546,7 +1546,7 @@ pub struct GetDevEndpointResponse {
     pub dev_endpoint: Option<DevEndpoint>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetDevEndpointsRequest {
     /// <p>The maximum size of information to return.</p>
     #[serde(rename = "MaxResults")]
@@ -1558,7 +1558,7 @@ pub struct GetDevEndpointsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetDevEndpointsResponse {
     /// <p>A list of DevEndpoint definitions.</p>
     #[serde(rename = "DevEndpoints")]
@@ -1570,14 +1570,14 @@ pub struct GetDevEndpointsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetJobRequest {
     /// <p>The name of the job to retrieve.</p>
     #[serde(rename = "JobName")]
     pub job_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetJobResponse {
     /// <p>The requested job definition.</p>
     #[serde(rename = "Job")]
@@ -1585,7 +1585,7 @@ pub struct GetJobResponse {
     pub job: Option<Job>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetJobRunRequest {
     /// <p>Name of the job being run.</p>
     #[serde(rename = "JobName")]
@@ -1599,7 +1599,7 @@ pub struct GetJobRunRequest {
     pub run_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetJobRunResponse {
     /// <p>The requested job-run metadata.</p>
     #[serde(rename = "JobRun")]
@@ -1607,7 +1607,7 @@ pub struct GetJobRunResponse {
     pub job_run: Option<JobRun>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetJobRunsRequest {
     /// <p>The name of the job for which to retrieve all job runs.</p>
     #[serde(rename = "JobName")]
@@ -1622,7 +1622,7 @@ pub struct GetJobRunsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetJobRunsResponse {
     /// <p>A list of job-run metatdata objects.</p>
     #[serde(rename = "JobRuns")]
@@ -1634,7 +1634,7 @@ pub struct GetJobRunsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetJobsRequest {
     /// <p>The maximum size of the response.</p>
     #[serde(rename = "MaxResults")]
@@ -1646,7 +1646,7 @@ pub struct GetJobsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetJobsResponse {
     /// <p>A list of jobs.</p>
     #[serde(rename = "Jobs")]
@@ -1658,7 +1658,7 @@ pub struct GetJobsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetMappingRequest {
     /// <p>Parameters for the mapping.</p>
     #[serde(rename = "Location")]
@@ -1673,14 +1673,14 @@ pub struct GetMappingRequest {
     pub source: CatalogEntry,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetMappingResponse {
     /// <p>A list of mappings to the specified targets.</p>
     #[serde(rename = "Mapping")]
     pub mapping: Vec<MappingEntry>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetPartitionRequest {
     /// <p>The ID of the Data Catalog where the partition in question resides. If none is supplied, the AWS account ID is used by default.</p>
     #[serde(rename = "CatalogId")]
@@ -1697,7 +1697,7 @@ pub struct GetPartitionRequest {
     pub table_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetPartitionResponse {
     /// <p>The requested information, in the form of a <code>Partition</code> object.</p>
     #[serde(rename = "Partition")]
@@ -1705,7 +1705,7 @@ pub struct GetPartitionResponse {
     pub partition: Option<Partition>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetPartitionsRequest {
     /// <p>The ID of the Data Catalog where the partitions in question reside. If none is supplied, the AWS account ID is used by default.</p>
     #[serde(rename = "CatalogId")]
@@ -1735,7 +1735,7 @@ pub struct GetPartitionsRequest {
     pub table_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetPartitionsResponse {
     /// <p>A continuation token, if the returned list of partitions does not does not include the last one.</p>
     #[serde(rename = "NextToken")]
@@ -1747,7 +1747,7 @@ pub struct GetPartitionsResponse {
     pub partitions: Option<Vec<Partition>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetPlanRequest {
     /// <p>The programming language of the code to perform the mapping.</p>
     #[serde(rename = "Language")]
@@ -1769,7 +1769,7 @@ pub struct GetPlanRequest {
     pub source: CatalogEntry,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetPlanResponse {
     /// <p>A Python script to perform the mapping.</p>
     #[serde(rename = "PythonScript")]
@@ -1781,7 +1781,7 @@ pub struct GetPlanResponse {
     pub scala_code: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetTableRequest {
     /// <p>The ID of the Data Catalog where the table resides. If none is supplied, the AWS account ID is used by default.</p>
     #[serde(rename = "CatalogId")]
@@ -1795,7 +1795,7 @@ pub struct GetTableRequest {
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetTableResponse {
     /// <p>The <code>Table</code> object that defines the specified table.</p>
     #[serde(rename = "Table")]
@@ -1803,7 +1803,7 @@ pub struct GetTableResponse {
     pub table: Option<Table>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetTableVersionRequest {
     /// <p>The ID of the Data Catalog where the tables reside. If none is supplied, the AWS account ID is used by default.</p>
     #[serde(rename = "CatalogId")]
@@ -1821,7 +1821,7 @@ pub struct GetTableVersionRequest {
     pub version_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetTableVersionResponse {
     /// <p>The requested table version.</p>
     #[serde(rename = "TableVersion")]
@@ -1829,7 +1829,7 @@ pub struct GetTableVersionResponse {
     pub table_version: Option<TableVersion>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetTableVersionsRequest {
     /// <p>The ID of the Data Catalog where the tables reside. If none is supplied, the AWS account ID is used by default.</p>
     #[serde(rename = "CatalogId")]
@@ -1851,7 +1851,7 @@ pub struct GetTableVersionsRequest {
     pub table_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetTableVersionsResponse {
     /// <p>A continuation token, if the list of available versions does not include the last one.</p>
     #[serde(rename = "NextToken")]
@@ -1863,7 +1863,7 @@ pub struct GetTableVersionsResponse {
     pub table_versions: Option<Vec<TableVersion>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetTablesRequest {
     /// <p>The ID of the Data Catalog where the tables reside. If none is supplied, the AWS account ID is used by default.</p>
     #[serde(rename = "CatalogId")]
@@ -1886,7 +1886,7 @@ pub struct GetTablesRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetTablesResponse {
     /// <p>A continuation token, present if the current list segment is not the last.</p>
     #[serde(rename = "NextToken")]
@@ -1898,14 +1898,14 @@ pub struct GetTablesResponse {
     pub table_list: Option<Vec<Table>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetTriggerRequest {
     /// <p>The name of the trigger to retrieve.</p>
     #[serde(rename = "Name")]
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetTriggerResponse {
     /// <p>The requested trigger definition.</p>
     #[serde(rename = "Trigger")]
@@ -1913,7 +1913,7 @@ pub struct GetTriggerResponse {
     pub trigger: Option<Trigger>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetTriggersRequest {
     /// <p>The name of the job for which to retrieve triggers. The trigger that can start this job will be returned, and if there is no such trigger, all triggers will be returned.</p>
     #[serde(rename = "DependentJobName")]
@@ -1929,7 +1929,7 @@ pub struct GetTriggersRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetTriggersResponse {
     /// <p>A continuation token, if not all the requested triggers have yet been returned.</p>
     #[serde(rename = "NextToken")]
@@ -1941,7 +1941,7 @@ pub struct GetTriggersResponse {
     pub triggers: Option<Vec<Trigger>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetUserDefinedFunctionRequest {
     /// <p>The ID of the Data Catalog where the function to be retrieved is located. If none is supplied, the AWS account ID is used by default.</p>
     #[serde(rename = "CatalogId")]
@@ -1955,7 +1955,7 @@ pub struct GetUserDefinedFunctionRequest {
     pub function_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetUserDefinedFunctionResponse {
     /// <p>The requested function definition.</p>
     #[serde(rename = "UserDefinedFunction")]
@@ -1963,7 +1963,7 @@ pub struct GetUserDefinedFunctionResponse {
     pub user_defined_function: Option<UserDefinedFunction>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetUserDefinedFunctionsRequest {
     /// <p>The ID of the Data Catalog where the functions to be retrieved are located. If none is supplied, the AWS account ID is used by default.</p>
     #[serde(rename = "CatalogId")]
@@ -1985,7 +1985,7 @@ pub struct GetUserDefinedFunctionsRequest {
     pub pattern: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetUserDefinedFunctionsResponse {
     /// <p>A continuation token, if the list of functions returned does not include the last requested function.</p>
     #[serde(rename = "NextToken")]
@@ -1998,7 +1998,7 @@ pub struct GetUserDefinedFunctionsResponse {
 }
 
 /// <p>A classifier that uses <code>grok</code> patterns.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GrokClassifier {
     /// <p>An identifier of the data format that the classifier matches, such as Twitter, JSON, Omniture logs, and so on.</p>
     #[serde(rename = "Classification")]
@@ -2027,7 +2027,7 @@ pub struct GrokClassifier {
     pub version: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ImportCatalogToGlueRequest {
     /// <p>The ID of the catalog to import. Currently, this should be the AWS account ID.</p>
     #[serde(rename = "CatalogId")]
@@ -2035,11 +2035,11 @@ pub struct ImportCatalogToGlueRequest {
     pub catalog_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ImportCatalogToGlueResponse {}
 
 /// <p>Specifies a JDBC data store to crawl.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct JdbcTarget {
     /// <p>The name of the connection to use to connect to the JDBC target.</p>
     #[serde(rename = "ConnectionName")]
@@ -2056,7 +2056,7 @@ pub struct JdbcTarget {
 }
 
 /// <p>Specifies a job.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Job {
     /// <p>The number of AWS Glue data processing units (DPUs) allocated to this Job. From 2 to 100 DPUs can be allocated; the default is 10. A DPU is a relative measure of processing power that consists of 4 vCPUs of compute capacity and 16 GB of memory. For more information, see the <a href="https://aws.amazon.com/glue/pricing/">AWS Glue pricing page</a>.</p>
     #[serde(rename = "AllocatedCapacity")]
@@ -2109,7 +2109,7 @@ pub struct Job {
 }
 
 /// <p>Defines a point which a job can resume processing.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct JobBookmarkEntry {
     /// <p>The attempt ID number.</p>
     #[serde(rename = "Attempt")]
@@ -2134,7 +2134,7 @@ pub struct JobBookmarkEntry {
 }
 
 /// <p>Specifies code that executes a job.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct JobCommand {
     /// <p>The name of the job command: this must be <code>glueetl</code>.</p>
     #[serde(rename = "Name")]
@@ -2147,7 +2147,7 @@ pub struct JobCommand {
 }
 
 /// <p>Contains information about a job run.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct JobRun {
     /// <p>The number of AWS Glue data processing units (DPUs) allocated to this JobRun. From 2 to 100 DPUs can be allocated; the default is 10. A DPU is a relative measure of processing power that consists of 4 vCPUs of compute capacity and 16 GB of memory. For more information, see the <a href="https://aws.amazon.com/glue/pricing/">AWS Glue pricing page</a>.</p>
     #[serde(rename = "AllocatedCapacity")]
@@ -2204,7 +2204,7 @@ pub struct JobRun {
 }
 
 /// <p>Specifies information used to update an existing job. Note that the previous job definition will be completely overwritten by this information.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct JobUpdate {
     /// <p>The number of AWS Glue data processing units (DPUs) to allocate to this Job. From 2 to 100 DPUs can be allocated; the default is 10. A DPU is a relative measure of processing power that consists of 4 vCPUs of compute capacity and 16 GB of memory. For more information, see the <a href="https://aws.amazon.com/glue/pricing/">AWS Glue pricing page</a>.</p>
     #[serde(rename = "AllocatedCapacity")]
@@ -2245,7 +2245,7 @@ pub struct JobUpdate {
 }
 
 /// <p>A classifier for <code>JSON</code> content.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct JsonClassifier {
     /// <p>The time this classifier was registered.</p>
     #[serde(rename = "CreationTime")]
@@ -2268,7 +2268,7 @@ pub struct JsonClassifier {
 }
 
 /// <p>Status and error information about the most recent crawl.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct LastCrawlInfo {
     /// <p>If an error occurred, the error information about the last crawl.</p>
     #[serde(rename = "ErrorMessage")]
@@ -2297,7 +2297,7 @@ pub struct LastCrawlInfo {
 }
 
 /// <p>The location of resources.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct Location {
     /// <p>A JDBC location.</p>
     #[serde(rename = "Jdbc")]
@@ -2310,7 +2310,7 @@ pub struct Location {
 }
 
 /// <p>Defines a mapping.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct MappingEntry {
     /// <p>The source path.</p>
     #[serde(rename = "SourcePath")]
@@ -2339,7 +2339,7 @@ pub struct MappingEntry {
 }
 
 /// <p>Specifies the sort order of a sorted column.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Order {
     /// <p>The name of the column.</p>
     #[serde(rename = "Column")]
@@ -2350,7 +2350,7 @@ pub struct Order {
 }
 
 /// <p>Represents a slice of table data.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Partition {
     /// <p>The time at which the partition was created.</p>
     #[serde(rename = "CreationTime")]
@@ -2387,7 +2387,7 @@ pub struct Partition {
 }
 
 /// <p>Contains information about a partition error.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PartitionError {
     /// <p>Details about the partition error.</p>
     #[serde(rename = "ErrorDetail")]
@@ -2400,7 +2400,7 @@ pub struct PartitionError {
 }
 
 /// <p>The structure used to create and update a partion.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PartitionInput {
     /// <p>The last time at which the partition was accessed.</p>
     #[serde(rename = "LastAccessTime")]
@@ -2425,7 +2425,7 @@ pub struct PartitionInput {
 }
 
 /// <p>Contains a list of values defining partitions.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct PartitionValueList {
     /// <p>The list of values.</p>
     #[serde(rename = "Values")]
@@ -2433,7 +2433,7 @@ pub struct PartitionValueList {
 }
 
 /// <p>Specifies the physical requirements for a connection.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct PhysicalConnectionRequirements {
     /// <p>The connection's availability zone. This field is deprecated and has no effect.</p>
     #[serde(rename = "AvailabilityZone")]
@@ -2450,7 +2450,7 @@ pub struct PhysicalConnectionRequirements {
 }
 
 /// <p>A job run that was used in the predicate of a conditional trigger that triggered this job run.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Predecessor {
     /// <p>The name of the predecessor job.</p>
     #[serde(rename = "JobName")]
@@ -2463,7 +2463,7 @@ pub struct Predecessor {
 }
 
 /// <p>Defines the predicate of the trigger, which determines when it fires.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Predicate {
     /// <p>A list of the conditions that determine when the trigger will fire.</p>
     #[serde(rename = "Conditions")]
@@ -2475,14 +2475,14 @@ pub struct Predicate {
     pub logical: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ResetJobBookmarkRequest {
     /// <p>The name of the job in question.</p>
     #[serde(rename = "JobName")]
     pub job_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ResetJobBookmarkResponse {
     /// <p>The reset bookmark entry.</p>
     #[serde(rename = "JobBookmarkEntry")]
@@ -2491,7 +2491,7 @@ pub struct ResetJobBookmarkResponse {
 }
 
 /// <p>URIs for function resources.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ResourceUri {
     /// <p>The type of the resource.</p>
     #[serde(rename = "ResourceType")]
@@ -2504,7 +2504,7 @@ pub struct ResourceUri {
 }
 
 /// <p>Specifies a data store in Amazon S3.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct S3Target {
     /// <p>A list of glob patterns used to exclude from the crawl. For more information, see <a href="http://docs.aws.amazon.com/glue/latest/dg/add-crawler.html">Catalog Tables with a Crawler</a>.</p>
     #[serde(rename = "Exclusions")]
@@ -2517,7 +2517,7 @@ pub struct S3Target {
 }
 
 /// <p>A scheduling object using a <code>cron</code> statement to schedule an event.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Schedule {
     /// <p>A <code>cron</code> expression used to specify the schedule (see <a href="http://docs.aws.amazon.com/glue/latest/dg/monitor-data-warehouse-schedule.html">Time-Based Schedules for Jobs and Crawlers</a>. For example, to run something every day at 12:15 UTC, you would specify: <code>cron(15 12 * * ? *)</code>.</p>
     #[serde(rename = "ScheduleExpression")]
@@ -2530,7 +2530,7 @@ pub struct Schedule {
 }
 
 /// <p>Crawler policy for update and deletion behavior.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SchemaChangePolicy {
     /// <p>The deletion behavior when the crawler finds a deleted object.</p>
     #[serde(rename = "DeleteBehavior")]
@@ -2543,7 +2543,7 @@ pub struct SchemaChangePolicy {
 }
 
 /// <p>Defines a non-overlapping region of a table's partitions, allowing multiple requests to be executed in parallel.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct Segment {
     /// <p>The zero-based index number of the this segment. For example, if the total number of segments is 4, SegmentNumber values will range from zero through three.</p>
     #[serde(rename = "SegmentNumber")]
@@ -2554,7 +2554,7 @@ pub struct Segment {
 }
 
 /// <p>Information about a serialization/deserialization program (SerDe) which serves as an extractor and loader.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SerDeInfo {
     /// <p>Name of the SerDe.</p>
     #[serde(rename = "Name")]
@@ -2571,7 +2571,7 @@ pub struct SerDeInfo {
 }
 
 /// <p>Specifies skewed values in a table. Skewed are ones that occur with very high frequency.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SkewedInfo {
     /// <p>A list of names of columns that contain skewed values.</p>
     #[serde(rename = "SkewedColumnNames")]
@@ -2587,27 +2587,27 @@ pub struct SkewedInfo {
     pub skewed_column_values: Option<Vec<String>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StartCrawlerRequest {
     /// <p>Name of the crawler to start.</p>
     #[serde(rename = "Name")]
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StartCrawlerResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StartCrawlerScheduleRequest {
     /// <p>Name of the crawler to schedule.</p>
     #[serde(rename = "CrawlerName")]
     pub crawler_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StartCrawlerScheduleResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StartJobRunRequest {
     /// <p>The number of AWS Glue data processing units (DPUs) to allocate to this JobRun. From 2 to 100 DPUs can be allocated; the default is 10. A DPU is a relative measure of processing power that consists of 4 vCPUs of compute capacity and 16 GB of memory. For more information, see the <a href="https://aws.amazon.com/glue/pricing/">AWS Glue pricing page</a>.</p>
     #[serde(rename = "AllocatedCapacity")]
@@ -2626,7 +2626,7 @@ pub struct StartJobRunRequest {
     pub job_run_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StartJobRunResponse {
     /// <p>The ID assigned to this job run.</p>
     #[serde(rename = "JobRunId")]
@@ -2634,14 +2634,14 @@ pub struct StartJobRunResponse {
     pub job_run_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StartTriggerRequest {
     /// <p>The name of the trigger to start.</p>
     #[serde(rename = "Name")]
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StartTriggerResponse {
     /// <p>The name of the trigger that was started.</p>
     #[serde(rename = "Name")]
@@ -2649,34 +2649,34 @@ pub struct StartTriggerResponse {
     pub name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StopCrawlerRequest {
     /// <p>Name of the crawler to stop.</p>
     #[serde(rename = "Name")]
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StopCrawlerResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StopCrawlerScheduleRequest {
     /// <p>Name of the crawler whose schedule state to set.</p>
     #[serde(rename = "CrawlerName")]
     pub crawler_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StopCrawlerScheduleResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StopTriggerRequest {
     /// <p>The name of the trigger to stop.</p>
     #[serde(rename = "Name")]
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StopTriggerResponse {
     /// <p>The name of the trigger that was stopped.</p>
     #[serde(rename = "Name")]
@@ -2685,7 +2685,7 @@ pub struct StopTriggerResponse {
 }
 
 /// <p>Describes the physical storage of table data.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct StorageDescriptor {
     /// <p>A list of reducer grouping columns, clustering columns, and bucketing columns in the table.</p>
     #[serde(rename = "BucketColumns")]
@@ -2738,7 +2738,7 @@ pub struct StorageDescriptor {
 }
 
 /// <p>Represents a collection of related data organized in columns and rows.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Table {
     /// <p>Time when the table definition was created in the Data Catalog.</p>
     #[serde(rename = "CreateTime")]
@@ -2806,7 +2806,7 @@ pub struct Table {
 }
 
 /// <p>An error record for table operations.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct TableError {
     /// <p>Detail about the error.</p>
     #[serde(rename = "ErrorDetail")]
@@ -2819,7 +2819,7 @@ pub struct TableError {
 }
 
 /// <p>Structure used to create or update the table.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct TableInput {
     /// <p>Description of the table.</p>
     #[serde(rename = "Description")]
@@ -2871,7 +2871,7 @@ pub struct TableInput {
 }
 
 /// <p>Specifies a version of a table.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct TableVersion {
     /// <p>The table in question</p>
     #[serde(rename = "Table")]
@@ -2884,7 +2884,7 @@ pub struct TableVersion {
 }
 
 /// <p>An error record for table-version operations.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct TableVersionError {
     /// <p>Detail about the error.</p>
     #[serde(rename = "ErrorDetail")]
@@ -2901,7 +2901,7 @@ pub struct TableVersionError {
 }
 
 /// <p>Information about a specific trigger.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Trigger {
     /// <p>The actions initiated by this trigger.</p>
     #[serde(rename = "Actions")]
@@ -2938,7 +2938,7 @@ pub struct Trigger {
 }
 
 /// <p>A structure used to provide information used to update a trigger. This object will update the the previous trigger definition by overwriting it completely.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct TriggerUpdate {
     /// <p>The actions initiated by this trigger.</p>
     #[serde(rename = "Actions")]
@@ -2962,7 +2962,7 @@ pub struct TriggerUpdate {
     pub schedule: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateClassifierRequest {
     /// <p>A <code>GrokClassifier</code> object with updated fields.</p>
     #[serde(rename = "GrokClassifier")]
@@ -2978,10 +2978,10 @@ pub struct UpdateClassifierRequest {
     pub xml_classifier: Option<UpdateXMLClassifierRequest>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateClassifierResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateConnectionRequest {
     /// <p>The ID of the Data Catalog in which the connection resides. If none is supplied, the AWS account ID is used by default.</p>
     #[serde(rename = "CatalogId")]
@@ -2995,10 +2995,10 @@ pub struct UpdateConnectionRequest {
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateConnectionResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateCrawlerRequest {
     /// <p>A list of custom classifiers that the user has registered. By default, all classifiers are included in a crawl, but these custom classifiers always override the default classifiers for a given classification.</p>
     #[serde(rename = "Classifiers")]
@@ -3041,10 +3041,10 @@ pub struct UpdateCrawlerRequest {
     pub targets: Option<CrawlerTargets>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateCrawlerResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateCrawlerScheduleRequest {
     /// <p>Name of the crawler whose schedule to update.</p>
     #[serde(rename = "CrawlerName")]
@@ -3055,10 +3055,10 @@ pub struct UpdateCrawlerScheduleRequest {
     pub schedule: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateCrawlerScheduleResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateDatabaseRequest {
     /// <p>The ID of the Data Catalog in which the metadata database resides. If none is supplied, the AWS account ID is used by default.</p>
     #[serde(rename = "CatalogId")]
@@ -3072,10 +3072,10 @@ pub struct UpdateDatabaseRequest {
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateDatabaseResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateDevEndpointRequest {
     /// <p>Custom Python or Java libraries to be loaded in the DevEndpoint.</p>
     #[serde(rename = "CustomLibraries")]
@@ -3094,11 +3094,11 @@ pub struct UpdateDevEndpointRequest {
     pub update_etl_libraries: Option<bool>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateDevEndpointResponse {}
 
 /// <p>Specifies a grok classifier to update when passed to <code>UpdateClassifier</code>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateGrokClassifierRequest {
     /// <p>An identifier of the data format that the classifier matches, such as Twitter, JSON, Omniture logs, Amazon CloudWatch Logs, and so on.</p>
     #[serde(rename = "Classification")]
@@ -3117,7 +3117,7 @@ pub struct UpdateGrokClassifierRequest {
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateJobRequest {
     /// <p>Name of the job definition to update.</p>
     #[serde(rename = "JobName")]
@@ -3127,7 +3127,7 @@ pub struct UpdateJobRequest {
     pub job_update: JobUpdate,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateJobResponse {
     /// <p>Returns the name of the updated job.</p>
     #[serde(rename = "JobName")]
@@ -3136,7 +3136,7 @@ pub struct UpdateJobResponse {
 }
 
 /// <p>Specifies a JSON classifier to be updated.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateJsonClassifierRequest {
     /// <p>A <code>JsonPath</code> string defining the JSON data for the classifier to classify. AWS Glue supports a subset of JsonPath, as described in <a href="https://docs.aws.amazon.com/glue/latest/dg/custom-classifier.html#custom-classifier-json">Writing JsonPath Custom Classifiers</a>.</p>
     #[serde(rename = "JsonPath")]
@@ -3147,7 +3147,7 @@ pub struct UpdateJsonClassifierRequest {
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdatePartitionRequest {
     /// <p>The ID of the Data Catalog where the partition to be updated resides. If none is supplied, the AWS account ID is used by default.</p>
     #[serde(rename = "CatalogId")]
@@ -3167,10 +3167,10 @@ pub struct UpdatePartitionRequest {
     pub table_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdatePartitionResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateTableRequest {
     /// <p>The ID of the Data Catalog where the table resides. If none is supplied, the AWS account ID is used by default.</p>
     #[serde(rename = "CatalogId")]
@@ -3188,10 +3188,10 @@ pub struct UpdateTableRequest {
     pub table_input: TableInput,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateTableResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateTriggerRequest {
     /// <p>The name of the trigger to update.</p>
     #[serde(rename = "Name")]
@@ -3201,7 +3201,7 @@ pub struct UpdateTriggerRequest {
     pub trigger_update: TriggerUpdate,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateTriggerResponse {
     /// <p>The resulting trigger definition.</p>
     #[serde(rename = "Trigger")]
@@ -3209,7 +3209,7 @@ pub struct UpdateTriggerResponse {
     pub trigger: Option<Trigger>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateUserDefinedFunctionRequest {
     /// <p>The ID of the Data Catalog where the function to be updated is located. If none is supplied, the AWS account ID is used by default.</p>
     #[serde(rename = "CatalogId")]
@@ -3226,11 +3226,11 @@ pub struct UpdateUserDefinedFunctionRequest {
     pub function_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateUserDefinedFunctionResponse {}
 
 /// <p>Specifies an XML classifier to be updated.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateXMLClassifierRequest {
     /// <p>An identifier of the data format that the classifier matches.</p>
     #[serde(rename = "Classification")]
@@ -3246,7 +3246,7 @@ pub struct UpdateXMLClassifierRequest {
 }
 
 /// <p>Represents the equivalent of a Hive user-defined function (<code>UDF</code>) definition.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UserDefinedFunction {
     /// <p>The Java class that contains the function code.</p>
     #[serde(rename = "ClassName")]
@@ -3275,7 +3275,7 @@ pub struct UserDefinedFunction {
 }
 
 /// <p>A structure used to create or updata a user-defined function.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UserDefinedFunctionInput {
     /// <p>The Java class that contains the function code.</p>
     #[serde(rename = "ClassName")]
@@ -3300,7 +3300,7 @@ pub struct UserDefinedFunctionInput {
 }
 
 /// <p>A classifier for <code>XML</code> content.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct XMLClassifier {
     /// <p>An identifier of the data format that the classifier matches.</p>
     #[serde(rename = "Classification")]

--- a/rusoto/services/glue/src/generated.rs
+++ b/rusoto/services/glue/src/generated.rs
@@ -3355,7 +3355,8 @@ impl BatchCreatePartitionError {
     pub fn from_body(body: &str) -> BatchCreatePartitionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3459,7 +3460,8 @@ impl BatchDeleteConnectionError {
     pub fn from_body(body: &str) -> BatchDeleteConnectionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3549,7 +3551,8 @@ impl BatchDeletePartitionError {
     pub fn from_body(body: &str) -> BatchDeletePartitionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3647,7 +3650,8 @@ impl BatchDeleteTableError {
     pub fn from_body(body: &str) -> BatchDeleteTableError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3743,7 +3747,8 @@ impl BatchDeleteTableVersionError {
     pub fn from_body(body: &str) -> BatchDeleteTableVersionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3841,7 +3846,8 @@ impl BatchGetPartitionError {
     pub fn from_body(body: &str) -> BatchGetPartitionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3937,7 +3943,8 @@ impl GlueBatchStopJobRunError {
     pub fn from_body(body: &str) -> GlueBatchStopJobRunError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4029,7 +4036,8 @@ impl CreateClassifierError {
     pub fn from_body(body: &str) -> CreateClassifierError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4121,7 +4129,8 @@ impl CreateConnectionError {
     pub fn from_body(body: &str) -> CreateConnectionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4219,7 +4228,8 @@ impl CreateCrawlerError {
     pub fn from_body(body: &str) -> CreateCrawlerError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4317,7 +4327,8 @@ impl CreateDatabaseError {
     pub fn from_body(body: &str) -> CreateDatabaseError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4425,7 +4436,8 @@ impl CreateDevEndpointError {
     pub fn from_body(body: &str) -> CreateDevEndpointError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4545,7 +4557,8 @@ impl CreateJobError {
     pub fn from_body(body: &str) -> CreateJobError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4655,7 +4668,8 @@ impl CreatePartitionError {
     pub fn from_body(body: &str) -> CreatePartitionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4759,7 +4773,8 @@ impl CreateScriptError {
     pub fn from_body(body: &str) -> CreateScriptError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4855,7 +4870,8 @@ impl CreateTableError {
     pub fn from_body(body: &str) -> CreateTableError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4965,7 +4981,8 @@ impl CreateTriggerError {
     pub fn from_body(body: &str) -> CreateTriggerError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5077,7 +5094,8 @@ impl CreateUserDefinedFunctionError {
     pub fn from_body(body: &str) -> CreateUserDefinedFunctionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5183,7 +5201,8 @@ impl DeleteClassifierError {
     pub fn from_body(body: &str) -> DeleteClassifierError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5267,7 +5286,8 @@ impl DeleteConnectionError {
     pub fn from_body(body: &str) -> DeleteConnectionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5355,7 +5375,8 @@ impl DeleteCrawlerError {
     pub fn from_body(body: &str) -> DeleteCrawlerError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5451,7 +5472,8 @@ impl DeleteDatabaseError {
     pub fn from_body(body: &str) -> DeleteDatabaseError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5547,7 +5569,8 @@ impl DeleteDevEndpointError {
     pub fn from_body(body: &str) -> DeleteDevEndpointError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5643,7 +5666,8 @@ impl DeleteJobError {
     pub fn from_body(body: &str) -> DeleteJobError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5733,7 +5757,8 @@ impl DeletePartitionError {
     pub fn from_body(body: &str) -> DeletePartitionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5829,7 +5854,8 @@ impl DeleteTableError {
     pub fn from_body(body: &str) -> DeleteTableError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5925,7 +5951,8 @@ impl DeleteTableVersionError {
     pub fn from_body(body: &str) -> DeleteTableVersionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6023,7 +6050,8 @@ impl DeleteTriggerError {
     pub fn from_body(body: &str) -> DeleteTriggerError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6119,7 +6147,8 @@ impl DeleteUserDefinedFunctionError {
     pub fn from_body(body: &str) -> DeleteUserDefinedFunctionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6215,7 +6244,8 @@ impl GetCatalogImportStatusError {
     pub fn from_body(body: &str) -> GetCatalogImportStatusError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6301,7 +6331,8 @@ impl GetClassifierError {
     pub fn from_body(body: &str) -> GetClassifierError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6383,7 +6414,8 @@ impl GetClassifiersError {
     pub fn from_body(body: &str) -> GetClassifiersError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6463,7 +6495,8 @@ impl GetConnectionError {
     pub fn from_body(body: &str) -> GetConnectionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6547,7 +6580,8 @@ impl GetConnectionsError {
     pub fn from_body(body: &str) -> GetConnectionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6631,7 +6665,8 @@ impl GetCrawlerError {
     pub fn from_body(body: &str) -> GetCrawlerError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6711,7 +6746,8 @@ impl GetCrawlerMetricsError {
     pub fn from_body(body: &str) -> GetCrawlerMetricsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6791,7 +6827,8 @@ impl GetCrawlersError {
     pub fn from_body(body: &str) -> GetCrawlersError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6875,7 +6912,8 @@ impl GetDatabaseError {
     pub fn from_body(body: &str) -> GetDatabaseError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6969,7 +7007,8 @@ impl GetDatabasesError {
     pub fn from_body(body: &str) -> GetDatabasesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7059,7 +7098,8 @@ impl GetDataflowGraphError {
     pub fn from_body(body: &str) -> GetDataflowGraphError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7151,7 +7191,8 @@ impl GetDevEndpointError {
     pub fn from_body(body: &str) -> GetDevEndpointError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7247,7 +7288,8 @@ impl GetDevEndpointsError {
     pub fn from_body(body: &str) -> GetDevEndpointsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7343,7 +7385,8 @@ impl GetJobError {
     pub fn from_body(body: &str) -> GetJobError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7437,7 +7480,8 @@ impl GetJobRunError {
     pub fn from_body(body: &str) -> GetJobRunError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7531,7 +7575,8 @@ impl GetJobRunsError {
     pub fn from_body(body: &str) -> GetJobRunsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7625,7 +7670,8 @@ impl GetJobsError {
     pub fn from_body(body: &str) -> GetJobsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7719,7 +7765,8 @@ impl GetMappingError {
     pub fn from_body(body: &str) -> GetMappingError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7813,7 +7860,8 @@ impl GetPartitionError {
     pub fn from_body(body: &str) -> GetPartitionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7909,7 +7957,8 @@ impl GetPartitionsError {
     pub fn from_body(body: &str) -> GetPartitionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8003,7 +8052,8 @@ impl GetPlanError {
     pub fn from_body(body: &str) -> GetPlanError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8093,7 +8143,8 @@ impl GetTableError {
     pub fn from_body(body: &str) -> GetTableError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8187,7 +8238,8 @@ impl GetTableVersionError {
     pub fn from_body(body: &str) -> GetTableVersionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8283,7 +8335,8 @@ impl GetTableVersionsError {
     pub fn from_body(body: &str) -> GetTableVersionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8379,7 +8432,8 @@ impl GetTablesError {
     pub fn from_body(body: &str) -> GetTablesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8473,7 +8527,8 @@ impl GetTriggerError {
     pub fn from_body(body: &str) -> GetTriggerError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8567,7 +8622,8 @@ impl GetTriggersError {
     pub fn from_body(body: &str) -> GetTriggersError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8663,7 +8719,8 @@ impl GetUserDefinedFunctionError {
     pub fn from_body(body: &str) -> GetUserDefinedFunctionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8761,7 +8818,8 @@ impl GetUserDefinedFunctionsError {
     pub fn from_body(body: &str) -> GetUserDefinedFunctionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8855,7 +8913,8 @@ impl ImportCatalogToGlueError {
     pub fn from_body(body: &str) -> ImportCatalogToGlueError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8945,7 +9004,8 @@ impl ResetJobBookmarkError {
     pub fn from_body(body: &str) -> ResetJobBookmarkError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9039,7 +9099,8 @@ impl StartCrawlerError {
     pub fn from_body(body: &str) -> StartCrawlerError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9133,7 +9194,8 @@ impl StartCrawlerScheduleError {
     pub fn from_body(body: &str) -> StartCrawlerScheduleError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9241,7 +9303,8 @@ impl StartJobRunError {
     pub fn from_body(body: &str) -> StartJobRunError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9349,7 +9412,8 @@ impl StartTriggerError {
     pub fn from_body(body: &str) -> StartTriggerError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9453,7 +9517,8 @@ impl StopCrawlerError {
     pub fn from_body(body: &str) -> StopCrawlerError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9549,7 +9614,8 @@ impl StopCrawlerScheduleError {
     pub fn from_body(body: &str) -> StopCrawlerScheduleError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9651,7 +9717,8 @@ impl StopTriggerError {
     pub fn from_body(body: &str) -> StopTriggerError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9751,7 +9818,8 @@ impl UpdateClassifierError {
     pub fn from_body(body: &str) -> UpdateClassifierError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9845,7 +9913,8 @@ impl UpdateConnectionError {
     pub fn from_body(body: &str) -> UpdateConnectionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9939,7 +10008,8 @@ impl UpdateCrawlerError {
     pub fn from_body(body: &str) -> UpdateCrawlerError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -10041,7 +10111,8 @@ impl UpdateCrawlerScheduleError {
     pub fn from_body(body: &str) -> UpdateCrawlerScheduleError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -10145,7 +10216,8 @@ impl UpdateDatabaseError {
     pub fn from_body(body: &str) -> UpdateDatabaseError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -10241,7 +10313,8 @@ impl UpdateDevEndpointError {
     pub fn from_body(body: &str) -> UpdateDevEndpointError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -10341,7 +10414,8 @@ impl UpdateJobError {
     pub fn from_body(body: &str) -> UpdateJobError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -10439,7 +10513,8 @@ impl UpdatePartitionError {
     pub fn from_body(body: &str) -> UpdatePartitionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -10539,7 +10614,8 @@ impl UpdateTableError {
     pub fn from_body(body: &str) -> UpdateTableError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -10645,7 +10721,8 @@ impl UpdateTriggerError {
     pub fn from_body(body: &str) -> UpdateTriggerError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -10745,7 +10822,8 @@ impl UpdateUserDefinedFunctionError {
     pub fn from_body(body: &str) -> UpdateUserDefinedFunctionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/greengrass/src/generated.rs
+++ b/rusoto/services/greengrass/src/generated.rs
@@ -30,7 +30,7 @@ use rusoto_core::signature::SignedRequest;
 use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AssociateRoleToGroupRequest {
     /// <p>The ID of the AWS Greengrass group.</p>
     #[serde(rename = "GroupId")]
@@ -41,7 +41,7 @@ pub struct AssociateRoleToGroupRequest {
     pub role_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AssociateRoleToGroupResponse {
     /// <p>The time, in milliseconds since the epoch, when the role ARN was associated with the group.</p>
     #[serde(rename = "AssociatedAt")]
@@ -49,7 +49,7 @@ pub struct AssociateRoleToGroupResponse {
     pub associated_at: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AssociateServiceRoleToAccountRequest {
     /// <p>The ARN of the service role you wish to associate with your account.</p>
     #[serde(rename = "RoleArn")]
@@ -57,7 +57,7 @@ pub struct AssociateServiceRoleToAccountRequest {
     pub role_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AssociateServiceRoleToAccountResponse {
     /// <p>The time when the service role was associated with the account.</p>
     #[serde(rename = "AssociatedAt")]
@@ -66,7 +66,7 @@ pub struct AssociateServiceRoleToAccountResponse {
 }
 
 /// <p>Information about a Greengrass core&#39;s connectivity.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ConnectivityInfo {
     /// <p>The endpoint for the Greengrass core. Can be an IP address or DNS.</p>
     #[serde(rename = "HostAddress")]
@@ -87,7 +87,7 @@ pub struct ConnectivityInfo {
 }
 
 /// <p>Information about a core.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Core {
     /// <p>The ARN of the certificate associated with the core.</p>
     #[serde(rename = "CertificateArn")]
@@ -108,7 +108,7 @@ pub struct Core {
 }
 
 /// <p>Information about a core definition version.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CoreDefinitionVersion {
     /// <p>A list of cores in the core definition version.</p>
     #[serde(rename = "Cores")]
@@ -117,7 +117,7 @@ pub struct CoreDefinitionVersion {
 }
 
 /// <p>Information needed to create a core definition.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateCoreDefinitionRequest {
     /// <p>A client token used to correlate requests and responses.</p>
     #[serde(rename = "AmznClientToken")]
@@ -133,7 +133,7 @@ pub struct CreateCoreDefinitionRequest {
     pub name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateCoreDefinitionResponse {
     /// <p>The ARN of the definition.</p>
     #[serde(rename = "Arn")]
@@ -165,7 +165,7 @@ pub struct CreateCoreDefinitionResponse {
     pub name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateCoreDefinitionVersionRequest {
     /// <p>A client token used to correlate requests and responses.</p>
     #[serde(rename = "AmznClientToken")]
@@ -180,7 +180,7 @@ pub struct CreateCoreDefinitionVersionRequest {
     pub cores: Option<Vec<Core>>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateCoreDefinitionVersionResponse {
     /// <p>The ARN of the version.</p>
     #[serde(rename = "Arn")]
@@ -200,7 +200,7 @@ pub struct CreateCoreDefinitionVersionResponse {
     pub version: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateDeploymentRequest {
     /// <p>A client token used to correlate requests and responses.</p>
     #[serde(rename = "AmznClientToken")]
@@ -223,7 +223,7 @@ pub struct CreateDeploymentRequest {
     pub group_version_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateDeploymentResponse {
     /// <p>The ARN of the deployment.</p>
     #[serde(rename = "DeploymentArn")]
@@ -235,7 +235,7 @@ pub struct CreateDeploymentResponse {
     pub deployment_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateDeviceDefinitionRequest {
     /// <p>A client token used to correlate requests and responses.</p>
     #[serde(rename = "AmznClientToken")]
@@ -251,7 +251,7 @@ pub struct CreateDeviceDefinitionRequest {
     pub name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateDeviceDefinitionResponse {
     /// <p>The ARN of the definition.</p>
     #[serde(rename = "Arn")]
@@ -283,7 +283,7 @@ pub struct CreateDeviceDefinitionResponse {
     pub name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateDeviceDefinitionVersionRequest {
     /// <p>A client token used to correlate requests and responses.</p>
     #[serde(rename = "AmznClientToken")]
@@ -298,7 +298,7 @@ pub struct CreateDeviceDefinitionVersionRequest {
     pub devices: Option<Vec<Device>>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateDeviceDefinitionVersionResponse {
     /// <p>The ARN of the version.</p>
     #[serde(rename = "Arn")]
@@ -318,7 +318,7 @@ pub struct CreateDeviceDefinitionVersionResponse {
     pub version: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateFunctionDefinitionRequest {
     /// <p>A client token used to correlate requests and responses.</p>
     #[serde(rename = "AmznClientToken")]
@@ -334,7 +334,7 @@ pub struct CreateFunctionDefinitionRequest {
     pub name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateFunctionDefinitionResponse {
     /// <p>The ARN of the definition.</p>
     #[serde(rename = "Arn")]
@@ -367,7 +367,7 @@ pub struct CreateFunctionDefinitionResponse {
 }
 
 /// <p>Information needed to create a function definition version.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateFunctionDefinitionVersionRequest {
     /// <p>A client token used to correlate requests and responses.</p>
     #[serde(rename = "AmznClientToken")]
@@ -382,7 +382,7 @@ pub struct CreateFunctionDefinitionVersionRequest {
     pub functions: Option<Vec<Function>>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateFunctionDefinitionVersionResponse {
     /// <p>The ARN of the version.</p>
     #[serde(rename = "Arn")]
@@ -402,7 +402,7 @@ pub struct CreateFunctionDefinitionVersionResponse {
     pub version: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateGroupCertificateAuthorityRequest {
     /// <p>A client token used to correlate requests and responses.</p>
     #[serde(rename = "AmznClientToken")]
@@ -413,7 +413,7 @@ pub struct CreateGroupCertificateAuthorityRequest {
     pub group_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateGroupCertificateAuthorityResponse {
     /// <p>The ARN of the group certificate authority.</p>
     #[serde(rename = "GroupCertificateAuthorityArn")]
@@ -421,7 +421,7 @@ pub struct CreateGroupCertificateAuthorityResponse {
     pub group_certificate_authority_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateGroupRequest {
     /// <p>A client token used to correlate requests and responses.</p>
     #[serde(rename = "AmznClientToken")]
@@ -437,7 +437,7 @@ pub struct CreateGroupRequest {
     pub name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateGroupResponse {
     /// <p>The ARN of the definition.</p>
     #[serde(rename = "Arn")]
@@ -469,7 +469,7 @@ pub struct CreateGroupResponse {
     pub name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateGroupVersionRequest {
     /// <p>A client token used to correlate requests and responses.</p>
     #[serde(rename = "AmznClientToken")]
@@ -504,7 +504,7 @@ pub struct CreateGroupVersionRequest {
     pub subscription_definition_version_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateGroupVersionResponse {
     /// <p>The ARN of the version.</p>
     #[serde(rename = "Arn")]
@@ -524,7 +524,7 @@ pub struct CreateGroupVersionResponse {
     pub version: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateLoggerDefinitionRequest {
     /// <p>A client token used to correlate requests and responses.</p>
     #[serde(rename = "AmznClientToken")]
@@ -540,7 +540,7 @@ pub struct CreateLoggerDefinitionRequest {
     pub name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateLoggerDefinitionResponse {
     /// <p>The ARN of the definition.</p>
     #[serde(rename = "Arn")]
@@ -572,7 +572,7 @@ pub struct CreateLoggerDefinitionResponse {
     pub name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateLoggerDefinitionVersionRequest {
     /// <p>A client token used to correlate requests and responses.</p>
     #[serde(rename = "AmznClientToken")]
@@ -587,7 +587,7 @@ pub struct CreateLoggerDefinitionVersionRequest {
     pub loggers: Option<Vec<Logger>>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateLoggerDefinitionVersionResponse {
     /// <p>The ARN of the version.</p>
     #[serde(rename = "Arn")]
@@ -607,7 +607,7 @@ pub struct CreateLoggerDefinitionVersionResponse {
     pub version: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateResourceDefinitionRequest {
     /// <p>A client token used to correlate requests and responses.</p>
     #[serde(rename = "AmznClientToken")]
@@ -623,7 +623,7 @@ pub struct CreateResourceDefinitionRequest {
     pub name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateResourceDefinitionResponse {
     /// <p>The ARN of the definition.</p>
     #[serde(rename = "Arn")]
@@ -655,7 +655,7 @@ pub struct CreateResourceDefinitionResponse {
     pub name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateResourceDefinitionVersionRequest {
     /// <p>A client token used to correlate requests and responses.</p>
     #[serde(rename = "AmznClientToken")]
@@ -670,7 +670,7 @@ pub struct CreateResourceDefinitionVersionRequest {
     pub resources: Option<Vec<Resource>>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateResourceDefinitionVersionResponse {
     /// <p>The ARN of the version.</p>
     #[serde(rename = "Arn")]
@@ -690,7 +690,7 @@ pub struct CreateResourceDefinitionVersionResponse {
     pub version: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateSoftwareUpdateJobRequest {
     /// <p>A client token used to correlate requests and responses.</p>
     #[serde(rename = "AmznClientToken")]
@@ -716,7 +716,7 @@ pub struct CreateSoftwareUpdateJobRequest {
     pub update_targets_operating_system: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateSoftwareUpdateJobResponse {
     /// <p>The IoT Job ARN corresponding to this update.</p>
     #[serde(rename = "IotJobArn")]
@@ -728,7 +728,7 @@ pub struct CreateSoftwareUpdateJobResponse {
     pub iot_job_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateSubscriptionDefinitionRequest {
     /// <p>A client token used to correlate requests and responses.</p>
     #[serde(rename = "AmznClientToken")]
@@ -744,7 +744,7 @@ pub struct CreateSubscriptionDefinitionRequest {
     pub name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateSubscriptionDefinitionResponse {
     /// <p>The ARN of the definition.</p>
     #[serde(rename = "Arn")]
@@ -776,7 +776,7 @@ pub struct CreateSubscriptionDefinitionResponse {
     pub name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateSubscriptionDefinitionVersionRequest {
     /// <p>A client token used to correlate requests and responses.</p>
     #[serde(rename = "AmznClientToken")]
@@ -791,7 +791,7 @@ pub struct CreateSubscriptionDefinitionVersionRequest {
     pub subscriptions: Option<Vec<Subscription>>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateSubscriptionDefinitionVersionResponse {
     /// <p>The ARN of the version.</p>
     #[serde(rename = "Arn")]
@@ -812,7 +812,7 @@ pub struct CreateSubscriptionDefinitionVersionResponse {
 }
 
 /// <p>Information about a definition.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DefinitionInformation {
     /// <p>The ARN of the definition.</p>
     #[serde(rename = "Arn")]
@@ -844,78 +844,78 @@ pub struct DefinitionInformation {
     pub name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteCoreDefinitionRequest {
     /// <p>The ID of the core definition.</p>
     #[serde(rename = "CoreDefinitionId")]
     pub core_definition_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteCoreDefinitionResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteDeviceDefinitionRequest {
     /// <p>The ID of the device definition.</p>
     #[serde(rename = "DeviceDefinitionId")]
     pub device_definition_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteDeviceDefinitionResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteFunctionDefinitionRequest {
     /// <p>The ID of the Lambda function definition.</p>
     #[serde(rename = "FunctionDefinitionId")]
     pub function_definition_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteFunctionDefinitionResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteGroupRequest {
     /// <p>The ID of the AWS Greengrass group.</p>
     #[serde(rename = "GroupId")]
     pub group_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteGroupResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteLoggerDefinitionRequest {
     /// <p>The ID of the logger definition.</p>
     #[serde(rename = "LoggerDefinitionId")]
     pub logger_definition_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteLoggerDefinitionResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteResourceDefinitionRequest {
     /// <p>The ID of the resource definition.</p>
     #[serde(rename = "ResourceDefinitionId")]
     pub resource_definition_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteResourceDefinitionResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteSubscriptionDefinitionRequest {
     /// <p>The ID of the subscription definition.</p>
     #[serde(rename = "SubscriptionDefinitionId")]
     pub subscription_definition_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteSubscriptionDefinitionResponse {}
 
 /// <p>Information about a deployment.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Deployment {
     /// <p>The time, in milliseconds since the epoch, when the deployment was created.</p>
     #[serde(rename = "CreatedAt")]
@@ -940,7 +940,7 @@ pub struct Deployment {
 }
 
 /// <p>Information about a device.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Device {
     /// <p>The ARN of the certificate associated with the device.</p>
     #[serde(rename = "CertificateArn")]
@@ -961,7 +961,7 @@ pub struct Device {
 }
 
 /// <p>Information about a device definition version.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct DeviceDefinitionVersion {
     /// <p>A list of devices in the definition version.</p>
     #[serde(rename = "Devices")]
@@ -969,14 +969,14 @@ pub struct DeviceDefinitionVersion {
     pub devices: Option<Vec<Device>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DisassociateRoleFromGroupRequest {
     /// <p>The ID of the AWS Greengrass group.</p>
     #[serde(rename = "GroupId")]
     pub group_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DisassociateRoleFromGroupResponse {
     /// <p>The time, in milliseconds since the epoch, when the role was disassociated from the group.</p>
     #[serde(rename = "DisassociatedAt")]
@@ -984,10 +984,10 @@ pub struct DisassociateRoleFromGroupResponse {
     pub disassociated_at: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DisassociateServiceRoleFromAccountRequest {}
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DisassociateServiceRoleFromAccountResponse {
     /// <p>The time when the service role was disassociated from the account.</p>
     #[serde(rename = "DisassociatedAt")]
@@ -996,11 +996,11 @@ pub struct DisassociateServiceRoleFromAccountResponse {
 }
 
 /// <p>Empty</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Empty {}
 
 /// <p>Details about the error.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ErrorDetail {
     /// <p>A detailed error code.</p>
     #[serde(rename = "DetailedErrorCode")]
@@ -1013,7 +1013,7 @@ pub struct ErrorDetail {
 }
 
 /// <p>Information about a Lambda function.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Function {
     /// <p>The ARN of the Lambda function.</p>
     #[serde(rename = "FunctionArn")]
@@ -1030,7 +1030,7 @@ pub struct Function {
 }
 
 /// <p>The configuration of the Lambda function.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct FunctionConfiguration {
     /// <p>The expected encoding type of the input payload for the function. The default is &#39;&#39;json&#39;&#39;.</p>
     #[serde(rename = "EncodingType")]
@@ -1063,7 +1063,7 @@ pub struct FunctionConfiguration {
 }
 
 /// <p>The environment configuration of the function.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct FunctionConfigurationEnvironment {
     /// <p>If true, the Lambda function is allowed to access the host&#39;s /sys folder. Use this when the Lambda function needs to read device information from /sys.</p>
     #[serde(rename = "AccessSysfs")]
@@ -1080,7 +1080,7 @@ pub struct FunctionConfigurationEnvironment {
 }
 
 /// <p>Information about a function definition version.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct FunctionDefinitionVersion {
     /// <p>A list of Lambda functions in this function definition version.</p>
     #[serde(rename = "Functions")]
@@ -1089,7 +1089,7 @@ pub struct FunctionDefinitionVersion {
 }
 
 /// <p>General error information.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GeneralError {
     /// <p>Details about the error.</p>
     pub error_details: Option<Vec<ErrorDetail>>,
@@ -1097,14 +1097,14 @@ pub struct GeneralError {
     pub message: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetAssociatedRoleRequest {
     /// <p>The ID of the AWS Greengrass group.</p>
     #[serde(rename = "GroupId")]
     pub group_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetAssociatedRoleResponse {
     /// <p>The time when the role was associated with the group.</p>
     #[serde(rename = "AssociatedAt")]
@@ -1116,14 +1116,14 @@ pub struct GetAssociatedRoleResponse {
     pub role_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetConnectivityInfoRequest {
     /// <p>The thing name.</p>
     #[serde(rename = "ThingName")]
     pub thing_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetConnectivityInfoResponse {
     /// <p>Connectivity info list.</p>
     #[serde(rename = "ConnectivityInfo")]
@@ -1135,14 +1135,14 @@ pub struct GetConnectivityInfoResponse {
     pub message: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetCoreDefinitionRequest {
     /// <p>The ID of the core definition.</p>
     #[serde(rename = "CoreDefinitionId")]
     pub core_definition_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetCoreDefinitionResponse {
     /// <p>The ARN of the definition.</p>
     #[serde(rename = "Arn")]
@@ -1174,7 +1174,7 @@ pub struct GetCoreDefinitionResponse {
     pub name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetCoreDefinitionVersionRequest {
     /// <p>The ID of the core definition.</p>
     #[serde(rename = "CoreDefinitionId")]
@@ -1184,7 +1184,7 @@ pub struct GetCoreDefinitionVersionRequest {
     pub core_definition_version_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetCoreDefinitionVersionResponse {
     /// <p>The ARN of the core definition version.</p>
     #[serde(rename = "Arn")]
@@ -1208,7 +1208,7 @@ pub struct GetCoreDefinitionVersionResponse {
     pub version: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetDeploymentStatusRequest {
     /// <p>The ID of the deployment.</p>
     #[serde(rename = "DeploymentId")]
@@ -1218,7 +1218,7 @@ pub struct GetDeploymentStatusRequest {
     pub group_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetDeploymentStatusResponse {
     /// <p>The status of the deployment.</p>
     #[serde(rename = "DeploymentStatus")]
@@ -1242,14 +1242,14 @@ pub struct GetDeploymentStatusResponse {
     pub updated_at: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetDeviceDefinitionRequest {
     /// <p>The ID of the device definition.</p>
     #[serde(rename = "DeviceDefinitionId")]
     pub device_definition_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetDeviceDefinitionResponse {
     /// <p>The ARN of the definition.</p>
     #[serde(rename = "Arn")]
@@ -1281,7 +1281,7 @@ pub struct GetDeviceDefinitionResponse {
     pub name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetDeviceDefinitionVersionRequest {
     /// <p>The ID of the device definition.</p>
     #[serde(rename = "DeviceDefinitionId")]
@@ -1291,7 +1291,7 @@ pub struct GetDeviceDefinitionVersionRequest {
     pub device_definition_version_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetDeviceDefinitionVersionResponse {
     /// <p>The ARN of the device definition version.</p>
     #[serde(rename = "Arn")]
@@ -1315,14 +1315,14 @@ pub struct GetDeviceDefinitionVersionResponse {
     pub version: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetFunctionDefinitionRequest {
     /// <p>The ID of the Lambda function definition.</p>
     #[serde(rename = "FunctionDefinitionId")]
     pub function_definition_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetFunctionDefinitionResponse {
     /// <p>The ARN of the definition.</p>
     #[serde(rename = "Arn")]
@@ -1354,7 +1354,7 @@ pub struct GetFunctionDefinitionResponse {
     pub name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetFunctionDefinitionVersionRequest {
     /// <p>The ID of the Lambda function definition.</p>
     #[serde(rename = "FunctionDefinitionId")]
@@ -1364,7 +1364,7 @@ pub struct GetFunctionDefinitionVersionRequest {
     pub function_definition_version_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetFunctionDefinitionVersionResponse {
     /// <p>The ARN of the function definition version.</p>
     #[serde(rename = "Arn")]
@@ -1388,7 +1388,7 @@ pub struct GetFunctionDefinitionVersionResponse {
     pub version: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetGroupCertificateAuthorityRequest {
     /// <p>The ID of the certificate authority.</p>
     #[serde(rename = "CertificateAuthorityId")]
@@ -1398,7 +1398,7 @@ pub struct GetGroupCertificateAuthorityRequest {
     pub group_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetGroupCertificateAuthorityResponse {
     /// <p>The ARN of the certificate authority for the group.</p>
     #[serde(rename = "GroupCertificateAuthorityArn")]
@@ -1414,14 +1414,14 @@ pub struct GetGroupCertificateAuthorityResponse {
     pub pem_encoded_certificate: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetGroupCertificateConfigurationRequest {
     /// <p>The ID of the AWS Greengrass group.</p>
     #[serde(rename = "GroupId")]
     pub group_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetGroupCertificateConfigurationResponse {
     /// <p>The amount of time remaining before the certificate authority expires, in milliseconds.</p>
     #[serde(rename = "CertificateAuthorityExpiryInMilliseconds")]
@@ -1437,14 +1437,14 @@ pub struct GetGroupCertificateConfigurationResponse {
     pub group_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetGroupRequest {
     /// <p>The ID of the AWS Greengrass group.</p>
     #[serde(rename = "GroupId")]
     pub group_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetGroupResponse {
     /// <p>The ARN of the definition.</p>
     #[serde(rename = "Arn")]
@@ -1476,7 +1476,7 @@ pub struct GetGroupResponse {
     pub name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetGroupVersionRequest {
     /// <p>The ID of the AWS Greengrass group.</p>
     #[serde(rename = "GroupId")]
@@ -1486,7 +1486,7 @@ pub struct GetGroupVersionRequest {
     pub group_version_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetGroupVersionResponse {
     /// <p>The ARN of the group version.</p>
     #[serde(rename = "Arn")]
@@ -1510,14 +1510,14 @@ pub struct GetGroupVersionResponse {
     pub version: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetLoggerDefinitionRequest {
     /// <p>The ID of the logger definition.</p>
     #[serde(rename = "LoggerDefinitionId")]
     pub logger_definition_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetLoggerDefinitionResponse {
     /// <p>The ARN of the definition.</p>
     #[serde(rename = "Arn")]
@@ -1549,7 +1549,7 @@ pub struct GetLoggerDefinitionResponse {
     pub name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetLoggerDefinitionVersionRequest {
     /// <p>The ID of the logger definition.</p>
     #[serde(rename = "LoggerDefinitionId")]
@@ -1559,7 +1559,7 @@ pub struct GetLoggerDefinitionVersionRequest {
     pub logger_definition_version_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetLoggerDefinitionVersionResponse {
     /// <p>The ARN of the logger definition version.</p>
     #[serde(rename = "Arn")]
@@ -1583,14 +1583,14 @@ pub struct GetLoggerDefinitionVersionResponse {
     pub version: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetResourceDefinitionRequest {
     /// <p>The ID of the resource definition.</p>
     #[serde(rename = "ResourceDefinitionId")]
     pub resource_definition_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetResourceDefinitionResponse {
     /// <p>The ARN of the definition.</p>
     #[serde(rename = "Arn")]
@@ -1622,7 +1622,7 @@ pub struct GetResourceDefinitionResponse {
     pub name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetResourceDefinitionVersionRequest {
     /// <p>The ID of the resource definition.</p>
     #[serde(rename = "ResourceDefinitionId")]
@@ -1632,7 +1632,7 @@ pub struct GetResourceDefinitionVersionRequest {
     pub resource_definition_version_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetResourceDefinitionVersionResponse {
     /// <p>Arn of the resource definition version.</p>
     #[serde(rename = "Arn")]
@@ -1656,10 +1656,10 @@ pub struct GetResourceDefinitionVersionResponse {
     pub version: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetServiceRoleForAccountRequest {}
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetServiceRoleForAccountResponse {
     /// <p>The time when the service role was associated with the account.</p>
     #[serde(rename = "AssociatedAt")]
@@ -1671,14 +1671,14 @@ pub struct GetServiceRoleForAccountResponse {
     pub role_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetSubscriptionDefinitionRequest {
     /// <p>The ID of the subscription definition.</p>
     #[serde(rename = "SubscriptionDefinitionId")]
     pub subscription_definition_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetSubscriptionDefinitionResponse {
     /// <p>The ARN of the definition.</p>
     #[serde(rename = "Arn")]
@@ -1710,7 +1710,7 @@ pub struct GetSubscriptionDefinitionResponse {
     pub name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetSubscriptionDefinitionVersionRequest {
     /// <p>The ID of the subscription definition.</p>
     #[serde(rename = "SubscriptionDefinitionId")]
@@ -1720,7 +1720,7 @@ pub struct GetSubscriptionDefinitionVersionRequest {
     pub subscription_definition_version_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetSubscriptionDefinitionVersionResponse {
     /// <p>The ARN of the subscription definition version.</p>
     #[serde(rename = "Arn")]
@@ -1745,7 +1745,7 @@ pub struct GetSubscriptionDefinitionVersionResponse {
 }
 
 /// <p>Information about a certificate authority for a group.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GroupCertificateAuthorityProperties {
     /// <p>The ARN of the certificate authority for the group.</p>
     #[serde(rename = "GroupCertificateAuthorityArn")]
@@ -1758,7 +1758,7 @@ pub struct GroupCertificateAuthorityProperties {
 }
 
 /// <p>Information about a group certificate configuration.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GroupCertificateConfiguration {
     /// <p>The amount of time remaining before the certificate authority expires, in milliseconds.</p>
     pub certificate_authority_expiry_in_milliseconds: Option<String>,
@@ -1769,7 +1769,7 @@ pub struct GroupCertificateConfiguration {
 }
 
 /// <p>Information about a group.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GroupInformation {
     /// <p>The ARN of the group.</p>
     #[serde(rename = "Arn")]
@@ -1802,7 +1802,7 @@ pub struct GroupInformation {
 }
 
 /// <p>Group owner related settings for local resources.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct GroupOwnerSetting {
     /// <p>If true, GreenGrass automatically adds the specified Linux OS group owner of the resource to the Lambda process privileges. Thus the Lambda process will have the file access permissions of the added Linux group.</p>
     #[serde(rename = "AutoAddGroupOwner")]
@@ -1815,7 +1815,7 @@ pub struct GroupOwnerSetting {
 }
 
 /// <p>Information about a group version.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct GroupVersion {
     /// <p>The ARN of the core definition version for this group.</p>
     #[serde(rename = "CoreDefinitionVersionArn")]
@@ -1843,7 +1843,7 @@ pub struct GroupVersion {
     pub subscription_definition_version_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListCoreDefinitionVersionsRequest {
     /// <p>The ID of the core definition.</p>
     #[serde(rename = "CoreDefinitionId")]
@@ -1858,7 +1858,7 @@ pub struct ListCoreDefinitionVersionsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListCoreDefinitionVersionsResponse {
     /// <p>The token for the next set of results, or &#39;&#39;null&#39;&#39; if there are no additional results.</p>
     #[serde(rename = "NextToken")]
@@ -1870,7 +1870,7 @@ pub struct ListCoreDefinitionVersionsResponse {
     pub versions: Option<Vec<VersionInformation>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListCoreDefinitionsRequest {
     /// <p>The maximum number of results to be returned per request.</p>
     #[serde(rename = "MaxResults")]
@@ -1882,7 +1882,7 @@ pub struct ListCoreDefinitionsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListCoreDefinitionsResponse {
     /// <p>Information about a definition.</p>
     #[serde(rename = "Definitions")]
@@ -1895,7 +1895,7 @@ pub struct ListCoreDefinitionsResponse {
 }
 
 /// <p>A list of definitions.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListDefinitionsResponse {
     /// <p>Information about a definition.</p>
     pub definitions: Option<Vec<DefinitionInformation>>,
@@ -1903,7 +1903,7 @@ pub struct ListDefinitionsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListDeploymentsRequest {
     /// <p>The ID of the AWS Greengrass group.</p>
     #[serde(rename = "GroupId")]
@@ -1918,7 +1918,7 @@ pub struct ListDeploymentsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListDeploymentsResponse {
     /// <p>A list of deployments for the requested groups.</p>
     #[serde(rename = "Deployments")]
@@ -1930,7 +1930,7 @@ pub struct ListDeploymentsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListDeviceDefinitionVersionsRequest {
     /// <p>The ID of the device definition.</p>
     #[serde(rename = "DeviceDefinitionId")]
@@ -1945,7 +1945,7 @@ pub struct ListDeviceDefinitionVersionsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListDeviceDefinitionVersionsResponse {
     /// <p>The token for the next set of results, or &#39;&#39;null&#39;&#39; if there are no additional results.</p>
     #[serde(rename = "NextToken")]
@@ -1957,7 +1957,7 @@ pub struct ListDeviceDefinitionVersionsResponse {
     pub versions: Option<Vec<VersionInformation>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListDeviceDefinitionsRequest {
     /// <p>The maximum number of results to be returned per request.</p>
     #[serde(rename = "MaxResults")]
@@ -1969,7 +1969,7 @@ pub struct ListDeviceDefinitionsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListDeviceDefinitionsResponse {
     /// <p>Information about a definition.</p>
     #[serde(rename = "Definitions")]
@@ -1981,7 +1981,7 @@ pub struct ListDeviceDefinitionsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListFunctionDefinitionVersionsRequest {
     /// <p>The ID of the Lambda function definition.</p>
     #[serde(rename = "FunctionDefinitionId")]
@@ -1996,7 +1996,7 @@ pub struct ListFunctionDefinitionVersionsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListFunctionDefinitionVersionsResponse {
     /// <p>The token for the next set of results, or &#39;&#39;null&#39;&#39; if there are no additional results.</p>
     #[serde(rename = "NextToken")]
@@ -2008,7 +2008,7 @@ pub struct ListFunctionDefinitionVersionsResponse {
     pub versions: Option<Vec<VersionInformation>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListFunctionDefinitionsRequest {
     /// <p>The maximum number of results to be returned per request.</p>
     #[serde(rename = "MaxResults")]
@@ -2020,7 +2020,7 @@ pub struct ListFunctionDefinitionsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListFunctionDefinitionsResponse {
     /// <p>Information about a definition.</p>
     #[serde(rename = "Definitions")]
@@ -2032,14 +2032,14 @@ pub struct ListFunctionDefinitionsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListGroupCertificateAuthoritiesRequest {
     /// <p>The ID of the AWS Greengrass group.</p>
     #[serde(rename = "GroupId")]
     pub group_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListGroupCertificateAuthoritiesResponse {
     /// <p>A list of certificate authorities associated with the group.</p>
     #[serde(rename = "GroupCertificateAuthorities")]
@@ -2047,7 +2047,7 @@ pub struct ListGroupCertificateAuthoritiesResponse {
     pub group_certificate_authorities: Option<Vec<GroupCertificateAuthorityProperties>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListGroupVersionsRequest {
     /// <p>The ID of the AWS Greengrass group.</p>
     #[serde(rename = "GroupId")]
@@ -2062,7 +2062,7 @@ pub struct ListGroupVersionsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListGroupVersionsResponse {
     /// <p>The token for the next set of results, or &#39;&#39;null&#39;&#39; if there are no additional results.</p>
     #[serde(rename = "NextToken")]
@@ -2074,7 +2074,7 @@ pub struct ListGroupVersionsResponse {
     pub versions: Option<Vec<VersionInformation>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListGroupsRequest {
     /// <p>The maximum number of results to be returned per request.</p>
     #[serde(rename = "MaxResults")]
@@ -2086,7 +2086,7 @@ pub struct ListGroupsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListGroupsResponse {
     /// <p>Information about a group.</p>
     #[serde(rename = "Groups")]
@@ -2098,7 +2098,7 @@ pub struct ListGroupsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListLoggerDefinitionVersionsRequest {
     /// <p>The ID of the logger definition.</p>
     #[serde(rename = "LoggerDefinitionId")]
@@ -2113,7 +2113,7 @@ pub struct ListLoggerDefinitionVersionsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListLoggerDefinitionVersionsResponse {
     /// <p>The token for the next set of results, or &#39;&#39;null&#39;&#39; if there are no additional results.</p>
     #[serde(rename = "NextToken")]
@@ -2125,7 +2125,7 @@ pub struct ListLoggerDefinitionVersionsResponse {
     pub versions: Option<Vec<VersionInformation>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListLoggerDefinitionsRequest {
     /// <p>The maximum number of results to be returned per request.</p>
     #[serde(rename = "MaxResults")]
@@ -2137,7 +2137,7 @@ pub struct ListLoggerDefinitionsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListLoggerDefinitionsResponse {
     /// <p>Information about a definition.</p>
     #[serde(rename = "Definitions")]
@@ -2149,7 +2149,7 @@ pub struct ListLoggerDefinitionsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListResourceDefinitionVersionsRequest {
     /// <p>The maximum number of results to be returned per request.</p>
     #[serde(rename = "MaxResults")]
@@ -2164,7 +2164,7 @@ pub struct ListResourceDefinitionVersionsRequest {
     pub resource_definition_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListResourceDefinitionVersionsResponse {
     /// <p>The token for the next set of results, or &#39;&#39;null&#39;&#39; if there are no additional results.</p>
     #[serde(rename = "NextToken")]
@@ -2176,7 +2176,7 @@ pub struct ListResourceDefinitionVersionsResponse {
     pub versions: Option<Vec<VersionInformation>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListResourceDefinitionsRequest {
     /// <p>The maximum number of results to be returned per request.</p>
     #[serde(rename = "MaxResults")]
@@ -2188,7 +2188,7 @@ pub struct ListResourceDefinitionsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListResourceDefinitionsResponse {
     /// <p>Information about a definition.</p>
     #[serde(rename = "Definitions")]
@@ -2200,7 +2200,7 @@ pub struct ListResourceDefinitionsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListSubscriptionDefinitionVersionsRequest {
     /// <p>The maximum number of results to be returned per request.</p>
     #[serde(rename = "MaxResults")]
@@ -2215,7 +2215,7 @@ pub struct ListSubscriptionDefinitionVersionsRequest {
     pub subscription_definition_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListSubscriptionDefinitionVersionsResponse {
     /// <p>The token for the next set of results, or &#39;&#39;null&#39;&#39; if there are no additional results.</p>
     #[serde(rename = "NextToken")]
@@ -2227,7 +2227,7 @@ pub struct ListSubscriptionDefinitionVersionsResponse {
     pub versions: Option<Vec<VersionInformation>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListSubscriptionDefinitionsRequest {
     /// <p>The maximum number of results to be returned per request.</p>
     #[serde(rename = "MaxResults")]
@@ -2239,7 +2239,7 @@ pub struct ListSubscriptionDefinitionsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListSubscriptionDefinitionsResponse {
     /// <p>Information about a definition.</p>
     #[serde(rename = "Definitions")]
@@ -2252,7 +2252,7 @@ pub struct ListSubscriptionDefinitionsResponse {
 }
 
 /// <p>A list of versions.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListVersionsResponse {
     /// <p>The token for the next set of results, or &#39;&#39;null&#39;&#39; if there are no additional results.</p>
     pub next_token: Option<String>,
@@ -2261,7 +2261,7 @@ pub struct ListVersionsResponse {
 }
 
 /// <p>Attributes that define a local device resource.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct LocalDeviceResourceData {
     /// <p>Group/owner related settings for local resources.</p>
     #[serde(rename = "GroupOwnerSetting")]
@@ -2274,7 +2274,7 @@ pub struct LocalDeviceResourceData {
 }
 
 /// <p>Attributes that define a local volume resource.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct LocalVolumeResourceData {
     /// <p>The absolute local path of the resource inside the lambda environment.</p>
     #[serde(rename = "DestinationPath")]
@@ -2291,7 +2291,7 @@ pub struct LocalVolumeResourceData {
 }
 
 /// <p>Information about a logger</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Logger {
     /// <p>The component that will be subject to logging.</p>
     #[serde(rename = "Component")]
@@ -2316,7 +2316,7 @@ pub struct Logger {
 }
 
 /// <p>Information about a logger definition version.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct LoggerDefinitionVersion {
     /// <p>A list of loggers.</p>
     #[serde(rename = "Loggers")]
@@ -2325,7 +2325,7 @@ pub struct LoggerDefinitionVersion {
 }
 
 /// <p>Information needed to reset deployments.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ResetDeploymentsRequest {
     /// <p>A client token used to correlate requests and responses.</p>
     #[serde(rename = "AmznClientToken")]
@@ -2340,7 +2340,7 @@ pub struct ResetDeploymentsRequest {
     pub group_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ResetDeploymentsResponse {
     /// <p>The ARN of the deployment.</p>
     #[serde(rename = "DeploymentArn")]
@@ -2353,7 +2353,7 @@ pub struct ResetDeploymentsResponse {
 }
 
 /// <p>Information about a resource.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Resource {
     /// <p>The resource ID, used to refer to a resource in the Lambda function configuration. Max length is 128 characters with pattern &#39;&#39;[a-zA-Z0-9:_-]+&#39;&#39;. This must be unique within a Greengrass group.</p>
     #[serde(rename = "Id")]
@@ -2370,7 +2370,7 @@ pub struct Resource {
 }
 
 /// <p>A policy used by the function to access a resource.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ResourceAccessPolicy {
     /// <p>The permissions that the Lambda function has to the resource. Can be one of &#39;&#39;rw&#39;&#39; (read/write) or &#39;&#39;ro&#39;&#39; (read-only).</p>
     #[serde(rename = "Permission")]
@@ -2383,7 +2383,7 @@ pub struct ResourceAccessPolicy {
 }
 
 /// <p>A container for resource data. The container takes only one of the following supported resource data types: &#39;&#39;LocalDeviceResourceData&#39;&#39;, &#39;&#39;LocalVolumeResourceData&#39;&#39;, &#39;&#39;SageMakerMachineLearningModelResourceData&#39;&#39;, &#39;&#39;S3MachineLearningModelResourceData&#39;&#39;.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ResourceDataContainer {
     /// <p>Attributes that define the local device resource.</p>
     #[serde(rename = "LocalDeviceResourceData")]
@@ -2405,7 +2405,7 @@ pub struct ResourceDataContainer {
 }
 
 /// <p>Information about a resource definition version.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ResourceDefinitionVersion {
     /// <p>A list of resources.</p>
     #[serde(rename = "Resources")]
@@ -2414,7 +2414,7 @@ pub struct ResourceDefinitionVersion {
 }
 
 /// <p>Attributes that define an S3 machine learning resource.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct S3MachineLearningModelResourceData {
     /// <p>The absolute local path of the resource inside the Lambda environment.</p>
     #[serde(rename = "DestinationPath")]
@@ -2427,7 +2427,7 @@ pub struct S3MachineLearningModelResourceData {
 }
 
 /// <p>Attributes that define an SageMaker machine learning resource.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SageMakerMachineLearningModelResourceData {
     /// <p>The absolute local path of the resource inside the Lambda environment.</p>
     #[serde(rename = "DestinationPath")]
@@ -2440,7 +2440,7 @@ pub struct SageMakerMachineLearningModelResourceData {
 }
 
 /// <p>Information about a subscription.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Subscription {
     /// <p>The id of the subscription.</p>
     #[serde(rename = "Id")]
@@ -2461,7 +2461,7 @@ pub struct Subscription {
 }
 
 /// <p>Information about a subscription definition version.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SubscriptionDefinitionVersion {
     /// <p>A list of subscriptions.</p>
     #[serde(rename = "Subscriptions")]
@@ -2470,7 +2470,7 @@ pub struct SubscriptionDefinitionVersion {
 }
 
 /// <p>Connectivity information.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateConnectivityInfoRequest {
     /// <p>A list of connectivity info.</p>
     #[serde(rename = "ConnectivityInfo")]
@@ -2481,7 +2481,7 @@ pub struct UpdateConnectivityInfoRequest {
     pub thing_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateConnectivityInfoResponse {
     /// <p>A message about the connectivity info update request.</p>
     #[serde(rename = "Message")]
@@ -2493,7 +2493,7 @@ pub struct UpdateConnectivityInfoResponse {
     pub version: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateCoreDefinitionRequest {
     /// <p>The ID of the core definition.</p>
     #[serde(rename = "CoreDefinitionId")]
@@ -2504,10 +2504,10 @@ pub struct UpdateCoreDefinitionRequest {
     pub name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateCoreDefinitionResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateDeviceDefinitionRequest {
     /// <p>The ID of the device definition.</p>
     #[serde(rename = "DeviceDefinitionId")]
@@ -2518,10 +2518,10 @@ pub struct UpdateDeviceDefinitionRequest {
     pub name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateDeviceDefinitionResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateFunctionDefinitionRequest {
     /// <p>The ID of the Lambda function definition.</p>
     #[serde(rename = "FunctionDefinitionId")]
@@ -2532,10 +2532,10 @@ pub struct UpdateFunctionDefinitionRequest {
     pub name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateFunctionDefinitionResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateGroupCertificateConfigurationRequest {
     /// <p>The amount of time remaining before the certificate expires, in milliseconds.</p>
     #[serde(rename = "CertificateExpiryInMilliseconds")]
@@ -2546,7 +2546,7 @@ pub struct UpdateGroupCertificateConfigurationRequest {
     pub group_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateGroupCertificateConfigurationResponse {
     /// <p>The amount of time remaining before the certificate authority expires, in milliseconds.</p>
     #[serde(rename = "CertificateAuthorityExpiryInMilliseconds")]
@@ -2562,7 +2562,7 @@ pub struct UpdateGroupCertificateConfigurationResponse {
     pub group_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateGroupRequest {
     /// <p>The ID of the AWS Greengrass group.</p>
     #[serde(rename = "GroupId")]
@@ -2573,10 +2573,10 @@ pub struct UpdateGroupRequest {
     pub name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateGroupResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateLoggerDefinitionRequest {
     /// <p>The ID of the logger definition.</p>
     #[serde(rename = "LoggerDefinitionId")]
@@ -2587,10 +2587,10 @@ pub struct UpdateLoggerDefinitionRequest {
     pub name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateLoggerDefinitionResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateResourceDefinitionRequest {
     /// <p>The name of the definition.</p>
     #[serde(rename = "Name")]
@@ -2601,10 +2601,10 @@ pub struct UpdateResourceDefinitionRequest {
     pub resource_definition_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateResourceDefinitionResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateSubscriptionDefinitionRequest {
     /// <p>The name of the definition.</p>
     #[serde(rename = "Name")]
@@ -2615,11 +2615,11 @@ pub struct UpdateSubscriptionDefinitionRequest {
     pub subscription_definition_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateSubscriptionDefinitionResponse {}
 
 /// <p>Information about a version.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct VersionInformation {
     /// <p>The ARN of the version.</p>
     #[serde(rename = "Arn")]

--- a/rusoto/services/greengrass/src/generated.rs
+++ b/rusoto/services/greengrass/src/generated.rs
@@ -2660,7 +2660,8 @@ impl AssociateRoleToGroupError {
     pub fn from_body(body: &str) -> AssociateRoleToGroupError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2746,7 +2747,8 @@ impl AssociateServiceRoleToAccountError {
     pub fn from_body(body: &str) -> AssociateServiceRoleToAccountError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2832,7 +2834,8 @@ impl CreateCoreDefinitionError {
     pub fn from_body(body: &str) -> CreateCoreDefinitionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2912,7 +2915,8 @@ impl CreateCoreDefinitionVersionError {
     pub fn from_body(body: &str) -> CreateCoreDefinitionVersionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2992,7 +2996,8 @@ impl CreateDeploymentError {
     pub fn from_body(body: &str) -> CreateDeploymentError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3070,7 +3075,8 @@ impl CreateDeviceDefinitionError {
     pub fn from_body(body: &str) -> CreateDeviceDefinitionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3150,7 +3156,8 @@ impl CreateDeviceDefinitionVersionError {
     pub fn from_body(body: &str) -> CreateDeviceDefinitionVersionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3230,7 +3237,8 @@ impl CreateFunctionDefinitionError {
     pub fn from_body(body: &str) -> CreateFunctionDefinitionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3310,7 +3318,8 @@ impl CreateFunctionDefinitionVersionError {
     pub fn from_body(body: &str) -> CreateFunctionDefinitionVersionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3390,7 +3399,8 @@ impl CreateGroupError {
     pub fn from_body(body: &str) -> CreateGroupError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3470,7 +3480,8 @@ impl CreateGroupCertificateAuthorityError {
     pub fn from_body(body: &str) -> CreateGroupCertificateAuthorityError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3556,7 +3567,8 @@ impl CreateGroupVersionError {
     pub fn from_body(body: &str) -> CreateGroupVersionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3636,7 +3648,8 @@ impl CreateLoggerDefinitionError {
     pub fn from_body(body: &str) -> CreateLoggerDefinitionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3716,7 +3729,8 @@ impl CreateLoggerDefinitionVersionError {
     pub fn from_body(body: &str) -> CreateLoggerDefinitionVersionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3796,7 +3810,8 @@ impl CreateResourceDefinitionError {
     pub fn from_body(body: &str) -> CreateResourceDefinitionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3876,7 +3891,8 @@ impl CreateResourceDefinitionVersionError {
     pub fn from_body(body: &str) -> CreateResourceDefinitionVersionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3958,7 +3974,8 @@ impl CreateSoftwareUpdateJobError {
     pub fn from_body(body: &str) -> CreateSoftwareUpdateJobError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4044,7 +4061,8 @@ impl CreateSubscriptionDefinitionError {
     pub fn from_body(body: &str) -> CreateSubscriptionDefinitionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4124,7 +4142,8 @@ impl CreateSubscriptionDefinitionVersionError {
     pub fn from_body(body: &str) -> CreateSubscriptionDefinitionVersionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4204,7 +4223,8 @@ impl DeleteCoreDefinitionError {
     pub fn from_body(body: &str) -> DeleteCoreDefinitionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4284,7 +4304,8 @@ impl DeleteDeviceDefinitionError {
     pub fn from_body(body: &str) -> DeleteDeviceDefinitionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4364,7 +4385,8 @@ impl DeleteFunctionDefinitionError {
     pub fn from_body(body: &str) -> DeleteFunctionDefinitionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4444,7 +4466,8 @@ impl DeleteGroupError {
     pub fn from_body(body: &str) -> DeleteGroupError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4522,7 +4545,8 @@ impl DeleteLoggerDefinitionError {
     pub fn from_body(body: &str) -> DeleteLoggerDefinitionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4602,7 +4626,8 @@ impl DeleteResourceDefinitionError {
     pub fn from_body(body: &str) -> DeleteResourceDefinitionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4682,7 +4707,8 @@ impl DeleteSubscriptionDefinitionError {
     pub fn from_body(body: &str) -> DeleteSubscriptionDefinitionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4764,7 +4790,8 @@ impl DisassociateRoleFromGroupError {
     pub fn from_body(body: &str) -> DisassociateRoleFromGroupError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4850,7 +4877,8 @@ impl DisassociateServiceRoleFromAccountError {
     pub fn from_body(body: &str) -> DisassociateServiceRoleFromAccountError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4934,7 +4962,8 @@ impl GetAssociatedRoleError {
     pub fn from_body(body: &str) -> GetAssociatedRoleError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5020,7 +5049,8 @@ impl GetConnectivityInfoError {
     pub fn from_body(body: &str) -> GetConnectivityInfoError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5104,7 +5134,8 @@ impl GetCoreDefinitionError {
     pub fn from_body(body: &str) -> GetCoreDefinitionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5184,7 +5215,8 @@ impl GetCoreDefinitionVersionError {
     pub fn from_body(body: &str) -> GetCoreDefinitionVersionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5264,7 +5296,8 @@ impl GetDeploymentStatusError {
     pub fn from_body(body: &str) -> GetDeploymentStatusError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5344,7 +5377,8 @@ impl GetDeviceDefinitionError {
     pub fn from_body(body: &str) -> GetDeviceDefinitionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5424,7 +5458,8 @@ impl GetDeviceDefinitionVersionError {
     pub fn from_body(body: &str) -> GetDeviceDefinitionVersionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5504,7 +5539,8 @@ impl GetFunctionDefinitionError {
     pub fn from_body(body: &str) -> GetFunctionDefinitionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5584,7 +5620,8 @@ impl GetFunctionDefinitionVersionError {
     pub fn from_body(body: &str) -> GetFunctionDefinitionVersionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5664,7 +5701,8 @@ impl GetGroupError {
     pub fn from_body(body: &str) -> GetGroupError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5740,7 +5778,8 @@ impl GetGroupCertificateAuthorityError {
     pub fn from_body(body: &str) -> GetGroupCertificateAuthorityError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5828,7 +5867,8 @@ impl GetGroupCertificateConfigurationError {
     pub fn from_body(body: &str) -> GetGroupCertificateConfigurationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5914,7 +5954,8 @@ impl GetGroupVersionError {
     pub fn from_body(body: &str) -> GetGroupVersionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5992,7 +6033,8 @@ impl GetLoggerDefinitionError {
     pub fn from_body(body: &str) -> GetLoggerDefinitionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6072,7 +6114,8 @@ impl GetLoggerDefinitionVersionError {
     pub fn from_body(body: &str) -> GetLoggerDefinitionVersionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6152,7 +6195,8 @@ impl GetResourceDefinitionError {
     pub fn from_body(body: &str) -> GetResourceDefinitionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6232,7 +6276,8 @@ impl GetResourceDefinitionVersionError {
     pub fn from_body(body: &str) -> GetResourceDefinitionVersionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6312,7 +6357,8 @@ impl GetServiceRoleForAccountError {
     pub fn from_body(body: &str) -> GetServiceRoleForAccountError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6394,7 +6440,8 @@ impl GetSubscriptionDefinitionError {
     pub fn from_body(body: &str) -> GetSubscriptionDefinitionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6474,7 +6521,8 @@ impl GetSubscriptionDefinitionVersionError {
     pub fn from_body(body: &str) -> GetSubscriptionDefinitionVersionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6554,7 +6602,8 @@ impl ListCoreDefinitionVersionsError {
     pub fn from_body(body: &str) -> ListCoreDefinitionVersionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6632,7 +6681,8 @@ impl ListCoreDefinitionsError {
     pub fn from_body(body: &str) -> ListCoreDefinitionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6708,7 +6758,8 @@ impl ListDeploymentsError {
     pub fn from_body(body: &str) -> ListDeploymentsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6786,7 +6837,8 @@ impl ListDeviceDefinitionVersionsError {
     pub fn from_body(body: &str) -> ListDeviceDefinitionVersionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6864,7 +6916,8 @@ impl ListDeviceDefinitionsError {
     pub fn from_body(body: &str) -> ListDeviceDefinitionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6940,7 +6993,8 @@ impl ListFunctionDefinitionVersionsError {
     pub fn from_body(body: &str) -> ListFunctionDefinitionVersionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7018,7 +7072,8 @@ impl ListFunctionDefinitionsError {
     pub fn from_body(body: &str) -> ListFunctionDefinitionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7096,7 +7151,8 @@ impl ListGroupCertificateAuthoritiesError {
     pub fn from_body(body: &str) -> ListGroupCertificateAuthoritiesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7182,7 +7238,8 @@ impl ListGroupVersionsError {
     pub fn from_body(body: &str) -> ListGroupVersionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7260,7 +7317,8 @@ impl ListGroupsError {
     pub fn from_body(body: &str) -> ListGroupsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7332,7 +7390,8 @@ impl ListLoggerDefinitionVersionsError {
     pub fn from_body(body: &str) -> ListLoggerDefinitionVersionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7410,7 +7469,8 @@ impl ListLoggerDefinitionsError {
     pub fn from_body(body: &str) -> ListLoggerDefinitionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7486,7 +7546,8 @@ impl ListResourceDefinitionVersionsError {
     pub fn from_body(body: &str) -> ListResourceDefinitionVersionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7564,7 +7625,8 @@ impl ListResourceDefinitionsError {
     pub fn from_body(body: &str) -> ListResourceDefinitionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7640,7 +7702,8 @@ impl ListSubscriptionDefinitionVersionsError {
     pub fn from_body(body: &str) -> ListSubscriptionDefinitionVersionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7718,7 +7781,8 @@ impl ListSubscriptionDefinitionsError {
     pub fn from_body(body: &str) -> ListSubscriptionDefinitionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7794,7 +7858,8 @@ impl ResetDeploymentsError {
     pub fn from_body(body: &str) -> ResetDeploymentsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7874,7 +7939,8 @@ impl UpdateConnectivityInfoError {
     pub fn from_body(body: &str) -> UpdateConnectivityInfoError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7960,7 +8026,8 @@ impl UpdateCoreDefinitionError {
     pub fn from_body(body: &str) -> UpdateCoreDefinitionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8040,7 +8107,8 @@ impl UpdateDeviceDefinitionError {
     pub fn from_body(body: &str) -> UpdateDeviceDefinitionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8120,7 +8188,8 @@ impl UpdateFunctionDefinitionError {
     pub fn from_body(body: &str) -> UpdateFunctionDefinitionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8200,7 +8269,8 @@ impl UpdateGroupError {
     pub fn from_body(body: &str) -> UpdateGroupError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8280,7 +8350,8 @@ impl UpdateGroupCertificateConfigurationError {
     pub fn from_body(body: &str) -> UpdateGroupCertificateConfigurationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8366,7 +8437,8 @@ impl UpdateLoggerDefinitionError {
     pub fn from_body(body: &str) -> UpdateLoggerDefinitionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8446,7 +8518,8 @@ impl UpdateResourceDefinitionError {
     pub fn from_body(body: &str) -> UpdateResourceDefinitionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8526,7 +8599,8 @@ impl UpdateSubscriptionDefinitionError {
     pub fn from_body(body: &str) -> UpdateSubscriptionDefinitionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/health/src/generated.rs
+++ b/rusoto/services/health/src/generated.rs
@@ -469,7 +469,8 @@ impl DescribeAffectedEntitiesError {
     pub fn from_body(body: &str) -> DescribeAffectedEntitiesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -553,7 +554,8 @@ impl DescribeEntityAggregatesError {
     pub fn from_body(body: &str) -> DescribeEntityAggregatesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -629,7 +631,8 @@ impl DescribeEventAggregatesError {
     pub fn from_body(body: &str) -> DescribeEventAggregatesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -711,7 +714,8 @@ impl DescribeEventDetailsError {
     pub fn from_body(body: &str) -> DescribeEventDetailsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -793,7 +797,8 @@ impl DescribeEventTypesError {
     pub fn from_body(body: &str) -> DescribeEventTypesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -879,7 +884,8 @@ impl DescribeEventsError {
     pub fn from_body(body: &str) -> DescribeEventsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/health/src/generated.rs
+++ b/rusoto/services/health/src/generated.rs
@@ -31,7 +31,7 @@ use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 /// <p>Information about an entity that is affected by a Health event.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AffectedEntity {
     /// <p>The 12-digit AWS account number that contains the affected entity.</p>
     #[serde(rename = "awsAccountId")]
@@ -64,7 +64,7 @@ pub struct AffectedEntity {
 }
 
 /// <p>A range of dates and times that is used by the <a>EventFilter</a> and <a>EntityFilter</a> objects. If <code>from</code> is set and <code>to</code> is set: match items where the timestamp (<code>startTime</code>, <code>endTime</code>, or <code>lastUpdatedTime</code>) is between <code>from</code> and <code>to</code> inclusive. If <code>from</code> is set and <code>to</code> is not set: match items where the timestamp value is equal to or after <code>from</code>. If <code>from</code> is not set and <code>to</code> is set: match items where the timestamp value is equal to or before <code>to</code>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DateTimeRange {
     /// <p>The starting date and time of a time range.</p>
     #[serde(rename = "from")]
@@ -76,7 +76,7 @@ pub struct DateTimeRange {
     pub to: Option<f64>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeAffectedEntitiesRequest {
     /// <p>Values to narrow the results returned. At least one event ARN is required. </p>
     #[serde(rename = "filter")]
@@ -95,7 +95,7 @@ pub struct DescribeAffectedEntitiesRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeAffectedEntitiesResponse {
     /// <p>The entities that match the filter criteria.</p>
     #[serde(rename = "entities")]
@@ -107,7 +107,7 @@ pub struct DescribeAffectedEntitiesResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeEntityAggregatesRequest {
     /// <p>A list of event ARNs (unique identifiers). For example: <code>"arn:aws:health:us-east-1::event/AWS_EC2_MAINTENANCE_5331", "arn:aws:health:us-west-1::event/AWS_EBS_LOST_VOLUME_xyz"</code> </p>
     #[serde(rename = "eventArns")]
@@ -115,7 +115,7 @@ pub struct DescribeEntityAggregatesRequest {
     pub event_arns: Option<Vec<String>>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeEntityAggregatesResponse {
     /// <p>The number of entities that are affected by each of the specified events.</p>
     #[serde(rename = "entityAggregates")]
@@ -123,7 +123,7 @@ pub struct DescribeEntityAggregatesResponse {
     pub entity_aggregates: Option<Vec<EntityAggregate>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeEventAggregatesRequest {
     /// <p>The only currently supported value is <code>eventTypeCategory</code>.</p>
     #[serde(rename = "aggregateField")]
@@ -142,7 +142,7 @@ pub struct DescribeEventAggregatesRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeEventAggregatesResponse {
     /// <p>The number of events in each category that meet the optional filter criteria.</p>
     #[serde(rename = "eventAggregates")]
@@ -154,7 +154,7 @@ pub struct DescribeEventAggregatesResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeEventDetailsRequest {
     /// <p>A list of event ARNs (unique identifiers). For example: <code>"arn:aws:health:us-east-1::event/AWS_EC2_MAINTENANCE_5331", "arn:aws:health:us-west-1::event/AWS_EBS_LOST_VOLUME_xyz"</code> </p>
     #[serde(rename = "eventArns")]
@@ -165,7 +165,7 @@ pub struct DescribeEventDetailsRequest {
     pub locale: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeEventDetailsResponse {
     /// <p>Error messages for any events that could not be retrieved.</p>
     #[serde(rename = "failedSet")]
@@ -177,7 +177,7 @@ pub struct DescribeEventDetailsResponse {
     pub successful_set: Option<Vec<EventDetails>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeEventTypesRequest {
     /// <p>Values to narrow the results returned.</p>
     #[serde(rename = "filter")]
@@ -197,7 +197,7 @@ pub struct DescribeEventTypesRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeEventTypesResponse {
     /// <p>A list of event types that match the filter criteria. Event types have a category (<code>issue</code>, <code>accountNotification</code>, or <code>scheduledChange</code>), a service (for example, <code>EC2</code>, <code>RDS</code>, <code>DATAPIPELINE</code>, <code>BILLING</code>), and a code (in the format <code>AWS_<i>SERVICE</i>_<i>DESCRIPTION</i> </code>; for example, <code>AWS_EC2_SYSTEM_MAINTENANCE_EVENT</code>).</p>
     #[serde(rename = "eventTypes")]
@@ -209,7 +209,7 @@ pub struct DescribeEventTypesResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeEventsRequest {
     /// <p>Values to narrow the results returned.</p>
     #[serde(rename = "filter")]
@@ -229,7 +229,7 @@ pub struct DescribeEventsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeEventsResponse {
     /// <p>The events that match the specified filter criteria.</p>
     #[serde(rename = "events")]
@@ -242,7 +242,7 @@ pub struct DescribeEventsResponse {
 }
 
 /// <p>The number of entities that are affected by one or more events. Returned by the <a>DescribeEntityAggregates</a> operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct EntityAggregate {
     /// <p>The number entities that match the criteria for the specified events.</p>
     #[serde(rename = "count")]
@@ -255,7 +255,7 @@ pub struct EntityAggregate {
 }
 
 /// <p>The values to use to filter results from the <a>DescribeAffectedEntities</a> operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct EntityFilter {
     /// <p>A list of entity ARNs (unique identifiers).</p>
     #[serde(rename = "entityArns")]
@@ -283,7 +283,7 @@ pub struct EntityFilter {
 }
 
 /// <p>Summary information about an event, returned by the <a>DescribeEvents</a> operation. The <a>DescribeEventDetails</a> operation also returns this information, as well as the <a>EventDescription</a> and additional event metadata.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Event {
     /// <p>The unique identifier for the event. Format: <code>arn:aws:health:<i>event-region</i>::event/<i>EVENT_TYPE_PLUS_ID</i> </code>. Example: <code>arn:aws:health:us-east-1::event/AWS_EC2_MAINTENANCE_5331</code> </p>
     #[serde(rename = "arn")]
@@ -328,7 +328,7 @@ pub struct Event {
 }
 
 /// <p>The number of events of each issue type. Returned by the <a>DescribeEventAggregates</a> operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct EventAggregate {
     /// <p>The issue type for the associated count.</p>
     #[serde(rename = "aggregateValue")]
@@ -341,7 +341,7 @@ pub struct EventAggregate {
 }
 
 /// <p>Detailed information about an event. A combination of an <a>Event</a> object, an <a>EventDescription</a> object, and additional metadata about the event. Returned by the <a>DescribeEventDetails</a> operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct EventDetails {
     /// <p>Summary information about the event.</p>
     #[serde(rename = "event")]
@@ -358,7 +358,7 @@ pub struct EventDetails {
 }
 
 /// <p>Error information returned when a <a>DescribeEventDetails</a> operation cannot find a specified event.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct EventDetailsErrorItem {
     /// <p>A message that describes the error.</p>
     #[serde(rename = "errorMessage")]
@@ -375,7 +375,7 @@ pub struct EventDetailsErrorItem {
 }
 
 /// <p>The values to use to filter results from the <a>DescribeEvents</a> and <a>DescribeEventAggregates</a> operations.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct EventFilter {
     /// <p>A list of AWS availability zones.</p>
     #[serde(rename = "availabilityZones")]
@@ -432,7 +432,7 @@ pub struct EventFilter {
 }
 
 /// <p>The values to use to filter results from the <a>DescribeEventTypes</a> operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct EventTypeFilter {
     /// <p>A list of event type category codes (<code>issue</code>, <code>scheduledChange</code>, or <code>accountNotification</code>).</p>
     #[serde(rename = "eventTypeCategories")]

--- a/rusoto/services/iam/src/generated.rs
+++ b/rusoto/services/iam/src/generated.rs
@@ -44,7 +44,7 @@ enum DeserializerNext {
     Element(String),
 }
 /// <p><p>Contains information about an AWS access key.</p> <p> This data type is used as a response element in the <a>CreateAccessKey</a> and <a>ListAccessKeys</a> operations. </p> <note> <p>The <code>SecretAccessKey</code> value is returned only in response to <a>CreateAccessKey</a>. You can get a secret access key only when you first create an access key; you cannot recover the secret access key later. If you lose a secret access key, you must create a new access key.</p> </note></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AccessKey {
     /// <p>The ID for this access key.</p>
     pub access_key_id: String,
@@ -132,7 +132,7 @@ impl AccessKeyIdTypeDeserializer {
     }
 }
 /// <p>Contains information about the last time an AWS access key was used.</p> <p>This data type is used as a response element in the <a>GetAccessKeyLastUsed</a> operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AccessKeyLastUsed {
     /// <p><p>The date and time, in <a href="http://www.iso.org/iso/iso8601">ISO 8601 date-time format</a>, when the access key was most recently used. This field is null in the following situations:</p> <ul> <li> <p>The user does not have an access key.</p> </li> <li> <p>An access key exists but has never been used, at least not since IAM started tracking this information on April 22nd, 2015.</p> </li> <li> <p>There is no sign-in data associated with the user</p> </li> </ul></p>
     pub last_used_date: String,
@@ -190,7 +190,7 @@ impl AccessKeyLastUsedDeserializer {
     }
 }
 /// <p>Contains information about an AWS access key, without its secret key.</p> <p>This data type is used as a response element in the <a>ListAccessKeys</a> operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AccessKeyMetadata {
     /// <p>The ID for this access key.</p>
     pub access_key_id: Option<String>,
@@ -395,7 +395,7 @@ impl ActionNameTypeDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AddClientIDToOpenIDConnectProviderRequest {
     /// <p>The client ID (also known as audience) to add to the IAM OpenID Connect provider resource.</p>
     pub client_id: String,
@@ -423,7 +423,7 @@ impl AddClientIDToOpenIDConnectProviderRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AddRoleToInstanceProfileRequest {
     /// <p>The name of the instance profile to update.</p> <p>This parameter allows (per its <a href="http://wikipedia.org/wiki/regex">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-</p>
     pub instance_profile_name: String,
@@ -451,7 +451,7 @@ impl AddRoleToInstanceProfileRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AddUserToGroupRequest {
     /// <p>The name of the group to update.</p> <p>This parameter allows (per its <a href="http://wikipedia.org/wiki/regex">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-</p>
     pub group_name: String,
@@ -533,7 +533,7 @@ impl ArnTypeDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AttachGroupPolicyRequest {
     /// <p>The name (friendly name, not ARN) of the group to attach the policy to.</p> <p>This parameter allows (per its <a href="http://wikipedia.org/wiki/regex">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-</p>
     pub group_name: String,
@@ -561,7 +561,7 @@ impl AttachGroupPolicyRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AttachRolePolicyRequest {
     /// <p>The Amazon Resource Name (ARN) of the IAM policy you want to attach.</p> <p>For more information about ARNs, see <a href="http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html">Amazon Resource Names (ARNs) and AWS Service Namespaces</a> in the <i>AWS General Reference</i>.</p>
     pub policy_arn: String,
@@ -589,7 +589,7 @@ impl AttachRolePolicyRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AttachUserPolicyRequest {
     /// <p>The Amazon Resource Name (ARN) of the IAM policy you want to attach.</p> <p>For more information about ARNs, see <a href="http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html">Amazon Resource Names (ARNs) and AWS Service Namespaces</a> in the <i>AWS General Reference</i>.</p>
     pub policy_arn: String,
@@ -660,7 +660,7 @@ impl AttachedPoliciesListTypeDeserializer {
     }
 }
 /// <p>Contains information about an attached policy.</p> <p>An attached policy is a managed policy that has been attached to a user, group, or role. This data type is used as a response element in the <a>ListAttachedGroupPolicies</a>, <a>ListAttachedRolePolicies</a>, <a>ListAttachedUserPolicies</a>, and <a>GetAccountAuthorizationDetails</a> operations. </p> <p>For more information about managed policies, refer to <a href="http://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html">Managed Policies and Inline Policies</a> in the <i>Using IAM</i> guide. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AttachedPolicy {
     pub policy_arn: Option<String>,
     /// <p>The friendly name of the attached policy.</p>
@@ -853,7 +853,7 @@ impl CertificateListTypeDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ChangePasswordRequest {
     /// <p>The new password. The new password must conform to the AWS account's password policy, if one exists.</p> <p>The <a href="http://wikipedia.org/wiki/regex">regex pattern</a> that is used to validate this parameter is a string of characters. That string can include almost any printable ASCII character from the space (\u0020) through the end of the ASCII character range (\u00FF). You can also include the tab (\u0009), line feed (\u000A), and carriage return (\u000D) characters. Any of these characters are valid in a password. However, many tools, such as the AWS Management Console, might restrict the ability to type certain characters because they have special meaning within that tool.</p>
     pub new_password: String,
@@ -962,7 +962,7 @@ impl ColumnNumberDeserializer {
     }
 }
 /// <p>Contains information about a condition context key. It includes the name of the key and specifies the value (or values, if the context key supports multiple values) to use in the simulation. This information is used when evaluating the <code>Condition</code> elements of the input policies.</p> <p>This data type is used as an input parameter to <code> <a>SimulateCustomPolicy</a> </code> and <code> <a>SimulateCustomPolicy</a> </code>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ContextEntry {
     /// <p>The full name of a condition context key, including the service prefix. For example, <code>aws:SourceIp</code> or <code>s3:VersionId</code>.</p>
     pub context_key_name: Option<String>,
@@ -1082,7 +1082,7 @@ impl ContextKeyValueListTypeSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateAccessKeyRequest {
     /// <p>The name of the IAM user that the new key will belong to.</p> <p>This parameter allows (per its <a href="http://wikipedia.org/wiki/regex">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-</p>
     pub user_name: Option<String>,
@@ -1107,7 +1107,7 @@ impl CreateAccessKeyRequestSerializer {
 }
 
 /// <p>Contains the response to a successful <a>CreateAccessKey</a> request. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateAccessKeyResponse {
     /// <p>A structure with details about the access key.</p>
     pub access_key: AccessKey,
@@ -1153,7 +1153,7 @@ impl CreateAccessKeyResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateAccountAliasRequest {
     /// <p>The account alias to create.</p> <p>This parameter allows (per its <a href="http://wikipedia.org/wiki/regex">regex pattern</a>) a string of characters consisting of lowercase letters, digits, and dashes. You cannot start or finish with a dash, nor can you have two dashes in a row.</p>
     pub account_alias: String,
@@ -1175,7 +1175,7 @@ impl CreateAccountAliasRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateGroupRequest {
     /// <p>The name of the group to create. Do not include the path in this value.</p> <p>This parameter allows (per its <a href="http://wikipedia.org/wiki/regex">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-. The group name must be unique within the account. Group names are not distinguished by case. For example, you cannot create groups named both "ADMINS" and "admins".</p>
     pub group_name: String,
@@ -1206,7 +1206,7 @@ impl CreateGroupRequestSerializer {
 }
 
 /// <p>Contains the response to a successful <a>CreateGroup</a> request. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateGroupResponse {
     /// <p>A structure containing details about the new group.</p>
     pub group: Group,
@@ -1251,7 +1251,7 @@ impl CreateGroupResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateInstanceProfileRequest {
     /// <p>The name of the instance profile to create.</p> <p>This parameter allows (per its <a href="http://wikipedia.org/wiki/regex">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-</p>
     pub instance_profile_name: String,
@@ -1282,7 +1282,7 @@ impl CreateInstanceProfileRequestSerializer {
 }
 
 /// <p>Contains the response to a successful <a>CreateInstanceProfile</a> request. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateInstanceProfileResponse {
     /// <p>A structure containing details about the new instance profile.</p>
     pub instance_profile: InstanceProfile,
@@ -1330,7 +1330,7 @@ impl CreateInstanceProfileResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateLoginProfileRequest {
     /// <p>The new password for the user.</p> <p>The <a href="http://wikipedia.org/wiki/regex">regex pattern</a> that is used to validate this parameter is a string of characters. That string can include almost any printable ASCII character from the space (\u0020) through the end of the ASCII character range (\u00FF). You can also include the tab (\u0009), line feed (\u000A), and carriage return (\u000D) characters. Any of these characters are valid in a password. However, many tools, such as the AWS Management Console, might restrict the ability to type certain characters because they have special meaning within that tool.</p>
     pub password: String,
@@ -1367,7 +1367,7 @@ impl CreateLoginProfileRequestSerializer {
 }
 
 /// <p>Contains the response to a successful <a>CreateLoginProfile</a> request. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateLoginProfileResponse {
     /// <p>A structure containing the user name and password create date.</p>
     pub login_profile: LoginProfile,
@@ -1413,7 +1413,7 @@ impl CreateLoginProfileResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateOpenIDConnectProviderRequest {
     /// <p>A list of client IDs (also known as audiences). When a mobile or web app registers with an OpenID Connect provider, they establish a value that identifies the application. (This is the value that's sent as the <code>client_id</code> parameter on OAuth requests.)</p> <p>You can register multiple client IDs with the same provider. For example, you might have multiple applications that use the same OIDC provider. You cannot register more than 100 client IDs with a single IAM OIDC provider.</p> <p>There is no defined format for a client ID. The <code>CreateOpenIDConnectProviderRequest</code> operation accepts client IDs up to 255 characters long.</p>
     pub client_id_list: Option<Vec<String>>,
@@ -1452,7 +1452,7 @@ impl CreateOpenIDConnectProviderRequestSerializer {
 }
 
 /// <p>Contains the response to a successful <a>CreateOpenIDConnectProvider</a> request. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateOpenIDConnectProviderResponse {
     /// <p>The Amazon Resource Name (ARN) of the new IAM OpenID Connect provider that is created. For more information, see <a>OpenIDConnectProviderListEntry</a>. </p>
     pub open_id_connect_provider_arn: Option<String>,
@@ -1499,7 +1499,7 @@ impl CreateOpenIDConnectProviderResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreatePolicyRequest {
     /// <p>A friendly description of the policy.</p> <p>Typically used to store information about the permissions defined in the policy. For example, "Grants access to production DynamoDB tables."</p> <p>The policy description is immutable. After a value is assigned, it cannot be changed.</p>
     pub description: Option<String>,
@@ -1544,7 +1544,7 @@ impl CreatePolicyRequestSerializer {
 }
 
 /// <p>Contains the response to a successful <a>CreatePolicy</a> request. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreatePolicyResponse {
     /// <p>A structure containing details about the new policy.</p>
     pub policy: Option<Policy>,
@@ -1589,7 +1589,7 @@ impl CreatePolicyResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreatePolicyVersionRequest {
     /// <p>The Amazon Resource Name (ARN) of the IAM policy to which you want to add a new version.</p> <p>For more information about ARNs, see <a href="http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html">Amazon Resource Names (ARNs) and AWS Service Namespaces</a> in the <i>AWS General Reference</i>.</p>
     pub policy_arn: String,
@@ -1626,7 +1626,7 @@ impl CreatePolicyVersionRequestSerializer {
 }
 
 /// <p>Contains the response to a successful <a>CreatePolicyVersion</a> request. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreatePolicyVersionResponse {
     /// <p>A structure containing details about the new policy version.</p>
     pub policy_version: Option<PolicyVersion>,
@@ -1674,7 +1674,7 @@ impl CreatePolicyVersionResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateRoleRequest {
     /// <p><p>The trust relationship policy document that grants an entity permission to assume the role.</p> <p>The <a href="http://wikipedia.org/wiki/regex">regex pattern</a> used to validate this parameter is a string of characters consisting of the following:</p> <ul> <li> <p>Any printable ASCII character ranging from the space character (\u0020) through the end of the ASCII character range</p> </li> <li> <p>The printable characters in the Basic Latin and Latin-1 Supplement character set (through \u00FF)</p> </li> <li> <p>The special characters tab (\u0009), line feed (\u000A), and carriage return (\u000D)</p> </li> </ul></p>
     pub assume_role_policy_document: String,
@@ -1727,7 +1727,7 @@ impl CreateRoleRequestSerializer {
 }
 
 /// <p>Contains the response to a successful <a>CreateRole</a> request. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateRoleResponse {
     /// <p>A structure containing details about the new role.</p>
     pub role: Role,
@@ -1772,7 +1772,7 @@ impl CreateRoleResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateSAMLProviderRequest {
     /// <p>The name of the provider to create.</p> <p>This parameter allows (per its <a href="http://wikipedia.org/wiki/regex">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-</p>
     pub name: String,
@@ -1801,7 +1801,7 @@ impl CreateSAMLProviderRequestSerializer {
 }
 
 /// <p>Contains the response to a successful <a>CreateSAMLProvider</a> request. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateSAMLProviderResponse {
     /// <p>The Amazon Resource Name (ARN) of the new SAML provider resource in IAM.</p>
     pub saml_provider_arn: Option<String>,
@@ -1849,7 +1849,7 @@ impl CreateSAMLProviderResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateServiceLinkedRoleRequest {
     /// <p>The AWS service to which this role is attached. You use a string similar to a URL but without the http:// in front. For example: <code>elasticbeanstalk.amazonaws.com</code> </p>
     pub aws_service_name: String,
@@ -1887,7 +1887,7 @@ impl CreateServiceLinkedRoleRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateServiceLinkedRoleResponse {
     /// <p>A <a>Role</a> object that contains details about the newly created role.</p>
     pub role: Option<Role>,
@@ -1932,7 +1932,7 @@ impl CreateServiceLinkedRoleResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateServiceSpecificCredentialRequest {
     /// <p>The name of the AWS service that is to be associated with the credentials. The service you specify here is the only service that can be accessed using these credentials.</p>
     pub service_name: String,
@@ -1960,7 +1960,7 @@ impl CreateServiceSpecificCredentialRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateServiceSpecificCredentialResponse {
     /// <p><p>A structure that contains information about the newly created service-specific credential.</p> <important> <p>This is the only time that the password for this credential set is available. It cannot be recovered later. Instead, you will have to reset the password with <a>ResetServiceSpecificCredential</a>.</p> </important></p>
     pub service_specific_credential: Option<ServiceSpecificCredential>,
@@ -2009,7 +2009,7 @@ impl CreateServiceSpecificCredentialResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateUserRequest {
     /// <p> The path for the user name. For more information about paths, see <a href="http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html">IAM Identifiers</a> in the <i>IAM User Guide</i>.</p> <p>This parameter is optional. If it is not included, it defaults to a slash (/).</p> <p>This parameter allows (per its <a href="http://wikipedia.org/wiki/regex">regex pattern</a>) a string of characters consisting of either a forward slash (/) by itself or a string that must begin and end with forward slashes. In addition, it can contain any ASCII character from the ! (\u0021) through the DEL character (\u007F), including most punctuation characters, digits, and upper and lowercased letters.</p>
     pub path: Option<String>,
@@ -2040,7 +2040,7 @@ impl CreateUserRequestSerializer {
 }
 
 /// <p>Contains the response to a successful <a>CreateUser</a> request. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateUserResponse {
     /// <p>A structure with details about the new IAM user.</p>
     pub user: Option<User>,
@@ -2085,7 +2085,7 @@ impl CreateUserResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateVirtualMFADeviceRequest {
     /// <p> The path for the virtual MFA device. For more information about paths, see <a href="http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html">IAM Identifiers</a> in the <i>IAM User Guide</i>.</p> <p>This parameter is optional. If it is not included, it defaults to a slash (/).</p> <p>This parameter allows (per its <a href="http://wikipedia.org/wiki/regex">regex pattern</a>) a string of characters consisting of either a forward slash (/) by itself or a string that must begin and end with forward slashes. In addition, it can contain any ASCII character from the ! (\u0021) through the DEL character (\u007F), including most punctuation characters, digits, and upper and lowercased letters.</p>
     pub path: Option<String>,
@@ -2116,7 +2116,7 @@ impl CreateVirtualMFADeviceRequestSerializer {
 }
 
 /// <p>Contains the response to a successful <a>CreateVirtualMFADevice</a> request. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateVirtualMFADeviceResponse {
     /// <p>A structure containing details about the new virtual MFA device.</p>
     pub virtual_mfa_device: VirtualMFADevice,
@@ -2178,7 +2178,7 @@ impl DateTypeDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeactivateMFADeviceRequest {
     /// <p>The serial number that uniquely identifies the MFA device. For virtual MFA devices, the serial number is the device ARN.</p> <p>This parameter allows (per its <a href="http://wikipedia.org/wiki/regex">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@:/-</p>
     pub serial_number: String,
@@ -2206,7 +2206,7 @@ impl DeactivateMFADeviceRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteAccessKeyRequest {
     /// <p>The access key ID for the access key ID and secret access key you want to delete.</p> <p>This parameter allows (per its <a href="http://wikipedia.org/wiki/regex">regex pattern</a>) a string of characters that can consist of any upper or lowercased letter or digit.</p>
     pub access_key_id: String,
@@ -2236,7 +2236,7 @@ impl DeleteAccessKeyRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteAccountAliasRequest {
     /// <p>The name of the account alias to delete.</p> <p>This parameter allows (per its <a href="http://wikipedia.org/wiki/regex">regex pattern</a>) a string of characters consisting of lowercase letters, digits, and dashes. You cannot start or finish with a dash, nor can you have two dashes in a row.</p>
     pub account_alias: String,
@@ -2258,7 +2258,7 @@ impl DeleteAccountAliasRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteGroupPolicyRequest {
     /// <p>The name (friendly name, not ARN) identifying the group that the policy is embedded in.</p> <p>This parameter allows (per its <a href="http://wikipedia.org/wiki/regex">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-</p>
     pub group_name: String,
@@ -2286,7 +2286,7 @@ impl DeleteGroupPolicyRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteGroupRequest {
     /// <p>The name of the IAM group to delete.</p> <p>This parameter allows (per its <a href="http://wikipedia.org/wiki/regex">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-</p>
     pub group_name: String,
@@ -2308,7 +2308,7 @@ impl DeleteGroupRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteInstanceProfileRequest {
     /// <p>The name of the instance profile to delete.</p> <p>This parameter allows (per its <a href="http://wikipedia.org/wiki/regex">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-</p>
     pub instance_profile_name: String,
@@ -2330,7 +2330,7 @@ impl DeleteInstanceProfileRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteLoginProfileRequest {
     /// <p>The name of the user whose password you want to delete.</p> <p>This parameter allows (per its <a href="http://wikipedia.org/wiki/regex">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-</p>
     pub user_name: String,
@@ -2352,7 +2352,7 @@ impl DeleteLoginProfileRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteOpenIDConnectProviderRequest {
     /// <p>The Amazon Resource Name (ARN) of the IAM OpenID Connect provider resource object to delete. You can get a list of OpenID Connect provider resource ARNs by using the <a>ListOpenIDConnectProviders</a> operation.</p>
     pub open_id_connect_provider_arn: String,
@@ -2374,7 +2374,7 @@ impl DeleteOpenIDConnectProviderRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeletePolicyRequest {
     /// <p>The Amazon Resource Name (ARN) of the IAM policy you want to delete.</p> <p>For more information about ARNs, see <a href="http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html">Amazon Resource Names (ARNs) and AWS Service Namespaces</a> in the <i>AWS General Reference</i>.</p>
     pub policy_arn: String,
@@ -2396,7 +2396,7 @@ impl DeletePolicyRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeletePolicyVersionRequest {
     /// <p>The Amazon Resource Name (ARN) of the IAM policy from which you want to delete a version.</p> <p>For more information about ARNs, see <a href="http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html">Amazon Resource Names (ARNs) and AWS Service Namespaces</a> in the <i>AWS General Reference</i>.</p>
     pub policy_arn: String,
@@ -2424,7 +2424,7 @@ impl DeletePolicyVersionRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteRolePolicyRequest {
     /// <p>The name of the inline policy to delete from the specified IAM role.</p> <p>This parameter allows (per its <a href="http://wikipedia.org/wiki/regex">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-</p>
     pub policy_name: String,
@@ -2452,7 +2452,7 @@ impl DeleteRolePolicyRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteRoleRequest {
     /// <p>The name of the role to delete.</p> <p>This parameter allows (per its <a href="http://wikipedia.org/wiki/regex">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-</p>
     pub role_name: String,
@@ -2474,7 +2474,7 @@ impl DeleteRoleRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteSAMLProviderRequest {
     /// <p>The Amazon Resource Name (ARN) of the SAML provider to delete.</p>
     pub saml_provider_arn: String,
@@ -2496,7 +2496,7 @@ impl DeleteSAMLProviderRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteSSHPublicKeyRequest {
     /// <p>The unique identifier for the SSH public key.</p> <p>This parameter allows (per its <a href="http://wikipedia.org/wiki/regex">regex pattern</a>) a string of characters that can consist of any upper or lowercased letter or digit.</p>
     pub ssh_public_key_id: String,
@@ -2524,7 +2524,7 @@ impl DeleteSSHPublicKeyRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteServerCertificateRequest {
     /// <p>The name of the server certificate you want to delete.</p> <p>This parameter allows (per its <a href="http://wikipedia.org/wiki/regex">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-</p>
     pub server_certificate_name: String,
@@ -2546,7 +2546,7 @@ impl DeleteServerCertificateRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteServiceLinkedRoleRequest {
     /// <p>The name of the service-linked role to be deleted.</p>
     pub role_name: String,
@@ -2568,7 +2568,7 @@ impl DeleteServiceLinkedRoleRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteServiceLinkedRoleResponse {
     /// <p>The deletion task identifier that you can use to check the status of the deletion. This identifier is returned in the format <code>task/aws-service-role/&lt;service-principal-name&gt;/&lt;role-name&gt;/&lt;task-uuid&gt;</code>.</p>
     pub deletion_task_id: String,
@@ -2616,7 +2616,7 @@ impl DeleteServiceLinkedRoleResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteServiceSpecificCredentialRequest {
     /// <p>The unique identifier of the service-specific credential. You can get this value by calling <a>ListServiceSpecificCredentials</a>.</p> <p>This parameter allows (per its <a href="http://wikipedia.org/wiki/regex">regex pattern</a>) a string of characters that can consist of any upper or lowercased letter or digit.</p>
     pub service_specific_credential_id: String,
@@ -2646,7 +2646,7 @@ impl DeleteServiceSpecificCredentialRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteSigningCertificateRequest {
     /// <p>The ID of the signing certificate to delete.</p> <p>The format of this parameter, as described by its <a href="http://wikipedia.org/wiki/regex">regex</a> pattern, is a string of characters that can be upper- or lower-cased letters or digits.</p>
     pub certificate_id: String,
@@ -2676,7 +2676,7 @@ impl DeleteSigningCertificateRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteUserPolicyRequest {
     /// <p>The name identifying the policy document to delete.</p> <p>This parameter allows (per its <a href="http://wikipedia.org/wiki/regex">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-</p>
     pub policy_name: String,
@@ -2704,7 +2704,7 @@ impl DeleteUserPolicyRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteUserRequest {
     /// <p>The name of the user to delete.</p> <p>This parameter allows (per its <a href="http://wikipedia.org/wiki/regex">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-</p>
     pub user_name: String,
@@ -2726,7 +2726,7 @@ impl DeleteUserRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteVirtualMFADeviceRequest {
     /// <p>The serial number that uniquely identifies the MFA device. For virtual MFA devices, the serial number is the same as the ARN.</p> <p>This parameter allows (per its <a href="http://wikipedia.org/wiki/regex">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: =,.@:/-</p>
     pub serial_number: String,
@@ -2749,7 +2749,7 @@ impl DeleteVirtualMFADeviceRequestSerializer {
 }
 
 /// <p>The reason that the service-linked role deletion failed.</p> <p>This data type is used as a response element in the <a>GetServiceLinkedRoleDeletionStatus</a> operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeletionTaskFailureReasonType {
     /// <p>A short description of the reason that the service-linked role deletion failed.</p>
     pub reason: Option<String>,
@@ -2830,7 +2830,7 @@ impl DeletionTaskStatusTypeDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DetachGroupPolicyRequest {
     /// <p>The name (friendly name, not ARN) of the IAM group to detach the policy from.</p> <p>This parameter allows (per its <a href="http://wikipedia.org/wiki/regex">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-</p>
     pub group_name: String,
@@ -2858,7 +2858,7 @@ impl DetachGroupPolicyRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DetachRolePolicyRequest {
     /// <p>The Amazon Resource Name (ARN) of the IAM policy you want to detach.</p> <p>For more information about ARNs, see <a href="http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html">Amazon Resource Names (ARNs) and AWS Service Namespaces</a> in the <i>AWS General Reference</i>.</p>
     pub policy_arn: String,
@@ -2886,7 +2886,7 @@ impl DetachRolePolicyRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DetachUserPolicyRequest {
     /// <p>The Amazon Resource Name (ARN) of the IAM policy you want to detach.</p> <p>For more information about ARNs, see <a href="http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html">Amazon Resource Names (ARNs) and AWS Service Namespaces</a> in the <i>AWS General Reference</i>.</p>
     pub policy_arn: String,
@@ -2914,7 +2914,7 @@ impl DetachUserPolicyRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct EnableMFADeviceRequest {
     /// <p><p>An authentication code emitted by the device. </p> <p>The format for this parameter is a string of six digits.</p> <important> <p>Submit your request immediately after generating the authentication codes. If you generate the codes and then wait too long to submit the request, the MFA device successfully associates with the user but the MFA device becomes out of sync. This happens because time-based one-time passwords (TOTP) expire after a short period of time. If this happens, you can <a href="http://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_mfa_sync.html">resync the device</a>.</p> </important></p>
     pub authentication_code_1: String,
@@ -3007,7 +3007,7 @@ impl EvalDecisionSourceTypeDeserializer {
     }
 }
 /// <p>Contains the results of a simulation.</p> <p>This data type is used by the return parameter of <code> <a>SimulateCustomPolicy</a> </code> and <code> <a>SimulatePrincipalPolicy</a> </code>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct EvaluationResult {
     /// <p>The name of the API operation tested on the indicated resource.</p>
     pub eval_action_name: String,
@@ -3173,7 +3173,7 @@ impl ExistingUserNameTypeDeserializer {
     }
 }
 /// <p>Contains the response to a successful <a>GenerateCredentialReport</a> request. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GenerateCredentialReportResponse {
     /// <p>Information about the credential report.</p>
     pub description: Option<String>,
@@ -3229,7 +3229,7 @@ impl GenerateCredentialReportResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetAccessKeyLastUsedRequest {
     /// <p>The identifier of an access key.</p> <p>This parameter allows (per its <a href="http://wikipedia.org/wiki/regex">regex pattern</a>) a string of characters that can consist of any upper or lowercased letter or digit.</p>
     pub access_key_id: String,
@@ -3252,7 +3252,7 @@ impl GetAccessKeyLastUsedRequestSerializer {
 }
 
 /// <p>Contains the response to a successful <a>GetAccessKeyLastUsed</a> request. It is also returned as a member of the <a>AccessKeyMetaData</a> structure returned by the <a>ListAccessKeys</a> action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetAccessKeyLastUsedResponse {
     /// <p>Contains information about the last time the access key was used.</p>
     pub access_key_last_used: Option<AccessKeyLastUsed>,
@@ -3306,7 +3306,7 @@ impl GetAccessKeyLastUsedResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetAccountAuthorizationDetailsRequest {
     /// <p>A list of entity types used to filter the results. Only the entities that match the types you specify are included in the output. Use the value <code>LocalManagedPolicy</code> to include customer managed policies.</p> <p>The format for this parameter is a comma-separated (if more than one) list of strings. Each string value in the list must be one of the valid values listed below.</p>
     pub filter: Option<Vec<String>>,
@@ -3348,7 +3348,7 @@ impl GetAccountAuthorizationDetailsRequestSerializer {
 }
 
 /// <p>Contains the response to a successful <a>GetAccountAuthorizationDetails</a> request. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetAccountAuthorizationDetailsResponse {
     /// <p>A list containing information about IAM groups.</p>
     pub group_detail_list: Option<Vec<GroupDetail>>,
@@ -3431,7 +3431,7 @@ impl GetAccountAuthorizationDetailsResponseDeserializer {
     }
 }
 /// <p>Contains the response to a successful <a>GetAccountPasswordPolicy</a> request. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetAccountPasswordPolicyResponse {
     /// <p>A structure that contains details about the account's password policy.</p>
     pub password_policy: PasswordPolicy,
@@ -3480,7 +3480,7 @@ impl GetAccountPasswordPolicyResponseDeserializer {
     }
 }
 /// <p>Contains the response to a successful <a>GetAccountSummary</a> request. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetAccountSummaryResponse {
     /// <p>A set of key value pairs containing information about IAM entity usage and IAM quotas.</p>
     pub summary_map: Option<::std::collections::HashMap<String, i64>>,
@@ -3528,7 +3528,7 @@ impl GetAccountSummaryResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetContextKeysForCustomPolicyRequest {
     /// <p><p>A list of policies for which you want the list of context keys referenced in those policies. Each document is specified as a string containing the complete, valid JSON text of an IAM policy.</p> <p>The <a href="http://wikipedia.org/wiki/regex">regex pattern</a> used to validate this parameter is a string of characters consisting of the following:</p> <ul> <li> <p>Any printable ASCII character ranging from the space character (\u0020) through the end of the ASCII character range</p> </li> <li> <p>The printable characters in the Basic Latin and Latin-1 Supplement character set (through \u00FF)</p> </li> <li> <p>The special characters tab (\u0009), line feed (\u000A), and carriage return (\u000D)</p> </li> </ul></p>
     pub policy_input_list: Vec<String>,
@@ -3552,7 +3552,7 @@ impl GetContextKeysForCustomPolicyRequestSerializer {
 }
 
 /// <p>Contains the response to a successful <a>GetContextKeysForPrincipalPolicy</a> or <a>GetContextKeysForCustomPolicy</a> request. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetContextKeysForPolicyResponse {
     /// <p>The list of context keys that are referenced in the input policies.</p>
     pub context_key_names: Option<Vec<String>>,
@@ -3602,7 +3602,7 @@ impl GetContextKeysForPolicyResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetContextKeysForPrincipalPolicyRequest {
     /// <p><p>An optional list of additional policies for which you want the list of context keys that are referenced.</p> <p>The <a href="http://wikipedia.org/wiki/regex">regex pattern</a> used to validate this parameter is a string of characters consisting of the following:</p> <ul> <li> <p>Any printable ASCII character ranging from the space character (\u0020) through the end of the ASCII character range</p> </li> <li> <p>The printable characters in the Basic Latin and Latin-1 Supplement character set (through \u00FF)</p> </li> <li> <p>The special characters tab (\u0009), line feed (\u000A), and carriage return (\u000D)</p> </li> </ul></p>
     pub policy_input_list: Option<Vec<String>>,
@@ -3634,7 +3634,7 @@ impl GetContextKeysForPrincipalPolicyRequestSerializer {
 }
 
 /// <p>Contains the response to a successful <a>GetCredentialReport</a> request. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetCredentialReportResponse {
     /// <p>Contains the credential report. The report is Base64-encoded.</p>
     pub content: Option<Vec<u8>>,
@@ -3697,7 +3697,7 @@ impl GetCredentialReportResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetGroupPolicyRequest {
     /// <p>The name of the group the policy is associated with.</p> <p>This parameter allows (per its <a href="http://wikipedia.org/wiki/regex">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-</p>
     pub group_name: String,
@@ -3726,7 +3726,7 @@ impl GetGroupPolicyRequestSerializer {
 }
 
 /// <p>Contains the response to a successful <a>GetGroupPolicy</a> request. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetGroupPolicyResponse {
     /// <p>The group the policy is associated with.</p>
     pub group_name: String,
@@ -3786,7 +3786,7 @@ impl GetGroupPolicyResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetGroupRequest {
     /// <p>The name of the group.</p> <p>This parameter allows (per its <a href="http://wikipedia.org/wiki/regex">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-</p>
     pub group_name: String,
@@ -3825,7 +3825,7 @@ impl GetGroupRequestSerializer {
 }
 
 /// <p>Contains the response to a successful <a>GetGroup</a> request. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetGroupResponse {
     /// <p>A structure that contains details about the group.</p>
     pub group: Group,
@@ -3889,7 +3889,7 @@ impl GetGroupResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetInstanceProfileRequest {
     /// <p>The name of the instance profile to get information about.</p> <p>This parameter allows (per its <a href="http://wikipedia.org/wiki/regex">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-</p>
     pub instance_profile_name: String,
@@ -3912,7 +3912,7 @@ impl GetInstanceProfileRequestSerializer {
 }
 
 /// <p>Contains the response to a successful <a>GetInstanceProfile</a> request. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetInstanceProfileResponse {
     /// <p>A structure containing details about the instance profile.</p>
     pub instance_profile: InstanceProfile,
@@ -3960,7 +3960,7 @@ impl GetInstanceProfileResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetLoginProfileRequest {
     /// <p>The name of the user whose login profile you want to retrieve.</p> <p>This parameter allows (per its <a href="http://wikipedia.org/wiki/regex">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-</p>
     pub user_name: String,
@@ -3983,7 +3983,7 @@ impl GetLoginProfileRequestSerializer {
 }
 
 /// <p>Contains the response to a successful <a>GetLoginProfile</a> request. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetLoginProfileResponse {
     /// <p>A structure containing the user name and password create date for the user.</p>
     pub login_profile: LoginProfile,
@@ -4029,7 +4029,7 @@ impl GetLoginProfileResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetOpenIDConnectProviderRequest {
     /// <p>The Amazon Resource Name (ARN) of the OIDC provider resource object in IAM to get information for. You can get a list of OIDC provider resource ARNs by using the <a>ListOpenIDConnectProviders</a> operation.</p> <p>For more information about ARNs, see <a href="http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html">Amazon Resource Names (ARNs) and AWS Service Namespaces</a> in the <i>AWS General Reference</i>.</p>
     pub open_id_connect_provider_arn: String,
@@ -4052,7 +4052,7 @@ impl GetOpenIDConnectProviderRequestSerializer {
 }
 
 /// <p>Contains the response to a successful <a>GetOpenIDConnectProvider</a> request. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetOpenIDConnectProviderResponse {
     /// <p>A list of client IDs (also known as audiences) that are associated with the specified IAM OIDC provider resource object. For more information, see <a>CreateOpenIDConnectProvider</a>.</p>
     pub client_id_list: Option<Vec<String>>,
@@ -4120,7 +4120,7 @@ impl GetOpenIDConnectProviderResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetPolicyRequest {
     /// <p>The Amazon Resource Name (ARN) of the managed policy that you want information about.</p> <p>For more information about ARNs, see <a href="http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html">Amazon Resource Names (ARNs) and AWS Service Namespaces</a> in the <i>AWS General Reference</i>.</p>
     pub policy_arn: String,
@@ -4143,7 +4143,7 @@ impl GetPolicyRequestSerializer {
 }
 
 /// <p>Contains the response to a successful <a>GetPolicy</a> request. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetPolicyResponse {
     /// <p>A structure containing details about the policy.</p>
     pub policy: Option<Policy>,
@@ -4188,7 +4188,7 @@ impl GetPolicyResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetPolicyVersionRequest {
     /// <p>The Amazon Resource Name (ARN) of the managed policy that you want information about.</p> <p>For more information about ARNs, see <a href="http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html">Amazon Resource Names (ARNs) and AWS Service Namespaces</a> in the <i>AWS General Reference</i>.</p>
     pub policy_arn: String,
@@ -4217,7 +4217,7 @@ impl GetPolicyVersionRequestSerializer {
 }
 
 /// <p>Contains the response to a successful <a>GetPolicyVersion</a> request. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetPolicyVersionResponse {
     /// <p>A structure containing details about the policy version.</p>
     pub policy_version: Option<PolicyVersion>,
@@ -4265,7 +4265,7 @@ impl GetPolicyVersionResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetRolePolicyRequest {
     /// <p>The name of the policy document to get.</p> <p>This parameter allows (per its <a href="http://wikipedia.org/wiki/regex">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-</p>
     pub policy_name: String,
@@ -4294,7 +4294,7 @@ impl GetRolePolicyRequestSerializer {
 }
 
 /// <p>Contains the response to a successful <a>GetRolePolicy</a> request. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetRolePolicyResponse {
     /// <p>The policy document.</p>
     pub policy_document: String,
@@ -4354,7 +4354,7 @@ impl GetRolePolicyResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetRoleRequest {
     /// <p>The name of the IAM role to get information about.</p> <p>This parameter allows (per its <a href="http://wikipedia.org/wiki/regex">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-</p>
     pub role_name: String,
@@ -4377,7 +4377,7 @@ impl GetRoleRequestSerializer {
 }
 
 /// <p>Contains the response to a successful <a>GetRole</a> request. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetRoleResponse {
     /// <p>A structure containing details about the IAM role.</p>
     pub role: Role,
@@ -4422,7 +4422,7 @@ impl GetRoleResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetSAMLProviderRequest {
     /// <p>The Amazon Resource Name (ARN) of the SAML provider resource object in IAM to get information about.</p> <p>For more information about ARNs, see <a href="http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html">Amazon Resource Names (ARNs) and AWS Service Namespaces</a> in the <i>AWS General Reference</i>.</p>
     pub saml_provider_arn: String,
@@ -4445,7 +4445,7 @@ impl GetSAMLProviderRequestSerializer {
 }
 
 /// <p>Contains the response to a successful <a>GetSAMLProvider</a> request. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetSAMLProviderResponse {
     /// <p>The date and time when the SAML provider was created.</p>
     pub create_date: Option<String>,
@@ -4506,7 +4506,7 @@ impl GetSAMLProviderResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetSSHPublicKeyRequest {
     /// <p>Specifies the public key encoding format to use in the response. To retrieve the public key in ssh-rsa format, use <code>SSH</code>. To retrieve the public key in PEM format, use <code>PEM</code>.</p>
     pub encoding: String,
@@ -4541,7 +4541,7 @@ impl GetSSHPublicKeyRequestSerializer {
 }
 
 /// <p>Contains the response to a successful <a>GetSSHPublicKey</a> request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetSSHPublicKeyResponse {
     /// <p>A structure containing details about the SSH public key.</p>
     pub ssh_public_key: Option<SSHPublicKey>,
@@ -4589,7 +4589,7 @@ impl GetSSHPublicKeyResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetServerCertificateRequest {
     /// <p>The name of the server certificate you want to retrieve information about.</p> <p>This parameter allows (per its <a href="http://wikipedia.org/wiki/regex">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-</p>
     pub server_certificate_name: String,
@@ -4612,7 +4612,7 @@ impl GetServerCertificateRequestSerializer {
 }
 
 /// <p>Contains the response to a successful <a>GetServerCertificate</a> request. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetServerCertificateResponse {
     /// <p>A structure containing details about the server certificate.</p>
     pub server_certificate: ServerCertificate,
@@ -4660,7 +4660,7 @@ impl GetServerCertificateResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetServiceLinkedRoleDeletionStatusRequest {
     /// <p>The deletion task identifier. This identifier is returned by the <a>DeleteServiceLinkedRole</a> operation in the format <code>task/aws-service-role/&lt;service-principal-name&gt;/&lt;role-name&gt;/&lt;task-uuid&gt;</code>.</p>
     pub deletion_task_id: String,
@@ -4682,7 +4682,7 @@ impl GetServiceLinkedRoleDeletionStatusRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetServiceLinkedRoleDeletionStatusResponse {
     /// <p>An object that contains details about the reason the deletion failed.</p>
     pub reason: Option<DeletionTaskFailureReasonType>,
@@ -4736,7 +4736,7 @@ impl GetServiceLinkedRoleDeletionStatusResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetUserPolicyRequest {
     /// <p>The name of the policy document to get.</p> <p>This parameter allows (per its <a href="http://wikipedia.org/wiki/regex">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-</p>
     pub policy_name: String,
@@ -4765,7 +4765,7 @@ impl GetUserPolicyRequestSerializer {
 }
 
 /// <p>Contains the response to a successful <a>GetUserPolicy</a> request. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetUserPolicyResponse {
     /// <p>The policy document.</p>
     pub policy_document: String,
@@ -4826,7 +4826,7 @@ impl GetUserPolicyResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetUserRequest {
     /// <p>The name of the user to get information about.</p> <p>This parameter is optional. If it is not included, it defaults to the user making the request. This parameter allows (per its <a href="http://wikipedia.org/wiki/regex">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-</p>
     pub user_name: Option<String>,
@@ -4851,7 +4851,7 @@ impl GetUserRequestSerializer {
 }
 
 /// <p>Contains the response to a successful <a>GetUser</a> request. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetUserResponse {
     /// <p>A structure containing details about the IAM user.</p>
     pub user: User,
@@ -4897,7 +4897,7 @@ impl GetUserResponseDeserializer {
     }
 }
 /// <p><p>Contains information about an IAM group entity.</p> <p>This data type is used as a response element in the following operations:</p> <ul> <li> <p> <a>CreateGroup</a> </p> </li> <li> <p> <a>GetGroup</a> </p> </li> <li> <p> <a>ListGroups</a> </p> </li> </ul></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Group {
     /// <p> The Amazon Resource Name (ARN) specifying the group. For more information about ARNs and how to use them in policies, see <a href="http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html">IAM Identifiers</a> in the <i>Using IAM</i> guide. </p>
     pub arn: String,
@@ -4965,7 +4965,7 @@ impl GroupDeserializer {
     }
 }
 /// <p>Contains information about an IAM group, including all of the group's policies.</p> <p>This data type is used as a response element in the <a>GetAccountAuthorizationDetails</a> operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GroupDetail {
     pub arn: Option<String>,
     /// <p>A list of the managed policies attached to the group.</p>
@@ -5201,7 +5201,7 @@ impl IdTypeDeserializer {
     }
 }
 /// <p><p>Contains information about an instance profile.</p> <p>This data type is used as a response element in the following operations:</p> <ul> <li> <p> <a>CreateInstanceProfile</a> </p> </li> <li> <p> <a>GetInstanceProfile</a> </p> </li> <li> <p> <a>ListInstanceProfiles</a> </p> </li> <li> <p> <a>ListInstanceProfilesForRole</a> </p> </li> </ul></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct InstanceProfile {
     /// <p> The Amazon Resource Name (ARN) specifying the instance profile. For more information about ARNs and how to use them in policies, see <a href="http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html">IAM Identifiers</a> in the <i>Using IAM</i> guide. </p>
     pub arn: String,
@@ -5347,7 +5347,7 @@ impl LineNumberDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListAccessKeysRequest {
     /// <p>Use this parameter only when paginating results and only after you receive a response indicating that the results are truncated. Set it to the value of the <code>Marker</code> element in the response that you received to indicate where the next call should start.</p>
     pub marker: Option<String>,
@@ -5388,7 +5388,7 @@ impl ListAccessKeysRequestSerializer {
 }
 
 /// <p>Contains the response to a successful <a>ListAccessKeys</a> request. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListAccessKeysResponse {
     /// <p>A list of objects containing metadata about the access keys.</p>
     pub access_key_metadata: Vec<AccessKeyMetadata>,
@@ -5451,7 +5451,7 @@ impl ListAccessKeysResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListAccountAliasesRequest {
     /// <p>Use this parameter only when paginating results and only after you receive a response indicating that the results are truncated. Set it to the value of the <code>Marker</code> element in the response that you received to indicate where the next call should start.</p>
     pub marker: Option<String>,
@@ -5484,7 +5484,7 @@ impl ListAccountAliasesRequestSerializer {
 }
 
 /// <p>Contains the response to a successful <a>ListAccountAliases</a> request. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListAccountAliasesResponse {
     /// <p>A list of aliases associated with the account. AWS supports only one alias per account.</p>
     pub account_aliases: Vec<String>,
@@ -5546,7 +5546,7 @@ impl ListAccountAliasesResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListAttachedGroupPoliciesRequest {
     /// <p>The name (friendly name, not ARN) of the group to list attached policies for.</p> <p>This parameter allows (per its <a href="http://wikipedia.org/wiki/regex">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-</p>
     pub group_name: String,
@@ -5593,7 +5593,7 @@ impl ListAttachedGroupPoliciesRequestSerializer {
 }
 
 /// <p>Contains the response to a successful <a>ListAttachedGroupPolicies</a> request. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListAttachedGroupPoliciesResponse {
     /// <p>A list of the attached policies.</p>
     pub attached_policies: Option<Vec<AttachedPolicy>>,
@@ -5656,7 +5656,7 @@ impl ListAttachedGroupPoliciesResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListAttachedRolePoliciesRequest {
     /// <p>Use this parameter only when paginating results and only after you receive a response indicating that the results are truncated. Set it to the value of the <code>Marker</code> element in the response that you received to indicate where the next call should start.</p>
     pub marker: Option<String>,
@@ -5703,7 +5703,7 @@ impl ListAttachedRolePoliciesRequestSerializer {
 }
 
 /// <p>Contains the response to a successful <a>ListAttachedRolePolicies</a> request. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListAttachedRolePoliciesResponse {
     /// <p>A list of the attached policies.</p>
     pub attached_policies: Option<Vec<AttachedPolicy>>,
@@ -5766,7 +5766,7 @@ impl ListAttachedRolePoliciesResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListAttachedUserPoliciesRequest {
     /// <p>Use this parameter only when paginating results and only after you receive a response indicating that the results are truncated. Set it to the value of the <code>Marker</code> element in the response that you received to indicate where the next call should start.</p>
     pub marker: Option<String>,
@@ -5813,7 +5813,7 @@ impl ListAttachedUserPoliciesRequestSerializer {
 }
 
 /// <p>Contains the response to a successful <a>ListAttachedUserPolicies</a> request. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListAttachedUserPoliciesResponse {
     /// <p>A list of the attached policies.</p>
     pub attached_policies: Option<Vec<AttachedPolicy>>,
@@ -5876,7 +5876,7 @@ impl ListAttachedUserPoliciesResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListEntitiesForPolicyRequest {
     /// <p>The entity type to use for filtering the results.</p> <p>For example, when <code>EntityFilter</code> is <code>Role</code>, only the roles that are attached to the specified policy are returned. This parameter is optional. If it is not included, all attached entities (users, groups, and roles) are returned. The argument for this parameter must be one of the valid values listed below.</p>
     pub entity_filter: Option<String>,
@@ -5931,7 +5931,7 @@ impl ListEntitiesForPolicyRequestSerializer {
 }
 
 /// <p>Contains the response to a successful <a>ListEntitiesForPolicy</a> request. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListEntitiesForPolicyResponse {
     /// <p>A flag that indicates whether there are more items to return. If your results were truncated, you can make a subsequent pagination request using the <code>Marker</code> request parameter to retrieve more items. Note that IAM might return fewer than the <code>MaxItems</code> number of results even when there are more results available. We recommend that you check <code>IsTruncated</code> after every call to ensure that you receive all of your results.</p>
     pub is_truncated: Option<bool>,
@@ -6008,7 +6008,7 @@ impl ListEntitiesForPolicyResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListGroupPoliciesRequest {
     /// <p>The name of the group to list policies for.</p> <p>This parameter allows (per its <a href="http://wikipedia.org/wiki/regex">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-</p>
     pub group_name: String,
@@ -6047,7 +6047,7 @@ impl ListGroupPoliciesRequestSerializer {
 }
 
 /// <p>Contains the response to a successful <a>ListGroupPolicies</a> request. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListGroupPoliciesResponse {
     /// <p>A flag that indicates whether there are more items to return. If your results were truncated, you can make a subsequent pagination request using the <code>Marker</code> request parameter to retrieve more items. Note that IAM might return fewer than the <code>MaxItems</code> number of results even when there are more results available. We recommend that you check <code>IsTruncated</code> after every call to ensure that you receive all of your results.</p>
     pub is_truncated: Option<bool>,
@@ -6109,7 +6109,7 @@ impl ListGroupPoliciesResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListGroupsForUserRequest {
     /// <p>Use this parameter only when paginating results and only after you receive a response indicating that the results are truncated. Set it to the value of the <code>Marker</code> element in the response that you received to indicate where the next call should start.</p>
     pub marker: Option<String>,
@@ -6148,7 +6148,7 @@ impl ListGroupsForUserRequestSerializer {
 }
 
 /// <p>Contains the response to a successful <a>ListGroupsForUser</a> request. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListGroupsForUserResponse {
     /// <p>A list of groups.</p>
     pub groups: Vec<Group>,
@@ -6207,7 +6207,7 @@ impl ListGroupsForUserResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListGroupsRequest {
     /// <p>Use this parameter only when paginating results and only after you receive a response indicating that the results are truncated. Set it to the value of the <code>Marker</code> element in the response that you received to indicate where the next call should start.</p>
     pub marker: Option<String>,
@@ -6248,7 +6248,7 @@ impl ListGroupsRequestSerializer {
 }
 
 /// <p>Contains the response to a successful <a>ListGroups</a> request. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListGroupsResponse {
     /// <p>A list of groups.</p>
     pub groups: Vec<Group>,
@@ -6307,7 +6307,7 @@ impl ListGroupsResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListInstanceProfilesForRoleRequest {
     /// <p>Use this parameter only when paginating results and only after you receive a response indicating that the results are truncated. Set it to the value of the <code>Marker</code> element in the response that you received to indicate where the next call should start.</p>
     pub marker: Option<String>,
@@ -6346,7 +6346,7 @@ impl ListInstanceProfilesForRoleRequestSerializer {
 }
 
 /// <p>Contains the response to a successful <a>ListInstanceProfilesForRole</a> request. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListInstanceProfilesForRoleResponse {
     /// <p>A list of instance profiles.</p>
     pub instance_profiles: Vec<InstanceProfile>,
@@ -6409,7 +6409,7 @@ impl ListInstanceProfilesForRoleResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListInstanceProfilesRequest {
     /// <p>Use this parameter only when paginating results and only after you receive a response indicating that the results are truncated. Set it to the value of the <code>Marker</code> element in the response that you received to indicate where the next call should start.</p>
     pub marker: Option<String>,
@@ -6450,7 +6450,7 @@ impl ListInstanceProfilesRequestSerializer {
 }
 
 /// <p>Contains the response to a successful <a>ListInstanceProfiles</a> request. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListInstanceProfilesResponse {
     /// <p>A list of instance profiles.</p>
     pub instance_profiles: Vec<InstanceProfile>,
@@ -6513,7 +6513,7 @@ impl ListInstanceProfilesResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListMFADevicesRequest {
     /// <p>Use this parameter only when paginating results and only after you receive a response indicating that the results are truncated. Set it to the value of the <code>Marker</code> element in the response that you received to indicate where the next call should start.</p>
     pub marker: Option<String>,
@@ -6554,7 +6554,7 @@ impl ListMFADevicesRequestSerializer {
 }
 
 /// <p>Contains the response to a successful <a>ListMFADevices</a> request. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListMFADevicesResponse {
     /// <p>A flag that indicates whether there are more items to return. If your results were truncated, you can make a subsequent pagination request using the <code>Marker</code> request parameter to retrieve more items. Note that IAM might return fewer than the <code>MaxItems</code> number of results even when there are more results available. We recommend that you check <code>IsTruncated</code> after every call to ensure that you receive all of your results.</p>
     pub is_truncated: Option<bool>,
@@ -6616,7 +6616,7 @@ impl ListMFADevicesResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListOpenIDConnectProvidersRequest {}
 
 /// Serialize `ListOpenIDConnectProvidersRequest` contents to a `SignedRequest`.
@@ -6631,7 +6631,7 @@ impl ListOpenIDConnectProvidersRequestSerializer {
 }
 
 /// <p>Contains the response to a successful <a>ListOpenIDConnectProviders</a> request. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListOpenIDConnectProvidersResponse {
     /// <p>The list of IAM OIDC provider resource objects defined in the AWS account.</p>
     pub open_id_connect_provider_list: Option<Vec<OpenIDConnectProviderListEntry>>,
@@ -6681,7 +6681,7 @@ impl ListOpenIDConnectProvidersResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListPoliciesRequest {
     /// <p>Use this parameter only when paginating results and only after you receive a response indicating that the results are truncated. Set it to the value of the <code>Marker</code> element in the response that you received to indicate where the next call should start.</p>
     pub marker: Option<String>,
@@ -6738,7 +6738,7 @@ impl ListPoliciesRequestSerializer {
 }
 
 /// <p>Contains the response to a successful <a>ListPolicies</a> request. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListPoliciesResponse {
     /// <p>A flag that indicates whether there are more items to return. If your results were truncated, you can make a subsequent pagination request using the <code>Marker</code> request parameter to retrieve more items. Note that IAM might return fewer than the <code>MaxItems</code> number of results even when there are more results available. We recommend that you check <code>IsTruncated</code> after every call to ensure that you receive all of your results.</p>
     pub is_truncated: Option<bool>,
@@ -6799,7 +6799,7 @@ impl ListPoliciesResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListPolicyVersionsRequest {
     /// <p>Use this parameter only when paginating results and only after you receive a response indicating that the results are truncated. Set it to the value of the <code>Marker</code> element in the response that you received to indicate where the next call should start.</p>
     pub marker: Option<String>,
@@ -6838,7 +6838,7 @@ impl ListPolicyVersionsRequestSerializer {
 }
 
 /// <p>Contains the response to a successful <a>ListPolicyVersions</a> request. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListPolicyVersionsResponse {
     /// <p>A flag that indicates whether there are more items to return. If your results were truncated, you can make a subsequent pagination request using the <code>Marker</code> request parameter to retrieve more items. Note that IAM might return fewer than the <code>MaxItems</code> number of results even when there are more results available. We recommend that you check <code>IsTruncated</code> after every call to ensure that you receive all of your results.</p>
     pub is_truncated: Option<bool>,
@@ -6901,7 +6901,7 @@ impl ListPolicyVersionsResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListRolePoliciesRequest {
     /// <p>Use this parameter only when paginating results and only after you receive a response indicating that the results are truncated. Set it to the value of the <code>Marker</code> element in the response that you received to indicate where the next call should start.</p>
     pub marker: Option<String>,
@@ -6940,7 +6940,7 @@ impl ListRolePoliciesRequestSerializer {
 }
 
 /// <p>Contains the response to a successful <a>ListRolePolicies</a> request. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListRolePoliciesResponse {
     /// <p>A flag that indicates whether there are more items to return. If your results were truncated, you can make a subsequent pagination request using the <code>Marker</code> request parameter to retrieve more items. Note that IAM might return fewer than the <code>MaxItems</code> number of results even when there are more results available. We recommend that you check <code>IsTruncated</code> after every call to ensure that you receive all of your results.</p>
     pub is_truncated: Option<bool>,
@@ -7002,7 +7002,7 @@ impl ListRolePoliciesResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListRolesRequest {
     /// <p>Use this parameter only when paginating results and only after you receive a response indicating that the results are truncated. Set it to the value of the <code>Marker</code> element in the response that you received to indicate where the next call should start.</p>
     pub marker: Option<String>,
@@ -7043,7 +7043,7 @@ impl ListRolesRequestSerializer {
 }
 
 /// <p>Contains the response to a successful <a>ListRoles</a> request. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListRolesResponse {
     /// <p>A flag that indicates whether there are more items to return. If your results were truncated, you can make a subsequent pagination request using the <code>Marker</code> request parameter to retrieve more items. Note that IAM might return fewer than the <code>MaxItems</code> number of results even when there are more results available. We recommend that you check <code>IsTruncated</code> after every call to ensure that you receive all of your results.</p>
     pub is_truncated: Option<bool>,
@@ -7102,7 +7102,7 @@ impl ListRolesResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListSAMLProvidersRequest {}
 
 /// Serialize `ListSAMLProvidersRequest` contents to a `SignedRequest`.
@@ -7117,7 +7117,7 @@ impl ListSAMLProvidersRequestSerializer {
 }
 
 /// <p>Contains the response to a successful <a>ListSAMLProviders</a> request. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListSAMLProvidersResponse {
     /// <p>The list of SAML provider resource objects defined in IAM for this AWS account.</p>
     pub saml_provider_list: Option<Vec<SAMLProviderListEntry>>,
@@ -7166,7 +7166,7 @@ impl ListSAMLProvidersResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListSSHPublicKeysRequest {
     /// <p>Use this parameter only when paginating results and only after you receive a response indicating that the results are truncated. Set it to the value of the <code>Marker</code> element in the response that you received to indicate where the next call should start.</p>
     pub marker: Option<String>,
@@ -7207,7 +7207,7 @@ impl ListSSHPublicKeysRequestSerializer {
 }
 
 /// <p>Contains the response to a successful <a>ListSSHPublicKeys</a> request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListSSHPublicKeysResponse {
     /// <p>A flag that indicates whether there are more items to return. If your results were truncated, you can make a subsequent pagination request using the <code>Marker</code> request parameter to retrieve more items. Note that IAM might return fewer than the <code>MaxItems</code> number of results even when there are more results available. We recommend that you check <code>IsTruncated</code> after every call to ensure that you receive all of your results.</p>
     pub is_truncated: Option<bool>,
@@ -7268,7 +7268,7 @@ impl ListSSHPublicKeysResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListServerCertificatesRequest {
     /// <p>Use this parameter only when paginating results and only after you receive a response indicating that the results are truncated. Set it to the value of the <code>Marker</code> element in the response that you received to indicate where the next call should start.</p>
     pub marker: Option<String>,
@@ -7309,7 +7309,7 @@ impl ListServerCertificatesRequestSerializer {
 }
 
 /// <p>Contains the response to a successful <a>ListServerCertificates</a> request. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListServerCertificatesResponse {
     /// <p>A flag that indicates whether there are more items to return. If your results were truncated, you can make a subsequent pagination request using the <code>Marker</code> request parameter to retrieve more items. Note that IAM might return fewer than the <code>MaxItems</code> number of results even when there are more results available. We recommend that you check <code>IsTruncated</code> after every call to ensure that you receive all of your results.</p>
     pub is_truncated: Option<bool>,
@@ -7372,7 +7372,7 @@ impl ListServerCertificatesResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListServiceSpecificCredentialsRequest {
     /// <p>Filters the returned results to only those for the specified AWS service. If not specified, then AWS returns service-specific credentials for all services.</p>
     pub service_name: Option<String>,
@@ -7404,7 +7404,7 @@ impl ListServiceSpecificCredentialsRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListServiceSpecificCredentialsResponse {
     /// <p>A list of structures that each contain details about a service-specific credential.</p>
     pub service_specific_credentials: Option<Vec<ServiceSpecificCredentialMetadata>>,
@@ -7454,7 +7454,7 @@ impl ListServiceSpecificCredentialsResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListSigningCertificatesRequest {
     /// <p>Use this parameter only when paginating results and only after you receive a response indicating that the results are truncated. Set it to the value of the <code>Marker</code> element in the response that you received to indicate where the next call should start.</p>
     pub marker: Option<String>,
@@ -7495,7 +7495,7 @@ impl ListSigningCertificatesRequestSerializer {
 }
 
 /// <p>Contains the response to a successful <a>ListSigningCertificates</a> request. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListSigningCertificatesResponse {
     /// <p>A list of the user's signing certificate information.</p>
     pub certificates: Vec<SigningCertificate>,
@@ -7557,7 +7557,7 @@ impl ListSigningCertificatesResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListUserPoliciesRequest {
     /// <p>Use this parameter only when paginating results and only after you receive a response indicating that the results are truncated. Set it to the value of the <code>Marker</code> element in the response that you received to indicate where the next call should start.</p>
     pub marker: Option<String>,
@@ -7596,7 +7596,7 @@ impl ListUserPoliciesRequestSerializer {
 }
 
 /// <p>Contains the response to a successful <a>ListUserPolicies</a> request. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListUserPoliciesResponse {
     /// <p>A flag that indicates whether there are more items to return. If your results were truncated, you can make a subsequent pagination request using the <code>Marker</code> request parameter to retrieve more items. Note that IAM might return fewer than the <code>MaxItems</code> number of results even when there are more results available. We recommend that you check <code>IsTruncated</code> after every call to ensure that you receive all of your results.</p>
     pub is_truncated: Option<bool>,
@@ -7658,7 +7658,7 @@ impl ListUserPoliciesResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListUsersRequest {
     /// <p>Use this parameter only when paginating results and only after you receive a response indicating that the results are truncated. Set it to the value of the <code>Marker</code> element in the response that you received to indicate where the next call should start.</p>
     pub marker: Option<String>,
@@ -7699,7 +7699,7 @@ impl ListUsersRequestSerializer {
 }
 
 /// <p>Contains the response to a successful <a>ListUsers</a> request. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListUsersResponse {
     /// <p>A flag that indicates whether there are more items to return. If your results were truncated, you can make a subsequent pagination request using the <code>Marker</code> request parameter to retrieve more items. Note that IAM might return fewer than the <code>MaxItems</code> number of results even when there are more results available. We recommend that you check <code>IsTruncated</code> after every call to ensure that you receive all of your results.</p>
     pub is_truncated: Option<bool>,
@@ -7758,7 +7758,7 @@ impl ListUsersResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListVirtualMFADevicesRequest {
     /// <p> The status (<code>Unassigned</code> or <code>Assigned</code>) of the devices to list. If you do not specify an <code>AssignmentStatus</code>, the operation defaults to <code>Any</code> which lists both assigned and unassigned virtual MFA devices.</p>
     pub assignment_status: Option<String>,
@@ -7799,7 +7799,7 @@ impl ListVirtualMFADevicesRequestSerializer {
 }
 
 /// <p>Contains the response to a successful <a>ListVirtualMFADevices</a> request. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListVirtualMFADevicesResponse {
     /// <p>A flag that indicates whether there are more items to return. If your results were truncated, you can make a subsequent pagination request using the <code>Marker</code> request parameter to retrieve more items. Note that IAM might return fewer than the <code>MaxItems</code> number of results even when there are more results available. We recommend that you check <code>IsTruncated</code> after every call to ensure that you receive all of your results.</p>
     pub is_truncated: Option<bool>,
@@ -7863,7 +7863,7 @@ impl ListVirtualMFADevicesResponseDeserializer {
     }
 }
 /// <p>Contains the user name and password create date for a user.</p> <p> This data type is used as a response element in the <a>CreateLoginProfile</a> and <a>GetLoginProfile</a> operations. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct LoginProfile {
     /// <p>The date when the password for the user was created.</p>
     pub create_date: String,
@@ -7923,7 +7923,7 @@ impl LoginProfileDeserializer {
     }
 }
 /// <p>Contains information about an MFA device.</p> <p>This data type is used as a response element in the <a>ListMFADevices</a> operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct MFADevice {
     /// <p>The date when the MFA device was enabled for the user.</p>
     pub enable_date: String,
@@ -7984,7 +7984,7 @@ impl MFADeviceDeserializer {
     }
 }
 /// <p>Contains information about a managed policy, including the policy's ARN, versions, and the number of principal entities (users, groups, and roles) that the policy is attached to.</p> <p>This data type is used as a response element in the <a>GetAccountAuthorizationDetails</a> operation.</p> <p>For more information about managed policies, see <a href="http://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html">Managed Policies and Inline Policies</a> in the <i>Using IAM</i> guide. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ManagedPolicyDetail {
     pub arn: Option<String>,
     /// <p>The number of principal entities (users, groups, and roles) that the policy is attached to.</p>
@@ -8224,7 +8224,7 @@ impl MinimumPasswordLengthTypeDeserializer {
     }
 }
 /// <p>Contains the Amazon Resource Name (ARN) for an IAM OpenID Connect provider.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct OpenIDConnectProviderListEntry {
     pub arn: Option<String>,
 }
@@ -8327,7 +8327,7 @@ impl OpenIDConnectProviderUrlTypeDeserializer {
     }
 }
 /// <p>Contains information about AWS Organizations's effect on a policy simulation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct OrganizationsDecisionDetail {
     /// <p>Specifies whether the simulated operation is allowed by the AWS Organizations service control policies that impact the simulated user's account.</p>
     pub allowed_by_organizations: Option<bool>,
@@ -8375,7 +8375,7 @@ impl OrganizationsDecisionDetailDeserializer {
     }
 }
 /// <p>Contains information about the account password policy.</p> <p> This data type is used as a response element in the <a>GetAccountPasswordPolicy</a> operation. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PasswordPolicy {
     /// <p>Specifies whether IAM users are allowed to change their own password.</p>
     pub allow_users_to_change_password: Option<bool>,
@@ -8528,7 +8528,7 @@ impl PathTypeDeserializer {
     }
 }
 /// <p>Contains information about a managed policy.</p> <p>This data type is used as a response element in the <a>CreatePolicy</a>, <a>GetPolicy</a>, and <a>ListPolicies</a> operations. </p> <p>For more information about managed policies, refer to <a href="http://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html">Managed Policies and Inline Policies</a> in the <i>Using IAM</i> guide. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Policy {
     pub arn: Option<String>,
     /// <p>The number of entities (users, groups, and roles) that the policy is attached to.</p>
@@ -8648,7 +8648,7 @@ impl PolicyDescriptionTypeDeserializer {
     }
 }
 /// <p>Contains information about an IAM policy, including the policy document.</p> <p>This data type is used as a response element in the <a>GetAccountAuthorizationDetails</a> operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PolicyDetail {
     /// <p>The policy document.</p>
     pub policy_document: Option<String>,
@@ -8814,7 +8814,7 @@ impl PolicyEvaluationDecisionTypeDeserializer {
     }
 }
 /// <p>Contains information about a group that a managed policy is attached to.</p> <p>This data type is used as a response element in the <a>ListEntitiesForPolicy</a> operation. </p> <p>For more information about managed policies, refer to <a href="http://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html">Managed Policies and Inline Policies</a> in the <i>Using IAM</i> guide. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PolicyGroup {
     /// <p>The stable and unique string identifying the group. For more information about IDs, see <a href="http://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html">IAM Identifiers</a> in the <i>IAM User Guide</i>.</p>
     pub group_id: Option<String>,
@@ -9033,7 +9033,7 @@ impl PolicyPathTypeDeserializer {
     }
 }
 /// <p>Contains information about a role that a managed policy is attached to.</p> <p>This data type is used as a response element in the <a>ListEntitiesForPolicy</a> operation. </p> <p>For more information about managed policies, refer to <a href="http://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html">Managed Policies and Inline Policies</a> in the <i>Using IAM</i> guide. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PolicyRole {
     /// <p>The stable and unique string identifying the role. For more information about IDs, see <a href="http://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html">IAM Identifiers</a> in the <i>IAM User Guide</i>.</p>
     pub role_id: Option<String>,
@@ -9140,7 +9140,7 @@ impl PolicySourceTypeDeserializer {
     }
 }
 /// <p>Contains information about a user that a managed policy is attached to.</p> <p>This data type is used as a response element in the <a>ListEntitiesForPolicy</a> operation. </p> <p>For more information about managed policies, refer to <a href="http://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html">Managed Policies and Inline Policies</a> in the <i>Using IAM</i> guide. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PolicyUser {
     /// <p>The stable and unique string identifying the user. For more information about IDs, see <a href="http://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html">IAM Identifiers</a> in the <i>IAM User Guide</i>.</p>
     pub user_id: Option<String>,
@@ -9233,7 +9233,7 @@ impl PolicyUserListTypeDeserializer {
     }
 }
 /// <p>Contains information about a version of a managed policy.</p> <p>This data type is used as a response element in the <a>CreatePolicyVersion</a>, <a>GetPolicyVersion</a>, <a>ListPolicyVersions</a>, and <a>GetAccountAuthorizationDetails</a> operations. </p> <p>For more information about managed policies, refer to <a href="http://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html">Managed Policies and Inline Policies</a> in the <i>Using IAM</i> guide. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PolicyVersion {
     /// <p>The date and time, in <a href="http://www.iso.org/iso/iso8601">ISO 8601 date-time format</a>, when the policy version was created.</p>
     pub create_date: Option<String>,
@@ -9317,7 +9317,7 @@ impl PolicyVersionIdTypeDeserializer {
     }
 }
 /// <p>Contains the row and column of a location of a <code>Statement</code> element in a policy document.</p> <p>This data type is used as a member of the <code> <a>Statement</a> </code> type.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Position {
     /// <p>The column in the line containing the specified position in the document.</p>
     pub column: Option<i64>,
@@ -9410,7 +9410,7 @@ impl PublicKeyMaterialTypeDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PutGroupPolicyRequest {
     /// <p>The name of the group to associate the policy with.</p> <p>This parameter allows (per its <a href="http://wikipedia.org/wiki/regex">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-</p>
     pub group_name: String,
@@ -9444,7 +9444,7 @@ impl PutGroupPolicyRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PutRolePolicyRequest {
     /// <p><p>The policy document.</p> <p>The <a href="http://wikipedia.org/wiki/regex">regex pattern</a> used to validate this parameter is a string of characters consisting of the following:</p> <ul> <li> <p>Any printable ASCII character ranging from the space character (\u0020) through the end of the ASCII character range</p> </li> <li> <p>The printable characters in the Basic Latin and Latin-1 Supplement character set (through \u00FF)</p> </li> <li> <p>The special characters tab (\u0009), line feed (\u000A), and carriage return (\u000D)</p> </li> </ul></p>
     pub policy_document: String,
@@ -9478,7 +9478,7 @@ impl PutRolePolicyRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PutUserPolicyRequest {
     /// <p><p>The policy document.</p> <p>The <a href="http://wikipedia.org/wiki/regex">regex pattern</a> used to validate this parameter is a string of characters consisting of the following:</p> <ul> <li> <p>Any printable ASCII character ranging from the space character (\u0020) through the end of the ASCII character range</p> </li> <li> <p>The printable characters in the Basic Latin and Latin-1 Supplement character set (through \u00FF)</p> </li> <li> <p>The special characters tab (\u0009), line feed (\u000A), and carriage return (\u000D)</p> </li> </ul></p>
     pub policy_document: String,
@@ -9540,7 +9540,7 @@ impl RegionNameTypeDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RemoveClientIDFromOpenIDConnectProviderRequest {
     /// <p>The client ID (also known as audience) to remove from the IAM OIDC provider resource. For more information about client IDs, see <a>CreateOpenIDConnectProvider</a>.</p>
     pub client_id: String,
@@ -9572,7 +9572,7 @@ impl RemoveClientIDFromOpenIDConnectProviderRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RemoveRoleFromInstanceProfileRequest {
     /// <p>The name of the instance profile to update.</p> <p>This parameter allows (per its <a href="http://wikipedia.org/wiki/regex">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-</p>
     pub instance_profile_name: String,
@@ -9600,7 +9600,7 @@ impl RemoveRoleFromInstanceProfileRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RemoveUserFromGroupRequest {
     /// <p>The name of the group to update.</p> <p>This parameter allows (per its <a href="http://wikipedia.org/wiki/regex">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-</p>
     pub group_name: String,
@@ -9684,7 +9684,7 @@ impl ReportStateTypeDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ResetServiceSpecificCredentialRequest {
     /// <p>The unique identifier of the service-specific credential.</p> <p>This parameter allows (per its <a href="http://wikipedia.org/wiki/regex">regex pattern</a>) a string of characters that can consist of any upper or lowercased letter or digit.</p>
     pub service_specific_credential_id: String,
@@ -9714,7 +9714,7 @@ impl ResetServiceSpecificCredentialRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ResetServiceSpecificCredentialResponse {
     /// <p><p>A structure with details about the updated service-specific credential, including the new password.</p> <important> <p>This is the <b>only</b> time that you can access the password. You cannot recover the password later, but you can reset it again.</p> </important></p>
     pub service_specific_credential: Option<ServiceSpecificCredential>,
@@ -9790,7 +9790,7 @@ impl ResourceNameTypeDeserializer {
     }
 }
 /// <p>Contains the result of the simulation of a single API operation call on a single resource.</p> <p>This data type is used by a member of the <a>EvaluationResult</a> data type.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ResourceSpecificResult {
     /// <p>Additional details about the results of the evaluation decision. When there are both IAM policies and resource policies, this parameter explains how each set of policies contributes to the final evaluation decision. When simulating cross-account access to a resource, both the resource-based policy and the caller's IAM policy must grant access.</p>
     pub eval_decision_details: Option<::std::collections::HashMap<String, String>>,
@@ -9915,7 +9915,7 @@ impl ResourceSpecificResultListTypeDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ResyncMFADeviceRequest {
     /// <p>An authentication code emitted by the device.</p> <p>The format for this parameter is a sequence of six digits.</p>
     pub authentication_code_1: String,
@@ -9956,7 +9956,7 @@ impl ResyncMFADeviceRequestSerializer {
 }
 
 /// <p>Contains information about an IAM role. This structure is returned as a response element in several API operations that interact with roles.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Role {
     /// <p> The Amazon Resource Name (ARN) specifying the role. For more information about ARNs and how to use them in policies, see <a href="http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html">IAM Identifiers</a> in the <i>IAM User Guide</i> guide. </p>
     pub arn: String,
@@ -10064,7 +10064,7 @@ impl RoleDescriptionTypeDeserializer {
     }
 }
 /// <p>Contains information about an IAM role, including all of the role's policies.</p> <p>This data type is used as a response element in the <a>GetAccountAuthorizationDetails</a> operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RoleDetail {
     pub arn: Option<String>,
     /// <p>The trust policy that grants permission to assume the role.</p>
@@ -10316,7 +10316,7 @@ impl RoleUsageListTypeDeserializer {
     }
 }
 /// <p>An object that contains details about how a service-linked role is used, if that information is returned by the service.</p> <p>This data type is used as a response element in the <a>GetServiceLinkedRoleDeletionStatus</a> operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RoleUsageType {
     /// <p>The name of the region where the service-linked role is being used.</p>
     pub region: Option<String>,
@@ -10386,7 +10386,7 @@ impl SAMLMetadataDocumentTypeDeserializer {
     }
 }
 /// <p>Contains the list of SAML providers for this account.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SAMLProviderListEntry {
     /// <p>The Amazon Resource Name (ARN) of the SAML provider.</p>
     pub arn: Option<String>,
@@ -10486,7 +10486,7 @@ impl SAMLProviderListTypeDeserializer {
     }
 }
 /// <p>Contains information about an SSH public key.</p> <p>This data type is used as a response element in the <a>GetSSHPublicKey</a> and <a>UploadSSHPublicKey</a> operations. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SSHPublicKey {
     /// <p>The MD5 message digest of the SSH public key.</p>
     pub fingerprint: String,
@@ -10611,7 +10611,7 @@ impl SSHPublicKeyListTypeDeserializer {
     }
 }
 /// <p>Contains information about an SSH public key, without the key's body or fingerprint.</p> <p>This data type is used as a response element in the <a>ListSSHPublicKeys</a> operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SSHPublicKeyMetadata {
     /// <p>The unique identifier for the SSH public key.</p>
     pub ssh_public_key_id: String,
@@ -10691,7 +10691,7 @@ impl SerialNumberTypeDeserializer {
     }
 }
 /// <p>Contains information about a server certificate.</p> <p> This data type is used as a response element in the <a>GetServerCertificate</a> operation. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ServerCertificate {
     /// <p>The contents of the public key certificate.</p>
     pub certificate_body: String,
@@ -10758,7 +10758,7 @@ impl ServerCertificateDeserializer {
     }
 }
 /// <p>Contains information about a server certificate without its certificate body, certificate chain, and private key.</p> <p> This data type is used as a response element in the <a>UploadServerCertificate</a> and <a>ListServerCertificates</a> operations. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ServerCertificateMetadata {
     /// <p> The Amazon Resource Name (ARN) specifying the server certificate. For more information about ARNs and how to use them in policies, see <a href="http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html">IAM Identifiers</a> in the <i>Using IAM</i> guide. </p>
     pub arn: String,
@@ -10922,7 +10922,7 @@ impl ServicePasswordDeserializer {
     }
 }
 /// <p>Contains the details of a service-specific credential.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ServiceSpecificCredential {
     /// <p>The date and time, in <a href="http://www.iso.org/iso/iso8601">ISO 8601 date-time format</a>, when the service-specific credential were created.</p>
     pub create_date: String,
@@ -11025,7 +11025,7 @@ impl ServiceSpecificCredentialIdDeserializer {
     }
 }
 /// <p>Contains additional details about a service-specific credential.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ServiceSpecificCredentialMetadata {
     /// <p>The date and time, in <a href="http://www.iso.org/iso/iso8601">ISO 8601 date-time format</a>, when the service-specific credential were created.</p>
     pub create_date: String,
@@ -11163,7 +11163,7 @@ impl ServiceUserNameDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SetDefaultPolicyVersionRequest {
     /// <p>The Amazon Resource Name (ARN) of the IAM policy whose default version you want to set.</p> <p>For more information about ARNs, see <a href="http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html">Amazon Resource Names (ARNs) and AWS Service Namespaces</a> in the <i>AWS General Reference</i>.</p>
     pub policy_arn: String,
@@ -11192,7 +11192,7 @@ impl SetDefaultPolicyVersionRequestSerializer {
 }
 
 /// <p>Contains information about an X.509 signing certificate.</p> <p>This data type is used as a response element in the <a>UploadSigningCertificate</a> and <a>ListSigningCertificates</a> operations. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SigningCertificate {
     /// <p>The contents of the signing certificate.</p>
     pub certificate_body: String,
@@ -11265,7 +11265,7 @@ impl SigningCertificateDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SimulateCustomPolicyRequest {
     /// <p>A list of names of API operations to evaluate in the simulation. Each operation is evaluated against each resource. Each operation must include the service identifier, such as <code>iam:CreateUser</code>.</p>
     pub action_names: Vec<String>,
@@ -11362,7 +11362,7 @@ impl SimulateCustomPolicyRequestSerializer {
 }
 
 /// <p>Contains the response to a successful <a>SimulatePrincipalPolicy</a> or <a>SimulateCustomPolicy</a> request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SimulatePolicyResponse {
     /// <p>The results of the simulation.</p>
     pub evaluation_results: Option<Vec<EvaluationResult>>,
@@ -11425,7 +11425,7 @@ impl SimulatePolicyResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SimulatePrincipalPolicyRequest {
     /// <p>A list of names of API operations to evaluate in the simulation. Each operation is evaluated for each resource. Each operation must include the service identifier, such as <code>iam:CreateUser</code>.</p>
     pub action_names: Vec<String>,
@@ -11541,7 +11541,7 @@ impl SimulationPolicyListTypeSerializer {
 }
 
 /// <p>Contains a reference to a <code>Statement</code> element in a policy document that determines the result of the simulation.</p> <p>This data type is used by the <code>MatchedStatements</code> member of the <code> <a>EvaluationResult</a> </code> type.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Statement {
     /// <p>The row and column of the end of a <code>Statement</code> in an IAM policy.</p>
     pub end_position: Option<Position>,
@@ -11798,7 +11798,7 @@ impl ThumbprintTypeDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateAccessKeyRequest {
     /// <p>The access key ID of the secret access key you want to update.</p> <p>This parameter allows (per its <a href="http://wikipedia.org/wiki/regex">regex pattern</a>) a string of characters that can consist of any upper or lowercased letter or digit.</p>
     pub access_key_id: String,
@@ -11834,7 +11834,7 @@ impl UpdateAccessKeyRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateAccountPasswordPolicyRequest {
     /// <p> Allows all IAM users in your account to use the AWS Management Console to change their own passwords. For more information, see <a href="http://docs.aws.amazon.com/IAM/latest/UserGuide/HowToPwdIAMUser.html">Letting IAM Users Change Their Own Passwords</a> in the <i>IAM User Guide</i>.</p> <p>If you do not specify a value for this parameter, then the operation uses the default value of <code>false</code>. The result is that IAM users in the account do not automatically have permissions to change their own password.</p>
     pub allow_users_to_change_password: Option<bool>,
@@ -11922,7 +11922,7 @@ impl UpdateAccountPasswordPolicyRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateAssumeRolePolicyRequest {
     /// <p><p>The policy that grants an entity permission to assume the role.</p> <p>The <a href="http://wikipedia.org/wiki/regex">regex pattern</a> used to validate this parameter is a string of characters consisting of the following:</p> <ul> <li> <p>Any printable ASCII character ranging from the space character (\u0020) through the end of the ASCII character range</p> </li> <li> <p>The printable characters in the Basic Latin and Latin-1 Supplement character set (through \u00FF)</p> </li> <li> <p>The special characters tab (\u0009), line feed (\u000A), and carriage return (\u000D)</p> </li> </ul></p>
     pub policy_document: String,
@@ -11950,7 +11950,7 @@ impl UpdateAssumeRolePolicyRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateGroupRequest {
     /// <p>Name of the IAM group to update. If you're changing the name of the group, this is the original name.</p> <p>This parameter allows (per its <a href="http://wikipedia.org/wiki/regex">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-</p>
     pub group_name: String,
@@ -11988,7 +11988,7 @@ impl UpdateGroupRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateLoginProfileRequest {
     /// <p>The new password for the specified IAM user.</p> <p>The <a href="http://wikipedia.org/wiki/regex">regex pattern</a> used to validate this parameter is a string of characters consisting of the following:</p> <ul> <li> <p>Any printable ASCII character ranging from the space character (\u0020) through the end of the ASCII character range</p> </li> <li> <p>The printable characters in the Basic Latin and Latin-1 Supplement character set (through \u00FF)</p> </li> <li> <p>The special characters tab (\u0009), line feed (\u000A), and carriage return (\u000D)</p> </li> </ul> <p>However, the format can be further restricted by the account administrator by setting a password policy on the AWS account. For more information, see <a>UpdateAccountPasswordPolicy</a>.</p>
     pub password: Option<String>,
@@ -12026,7 +12026,7 @@ impl UpdateLoginProfileRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateOpenIDConnectProviderThumbprintRequest {
     /// <p>The Amazon Resource Name (ARN) of the IAM OIDC provider resource object for which you want to update the thumbprint. You can get a list of OIDC provider ARNs by using the <a>ListOpenIDConnectProviders</a> operation.</p> <p>For more information about ARNs, see <a href="http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html">Amazon Resource Names (ARNs) and AWS Service Namespaces</a> in the <i>AWS General Reference</i>.</p>
     pub open_id_connect_provider_arn: String,
@@ -12059,7 +12059,7 @@ impl UpdateOpenIDConnectProviderThumbprintRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateRoleDescriptionRequest {
     /// <p>The new description that you want to apply to the specified role.</p>
     pub description: String,
@@ -12087,7 +12087,7 @@ impl UpdateRoleDescriptionRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateRoleDescriptionResponse {
     /// <p>A structure that contains details about the modified role.</p>
     pub role: Option<Role>,
@@ -12132,7 +12132,7 @@ impl UpdateRoleDescriptionResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateRoleRequest {
     /// <p>The new description that you want to apply to the specified role.</p>
     pub description: Option<String>,
@@ -12170,7 +12170,7 @@ impl UpdateRoleRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateRoleResponse {}
 
 struct UpdateRoleResponseDeserializer;
@@ -12189,7 +12189,7 @@ impl UpdateRoleResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateSAMLProviderRequest {
     /// <p>An XML document generated by an identity provider (IdP) that supports SAML 2.0. The document includes the issuer's name, expiration information, and keys that can be used to validate the SAML authentication response (assertions) that are received from the IdP. You must generate the metadata document using the identity management software that is used as your organization's IdP.</p>
     pub saml_metadata_document: String,
@@ -12218,7 +12218,7 @@ impl UpdateSAMLProviderRequestSerializer {
 }
 
 /// <p>Contains the response to a successful <a>UpdateSAMLProvider</a> request. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateSAMLProviderResponse {
     /// <p>The Amazon Resource Name (ARN) of the SAML provider that was updated.</p>
     pub saml_provider_arn: Option<String>,
@@ -12266,7 +12266,7 @@ impl UpdateSAMLProviderResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateSSHPublicKeyRequest {
     /// <p>The unique identifier for the SSH public key.</p> <p>This parameter allows (per its <a href="http://wikipedia.org/wiki/regex">regex pattern</a>) a string of characters that can consist of any upper or lowercased letter or digit.</p>
     pub ssh_public_key_id: String,
@@ -12300,7 +12300,7 @@ impl UpdateSSHPublicKeyRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateServerCertificateRequest {
     /// <p>The new path for the server certificate. Include this only if you are updating the server certificate's path.</p> <p>This parameter allows (per its <a href="http://wikipedia.org/wiki/regex">regex pattern</a>) a string of characters consisting of either a forward slash (/) by itself or a string that must begin and end with forward slashes. In addition, it can contain any ASCII character from the ! (\u0021) through the DEL character (\u007F), including most punctuation characters, digits, and upper and lowercased letters.</p>
     pub new_path: Option<String>,
@@ -12338,7 +12338,7 @@ impl UpdateServerCertificateRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateServiceSpecificCredentialRequest {
     /// <p>The unique identifier of the service-specific credential.</p> <p>This parameter allows (per its <a href="http://wikipedia.org/wiki/regex">regex pattern</a>) a string of characters that can consist of any upper or lowercased letter or digit.</p>
     pub service_specific_credential_id: String,
@@ -12374,7 +12374,7 @@ impl UpdateServiceSpecificCredentialRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateSigningCertificateRequest {
     /// <p>The ID of the signing certificate you want to update.</p> <p>This parameter allows (per its <a href="http://wikipedia.org/wiki/regex">regex pattern</a>) a string of characters that can consist of any upper or lowercased letter or digit.</p>
     pub certificate_id: String,
@@ -12410,7 +12410,7 @@ impl UpdateSigningCertificateRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateUserRequest {
     /// <p>New path for the IAM user. Include this parameter only if you're changing the user's path.</p> <p>This parameter allows (per its <a href="http://wikipedia.org/wiki/regex">regex pattern</a>) a string of characters consisting of either a forward slash (/) by itself or a string that must begin and end with forward slashes. In addition, it can contain any ASCII character from the ! (\u0021) through the DEL character (\u007F), including most punctuation characters, digits, and upper and lowercased letters.</p>
     pub new_path: Option<String>,
@@ -12448,7 +12448,7 @@ impl UpdateUserRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UploadSSHPublicKeyRequest {
     /// <p><p>The SSH public key. The public key must be encoded in ssh-rsa format or PEM format.</p> <p>The <a href="http://wikipedia.org/wiki/regex">regex pattern</a> used to validate this parameter is a string of characters consisting of the following:</p> <ul> <li> <p>Any printable ASCII character ranging from the space character (\u0020) through the end of the ASCII character range</p> </li> <li> <p>The printable characters in the Basic Latin and Latin-1 Supplement character set (through \u00FF)</p> </li> <li> <p>The special characters tab (\u0009), line feed (\u000A), and carriage return (\u000D)</p> </li> </ul></p>
     pub ssh_public_key_body: String,
@@ -12477,7 +12477,7 @@ impl UploadSSHPublicKeyRequestSerializer {
 }
 
 /// <p>Contains the response to a successful <a>UploadSSHPublicKey</a> request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UploadSSHPublicKeyResponse {
     /// <p>Contains information about the SSH public key.</p>
     pub ssh_public_key: Option<SSHPublicKey>,
@@ -12525,7 +12525,7 @@ impl UploadSSHPublicKeyResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UploadServerCertificateRequest {
     /// <p><p>The contents of the public key certificate in PEM-encoded format.</p> <p>The <a href="http://wikipedia.org/wiki/regex">regex pattern</a> used to validate this parameter is a string of characters consisting of the following:</p> <ul> <li> <p>Any printable ASCII character ranging from the space character (\u0020) through the end of the ASCII character range</p> </li> <li> <p>The printable characters in the Basic Latin and Latin-1 Supplement character set (through \u00FF)</p> </li> <li> <p>The special characters tab (\u0009), line feed (\u000A), and carriage return (\u000D)</p> </li> </ul></p>
     pub certificate_body: String,
@@ -12576,7 +12576,7 @@ impl UploadServerCertificateRequestSerializer {
 }
 
 /// <p>Contains the response to a successful <a>UploadServerCertificate</a> request. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UploadServerCertificateResponse {
     /// <p>The meta information of the uploaded server certificate without its certificate body, certificate chain, and private key.</p>
     pub server_certificate_metadata: Option<ServerCertificateMetadata>,
@@ -12625,7 +12625,7 @@ impl UploadServerCertificateResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UploadSigningCertificateRequest {
     /// <p><p>The contents of the signing certificate.</p> <p>The <a href="http://wikipedia.org/wiki/regex">regex pattern</a> used to validate this parameter is a string of characters consisting of the following:</p> <ul> <li> <p>Any printable ASCII character ranging from the space character (\u0020) through the end of the ASCII character range</p> </li> <li> <p>The printable characters in the Basic Latin and Latin-1 Supplement character set (through \u00FF)</p> </li> <li> <p>The special characters tab (\u0009), line feed (\u000A), and carriage return (\u000D)</p> </li> </ul></p>
     pub certificate_body: String,
@@ -12656,7 +12656,7 @@ impl UploadSigningCertificateRequestSerializer {
 }
 
 /// <p>Contains the response to a successful <a>UploadSigningCertificate</a> request. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UploadSigningCertificateResponse {
     /// <p>Information about the certificate.</p>
     pub certificate: SigningCertificate,
@@ -12705,7 +12705,7 @@ impl UploadSigningCertificateResponseDeserializer {
     }
 }
 /// <p><p>Contains information about an IAM user entity.</p> <p>This data type is used as a response element in the following operations:</p> <ul> <li> <p> <a>CreateUser</a> </p> </li> <li> <p> <a>GetUser</a> </p> </li> <li> <p> <a>ListUsers</a> </p> </li> </ul></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct User {
     /// <p>The Amazon Resource Name (ARN) that identifies the user. For more information about ARNs and how to use ARNs in policies, see <a href="http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html">IAM Identifiers</a> in the <i>Using IAM</i> guide. </p>
     pub arn: String,
@@ -12781,7 +12781,7 @@ impl UserDeserializer {
     }
 }
 /// <p>Contains information about an IAM user, including all the user's policies and all the IAM groups the user is in.</p> <p>This data type is used as a response element in the <a>GetAccountAuthorizationDetails</a> operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UserDetail {
     pub arn: Option<String>,
     /// <p>A list of the managed policies attached to the user.</p>
@@ -12967,7 +12967,7 @@ impl UserNameTypeDeserializer {
     }
 }
 /// <p>Contains information about a virtual MFA device.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct VirtualMFADevice {
     /// <p> The Base32 seed defined as specified in <a href="https://tools.ietf.org/html/rfc3548.txt">RFC3548</a>. The <code>Base32StringSeed</code> is Base64-encoded. </p>
     pub base_32_string_seed: Option<Vec<u8>>,

--- a/rusoto/services/iam/src/generated.rs
+++ b/rusoto/services/iam/src/generated.rs
@@ -29,8 +29,9 @@ use hyper::StatusCode;
 use rusoto_core::param::{Params, ServiceParams};
 use rusoto_core::signature::SignedRequest;
 use rusoto_core::xmlerror::*;
-use rusoto_core::xmlutil::{characters, end_element, find_start_element, peek_at_name, skip_tree,
-                           start_element};
+use rusoto_core::xmlutil::{
+    characters, end_element, find_start_element, peek_at_name, skip_tree, start_element,
+};
 use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
 use std::str::FromStr;
 use xml::reader::ParserConfig;

--- a/rusoto/services/importexport/src/generated.rs
+++ b/rusoto/services/importexport/src/generated.rs
@@ -44,7 +44,7 @@ enum DeserializerNext {
     Element(String),
 }
 /// <p>A discrete item that contains the description and URL of an artifact (such as a PDF).</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Artifact {
     pub description: Option<String>,
     pub url: Option<String>,
@@ -136,7 +136,7 @@ impl ArtifactListDeserializer {
     }
 }
 /// <p>Input structure for the CancelJob operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CancelJobInput {
     pub api_version: Option<String>,
     pub job_id: String,
@@ -165,7 +165,7 @@ impl CancelJobInputSerializer {
 }
 
 /// <p>Output structure for the CancelJob operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CancelJobOutput {
     pub success: Option<bool>,
 }
@@ -225,7 +225,7 @@ impl CarrierDeserializer {
     }
 }
 /// <p>Input structure for the CreateJob operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateJobInput {
     pub api_version: Option<String>,
     pub job_type: String,
@@ -271,7 +271,7 @@ impl CreateJobInputSerializer {
 }
 
 /// <p>Output structure for the CreateJob operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateJobOutput {
     pub artifact_list: Option<Vec<Artifact>>,
     pub job_id: Option<String>,
@@ -417,7 +417,7 @@ impl GenericStringDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetShippingLabelInput {
     pub api_version: Option<String>,
     pub city: Option<String>,
@@ -512,7 +512,7 @@ impl GetShippingLabelInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetShippingLabelOutput {
     pub shipping_label_url: Option<String>,
     pub warning: Option<String>,
@@ -565,7 +565,7 @@ impl GetShippingLabelOutputDeserializer {
     }
 }
 /// <p>Input structure for the GetStatus operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetStatusInput {
     pub api_version: Option<String>,
     pub job_id: String,
@@ -594,7 +594,7 @@ impl GetStatusInputSerializer {
 }
 
 /// <p>Output structure for the GetStatus operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetStatusOutput {
     pub artifact_list: Option<Vec<Artifact>>,
     pub carrier: Option<String>,
@@ -757,7 +757,7 @@ impl IsTruncatedDeserializer {
     }
 }
 /// <p>Representation of a job returned by the ListJobs operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Job {
     pub creation_date: Option<String>,
     pub is_canceled: Option<bool>,
@@ -901,7 +901,7 @@ impl JobsListDeserializer {
     }
 }
 /// <p>Input structure for the ListJobs operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListJobsInput {
     pub api_version: Option<String>,
     pub marker: Option<String>,
@@ -939,7 +939,7 @@ impl ListJobsInputSerializer {
 }
 
 /// <p>Output structure for the ListJobs operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListJobsOutput {
     pub is_truncated: Option<bool>,
     pub jobs: Option<Vec<Job>>,
@@ -1145,7 +1145,7 @@ impl URLDeserializer {
     }
 }
 /// <p>Input structure for the UpateJob operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateJobInput {
     pub api_version: Option<String>,
     pub job_id: String,
@@ -1189,7 +1189,7 @@ impl UpdateJobInputSerializer {
 }
 
 /// <p>Output structure for the UpateJob operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateJobOutput {
     pub artifact_list: Option<Vec<Artifact>>,
     pub success: Option<bool>,

--- a/rusoto/services/importexport/src/generated.rs
+++ b/rusoto/services/importexport/src/generated.rs
@@ -29,8 +29,9 @@ use hyper::StatusCode;
 use rusoto_core::param::{Params, ServiceParams};
 use rusoto_core::signature::SignedRequest;
 use rusoto_core::xmlerror::*;
-use rusoto_core::xmlutil::{characters, end_element, find_start_element, peek_at_name, skip_tree,
-                           start_element};
+use rusoto_core::xmlutil::{
+    characters, end_element, find_start_element, peek_at_name, skip_tree, start_element,
+};
 use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
 use std::str::FromStr;
 use xml::reader::ParserConfig;

--- a/rusoto/services/inspector/src/generated.rs
+++ b/rusoto/services/inspector/src/generated.rs
@@ -1240,7 +1240,8 @@ impl AddAttributesToFindingsError {
     pub fn from_body(body: &str) -> AddAttributesToFindingsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1340,7 +1341,8 @@ impl CreateAssessmentTargetError {
     pub fn from_body(body: &str) -> CreateAssessmentTargetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1444,7 +1446,8 @@ impl CreateAssessmentTemplateError {
     pub fn from_body(body: &str) -> CreateAssessmentTemplateError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1546,7 +1549,8 @@ impl CreateResourceGroupError {
     pub fn from_body(body: &str) -> CreateResourceGroupError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1646,7 +1650,8 @@ impl DeleteAssessmentRunError {
     pub fn from_body(body: &str) -> DeleteAssessmentRunError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1752,7 +1757,8 @@ impl DeleteAssessmentTargetError {
     pub fn from_body(body: &str) -> DeleteAssessmentTargetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1858,7 +1864,8 @@ impl DeleteAssessmentTemplateError {
     pub fn from_body(body: &str) -> DeleteAssessmentTemplateError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1958,7 +1965,8 @@ impl DescribeAssessmentRunsError {
     pub fn from_body(body: &str) -> DescribeAssessmentRunsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2044,7 +2052,8 @@ impl DescribeAssessmentTargetsError {
     pub fn from_body(body: &str) -> DescribeAssessmentTargetsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2130,7 +2139,8 @@ impl DescribeAssessmentTemplatesError {
     pub fn from_body(body: &str) -> DescribeAssessmentTemplatesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2214,7 +2224,8 @@ impl DescribeCrossAccountAccessRoleError {
     pub fn from_body(body: &str) -> DescribeCrossAccountAccessRoleError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2296,7 +2307,8 @@ impl DescribeFindingsError {
     pub fn from_body(body: &str) -> DescribeFindingsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2380,7 +2392,8 @@ impl DescribeResourceGroupsError {
     pub fn from_body(body: &str) -> DescribeResourceGroupsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2466,7 +2479,8 @@ impl DescribeRulesPackagesError {
     pub fn from_body(body: &str) -> DescribeRulesPackagesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2560,7 +2574,8 @@ impl GetAssessmentReportError {
     pub fn from_body(body: &str) -> GetAssessmentReportError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2668,7 +2683,8 @@ impl GetTelemetryMetadataError {
     pub fn from_body(body: &str) -> GetTelemetryMetadataError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2766,7 +2782,8 @@ impl ListAssessmentRunAgentsError {
     pub fn from_body(body: &str) -> ListAssessmentRunAgentsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2864,7 +2881,8 @@ impl ListAssessmentRunsError {
     pub fn from_body(body: &str) -> ListAssessmentRunsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2960,7 +2978,8 @@ impl ListAssessmentTargetsError {
     pub fn from_body(body: &str) -> ListAssessmentTargetsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3054,7 +3073,8 @@ impl ListAssessmentTemplatesError {
     pub fn from_body(body: &str) -> ListAssessmentTemplatesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3152,7 +3172,8 @@ impl ListEventSubscriptionsError {
     pub fn from_body(body: &str) -> ListEventSubscriptionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3250,7 +3271,8 @@ impl ListFindingsError {
     pub fn from_body(body: &str) -> ListFindingsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3342,7 +3364,8 @@ impl ListRulesPackagesError {
     pub fn from_body(body: &str) -> ListRulesPackagesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3436,7 +3459,8 @@ impl ListTagsForResourceError {
     pub fn from_body(body: &str) -> ListTagsForResourceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3536,7 +3560,8 @@ impl PreviewAgentsError {
     pub fn from_body(body: &str) -> PreviewAgentsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3636,7 +3661,8 @@ impl RegisterCrossAccountAccessRoleError {
     pub fn from_body(body: &str) -> RegisterCrossAccountAccessRoleError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3736,7 +3762,8 @@ impl RemoveAttributesFromFindingsError {
     pub fn from_body(body: &str) -> RemoveAttributesFromFindingsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3834,7 +3861,8 @@ impl SetTagsForResourceError {
     pub fn from_body(body: &str) -> SetTagsForResourceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3938,7 +3966,8 @@ impl StartAssessmentRunError {
     pub fn from_body(body: &str) -> StartAssessmentRunError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4052,7 +4081,8 @@ impl StopAssessmentRunError {
     pub fn from_body(body: &str) -> StopAssessmentRunError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4152,7 +4182,8 @@ impl SubscribeToEventError {
     pub fn from_body(body: &str) -> SubscribeToEventError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4252,7 +4283,8 @@ impl UnsubscribeFromEventError {
     pub fn from_body(body: &str) -> UnsubscribeFromEventError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4350,7 +4382,8 @@ impl UpdateAssessmentTargetError {
     pub fn from_body(body: &str) -> UpdateAssessmentTargetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/inspector/src/generated.rs
+++ b/rusoto/services/inspector/src/generated.rs
@@ -30,7 +30,7 @@ use rusoto_core::signature::SignedRequest;
 use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AddAttributesToFindingsRequest {
     /// <p>The array of attributes that you want to assign to specified findings.</p>
     #[serde(rename = "attributes")]
@@ -40,7 +40,7 @@ pub struct AddAttributesToFindingsRequest {
     pub finding_arns: Vec<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AddAttributesToFindingsResponse {
     /// <p>Attribute details that cannot be described. An error code is provided for each failed item.</p>
     #[serde(rename = "failedItems")]
@@ -48,7 +48,7 @@ pub struct AddAttributesToFindingsResponse {
 }
 
 /// <p>Used in the exception error that is thrown if you start an assessment run for an assessment target that includes an EC2 instance that is already participating in another started assessment run.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AgentAlreadyRunningAssessment {
     /// <p>ID of the agent that is running on an EC2 instance that is already participating in another started assessment run.</p>
     pub agent_id: String,
@@ -57,7 +57,7 @@ pub struct AgentAlreadyRunningAssessment {
 }
 
 /// <p>Contains information about an Amazon Inspector agent. This data type is used as a request parameter in the <a>ListAssessmentRunAgents</a> action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AgentFilter {
     /// <p>The detailed health state of the agent. Values can be set to <b>IDLE</b>, <b>RUNNING</b>, <b>SHUTDOWN</b>, <b>UNHEALTHY</b>, <b>THROTTLED</b>, and <b>UNKNOWN</b>. </p>
     #[serde(rename = "agentHealthCodes")]
@@ -68,7 +68,7 @@ pub struct AgentFilter {
 }
 
 /// <p>Used as a response element in the <a>PreviewAgents</a> action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AgentPreview {
     /// <p>The health status of the Amazon Inspector Agent.</p>
     #[serde(rename = "agentHealth")]
@@ -104,7 +104,7 @@ pub struct AgentPreview {
 }
 
 /// <p>A snapshot of an Amazon Inspector assessment run that contains the findings of the assessment run .</p> <p>Used as the response element in the <a>DescribeAssessmentRuns</a> action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AssessmentRun {
     /// <p>The ARN of the assessment run.</p>
     #[serde(rename = "arn")]
@@ -156,7 +156,7 @@ pub struct AssessmentRun {
 }
 
 /// <p>Contains information about an Amazon Inspector agent. This data type is used as a response element in the <a>ListAssessmentRunAgents</a> action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AssessmentRunAgent {
     /// <p>The current health state of the agent.</p>
     #[serde(rename = "agentHealth")]
@@ -184,7 +184,7 @@ pub struct AssessmentRunAgent {
 }
 
 /// <p>Used as the request parameter in the <a>ListAssessmentRuns</a> action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AssessmentRunFilter {
     /// <p>For a record to match a filter, the value that is specified for this data type property must inclusively match any value between the specified minimum and maximum values of the <b>completedAt</b> property of the <a>AssessmentRun</a> data type.</p>
     #[serde(rename = "completionTimeRange")]
@@ -217,7 +217,7 @@ pub struct AssessmentRunFilter {
 }
 
 /// <p>Used as one of the elements of the <a>AssessmentRun</a> data type.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AssessmentRunNotification {
     /// <p>The date of the notification.</p>
     #[serde(rename = "date")]
@@ -243,7 +243,7 @@ pub struct AssessmentRunNotification {
 }
 
 /// <p>Used as one of the elements of the <a>AssessmentRun</a> data type.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AssessmentRunStateChange {
     /// <p>The assessment run state.</p>
     #[serde(rename = "state")]
@@ -254,7 +254,7 @@ pub struct AssessmentRunStateChange {
 }
 
 /// <p>Contains information about an Amazon Inspector application. This data type is used as the response element in the <a>DescribeAssessmentTargets</a> action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AssessmentTarget {
     /// <p>The ARN that specifies the Amazon Inspector assessment target.</p>
     #[serde(rename = "arn")]
@@ -274,7 +274,7 @@ pub struct AssessmentTarget {
 }
 
 /// <p>Used as the request parameter in the <a>ListAssessmentTargets</a> action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AssessmentTargetFilter {
     /// <p>For a record to match a filter, an explicit value or a string that contains a wildcard that is specified for this data type property must match the value of the <b>assessmentTargetName</b> property of the <a>AssessmentTarget</a> data type.</p>
     #[serde(rename = "assessmentTargetNamePattern")]
@@ -283,7 +283,7 @@ pub struct AssessmentTargetFilter {
 }
 
 /// <p>Contains information about an Amazon Inspector assessment template. This data type is used as the response element in the <a>DescribeAssessmentTemplates</a> action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AssessmentTemplate {
     /// <p>The ARN of the assessment template.</p>
     #[serde(rename = "arn")]
@@ -316,7 +316,7 @@ pub struct AssessmentTemplate {
 }
 
 /// <p>Used as the request parameter in the <a>ListAssessmentTemplates</a> action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AssessmentTemplateFilter {
     /// <p>For a record to match a filter, the value specified for this data type property must inclusively match any value between the specified minimum and maximum values of the <b>durationInSeconds</b> property of the <a>AssessmentTemplate</a> data type.</p>
     #[serde(rename = "durationRange")]
@@ -333,7 +333,7 @@ pub struct AssessmentTemplateFilter {
 }
 
 /// <p>A collection of attributes of the host from which the finding is generated.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AssetAttributes {
     /// <p>The ID of the agent that is installed on the EC2 instance where the finding is generated.</p>
     #[serde(rename = "agentId")]
@@ -361,7 +361,7 @@ pub struct AssetAttributes {
 }
 
 /// <p>This data type is used as a request parameter in the <a>AddAttributesToFindings</a> and <a>CreateAssessmentTemplate</a> actions.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Attribute {
     /// <p>The attribute key.</p>
     #[serde(rename = "key")]
@@ -372,7 +372,7 @@ pub struct Attribute {
     pub value: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateAssessmentTargetRequest {
     /// <p>The user-defined name that identifies the assessment target that you want to create. The name must be unique within the AWS account.</p>
     #[serde(rename = "assessmentTargetName")]
@@ -382,14 +382,14 @@ pub struct CreateAssessmentTargetRequest {
     pub resource_group_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateAssessmentTargetResponse {
     /// <p>The ARN that specifies the assessment target that is created.</p>
     #[serde(rename = "assessmentTargetArn")]
     pub assessment_target_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateAssessmentTemplateRequest {
     /// <p>The ARN that specifies the assessment target for which you want to create the assessment template.</p>
     #[serde(rename = "assessmentTargetArn")]
@@ -409,56 +409,56 @@ pub struct CreateAssessmentTemplateRequest {
     pub user_attributes_for_findings: Option<Vec<Attribute>>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateAssessmentTemplateResponse {
     /// <p>The ARN that specifies the assessment template that is created.</p>
     #[serde(rename = "assessmentTemplateArn")]
     pub assessment_template_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateResourceGroupRequest {
     /// <p>A collection of keys and an array of possible values, '[{"key":"key1","values":["Value1","Value2"]},{"key":"Key2","values":["Value3"]}]'.</p> <p>For example,'[{"key":"Name","values":["TestEC2Instance"]}]'.</p>
     #[serde(rename = "resourceGroupTags")]
     pub resource_group_tags: Vec<ResourceGroupTag>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateResourceGroupResponse {
     /// <p>The ARN that specifies the resource group that is created.</p>
     #[serde(rename = "resourceGroupArn")]
     pub resource_group_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteAssessmentRunRequest {
     /// <p>The ARN that specifies the assessment run that you want to delete.</p>
     #[serde(rename = "assessmentRunArn")]
     pub assessment_run_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteAssessmentTargetRequest {
     /// <p>The ARN that specifies the assessment target that you want to delete.</p>
     #[serde(rename = "assessmentTargetArn")]
     pub assessment_target_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteAssessmentTemplateRequest {
     /// <p>The ARN that specifies the assessment template that you want to delete.</p>
     #[serde(rename = "assessmentTemplateArn")]
     pub assessment_template_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeAssessmentRunsRequest {
     /// <p>The ARN that specifies the assessment run that you want to describe.</p>
     #[serde(rename = "assessmentRunArns")]
     pub assessment_run_arns: Vec<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeAssessmentRunsResponse {
     /// <p>Information about the assessment run.</p>
     #[serde(rename = "assessmentRuns")]
@@ -468,14 +468,14 @@ pub struct DescribeAssessmentRunsResponse {
     pub failed_items: ::std::collections::HashMap<String, FailedItemDetails>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeAssessmentTargetsRequest {
     /// <p>The ARNs that specifies the assessment targets that you want to describe.</p>
     #[serde(rename = "assessmentTargetArns")]
     pub assessment_target_arns: Vec<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeAssessmentTargetsResponse {
     /// <p>Information about the assessment targets.</p>
     #[serde(rename = "assessmentTargets")]
@@ -485,13 +485,13 @@ pub struct DescribeAssessmentTargetsResponse {
     pub failed_items: ::std::collections::HashMap<String, FailedItemDetails>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeAssessmentTemplatesRequest {
     #[serde(rename = "assessmentTemplateArns")]
     pub assessment_template_arns: Vec<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeAssessmentTemplatesResponse {
     /// <p>Information about the assessment templates.</p>
     #[serde(rename = "assessmentTemplates")]
@@ -501,7 +501,7 @@ pub struct DescribeAssessmentTemplatesResponse {
     pub failed_items: ::std::collections::HashMap<String, FailedItemDetails>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeCrossAccountAccessRoleResponse {
     /// <p>The date when the cross-account access role was registered.</p>
     #[serde(rename = "registeredAt")]
@@ -514,7 +514,7 @@ pub struct DescribeCrossAccountAccessRoleResponse {
     pub valid: bool,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeFindingsRequest {
     /// <p>The ARN that specifies the finding that you want to describe.</p>
     #[serde(rename = "findingArns")]
@@ -525,7 +525,7 @@ pub struct DescribeFindingsRequest {
     pub locale: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeFindingsResponse {
     /// <p>Finding details that cannot be described. An error code is provided for each failed item.</p>
     #[serde(rename = "failedItems")]
@@ -535,14 +535,14 @@ pub struct DescribeFindingsResponse {
     pub findings: Vec<Finding>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeResourceGroupsRequest {
     /// <p>The ARN that specifies the resource group that you want to describe.</p>
     #[serde(rename = "resourceGroupArns")]
     pub resource_group_arns: Vec<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeResourceGroupsResponse {
     /// <p>Resource group details that cannot be described. An error code is provided for each failed item.</p>
     #[serde(rename = "failedItems")]
@@ -552,7 +552,7 @@ pub struct DescribeResourceGroupsResponse {
     pub resource_groups: Vec<ResourceGroup>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeRulesPackagesRequest {
     /// <p>The locale that you want to translate a rules package description into.</p>
     #[serde(rename = "locale")]
@@ -563,7 +563,7 @@ pub struct DescribeRulesPackagesRequest {
     pub rules_package_arns: Vec<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeRulesPackagesResponse {
     /// <p>Rules package details that cannot be described. An error code is provided for each failed item.</p>
     #[serde(rename = "failedItems")]
@@ -574,7 +574,7 @@ pub struct DescribeRulesPackagesResponse {
 }
 
 /// <p>This data type is used in the <a>AssessmentTemplateFilter</a> data type.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DurationRange {
     /// <p>The maximum value of the duration range. Must be less than or equal to 604800 seconds (1 week).</p>
     #[serde(rename = "maxSeconds")]
@@ -587,7 +587,7 @@ pub struct DurationRange {
 }
 
 /// <p>This data type is used in the <a>Subscription</a> data type.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct EventSubscription {
     /// <p>The event for which Amazon Simple Notification Service (SNS) notifications are sent.</p>
     #[serde(rename = "event")]
@@ -598,7 +598,7 @@ pub struct EventSubscription {
 }
 
 /// <p>Includes details about the failed items.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct FailedItemDetails {
     /// <p>The status code of a failed item.</p>
     #[serde(rename = "failureCode")]
@@ -609,7 +609,7 @@ pub struct FailedItemDetails {
 }
 
 /// <p>Contains information about an Amazon Inspector finding. This data type is used as the response element in the <a>DescribeFindings</a> action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Finding {
     /// <p>The ARN that specifies the finding.</p>
     #[serde(rename = "arn")]
@@ -681,7 +681,7 @@ pub struct Finding {
 }
 
 /// <p>This data type is used as a request parameter in the <a>ListFindings</a> action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct FindingFilter {
     /// <p>For a record to match a filter, one of the values that is specified for this data type property must be the exact match of the value of the <b>agentId</b> property of the <a>Finding</a> data type.</p>
     #[serde(rename = "agentIds")]
@@ -717,7 +717,7 @@ pub struct FindingFilter {
     pub user_attributes: Option<Vec<Attribute>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetAssessmentReportRequest {
     /// <p>The ARN that specifies the assessment run for which you want to generate a report.</p>
     #[serde(rename = "assessmentRunArn")]
@@ -730,7 +730,7 @@ pub struct GetAssessmentReportRequest {
     pub report_type: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetAssessmentReportResponse {
     /// <p>Specifies the status of the request to generate an assessment report. </p>
     #[serde(rename = "status")]
@@ -741,14 +741,14 @@ pub struct GetAssessmentReportResponse {
     pub url: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetTelemetryMetadataRequest {
     /// <p>The ARN that specifies the assessment run that has the telemetry data that you want to obtain.</p>
     #[serde(rename = "assessmentRunArn")]
     pub assessment_run_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetTelemetryMetadataResponse {
     /// <p>Telemetry details.</p>
     #[serde(rename = "telemetryMetadata")]
@@ -756,7 +756,7 @@ pub struct GetTelemetryMetadataResponse {
 }
 
 /// <p>This data type is used in the <a>Finding</a> data type.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct InspectorServiceAttributes {
     /// <p>The ARN of the assessment run during which the finding is generated.</p>
     #[serde(rename = "assessmentRunArn")]
@@ -771,7 +771,7 @@ pub struct InspectorServiceAttributes {
     pub schema_version: i64,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListAssessmentRunAgentsRequest {
     /// <p>The ARN that specifies the assessment run whose agents you want to list.</p>
     #[serde(rename = "assessmentRunArn")]
@@ -790,7 +790,7 @@ pub struct ListAssessmentRunAgentsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListAssessmentRunAgentsResponse {
     /// <p>A list of ARNs that specifies the agents returned by the action.</p>
     #[serde(rename = "assessmentRunAgents")]
@@ -801,7 +801,7 @@ pub struct ListAssessmentRunAgentsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListAssessmentRunsRequest {
     /// <p>The ARNs that specify the assessment templates whose assessment runs you want to list.</p>
     #[serde(rename = "assessmentTemplateArns")]
@@ -821,7 +821,7 @@ pub struct ListAssessmentRunsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListAssessmentRunsResponse {
     /// <p>A list of ARNs that specifies the assessment runs that are returned by the action.</p>
     #[serde(rename = "assessmentRunArns")]
@@ -832,7 +832,7 @@ pub struct ListAssessmentRunsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListAssessmentTargetsRequest {
     /// <p>You can use this parameter to specify a subset of data to be included in the action's response.</p> <p>For a record to match a filter, all specified filter attributes must match. When multiple values are specified for a filter attribute, any of the values can match.</p>
     #[serde(rename = "filter")]
@@ -848,7 +848,7 @@ pub struct ListAssessmentTargetsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListAssessmentTargetsResponse {
     /// <p>A list of ARNs that specifies the assessment targets that are returned by the action.</p>
     #[serde(rename = "assessmentTargetArns")]
@@ -859,7 +859,7 @@ pub struct ListAssessmentTargetsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListAssessmentTemplatesRequest {
     /// <p>A list of ARNs that specifies the assessment targets whose assessment templates you want to list.</p>
     #[serde(rename = "assessmentTargetArns")]
@@ -879,7 +879,7 @@ pub struct ListAssessmentTemplatesRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListAssessmentTemplatesResponse {
     /// <p>A list of ARNs that specifies the assessment templates returned by the action.</p>
     #[serde(rename = "assessmentTemplateArns")]
@@ -890,7 +890,7 @@ pub struct ListAssessmentTemplatesResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListEventSubscriptionsRequest {
     /// <p>You can use this parameter to indicate the maximum number of items you want in the response. The default value is 10. The maximum value is 500.</p>
     #[serde(rename = "maxResults")]
@@ -906,7 +906,7 @@ pub struct ListEventSubscriptionsRequest {
     pub resource_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListEventSubscriptionsResponse {
     /// <p> When a response is generated, if there is more data to be listed, this parameter is present in the response and contains the value to use for the <b>nextToken</b> parameter in a subsequent pagination request. If there is no more data to be listed, this parameter is set to null.</p>
     #[serde(rename = "nextToken")]
@@ -917,7 +917,7 @@ pub struct ListEventSubscriptionsResponse {
     pub subscriptions: Vec<Subscription>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListFindingsRequest {
     /// <p>The ARNs of the assessment runs that generate the findings that you want to list.</p>
     #[serde(rename = "assessmentRunArns")]
@@ -937,7 +937,7 @@ pub struct ListFindingsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListFindingsResponse {
     /// <p>A list of ARNs that specifies the findings returned by the action.</p>
     #[serde(rename = "findingArns")]
@@ -948,7 +948,7 @@ pub struct ListFindingsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListRulesPackagesRequest {
     /// <p>You can use this parameter to indicate the maximum number of items you want in the response. The default value is 10. The maximum value is 500.</p>
     #[serde(rename = "maxResults")]
@@ -960,7 +960,7 @@ pub struct ListRulesPackagesRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListRulesPackagesResponse {
     /// <p> When a response is generated, if there is more data to be listed, this parameter is present in the response and contains the value to use for the <b>nextToken</b> parameter in a subsequent pagination request. If there is no more data to be listed, this parameter is set to null.</p>
     #[serde(rename = "nextToken")]
@@ -971,21 +971,21 @@ pub struct ListRulesPackagesResponse {
     pub rules_package_arns: Vec<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListTagsForResourceRequest {
     /// <p>The ARN that specifies the assessment template whose tags you want to list.</p>
     #[serde(rename = "resourceArn")]
     pub resource_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListTagsForResourceResponse {
     /// <p>A collection of key and value pairs.</p>
     #[serde(rename = "tags")]
     pub tags: Vec<Tag>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PreviewAgentsRequest {
     /// <p>You can use this parameter to indicate the maximum number of items you want in the response. The default value is 10. The maximum value is 500.</p>
     #[serde(rename = "maxResults")]
@@ -1000,7 +1000,7 @@ pub struct PreviewAgentsRequest {
     pub preview_agents_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PreviewAgentsResponse {
     /// <p>The resulting list of agents.</p>
     #[serde(rename = "agentPreviews")]
@@ -1011,14 +1011,14 @@ pub struct PreviewAgentsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RegisterCrossAccountAccessRoleRequest {
     /// <p>The ARN of the IAM role that grants Amazon Inspector access to AWS Services needed to perform security assessments. </p>
     #[serde(rename = "roleArn")]
     pub role_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RemoveAttributesFromFindingsRequest {
     /// <p>The array of attribute keys that you want to remove from specified findings.</p>
     #[serde(rename = "attributeKeys")]
@@ -1028,7 +1028,7 @@ pub struct RemoveAttributesFromFindingsRequest {
     pub finding_arns: Vec<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RemoveAttributesFromFindingsResponse {
     /// <p>Attributes details that cannot be described. An error code is provided for each failed item.</p>
     #[serde(rename = "failedItems")]
@@ -1036,7 +1036,7 @@ pub struct RemoveAttributesFromFindingsResponse {
 }
 
 /// <p>Contains information about a resource group. The resource group defines a set of tags that, when queried, identify the AWS resources that make up the assessment target. This data type is used as the response element in the <a>DescribeResourceGroups</a> action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ResourceGroup {
     /// <p>The ARN of the resource group.</p>
     #[serde(rename = "arn")]
@@ -1050,7 +1050,7 @@ pub struct ResourceGroup {
 }
 
 /// <p>This data type is used as one of the elements of the <a>ResourceGroup</a> data type.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ResourceGroupTag {
     /// <p>A tag key.</p>
     #[serde(rename = "key")]
@@ -1062,7 +1062,7 @@ pub struct ResourceGroupTag {
 }
 
 /// <p>Contains information about an Amazon Inspector rules package. This data type is used as the response element in the <a>DescribeRulesPackages</a> action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RulesPackage {
     /// <p>The ARN of the rules package.</p>
     #[serde(rename = "arn")]
@@ -1082,7 +1082,7 @@ pub struct RulesPackage {
     pub version: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SetTagsForResourceRequest {
     /// <p>The ARN of the assessment template that you want to set tags to.</p>
     #[serde(rename = "resourceArn")]
@@ -1093,7 +1093,7 @@ pub struct SetTagsForResourceRequest {
     pub tags: Option<Vec<Tag>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StartAssessmentRunRequest {
     /// <p>You can specify the name for the assessment run. The name must be unique for the assessment template whose ARN is used to start the assessment run.</p>
     #[serde(rename = "assessmentRunName")]
@@ -1104,14 +1104,14 @@ pub struct StartAssessmentRunRequest {
     pub assessment_template_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StartAssessmentRunResponse {
     /// <p>The ARN of the assessment run that has been started.</p>
     #[serde(rename = "assessmentRunArn")]
     pub assessment_run_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StopAssessmentRunRequest {
     /// <p>The ARN of the assessment run that you want to stop.</p>
     #[serde(rename = "assessmentRunArn")]
@@ -1122,7 +1122,7 @@ pub struct StopAssessmentRunRequest {
     pub stop_action: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SubscribeToEventRequest {
     /// <p>The event for which you want to receive SNS notifications.</p>
     #[serde(rename = "event")]
@@ -1136,7 +1136,7 @@ pub struct SubscribeToEventRequest {
 }
 
 /// <p>This data type is used as a response element in the <a>ListEventSubscriptions</a> action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Subscription {
     /// <p>The list of existing event subscriptions.</p>
     #[serde(rename = "eventSubscriptions")]
@@ -1150,7 +1150,7 @@ pub struct Subscription {
 }
 
 /// <p>A key and value pair. This data type is used as a request parameter in the <a>SetTagsForResource</a> action and a response element in the <a>ListTagsForResource</a> action.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Tag {
     /// <p>A tag key.</p>
     #[serde(rename = "key")]
@@ -1162,7 +1162,7 @@ pub struct Tag {
 }
 
 /// <p>The metadata about the Amazon Inspector application data metrics collected by the agent. This data type is used as the response element in the <a>GetTelemetryMetadata</a> action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct TelemetryMetadata {
     /// <p>The count of messages that the agent sends to the Amazon Inspector service.</p>
     #[serde(rename = "count")]
@@ -1177,7 +1177,7 @@ pub struct TelemetryMetadata {
 }
 
 /// <p>This data type is used in the <a>AssessmentRunFilter</a> data type.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct TimestampRange {
     /// <p>The minimum value of the timestamp range.</p>
     #[serde(rename = "beginDate")]
@@ -1189,7 +1189,7 @@ pub struct TimestampRange {
     pub end_date: Option<f64>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UnsubscribeFromEventRequest {
     /// <p>The event for which you want to stop receiving SNS notifications.</p>
     #[serde(rename = "event")]
@@ -1202,7 +1202,7 @@ pub struct UnsubscribeFromEventRequest {
     pub topic_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateAssessmentTargetRequest {
     /// <p>The ARN of the assessment target that you want to update.</p>
     #[serde(rename = "assessmentTargetArn")]

--- a/rusoto/services/iot/src/generated.rs
+++ b/rusoto/services/iot/src/generated.rs
@@ -31,7 +31,7 @@ use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 /// <p>The input for the AcceptCertificateTransfer operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AcceptCertificateTransferRequest {
     /// <p>The ID of the certificate.</p>
     #[serde(rename = "certificateId")]
@@ -43,7 +43,7 @@ pub struct AcceptCertificateTransferRequest {
 }
 
 /// <p>Describes the actions associated with a rule.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Action {
     /// <p>Change the state of a CloudWatch alarm.</p>
     #[serde(rename = "cloudwatchAlarm")]
@@ -99,7 +99,7 @@ pub struct Action {
     pub sqs: Option<SqsAction>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AddThingToThingGroupRequest {
     /// <p>The ARN of the thing to add to a group.</p>
     #[serde(rename = "thingArn")]
@@ -119,11 +119,11 @@ pub struct AddThingToThingGroupRequest {
     pub thing_name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AddThingToThingGroupResponse {}
 
 /// <p>Contains information that allowed the authorization.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Allowed {
     /// <p>A list of policies that allowed the authentication.</p>
     #[serde(rename = "policies")]
@@ -131,7 +131,7 @@ pub struct Allowed {
     pub policies: Option<Vec<Policy>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AssociateTargetsWithJobRequest {
     /// <p>An optional comment string describing why the job was associated with the targets.</p>
     #[serde(rename = "comment")]
@@ -145,7 +145,7 @@ pub struct AssociateTargetsWithJobRequest {
     pub targets: Vec<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AssociateTargetsWithJobResponse {
     /// <p>A short text description of the job.</p>
     #[serde(rename = "description")]
@@ -161,7 +161,7 @@ pub struct AssociateTargetsWithJobResponse {
     pub job_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AttachPolicyRequest {
     /// <p>The name of the policy to attach.</p>
     #[serde(rename = "policyName")]
@@ -172,7 +172,7 @@ pub struct AttachPolicyRequest {
 }
 
 /// <p>The input for the AttachPrincipalPolicy operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AttachPrincipalPolicyRequest {
     /// <p>The policy name.</p>
     #[serde(rename = "policyName")]
@@ -183,7 +183,7 @@ pub struct AttachPrincipalPolicyRequest {
 }
 
 /// <p>The input for the AttachThingPrincipal operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AttachThingPrincipalRequest {
     /// <p>The principal, such as a certificate or other credential.</p>
     #[serde(rename = "principal")]
@@ -194,11 +194,11 @@ pub struct AttachThingPrincipalRequest {
 }
 
 /// <p>The output from the AttachThingPrincipal operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AttachThingPrincipalResponse {}
 
 /// <p>The attribute payload.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct AttributePayload {
     /// <p>A JSON string containing up to three key-value pair in JSON format. For example:</p> <p> <code>{\"attributes\":{\"string1\":\"string2\"}}</code> </p>
     #[serde(rename = "attributes")]
@@ -211,7 +211,7 @@ pub struct AttributePayload {
 }
 
 /// <p>A collection of authorization information.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct AuthInfo {
     /// <p>The type of action for which the principal is being authorized.</p>
     #[serde(rename = "actionType")]
@@ -224,7 +224,7 @@ pub struct AuthInfo {
 }
 
 /// <p>The authorizer result.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AuthResult {
     /// <p>The policies and statements that allowed the specified action.</p>
     #[serde(rename = "allowed")]
@@ -249,7 +249,7 @@ pub struct AuthResult {
 }
 
 /// <p>The authorizer description.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AuthorizerDescription {
     /// <p>The authorizer ARN.</p>
     #[serde(rename = "authorizerArn")]
@@ -286,7 +286,7 @@ pub struct AuthorizerDescription {
 }
 
 /// <p>The authorizer summary.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AuthorizerSummary {
     /// <p>The authorizer ARN.</p>
     #[serde(rename = "authorizerArn")]
@@ -299,7 +299,7 @@ pub struct AuthorizerSummary {
 }
 
 /// <p>A CA certificate.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CACertificate {
     /// <p>The ARN of the CA certificate.</p>
     #[serde(rename = "certificateArn")]
@@ -320,7 +320,7 @@ pub struct CACertificate {
 }
 
 /// <p>Describes a CA certificate.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CACertificateDescription {
     /// <p>Whether the CA certificate configured for auto registration of device certificates. Valid values are "ENABLE" and "DISABLE"</p>
     #[serde(rename = "autoRegistrationStatus")]
@@ -362,14 +362,14 @@ pub struct CACertificateDescription {
 }
 
 /// <p>The input for the CancelCertificateTransfer operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CancelCertificateTransferRequest {
     /// <p>The ID of the certificate.</p>
     #[serde(rename = "certificateId")]
     pub certificate_id: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CancelJobRequest {
     /// <p>An optional comment string describing why the job was canceled.</p>
     #[serde(rename = "comment")]
@@ -380,7 +380,7 @@ pub struct CancelJobRequest {
     pub job_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CancelJobResponse {
     /// <p>A short text description of the job.</p>
     #[serde(rename = "description")]
@@ -397,7 +397,7 @@ pub struct CancelJobResponse {
 }
 
 /// <p>Information about a certificate.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Certificate {
     /// <p>The ARN of the certificate.</p>
     #[serde(rename = "certificateArn")]
@@ -418,7 +418,7 @@ pub struct Certificate {
 }
 
 /// <p>Describes a certificate.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CertificateDescription {
     /// <p>The certificate ID of the CA certificate used to sign this certificate.</p>
     #[serde(rename = "caCertificateId")]
@@ -468,14 +468,14 @@ pub struct CertificateDescription {
     pub transfer_data: Option<TransferData>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ClearDefaultAuthorizerRequest {}
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ClearDefaultAuthorizerResponse {}
 
 /// <p>Describes an action that updates a CloudWatch alarm.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CloudwatchAlarmAction {
     /// <p>The CloudWatch alarm name.</p>
     #[serde(rename = "alarmName")]
@@ -492,7 +492,7 @@ pub struct CloudwatchAlarmAction {
 }
 
 /// <p>Describes an action that captures a CloudWatch metric.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CloudwatchMetricAction {
     /// <p>The CloudWatch metric name.</p>
     #[serde(rename = "metricName")]
@@ -516,7 +516,7 @@ pub struct CloudwatchMetricAction {
 }
 
 /// <p>Describes the method to use when code signing a file.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CodeSigning {
     /// <p>The ID of the AWSSignerJob which was created to sign the file.</p>
     #[serde(rename = "awsSignerJobId")]
@@ -529,7 +529,7 @@ pub struct CodeSigning {
 }
 
 /// <p>Describes the certificate chain being used when code signing a file.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CodeSigningCertificateChain {
     /// <p>The name of the certificate.</p>
     #[serde(rename = "certificateName")]
@@ -546,7 +546,7 @@ pub struct CodeSigningCertificateChain {
 }
 
 /// <p>Describes the signature for a file.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CodeSigningSignature {
     /// <p>A base64 encoded binary representation of the code signing signature.</p>
     #[serde(rename = "inlineDocument")]
@@ -563,7 +563,7 @@ pub struct CodeSigningSignature {
 }
 
 /// <p>Configuration.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Configuration {
     /// <p>True to enable the configuration.</p>
     #[serde(rename = "Enabled")]
@@ -571,7 +571,7 @@ pub struct Configuration {
     pub enabled: Option<bool>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateAuthorizerRequest {
     /// <p>The ARN of the authorizer's Lambda function.</p>
     #[serde(rename = "authorizerFunctionArn")]
@@ -591,7 +591,7 @@ pub struct CreateAuthorizerRequest {
     pub token_signing_public_keys: ::std::collections::HashMap<String, String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateAuthorizerResponse {
     /// <p>The authorizer ARN.</p>
     #[serde(rename = "authorizerArn")]
@@ -604,7 +604,7 @@ pub struct CreateAuthorizerResponse {
 }
 
 /// <p>The input for the CreateCertificateFromCsr operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateCertificateFromCsrRequest {
     /// <p>The certificate signing request (CSR).</p>
     #[serde(rename = "certificateSigningRequest")]
@@ -616,7 +616,7 @@ pub struct CreateCertificateFromCsrRequest {
 }
 
 /// <p>The output from the CreateCertificateFromCsr operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateCertificateFromCsrResponse {
     /// <p>The Amazon Resource Name (ARN) of the certificate. You can use the ARN as a principal for policy operations.</p>
     #[serde(rename = "certificateArn")]
@@ -632,7 +632,7 @@ pub struct CreateCertificateFromCsrResponse {
     pub certificate_pem: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateJobRequest {
     /// <p>A short text description of the job.</p>
     #[serde(rename = "description")]
@@ -670,7 +670,7 @@ pub struct CreateJobRequest {
     pub targets: Vec<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateJobResponse {
     /// <p>The job description.</p>
     #[serde(rename = "description")]
@@ -687,7 +687,7 @@ pub struct CreateJobResponse {
 }
 
 /// <p>The input for the CreateKeysAndCertificate operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateKeysAndCertificateRequest {
     /// <p>Specifies whether the certificate is active.</p>
     #[serde(rename = "setAsActive")]
@@ -696,7 +696,7 @@ pub struct CreateKeysAndCertificateRequest {
 }
 
 /// <p>The output of the CreateKeysAndCertificate operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateKeysAndCertificateResponse {
     /// <p>The ARN of the certificate.</p>
     #[serde(rename = "certificateArn")]
@@ -716,7 +716,7 @@ pub struct CreateKeysAndCertificateResponse {
     pub key_pair: Option<KeyPair>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateOTAUpdateRequest {
     /// <p>A list of additional OTA update parameters which are name-value pairs.</p>
     #[serde(rename = "additionalParameters")]
@@ -744,7 +744,7 @@ pub struct CreateOTAUpdateRequest {
     pub targets: Vec<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateOTAUpdateResponse {
     /// <p>The AWS IoT job ARN associated with the OTA update.</p>
     #[serde(rename = "awsIotJobArn")]
@@ -769,7 +769,7 @@ pub struct CreateOTAUpdateResponse {
 }
 
 /// <p>The input for the CreatePolicy operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreatePolicyRequest {
     /// <p>The JSON document that describes the policy. <b>policyDocument</b> must have a minimum length of 1, with a maximum length of 2048, excluding whitespace.</p>
     #[serde(rename = "policyDocument")]
@@ -780,7 +780,7 @@ pub struct CreatePolicyRequest {
 }
 
 /// <p>The output from the CreatePolicy operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreatePolicyResponse {
     /// <p>The policy ARN.</p>
     #[serde(rename = "policyArn")]
@@ -801,7 +801,7 @@ pub struct CreatePolicyResponse {
 }
 
 /// <p>The input for the CreatePolicyVersion operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreatePolicyVersionRequest {
     /// <p>The JSON document that describes the policy. Minimum length of 1. Maximum length of 2048, excluding whitespace.</p>
     #[serde(rename = "policyDocument")]
@@ -816,7 +816,7 @@ pub struct CreatePolicyVersionRequest {
 }
 
 /// <p>The output of the CreatePolicyVersion operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreatePolicyVersionResponse {
     /// <p>Specifies whether the policy version is the default.</p>
     #[serde(rename = "isDefaultVersion")]
@@ -836,7 +836,7 @@ pub struct CreatePolicyVersionResponse {
     pub policy_version_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateRoleAliasRequest {
     /// <p>How long (in seconds) the credentials will be valid.</p>
     #[serde(rename = "credentialDurationSeconds")]
@@ -850,7 +850,7 @@ pub struct CreateRoleAliasRequest {
     pub role_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateRoleAliasResponse {
     /// <p>The role alias.</p>
     #[serde(rename = "roleAlias")]
@@ -862,7 +862,7 @@ pub struct CreateRoleAliasResponse {
     pub role_alias_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateStreamRequest {
     /// <p>A description of the stream.</p>
     #[serde(rename = "description")]
@@ -879,7 +879,7 @@ pub struct CreateStreamRequest {
     pub stream_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateStreamResponse {
     /// <p>A description of the stream.</p>
     #[serde(rename = "description")]
@@ -899,7 +899,7 @@ pub struct CreateStreamResponse {
     pub stream_version: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateThingGroupRequest {
     /// <p>The name of the parent thing group.</p>
     #[serde(rename = "parentGroupName")]
@@ -914,7 +914,7 @@ pub struct CreateThingGroupRequest {
     pub thing_group_properties: Option<ThingGroupProperties>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateThingGroupResponse {
     /// <p>The thing group ARN.</p>
     #[serde(rename = "thingGroupArn")]
@@ -931,7 +931,7 @@ pub struct CreateThingGroupResponse {
 }
 
 /// <p>The input for the CreateThing operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateThingRequest {
     /// <p>The attribute payload, which consists of up to three name/value pairs in a JSON document. For example:</p> <p> <code>{\"attributes\":{\"string1\":\"string2\"}}</code> </p>
     #[serde(rename = "attributePayload")]
@@ -947,7 +947,7 @@ pub struct CreateThingRequest {
 }
 
 /// <p>The output of the CreateThing operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateThingResponse {
     /// <p>The ARN of the new thing.</p>
     #[serde(rename = "thingArn")]
@@ -964,7 +964,7 @@ pub struct CreateThingResponse {
 }
 
 /// <p>The input for the CreateThingType operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateThingTypeRequest {
     /// <p>The name of the thing type.</p>
     #[serde(rename = "thingTypeName")]
@@ -976,7 +976,7 @@ pub struct CreateThingTypeRequest {
 }
 
 /// <p>The output of the CreateThingType operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateThingTypeResponse {
     /// <p>The Amazon Resource Name (ARN) of the thing type.</p>
     #[serde(rename = "thingTypeArn")]
@@ -993,7 +993,7 @@ pub struct CreateThingTypeResponse {
 }
 
 /// <p>The input for the CreateTopicRule operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateTopicRuleRequest {
     /// <p>The name of the rule.</p>
     #[serde(rename = "ruleName")]
@@ -1004,7 +1004,7 @@ pub struct CreateTopicRuleRequest {
 }
 
 /// <p>Describes a custom method used to code sign a file.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CustomCodeSigning {
     /// <p>The certificate chain.</p>
     #[serde(rename = "certificateChain")]
@@ -1024,18 +1024,18 @@ pub struct CustomCodeSigning {
     pub signature_algorithm: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteAuthorizerRequest {
     /// <p>The name of the authorizer to delete.</p>
     #[serde(rename = "authorizerName")]
     pub authorizer_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteAuthorizerResponse {}
 
 /// <p>Input for the DeleteCACertificate operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteCACertificateRequest {
     /// <p>The ID of the certificate to delete.</p>
     #[serde(rename = "certificateId")]
@@ -1043,11 +1043,11 @@ pub struct DeleteCACertificateRequest {
 }
 
 /// <p>The output for the DeleteCACertificate operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteCACertificateResponse {}
 
 /// <p>The input for the DeleteCertificate operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteCertificateRequest {
     /// <p>The ID of the certificate.</p>
     #[serde(rename = "certificateId")]
@@ -1058,18 +1058,18 @@ pub struct DeleteCertificateRequest {
     pub force_delete: Option<bool>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteOTAUpdateRequest {
     /// <p>The OTA update ID to delete.</p>
     #[serde(rename = "otaUpdateId")]
     pub ota_update_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteOTAUpdateResponse {}
 
 /// <p>The input for the DeletePolicy operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeletePolicyRequest {
     /// <p>The name of the policy to delete.</p>
     #[serde(rename = "policyName")]
@@ -1077,7 +1077,7 @@ pub struct DeletePolicyRequest {
 }
 
 /// <p>The input for the DeletePolicyVersion operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeletePolicyVersionRequest {
     /// <p>The name of the policy.</p>
     #[serde(rename = "policyName")]
@@ -1088,34 +1088,34 @@ pub struct DeletePolicyVersionRequest {
 }
 
 /// <p>The input for the DeleteRegistrationCode operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteRegistrationCodeRequest {}
 
 /// <p>The output for the DeleteRegistrationCode operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteRegistrationCodeResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteRoleAliasRequest {
     /// <p>The role alias to delete.</p>
     #[serde(rename = "roleAlias")]
     pub role_alias: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteRoleAliasResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteStreamRequest {
     /// <p>The stream ID.</p>
     #[serde(rename = "streamId")]
     pub stream_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteStreamResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteThingGroupRequest {
     /// <p>The expected version of the thing group to delete.</p>
     #[serde(rename = "expectedVersion")]
@@ -1126,11 +1126,11 @@ pub struct DeleteThingGroupRequest {
     pub thing_group_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteThingGroupResponse {}
 
 /// <p>The input for the DeleteThing operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteThingRequest {
     /// <p>The expected version of the thing record in the registry. If the version of the record in the registry does not match the expected version specified in the request, the <code>DeleteThing</code> request is rejected with a <code>VersionConflictException</code>.</p>
     #[serde(rename = "expectedVersion")]
@@ -1142,11 +1142,11 @@ pub struct DeleteThingRequest {
 }
 
 /// <p>The output of the DeleteThing operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteThingResponse {}
 
 /// <p>The input for the DeleteThingType operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteThingTypeRequest {
     /// <p>The name of the thing type.</p>
     #[serde(rename = "thingTypeName")]
@@ -1154,18 +1154,18 @@ pub struct DeleteThingTypeRequest {
 }
 
 /// <p>The output for the DeleteThingType operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteThingTypeResponse {}
 
 /// <p>The input for the DeleteTopicRule operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteTopicRuleRequest {
     /// <p>The name of the rule.</p>
     #[serde(rename = "ruleName")]
     pub rule_name: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteV2LoggingLevelRequest {
     /// <p>The name of the resource for which you are configuring logging.</p>
     #[serde(rename = "targetName")]
@@ -1176,7 +1176,7 @@ pub struct DeleteV2LoggingLevelRequest {
 }
 
 /// <p>Contains information that denied the authorization.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Denied {
     /// <p>Information that explicitly denies the authorization. </p>
     #[serde(rename = "explicitDeny")]
@@ -1189,7 +1189,7 @@ pub struct Denied {
 }
 
 /// <p>The input for the DeprecateThingType operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeprecateThingTypeRequest {
     /// <p>The name of the thing type to deprecate.</p>
     #[serde(rename = "thingTypeName")]
@@ -1201,17 +1201,17 @@ pub struct DeprecateThingTypeRequest {
 }
 
 /// <p>The output for the DeprecateThingType operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeprecateThingTypeResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeAuthorizerRequest {
     /// <p>The name of the authorizer to describe.</p>
     #[serde(rename = "authorizerName")]
     pub authorizer_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeAuthorizerResponse {
     /// <p>The authorizer description.</p>
     #[serde(rename = "authorizerDescription")]
@@ -1220,7 +1220,7 @@ pub struct DescribeAuthorizerResponse {
 }
 
 /// <p>The input for the DescribeCACertificate operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeCACertificateRequest {
     /// <p>The CA certificate identifier.</p>
     #[serde(rename = "certificateId")]
@@ -1228,7 +1228,7 @@ pub struct DescribeCACertificateRequest {
 }
 
 /// <p>The output from the DescribeCACertificate operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeCACertificateResponse {
     /// <p>The CA certificate description.</p>
     #[serde(rename = "certificateDescription")]
@@ -1241,7 +1241,7 @@ pub struct DescribeCACertificateResponse {
 }
 
 /// <p>The input for the DescribeCertificate operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeCertificateRequest {
     /// <p>The ID of the certificate.</p>
     #[serde(rename = "certificateId")]
@@ -1249,7 +1249,7 @@ pub struct DescribeCertificateRequest {
 }
 
 /// <p>The output of the DescribeCertificate operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeCertificateResponse {
     /// <p>The description of the certificate.</p>
     #[serde(rename = "certificateDescription")]
@@ -1257,10 +1257,10 @@ pub struct DescribeCertificateResponse {
     pub certificate_description: Option<CertificateDescription>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeDefaultAuthorizerRequest {}
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeDefaultAuthorizerResponse {
     /// <p>The default authorizer's description.</p>
     #[serde(rename = "authorizerDescription")]
@@ -1269,7 +1269,7 @@ pub struct DescribeDefaultAuthorizerResponse {
 }
 
 /// <p>The input for the DescribeEndpoint operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeEndpointRequest {
     /// <p>The endpoint type.</p>
     #[serde(rename = "endpointType")]
@@ -1278,7 +1278,7 @@ pub struct DescribeEndpointRequest {
 }
 
 /// <p>The output from the DescribeEndpoint operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeEndpointResponse {
     /// <p>The endpoint. The format of the endpoint is as follows: <i>identifier</i>.iot.<i>region</i>.amazonaws.com.</p>
     #[serde(rename = "endpointAddress")]
@@ -1286,10 +1286,10 @@ pub struct DescribeEndpointResponse {
     pub endpoint_address: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeEventConfigurationsRequest {}
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeEventConfigurationsResponse {
     /// <p>The creation date of the event configuration.</p>
     #[serde(rename = "creationDate")]
@@ -1305,14 +1305,14 @@ pub struct DescribeEventConfigurationsResponse {
     pub last_modified_date: Option<f64>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeIndexRequest {
     /// <p>The index name.</p>
     #[serde(rename = "indexName")]
     pub index_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeIndexResponse {
     /// <p>The index name.</p>
     #[serde(rename = "indexName")]
@@ -1328,7 +1328,7 @@ pub struct DescribeIndexResponse {
     pub schema: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeJobExecutionRequest {
     /// <p>A string (consisting of the digits "0" through "9" which is used to specify a particular job execution on a particular device.</p>
     #[serde(rename = "executionNumber")]
@@ -1342,7 +1342,7 @@ pub struct DescribeJobExecutionRequest {
     pub thing_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeJobExecutionResponse {
     /// <p>Information about the job execution.</p>
     #[serde(rename = "execution")]
@@ -1350,14 +1350,14 @@ pub struct DescribeJobExecutionResponse {
     pub execution: Option<JobExecution>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeJobRequest {
     /// <p>The unique identifier you assigned to this job when it was created.</p>
     #[serde(rename = "jobId")]
     pub job_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeJobResponse {
     /// <p>An S3 link to the job document.</p>
     #[serde(rename = "documentSource")]
@@ -1369,14 +1369,14 @@ pub struct DescribeJobResponse {
     pub job: Option<Job>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeRoleAliasRequest {
     /// <p>The role alias to describe.</p>
     #[serde(rename = "roleAlias")]
     pub role_alias: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeRoleAliasResponse {
     /// <p>The role alias description.</p>
     #[serde(rename = "roleAliasDescription")]
@@ -1384,14 +1384,14 @@ pub struct DescribeRoleAliasResponse {
     pub role_alias_description: Option<RoleAliasDescription>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeStreamRequest {
     /// <p>The stream ID.</p>
     #[serde(rename = "streamId")]
     pub stream_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeStreamResponse {
     /// <p>Information about the stream.</p>
     #[serde(rename = "streamInfo")]
@@ -1399,14 +1399,14 @@ pub struct DescribeStreamResponse {
     pub stream_info: Option<StreamInfo>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeThingGroupRequest {
     /// <p>The name of the thing group.</p>
     #[serde(rename = "thingGroupName")]
     pub thing_group_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeThingGroupResponse {
     /// <p>The thing group ARN.</p>
     #[serde(rename = "thingGroupArn")]
@@ -1434,14 +1434,14 @@ pub struct DescribeThingGroupResponse {
     pub version: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeThingRegistrationTaskRequest {
     /// <p>The task ID.</p>
     #[serde(rename = "taskId")]
     pub task_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeThingRegistrationTaskResponse {
     /// <p>The task creation date.</p>
     #[serde(rename = "creationDate")]
@@ -1494,7 +1494,7 @@ pub struct DescribeThingRegistrationTaskResponse {
 }
 
 /// <p>The input for the DescribeThing operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeThingRequest {
     /// <p>The name of the thing.</p>
     #[serde(rename = "thingName")]
@@ -1502,7 +1502,7 @@ pub struct DescribeThingRequest {
 }
 
 /// <p>The output from the DescribeThing operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeThingResponse {
     /// <p>The thing attributes.</p>
     #[serde(rename = "attributes")]
@@ -1535,7 +1535,7 @@ pub struct DescribeThingResponse {
 }
 
 /// <p>The input for the DescribeThingType operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeThingTypeRequest {
     /// <p>The name of the thing type.</p>
     #[serde(rename = "thingTypeName")]
@@ -1543,7 +1543,7 @@ pub struct DescribeThingTypeRequest {
 }
 
 /// <p>The output for the DescribeThingType operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeThingTypeResponse {
     /// <p>The thing type ARN.</p>
     #[serde(rename = "thingTypeArn")]
@@ -1567,7 +1567,7 @@ pub struct DescribeThingTypeResponse {
     pub thing_type_properties: Option<ThingTypeProperties>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DetachPolicyRequest {
     /// <p>The policy to detach.</p>
     #[serde(rename = "policyName")]
@@ -1578,7 +1578,7 @@ pub struct DetachPolicyRequest {
 }
 
 /// <p>The input for the DetachPrincipalPolicy operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DetachPrincipalPolicyRequest {
     /// <p>The name of the policy to detach.</p>
     #[serde(rename = "policyName")]
@@ -1589,7 +1589,7 @@ pub struct DetachPrincipalPolicyRequest {
 }
 
 /// <p>The input for the DetachThingPrincipal operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DetachThingPrincipalRequest {
     /// <p>If the principal is a certificate, this value must be ARN of the certificate. If the principal is an Amazon Cognito identity, this value must be the ID of the Amazon Cognito identity.</p>
     #[serde(rename = "principal")]
@@ -1600,11 +1600,11 @@ pub struct DetachThingPrincipalRequest {
 }
 
 /// <p>The output from the DetachThingPrincipal operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DetachThingPrincipalResponse {}
 
 /// <p>The input for the DisableTopicRuleRequest operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DisableTopicRuleRequest {
     /// <p>The name of the rule to disable.</p>
     #[serde(rename = "ruleName")]
@@ -1612,7 +1612,7 @@ pub struct DisableTopicRuleRequest {
 }
 
 /// <p>Describes an action to write to a DynamoDB table.</p> <p>The <code>tableName</code>, <code>hashKeyField</code>, and <code>rangeKeyField</code> values must match the values used when you created the table.</p> <p>The <code>hashKeyValue</code> and <code>rangeKeyvalue</code> fields use a substitution template syntax. These templates provide data at runtime. The syntax is as follows: ${<i>sql-expression</i>}.</p> <p>You can specify any valid expression in a WHERE or SELECT clause, including JSON properties, comparisons, calculations, and functions. For example, the following field uses the third level of the topic:</p> <p> <code>"hashKeyValue": "${topic(3)}"</code> </p> <p>The following field uses the timestamp:</p> <p> <code>"rangeKeyValue": "${timestamp()}"</code> </p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct DynamoDBAction {
     /// <p>The hash key name.</p>
     #[serde(rename = "hashKeyField")]
@@ -1653,7 +1653,7 @@ pub struct DynamoDBAction {
 }
 
 /// <p>Describes an action to write to a DynamoDB table.</p> <p>This DynamoDB action writes each attribute in the message payload into it's own column in the DynamoDB table.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct DynamoDBv2Action {
     /// <p>Specifies the DynamoDB table to which the message data will be written. For example:</p> <p> <code>{ "dynamoDBv2": { "roleArn": "aws:iam:12341251:my-role" "putItem": { "tableName": "my-table" } } }</code> </p> <p>Each attribute in the message payload will be written to a separate column in the DynamoDB database.</p>
     #[serde(rename = "putItem")]
@@ -1666,7 +1666,7 @@ pub struct DynamoDBv2Action {
 }
 
 /// <p>The policy that has the effect on the authorization results.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct EffectivePolicy {
     /// <p>The policy ARN.</p>
     #[serde(rename = "policyArn")]
@@ -1683,7 +1683,7 @@ pub struct EffectivePolicy {
 }
 
 /// <p>Describes an action that writes data to an Amazon Elasticsearch Service domain.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ElasticsearchAction {
     /// <p>The endpoint of your Elasticsearch domain.</p>
     #[serde(rename = "endpoint")]
@@ -1703,7 +1703,7 @@ pub struct ElasticsearchAction {
 }
 
 /// <p>The input for the EnableTopicRuleRequest operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct EnableTopicRuleRequest {
     /// <p>The name of the topic rule to enable.</p>
     #[serde(rename = "ruleName")]
@@ -1711,7 +1711,7 @@ pub struct EnableTopicRuleRequest {
 }
 
 /// <p>Error information.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ErrorInfo {
     /// <p>The error code.</p>
     #[serde(rename = "code")]
@@ -1724,7 +1724,7 @@ pub struct ErrorInfo {
 }
 
 /// <p>Information that explicitly denies authorization.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ExplicitDeny {
     /// <p>The policies that denied the authorization.</p>
     #[serde(rename = "policies")]
@@ -1733,7 +1733,7 @@ pub struct ExplicitDeny {
 }
 
 /// <p>Describes an action that writes data to an Amazon Kinesis Firehose stream.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct FirehoseAction {
     /// <p>The delivery stream name.</p>
     #[serde(rename = "deliveryStreamName")]
@@ -1747,7 +1747,7 @@ pub struct FirehoseAction {
     pub separator: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetEffectivePoliciesRequest {
     /// <p>The Cognito identity pool ID.</p>
     #[serde(rename = "cognitoIdentityPoolId")]
@@ -1763,7 +1763,7 @@ pub struct GetEffectivePoliciesRequest {
     pub thing_name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetEffectivePoliciesResponse {
     /// <p>The effective policies.</p>
     #[serde(rename = "effectivePolicies")]
@@ -1771,10 +1771,10 @@ pub struct GetEffectivePoliciesResponse {
     pub effective_policies: Option<Vec<EffectivePolicy>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetIndexingConfigurationRequest {}
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetIndexingConfigurationResponse {
     /// <p>Thing indexing configuration.</p>
     #[serde(rename = "thingIndexingConfiguration")]
@@ -1782,14 +1782,14 @@ pub struct GetIndexingConfigurationResponse {
     pub thing_indexing_configuration: Option<ThingIndexingConfiguration>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetJobDocumentRequest {
     /// <p>The unique identifier you assigned to this job when it was created.</p>
     #[serde(rename = "jobId")]
     pub job_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetJobDocumentResponse {
     /// <p>The job document content.</p>
     #[serde(rename = "document")]
@@ -1798,11 +1798,11 @@ pub struct GetJobDocumentResponse {
 }
 
 /// <p>The input for the GetLoggingOptions operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetLoggingOptionsRequest {}
 
 /// <p>The output from the GetLoggingOptions operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetLoggingOptionsResponse {
     /// <p>The logging level.</p>
     #[serde(rename = "logLevel")]
@@ -1814,14 +1814,14 @@ pub struct GetLoggingOptionsResponse {
     pub role_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetOTAUpdateRequest {
     /// <p>The OTA update ID.</p>
     #[serde(rename = "otaUpdateId")]
     pub ota_update_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetOTAUpdateResponse {
     /// <p>The OTA update info.</p>
     #[serde(rename = "otaUpdateInfo")]
@@ -1830,7 +1830,7 @@ pub struct GetOTAUpdateResponse {
 }
 
 /// <p>The input for the GetPolicy operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetPolicyRequest {
     /// <p>The name of the policy.</p>
     #[serde(rename = "policyName")]
@@ -1838,7 +1838,7 @@ pub struct GetPolicyRequest {
 }
 
 /// <p>The output from the GetPolicy operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetPolicyResponse {
     #[serde(rename = "creationDate")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1868,7 +1868,7 @@ pub struct GetPolicyResponse {
 }
 
 /// <p>The input for the GetPolicyVersion operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetPolicyVersionRequest {
     /// <p>The name of the policy.</p>
     #[serde(rename = "policyName")]
@@ -1879,7 +1879,7 @@ pub struct GetPolicyVersionRequest {
 }
 
 /// <p>The output from the GetPolicyVersion operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetPolicyVersionResponse {
     #[serde(rename = "creationDate")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1913,11 +1913,11 @@ pub struct GetPolicyVersionResponse {
 }
 
 /// <p>The input to the GetRegistrationCode operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetRegistrationCodeRequest {}
 
 /// <p>The output from the GetRegistrationCode operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetRegistrationCodeResponse {
     /// <p>The CA certificate registration code.</p>
     #[serde(rename = "registrationCode")]
@@ -1926,7 +1926,7 @@ pub struct GetRegistrationCodeResponse {
 }
 
 /// <p>The input for the GetTopicRule operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetTopicRuleRequest {
     /// <p>The name of the rule.</p>
     #[serde(rename = "ruleName")]
@@ -1934,7 +1934,7 @@ pub struct GetTopicRuleRequest {
 }
 
 /// <p>The output from the GetTopicRule operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetTopicRuleResponse {
     /// <p>The rule.</p>
     #[serde(rename = "rule")]
@@ -1946,10 +1946,10 @@ pub struct GetTopicRuleResponse {
     pub rule_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetV2LoggingOptionsRequest {}
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetV2LoggingOptionsResponse {
     /// <p>The default log level.</p>
     #[serde(rename = "defaultLogLevel")]
@@ -1966,7 +1966,7 @@ pub struct GetV2LoggingOptionsResponse {
 }
 
 /// <p>The name and ARN of a group.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GroupNameAndArn {
     /// <p>The group ARN.</p>
     #[serde(rename = "groupArn")]
@@ -1979,7 +1979,7 @@ pub struct GroupNameAndArn {
 }
 
 /// <p>Information that implicitly denies authorization. When policy doesn't explicitly deny or allow an action on a resource it is considered an implicit deny.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ImplicitDeny {
     /// <p>Policies that don't contain a matching allow or deny statement for the specified action on the specified resource. </p>
     #[serde(rename = "policies")]
@@ -1988,7 +1988,7 @@ pub struct ImplicitDeny {
 }
 
 /// <p>The <code>Job</code> object contains details about a job.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Job {
     /// <p>If the job was updated, describes the reason for the update.</p>
     #[serde(rename = "comment")]
@@ -2049,7 +2049,7 @@ pub struct Job {
 }
 
 /// <p>The job execution object represents the execution of a job on a particular device.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct JobExecution {
     /// <p>A string (consisting of the digits "0" through "9") which identifies this particular job execution on this particular device. It can be used in commands which return or update job execution information. </p>
     #[serde(rename = "executionNumber")]
@@ -2086,7 +2086,7 @@ pub struct JobExecution {
 }
 
 /// <p>Details of the job execution status.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct JobExecutionStatusDetails {
     /// <p>The job execution status.</p>
     #[serde(rename = "detailsMap")]
@@ -2095,7 +2095,7 @@ pub struct JobExecutionStatusDetails {
 }
 
 /// <p>The job execution summary.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct JobExecutionSummary {
     /// <p>A string (consisting of the digits "0" through "9") which identifies this particular job execution on this particular device. It can be used later in commands which return or update job execution information.</p>
     #[serde(rename = "executionNumber")]
@@ -2120,7 +2120,7 @@ pub struct JobExecutionSummary {
 }
 
 /// <p>Contains a summary of information about job executions for a specific job.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct JobExecutionSummaryForJob {
     /// <p>Contains a subset of information about a job execution.</p>
     #[serde(rename = "jobExecutionSummary")]
@@ -2133,7 +2133,7 @@ pub struct JobExecutionSummaryForJob {
 }
 
 /// <p>The job execution summary for a thing.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct JobExecutionSummaryForThing {
     /// <p>Contains a subset of information about a job execution.</p>
     #[serde(rename = "jobExecutionSummary")]
@@ -2146,7 +2146,7 @@ pub struct JobExecutionSummaryForThing {
 }
 
 /// <p>Allows you to create a staged rollout of a job.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct JobExecutionsRolloutConfig {
     /// <p>The maximum number of things that will be notified of a pending job, per minute. This parameter allows you to create a staged rollout.</p>
     #[serde(rename = "maximumPerMinute")]
@@ -2155,7 +2155,7 @@ pub struct JobExecutionsRolloutConfig {
 }
 
 /// <p>The job process details.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct JobProcessDetails {
     /// <p>The number of things that cancelled the job.</p>
     #[serde(rename = "numberOfCanceledThings")]
@@ -2192,7 +2192,7 @@ pub struct JobProcessDetails {
 }
 
 /// <p>The job summary.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct JobSummary {
     /// <p>The time, in milliseconds since the epoch, when the job completed.</p>
     #[serde(rename = "completedAt")]
@@ -2229,7 +2229,7 @@ pub struct JobSummary {
 }
 
 /// <p>Describes a key pair.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct KeyPair {
     /// <p>The private key.</p>
     #[serde(rename = "PrivateKey")]
@@ -2242,7 +2242,7 @@ pub struct KeyPair {
 }
 
 /// <p>Describes an action to write data to an Amazon Kinesis stream.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct KinesisAction {
     /// <p>The partition key.</p>
     #[serde(rename = "partitionKey")]
@@ -2257,14 +2257,14 @@ pub struct KinesisAction {
 }
 
 /// <p>Describes an action to invoke a Lambda function.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct LambdaAction {
     /// <p>The ARN of the Lambda function.</p>
     #[serde(rename = "functionArn")]
     pub function_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListAttachedPoliciesRequest {
     /// <p>The token to retrieve the next set of results.</p>
     #[serde(rename = "marker")]
@@ -2283,7 +2283,7 @@ pub struct ListAttachedPoliciesRequest {
     pub target: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListAttachedPoliciesResponse {
     /// <p>The token to retrieve the next set of results, or ``null`` if there are no more results.</p>
     #[serde(rename = "nextMarker")]
@@ -2295,7 +2295,7 @@ pub struct ListAttachedPoliciesResponse {
     pub policies: Option<Vec<Policy>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListAuthorizersRequest {
     /// <p>Return the list of authorizers in ascending alphabetical order.</p>
     #[serde(rename = "ascendingOrder")]
@@ -2315,7 +2315,7 @@ pub struct ListAuthorizersRequest {
     pub status: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListAuthorizersResponse {
     /// <p>The authorizers.</p>
     #[serde(rename = "authorizers")]
@@ -2328,7 +2328,7 @@ pub struct ListAuthorizersResponse {
 }
 
 /// <p>Input for the ListCACertificates operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListCACertificatesRequest {
     /// <p>Determines the order of the results.</p>
     #[serde(rename = "ascendingOrder")]
@@ -2345,7 +2345,7 @@ pub struct ListCACertificatesRequest {
 }
 
 /// <p>The output from the ListCACertificates operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListCACertificatesResponse {
     /// <p>The CA certificates registered in your AWS account.</p>
     #[serde(rename = "certificates")]
@@ -2358,7 +2358,7 @@ pub struct ListCACertificatesResponse {
 }
 
 /// <p>The input to the ListCertificatesByCA operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListCertificatesByCARequest {
     /// <p>Specifies the order for results. If True, the results are returned in ascending order, based on the creation date.</p>
     #[serde(rename = "ascendingOrder")]
@@ -2378,7 +2378,7 @@ pub struct ListCertificatesByCARequest {
 }
 
 /// <p>The output of the ListCertificatesByCA operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListCertificatesByCAResponse {
     /// <p>The device certificates signed by the specified CA certificate.</p>
     #[serde(rename = "certificates")]
@@ -2391,7 +2391,7 @@ pub struct ListCertificatesByCAResponse {
 }
 
 /// <p>The input for the ListCertificates operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListCertificatesRequest {
     /// <p>Specifies the order for results. If True, the results are returned in ascending order, based on the creation date.</p>
     #[serde(rename = "ascendingOrder")]
@@ -2408,7 +2408,7 @@ pub struct ListCertificatesRequest {
 }
 
 /// <p>The output of the ListCertificates operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListCertificatesResponse {
     /// <p>The descriptions of the certificates.</p>
     #[serde(rename = "certificates")]
@@ -2420,7 +2420,7 @@ pub struct ListCertificatesResponse {
     pub next_marker: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListIndicesRequest {
     /// <p>The maximum number of results to return at one time.</p>
     #[serde(rename = "maxResults")]
@@ -2432,7 +2432,7 @@ pub struct ListIndicesRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListIndicesResponse {
     /// <p>The index names.</p>
     #[serde(rename = "indexNames")]
@@ -2444,7 +2444,7 @@ pub struct ListIndicesResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListJobExecutionsForJobRequest {
     /// <p>The unique identifier you assigned to this job when it was created.</p>
     #[serde(rename = "jobId")]
@@ -2463,7 +2463,7 @@ pub struct ListJobExecutionsForJobRequest {
     pub status: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListJobExecutionsForJobResponse {
     /// <p>A list of job execution summaries.</p>
     #[serde(rename = "executionSummaries")]
@@ -2475,7 +2475,7 @@ pub struct ListJobExecutionsForJobResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListJobExecutionsForThingRequest {
     /// <p>The maximum number of results to be returned per request.</p>
     #[serde(rename = "maxResults")]
@@ -2494,7 +2494,7 @@ pub struct ListJobExecutionsForThingRequest {
     pub thing_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListJobExecutionsForThingResponse {
     /// <p>A list of job execution summaries.</p>
     #[serde(rename = "executionSummaries")]
@@ -2506,7 +2506,7 @@ pub struct ListJobExecutionsForThingResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListJobsRequest {
     /// <p>The maximum number of results to return per request.</p>
     #[serde(rename = "maxResults")]
@@ -2534,7 +2534,7 @@ pub struct ListJobsRequest {
     pub thing_group_name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListJobsResponse {
     /// <p>A list of jobs.</p>
     #[serde(rename = "jobs")]
@@ -2546,7 +2546,7 @@ pub struct ListJobsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListOTAUpdatesRequest {
     /// <p>The maximum number of results to return at one time.</p>
     #[serde(rename = "maxResults")]
@@ -2562,7 +2562,7 @@ pub struct ListOTAUpdatesRequest {
     pub ota_update_status: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListOTAUpdatesResponse {
     /// <p>A token to use to get the next set of results.</p>
     #[serde(rename = "nextToken")]
@@ -2575,7 +2575,7 @@ pub struct ListOTAUpdatesResponse {
 }
 
 /// <p>The input to the ListOutgoingCertificates operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListOutgoingCertificatesRequest {
     /// <p>Specifies the order for results. If True, the results are returned in ascending order, based on the creation date.</p>
     #[serde(rename = "ascendingOrder")]
@@ -2592,7 +2592,7 @@ pub struct ListOutgoingCertificatesRequest {
 }
 
 /// <p>The output from the ListOutgoingCertificates operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListOutgoingCertificatesResponse {
     /// <p>The marker for the next set of results.</p>
     #[serde(rename = "nextMarker")]
@@ -2605,7 +2605,7 @@ pub struct ListOutgoingCertificatesResponse {
 }
 
 /// <p>The input for the ListPolicies operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListPoliciesRequest {
     /// <p>Specifies the order for results. If true, the results are returned in ascending creation order.</p>
     #[serde(rename = "ascendingOrder")]
@@ -2622,7 +2622,7 @@ pub struct ListPoliciesRequest {
 }
 
 /// <p>The output from the ListPolicies operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListPoliciesResponse {
     /// <p>The marker for the next set of results, or null if there are no additional results.</p>
     #[serde(rename = "nextMarker")]
@@ -2635,7 +2635,7 @@ pub struct ListPoliciesResponse {
 }
 
 /// <p>The input for the ListPolicyPrincipals operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListPolicyPrincipalsRequest {
     /// <p>Specifies the order for results. If true, the results are returned in ascending creation order.</p>
     #[serde(rename = "ascendingOrder")]
@@ -2655,7 +2655,7 @@ pub struct ListPolicyPrincipalsRequest {
 }
 
 /// <p>The output from the ListPolicyPrincipals operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListPolicyPrincipalsResponse {
     /// <p>The marker for the next set of results, or null if there are no additional results.</p>
     #[serde(rename = "nextMarker")]
@@ -2668,7 +2668,7 @@ pub struct ListPolicyPrincipalsResponse {
 }
 
 /// <p>The input for the ListPolicyVersions operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListPolicyVersionsRequest {
     /// <p>The policy name.</p>
     #[serde(rename = "policyName")]
@@ -2676,7 +2676,7 @@ pub struct ListPolicyVersionsRequest {
 }
 
 /// <p>The output from the ListPolicyVersions operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListPolicyVersionsResponse {
     /// <p>The policy versions.</p>
     #[serde(rename = "policyVersions")]
@@ -2685,7 +2685,7 @@ pub struct ListPolicyVersionsResponse {
 }
 
 /// <p>The input for the ListPrincipalPolicies operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListPrincipalPoliciesRequest {
     /// <p>Specifies the order for results. If true, results are returned in ascending creation order.</p>
     #[serde(rename = "ascendingOrder")]
@@ -2705,7 +2705,7 @@ pub struct ListPrincipalPoliciesRequest {
 }
 
 /// <p>The output from the ListPrincipalPolicies operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListPrincipalPoliciesResponse {
     /// <p>The marker for the next set of results, or null if there are no additional results.</p>
     #[serde(rename = "nextMarker")]
@@ -2718,7 +2718,7 @@ pub struct ListPrincipalPoliciesResponse {
 }
 
 /// <p>The input for the ListPrincipalThings operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListPrincipalThingsRequest {
     /// <p>The maximum number of results to return in this operation.</p>
     #[serde(rename = "maxResults")]
@@ -2734,7 +2734,7 @@ pub struct ListPrincipalThingsRequest {
 }
 
 /// <p>The output from the ListPrincipalThings operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListPrincipalThingsResponse {
     /// <p>The token used to get the next set of results, or <b>null</b> if there are no additional results.</p>
     #[serde(rename = "nextToken")]
@@ -2746,7 +2746,7 @@ pub struct ListPrincipalThingsResponse {
     pub things: Option<Vec<String>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListRoleAliasesRequest {
     /// <p>Return the list of role aliases in ascending alphabetical order.</p>
     #[serde(rename = "ascendingOrder")]
@@ -2762,7 +2762,7 @@ pub struct ListRoleAliasesRequest {
     pub page_size: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListRoleAliasesResponse {
     /// <p>A marker used to get the next set of results.</p>
     #[serde(rename = "nextMarker")]
@@ -2774,7 +2774,7 @@ pub struct ListRoleAliasesResponse {
     pub role_aliases: Option<Vec<String>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListStreamsRequest {
     /// <p>Set to true to return the list of streams in ascending order.</p>
     #[serde(rename = "ascendingOrder")]
@@ -2790,7 +2790,7 @@ pub struct ListStreamsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListStreamsResponse {
     /// <p>A token used to get the next set of results.</p>
     #[serde(rename = "nextToken")]
@@ -2802,7 +2802,7 @@ pub struct ListStreamsResponse {
     pub streams: Option<Vec<StreamSummary>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListTargetsForPolicyRequest {
     /// <p>A marker used to get the next set of results.</p>
     #[serde(rename = "marker")]
@@ -2817,7 +2817,7 @@ pub struct ListTargetsForPolicyRequest {
     pub policy_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListTargetsForPolicyResponse {
     /// <p>A marker used to get the next set of results.</p>
     #[serde(rename = "nextMarker")]
@@ -2829,7 +2829,7 @@ pub struct ListTargetsForPolicyResponse {
     pub targets: Option<Vec<String>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListThingGroupsForThingRequest {
     /// <p>The maximum number of results to return at one time.</p>
     #[serde(rename = "maxResults")]
@@ -2844,7 +2844,7 @@ pub struct ListThingGroupsForThingRequest {
     pub thing_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListThingGroupsForThingResponse {
     /// <p>The token used to get the next set of results, or <b>null</b> if there are no additional results.</p>
     #[serde(rename = "nextToken")]
@@ -2856,7 +2856,7 @@ pub struct ListThingGroupsForThingResponse {
     pub thing_groups: Option<Vec<GroupNameAndArn>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListThingGroupsRequest {
     /// <p>The maximum number of results to return at one time.</p>
     #[serde(rename = "maxResults")]
@@ -2880,7 +2880,7 @@ pub struct ListThingGroupsRequest {
     pub recursive: Option<bool>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListThingGroupsResponse {
     /// <p>The token used to get the next set of results, or <b>null</b> if there are no additional results.</p>
     #[serde(rename = "nextToken")]
@@ -2893,7 +2893,7 @@ pub struct ListThingGroupsResponse {
 }
 
 /// <p>The input for the ListThingPrincipal operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListThingPrincipalsRequest {
     /// <p>The name of the thing.</p>
     #[serde(rename = "thingName")]
@@ -2901,7 +2901,7 @@ pub struct ListThingPrincipalsRequest {
 }
 
 /// <p>The output from the ListThingPrincipals operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListThingPrincipalsResponse {
     /// <p>The principals associated with the thing.</p>
     #[serde(rename = "principals")]
@@ -2909,7 +2909,7 @@ pub struct ListThingPrincipalsResponse {
     pub principals: Option<Vec<String>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListThingRegistrationTaskReportsRequest {
     /// <p>The maximum number of results to return per request.</p>
     #[serde(rename = "maxResults")]
@@ -2927,7 +2927,7 @@ pub struct ListThingRegistrationTaskReportsRequest {
     pub task_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListThingRegistrationTaskReportsResponse {
     /// <p>The token to retrieve the next set of results.</p>
     #[serde(rename = "nextToken")]
@@ -2943,7 +2943,7 @@ pub struct ListThingRegistrationTaskReportsResponse {
     pub resource_links: Option<Vec<String>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListThingRegistrationTasksRequest {
     /// <p>The maximum number of results to return at one time.</p>
     #[serde(rename = "maxResults")]
@@ -2959,7 +2959,7 @@ pub struct ListThingRegistrationTasksRequest {
     pub status: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListThingRegistrationTasksResponse {
     /// <p>The token used to get the next set of results, or <b>null</b> if there are no additional results.</p>
     #[serde(rename = "nextToken")]
@@ -2972,7 +2972,7 @@ pub struct ListThingRegistrationTasksResponse {
 }
 
 /// <p>The input for the ListThingTypes operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListThingTypesRequest {
     /// <p>The maximum number of results to return in this operation.</p>
     #[serde(rename = "maxResults")]
@@ -2989,7 +2989,7 @@ pub struct ListThingTypesRequest {
 }
 
 /// <p>The output for the ListThingTypes operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListThingTypesResponse {
     /// <p>The token for the next set of results, or <b>null</b> if there are no additional results.</p>
     #[serde(rename = "nextToken")]
@@ -3001,7 +3001,7 @@ pub struct ListThingTypesResponse {
     pub thing_types: Option<Vec<ThingTypeDefinition>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListThingsInThingGroupRequest {
     /// <p>The maximum number of results to return at one time.</p>
     #[serde(rename = "maxResults")]
@@ -3020,7 +3020,7 @@ pub struct ListThingsInThingGroupRequest {
     pub thing_group_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListThingsInThingGroupResponse {
     /// <p>The token used to get the next set of results, or <b>null</b> if there are no additional results.</p>
     #[serde(rename = "nextToken")]
@@ -3033,7 +3033,7 @@ pub struct ListThingsInThingGroupResponse {
 }
 
 /// <p>The input for the ListThings operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListThingsRequest {
     /// <p>The attribute name used to search for things.</p>
     #[serde(rename = "attributeName")]
@@ -3058,7 +3058,7 @@ pub struct ListThingsRequest {
 }
 
 /// <p>The output from the ListThings operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListThingsResponse {
     /// <p>The token used to get the next set of results, or <b>null</b> if there are no additional results.</p>
     #[serde(rename = "nextToken")]
@@ -3071,7 +3071,7 @@ pub struct ListThingsResponse {
 }
 
 /// <p>The input for the ListTopicRules operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListTopicRulesRequest {
     /// <p>The maximum number of results to return.</p>
     #[serde(rename = "maxResults")]
@@ -3092,7 +3092,7 @@ pub struct ListTopicRulesRequest {
 }
 
 /// <p>The output from the ListTopicRules operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListTopicRulesResponse {
     /// <p>A token used to retrieve the next value.</p>
     #[serde(rename = "nextToken")]
@@ -3104,7 +3104,7 @@ pub struct ListTopicRulesResponse {
     pub rules: Option<Vec<TopicRuleListItem>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListV2LoggingLevelsRequest {
     /// <p>The maximum number of results to return at one time.</p>
     #[serde(rename = "maxResults")]
@@ -3120,7 +3120,7 @@ pub struct ListV2LoggingLevelsRequest {
     pub target_type: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListV2LoggingLevelsResponse {
     /// <p>The logging configuration for a target.</p>
     #[serde(rename = "logTargetConfigurations")]
@@ -3133,7 +3133,7 @@ pub struct ListV2LoggingLevelsResponse {
 }
 
 /// <p>A log target.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct LogTarget {
     /// <p>The target name.</p>
     #[serde(rename = "targetName")]
@@ -3145,7 +3145,7 @@ pub struct LogTarget {
 }
 
 /// <p>The target configuration.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct LogTargetConfiguration {
     /// <p>The logging level.</p>
     #[serde(rename = "logLevel")]
@@ -3158,7 +3158,7 @@ pub struct LogTargetConfiguration {
 }
 
 /// <p>Describes the logging options payload.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct LoggingOptionsPayload {
     /// <p>The log level.</p>
     #[serde(rename = "logLevel")]
@@ -3170,7 +3170,7 @@ pub struct LoggingOptionsPayload {
 }
 
 /// <p>Describes a file to be associated with an OTA update.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct OTAUpdateFile {
     /// <p>A list of name/attribute pairs.</p>
     #[serde(rename = "attributes")]
@@ -3195,7 +3195,7 @@ pub struct OTAUpdateFile {
 }
 
 /// <p>Information about an OTA update.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct OTAUpdateInfo {
     /// <p>A collection of name/value pairs</p>
     #[serde(rename = "additionalParameters")]
@@ -3252,7 +3252,7 @@ pub struct OTAUpdateInfo {
 }
 
 /// <p>An OTA update summary.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct OTAUpdateSummary {
     /// <p>The date when the OTA update was created.</p>
     #[serde(rename = "creationDate")]
@@ -3269,7 +3269,7 @@ pub struct OTAUpdateSummary {
 }
 
 /// <p>A certificate that has been transferred but not yet accepted.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct OutgoingCertificate {
     /// <p>The certificate ARN.</p>
     #[serde(rename = "certificateArn")]
@@ -3298,7 +3298,7 @@ pub struct OutgoingCertificate {
 }
 
 /// <p>Describes an AWS IoT policy.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Policy {
     /// <p>The policy ARN.</p>
     #[serde(rename = "policyArn")]
@@ -3311,7 +3311,7 @@ pub struct Policy {
 }
 
 /// <p>Describes a policy version.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PolicyVersion {
     /// <p>The date and time the policy was created.</p>
     #[serde(rename = "createDate")]
@@ -3328,7 +3328,7 @@ pub struct PolicyVersion {
 }
 
 /// <p>Configuration for pre-signed S3 URLs.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct PresignedUrlConfig {
     /// <p>How long (in seconds) pre-signed URLs are valid. Valid values are 60 - 3600, the default value is 3600 seconds. Pre-signed URLs are generated when Jobs receives an MQTT request for the job document.</p>
     #[serde(rename = "expiresInSec")]
@@ -3341,7 +3341,7 @@ pub struct PresignedUrlConfig {
 }
 
 /// <p>The input for the DynamoActionVS action that specifies the DynamoDB table to which the message data will be written.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct PutItemInput {
     /// <p>The table where the message data will be written</p>
     #[serde(rename = "tableName")]
@@ -3349,7 +3349,7 @@ pub struct PutItemInput {
 }
 
 /// <p>The input to the RegisterCACertificate operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RegisterCACertificateRequest {
     /// <p>Allows this CA certificate to be used for auto registration of device certificates.</p>
     #[serde(rename = "allowAutoRegistration")]
@@ -3372,7 +3372,7 @@ pub struct RegisterCACertificateRequest {
 }
 
 /// <p>The output from the RegisterCACertificateResponse operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RegisterCACertificateResponse {
     /// <p>The CA certificate ARN.</p>
     #[serde(rename = "certificateArn")]
@@ -3385,7 +3385,7 @@ pub struct RegisterCACertificateResponse {
 }
 
 /// <p>The input to the RegisterCertificate operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RegisterCertificateRequest {
     /// <p>The CA certificate used to sign the device certificate being registered.</p>
     #[serde(rename = "caCertificatePem")]
@@ -3401,7 +3401,7 @@ pub struct RegisterCertificateRequest {
 }
 
 /// <p>The output from the RegisterCertificate operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RegisterCertificateResponse {
     /// <p>The certificate ARN.</p>
     #[serde(rename = "certificateArn")]
@@ -3413,7 +3413,7 @@ pub struct RegisterCertificateResponse {
     pub certificate_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RegisterThingRequest {
     /// <p>The parameters for provisioning a thing.</p>
     #[serde(rename = "parameters")]
@@ -3424,7 +3424,7 @@ pub struct RegisterThingRequest {
     pub template_body: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RegisterThingResponse {
     #[serde(rename = "certificatePem")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -3436,7 +3436,7 @@ pub struct RegisterThingResponse {
 }
 
 /// <p>The registration configuration.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RegistrationConfig {
     /// <p>The ARN of the role.</p>
     #[serde(rename = "roleArn")]
@@ -3449,7 +3449,7 @@ pub struct RegistrationConfig {
 }
 
 /// <p>The input for the RejectCertificateTransfer operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RejectCertificateTransferRequest {
     /// <p>The ID of the certificate.</p>
     #[serde(rename = "certificateId")]
@@ -3460,7 +3460,7 @@ pub struct RejectCertificateTransferRequest {
     pub reject_reason: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RemoveThingFromThingGroupRequest {
     /// <p>The ARN of the thing to remove from the group.</p>
     #[serde(rename = "thingArn")]
@@ -3480,11 +3480,11 @@ pub struct RemoveThingFromThingGroupRequest {
     pub thing_name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RemoveThingFromThingGroupResponse {}
 
 /// <p>The input for the ReplaceTopicRule operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ReplaceTopicRuleRequest {
     /// <p>The name of the rule.</p>
     #[serde(rename = "ruleName")]
@@ -3495,7 +3495,7 @@ pub struct ReplaceTopicRuleRequest {
 }
 
 /// <p>Describes an action to republish to another topic.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RepublishAction {
     /// <p>The ARN of the IAM role that grants access.</p>
     #[serde(rename = "roleArn")]
@@ -3506,7 +3506,7 @@ pub struct RepublishAction {
 }
 
 /// <p>Role alias description.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RoleAliasDescription {
     /// <p>The UNIX timestamp of when the role alias was created.</p>
     #[serde(rename = "creationDate")]
@@ -3538,7 +3538,7 @@ pub struct RoleAliasDescription {
 }
 
 /// <p>Describes an action to write data to an Amazon S3 bucket.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct S3Action {
     /// <p>The Amazon S3 bucket.</p>
     #[serde(rename = "bucketName")]
@@ -3556,7 +3556,7 @@ pub struct S3Action {
 }
 
 /// <p>The location in S3 the contains the files to stream.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct S3Location {
     /// <p>The S3 bucket that contains the file to stream.</p>
     #[serde(rename = "bucket")]
@@ -3571,7 +3571,7 @@ pub struct S3Location {
 }
 
 /// <p>Describes an action to write a message to a Salesforce IoT Cloud Input Stream.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SalesforceAction {
     /// <p>The token used to authenticate access to the Salesforce IoT Cloud Input Stream. The token is available from the Salesforce IoT Cloud platform after creation of the Input Stream.</p>
     #[serde(rename = "token")]
@@ -3581,7 +3581,7 @@ pub struct SalesforceAction {
     pub url: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SearchIndexRequest {
     /// <p>The search index name.</p>
     #[serde(rename = "indexName")]
@@ -3604,7 +3604,7 @@ pub struct SearchIndexRequest {
     pub query_version: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SearchIndexResponse {
     /// <p>The token used to get the next set of results, or <b>null</b> if there are no additional results.</p>
     #[serde(rename = "nextToken")]
@@ -3616,14 +3616,14 @@ pub struct SearchIndexResponse {
     pub things: Option<Vec<ThingDocument>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SetDefaultAuthorizerRequest {
     /// <p>The authorizer name.</p>
     #[serde(rename = "authorizerName")]
     pub authorizer_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SetDefaultAuthorizerResponse {
     /// <p>The authorizer ARN.</p>
     #[serde(rename = "authorizerArn")]
@@ -3636,7 +3636,7 @@ pub struct SetDefaultAuthorizerResponse {
 }
 
 /// <p>The input for the SetDefaultPolicyVersion operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SetDefaultPolicyVersionRequest {
     /// <p>The policy name.</p>
     #[serde(rename = "policyName")]
@@ -3647,14 +3647,14 @@ pub struct SetDefaultPolicyVersionRequest {
 }
 
 /// <p>The input for the SetLoggingOptions operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SetLoggingOptionsRequest {
     /// <p>The logging options payload.</p>
     #[serde(rename = "loggingOptionsPayload")]
     pub logging_options_payload: LoggingOptionsPayload,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SetV2LoggingLevelRequest {
     /// <p>The log level.</p>
     #[serde(rename = "logLevel")]
@@ -3664,7 +3664,7 @@ pub struct SetV2LoggingLevelRequest {
     pub log_target: LogTarget,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SetV2LoggingOptionsRequest {
     /// <p>The default logging level.</p>
     #[serde(rename = "defaultLogLevel")]
@@ -3681,7 +3681,7 @@ pub struct SetV2LoggingOptionsRequest {
 }
 
 /// <p>Describes an action to publish to an Amazon SNS topic.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SnsAction {
     /// <p>The message format of the message to publish. Optional. Accepted values are "JSON" and "RAW". The default value of the attribute is "RAW". SNS uses this setting to determine if the payload should be parsed and relevant platform-specific bits of the payload should be extracted. To read more about SNS message formats, see <a href="http://docs.aws.amazon.com/sns/latest/dg/json-formats.html">http://docs.aws.amazon.com/sns/latest/dg/json-formats.html</a> refer to their official documentation.</p>
     #[serde(rename = "messageFormat")]
@@ -3696,7 +3696,7 @@ pub struct SnsAction {
 }
 
 /// <p>Describes an action to publish data to an Amazon SQS queue.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SqsAction {
     /// <p>The URL of the Amazon SQS queue.</p>
     #[serde(rename = "queueUrl")]
@@ -3710,7 +3710,7 @@ pub struct SqsAction {
     pub use_base_64: Option<bool>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StartThingRegistrationTaskRequest {
     /// <p>The S3 bucket that contains the input file.</p>
     #[serde(rename = "inputFileBucket")]
@@ -3726,7 +3726,7 @@ pub struct StartThingRegistrationTaskRequest {
     pub template_body: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StartThingRegistrationTaskResponse {
     /// <p>The bulk thing provisioning task ID.</p>
     #[serde(rename = "taskId")]
@@ -3734,18 +3734,18 @@ pub struct StartThingRegistrationTaskResponse {
     pub task_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StopThingRegistrationTaskRequest {
     /// <p>The bulk thing provisioning task ID.</p>
     #[serde(rename = "taskId")]
     pub task_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StopThingRegistrationTaskResponse {}
 
 /// <p>Describes a group of files that can be streamed.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Stream {
     /// <p>The ID of a file associated with a stream.</p>
     #[serde(rename = "fileId")]
@@ -3758,7 +3758,7 @@ pub struct Stream {
 }
 
 /// <p>Represents a file to stream.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct StreamFile {
     /// <p>The file ID.</p>
     #[serde(rename = "fileId")]
@@ -3771,7 +3771,7 @@ pub struct StreamFile {
 }
 
 /// <p>Information about a stream.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StreamInfo {
     /// <p>The date when the stream was created.</p>
     #[serde(rename = "createdAt")]
@@ -3808,7 +3808,7 @@ pub struct StreamInfo {
 }
 
 /// <p>A summary of a stream.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StreamSummary {
     /// <p>A description of the stream.</p>
     #[serde(rename = "description")]
@@ -3828,7 +3828,7 @@ pub struct StreamSummary {
     pub stream_version: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct TestAuthorizationRequest {
     /// <p>A list of authorization info objects. Simulating authorization will create a response for each <code>authInfo</code> object in the list.</p>
     #[serde(rename = "authInfos")]
@@ -3855,7 +3855,7 @@ pub struct TestAuthorizationRequest {
     pub principal: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct TestAuthorizationResponse {
     /// <p>The authentication results.</p>
     #[serde(rename = "authResults")]
@@ -3863,7 +3863,7 @@ pub struct TestAuthorizationResponse {
     pub auth_results: Option<Vec<AuthResult>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct TestInvokeAuthorizerRequest {
     /// <p>The custom authorizer name.</p>
     #[serde(rename = "authorizerName")]
@@ -3876,7 +3876,7 @@ pub struct TestInvokeAuthorizerRequest {
     pub token_signature: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct TestInvokeAuthorizerResponse {
     /// <p>The number of seconds after which the connection is terminated.</p>
     #[serde(rename = "disconnectAfterInSeconds")]
@@ -3901,7 +3901,7 @@ pub struct TestInvokeAuthorizerResponse {
 }
 
 /// <p>The properties of the thing, including thing name, thing type name, and a list of thing attributes.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ThingAttribute {
     /// <p>A list of thing attributes which are name-value pairs.</p>
     #[serde(rename = "attributes")]
@@ -3926,7 +3926,7 @@ pub struct ThingAttribute {
 }
 
 /// <p>The thing search index document.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ThingDocument {
     /// <p>The attributes.</p>
     #[serde(rename = "attributes")]
@@ -3955,7 +3955,7 @@ pub struct ThingDocument {
 }
 
 /// <p>Thing group metadata.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ThingGroupMetadata {
     /// <p>The UNIX timestamp of when the thing group was created.</p>
     #[serde(rename = "creationDate")]
@@ -3972,7 +3972,7 @@ pub struct ThingGroupMetadata {
 }
 
 /// <p>Thing group properties.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ThingGroupProperties {
     /// <p>The thing group attributes in JSON format.</p>
     #[serde(rename = "attributePayload")]
@@ -3985,7 +3985,7 @@ pub struct ThingGroupProperties {
 }
 
 /// <p>Thing indexing configuration.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ThingIndexingConfiguration {
     /// <p><p>Thing indexing mode. Valid values are: </p> <ul> <li> <p>REGISTRY – Your thing index will contain only registry data.</p> </li> <li> <p>REGISTRY<em>AND</em>SHADOW - Your thing index will contain registry and shadow data.</p> </li> <li> <p>OFF - Thing indexing is disabled.</p> </li> </ul></p>
     #[serde(rename = "thingIndexingMode")]
@@ -3994,7 +3994,7 @@ pub struct ThingIndexingConfiguration {
 }
 
 /// <p>The definition of the thing type, including thing type name and description.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ThingTypeDefinition {
     /// <p>The thing type ARN.</p>
     #[serde(rename = "thingTypeArn")]
@@ -4015,7 +4015,7 @@ pub struct ThingTypeDefinition {
 }
 
 /// <p>The ThingTypeMetadata contains additional information about the thing type including: creation date and time, a value indicating whether the thing type is deprecated, and a date and time when time was deprecated.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ThingTypeMetadata {
     /// <p>The date and time when the thing type was created.</p>
     #[serde(rename = "creationDate")]
@@ -4032,7 +4032,7 @@ pub struct ThingTypeMetadata {
 }
 
 /// <p>The ThingTypeProperties contains information about the thing type including: a thing type description, and a list of searchable thing attribute names.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ThingTypeProperties {
     /// <p>A list of searchable thing attribute names.</p>
     #[serde(rename = "searchableAttributes")]
@@ -4045,7 +4045,7 @@ pub struct ThingTypeProperties {
 }
 
 /// <p>Describes a rule.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct TopicRule {
     /// <p>The actions associated with the rule.</p>
     #[serde(rename = "actions")]
@@ -4082,7 +4082,7 @@ pub struct TopicRule {
 }
 
 /// <p>Describes a rule.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct TopicRuleListItem {
     /// <p>The date and time the rule was created.</p>
     #[serde(rename = "createdAt")]
@@ -4107,7 +4107,7 @@ pub struct TopicRuleListItem {
 }
 
 /// <p>Describes a rule.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct TopicRulePayload {
     /// <p>The actions associated with the rule.</p>
     #[serde(rename = "actions")]
@@ -4134,7 +4134,7 @@ pub struct TopicRulePayload {
 }
 
 /// <p>The input for the TransferCertificate operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct TransferCertificateRequest {
     /// <p>The ID of the certificate.</p>
     #[serde(rename = "certificateId")]
@@ -4149,7 +4149,7 @@ pub struct TransferCertificateRequest {
 }
 
 /// <p>The output from the TransferCertificate operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct TransferCertificateResponse {
     /// <p>The ARN of the certificate.</p>
     #[serde(rename = "transferredCertificateArn")]
@@ -4158,7 +4158,7 @@ pub struct TransferCertificateResponse {
 }
 
 /// <p>Data used to transfer a certificate to an AWS account.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct TransferData {
     /// <p>The date the transfer was accepted.</p>
     #[serde(rename = "acceptDate")]
@@ -4182,7 +4182,7 @@ pub struct TransferData {
     pub transfer_message: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateAuthorizerRequest {
     /// <p>The ARN of the authorizer's Lambda function.</p>
     #[serde(rename = "authorizerFunctionArn")]
@@ -4205,7 +4205,7 @@ pub struct UpdateAuthorizerRequest {
     pub token_signing_public_keys: Option<::std::collections::HashMap<String, String>>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateAuthorizerResponse {
     /// <p>The authorizer ARN.</p>
     #[serde(rename = "authorizerArn")]
@@ -4218,7 +4218,7 @@ pub struct UpdateAuthorizerResponse {
 }
 
 /// <p>The input to the UpdateCACertificate operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateCACertificateRequest {
     /// <p>The CA certificate identifier.</p>
     #[serde(rename = "certificateId")]
@@ -4242,7 +4242,7 @@ pub struct UpdateCACertificateRequest {
 }
 
 /// <p>The input for the UpdateCertificate operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateCertificateRequest {
     /// <p>The ID of the certificate.</p>
     #[serde(rename = "certificateId")]
@@ -4252,7 +4252,7 @@ pub struct UpdateCertificateRequest {
     pub new_status: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateEventConfigurationsRequest {
     /// <p>The new event configuration values.</p>
     #[serde(rename = "eventConfigurations")]
@@ -4260,10 +4260,10 @@ pub struct UpdateEventConfigurationsRequest {
     pub event_configurations: Option<::std::collections::HashMap<String, Configuration>>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateEventConfigurationsResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateIndexingConfigurationRequest {
     /// <p>Thing indexing configuration.</p>
     #[serde(rename = "thingIndexingConfiguration")]
@@ -4271,10 +4271,10 @@ pub struct UpdateIndexingConfigurationRequest {
     pub thing_indexing_configuration: Option<ThingIndexingConfiguration>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateIndexingConfigurationResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateRoleAliasRequest {
     /// <p>The number of seconds the credential will be valid.</p>
     #[serde(rename = "credentialDurationSeconds")]
@@ -4289,7 +4289,7 @@ pub struct UpdateRoleAliasRequest {
     pub role_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateRoleAliasResponse {
     /// <p>The role alias.</p>
     #[serde(rename = "roleAlias")]
@@ -4301,7 +4301,7 @@ pub struct UpdateRoleAliasResponse {
     pub role_alias_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateStreamRequest {
     /// <p>The description of the stream.</p>
     #[serde(rename = "description")]
@@ -4320,7 +4320,7 @@ pub struct UpdateStreamRequest {
     pub stream_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateStreamResponse {
     /// <p>A description of the stream.</p>
     #[serde(rename = "description")]
@@ -4340,7 +4340,7 @@ pub struct UpdateStreamResponse {
     pub stream_version: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateThingGroupRequest {
     /// <p>The expected version of the thing group. If this does not match the version of the thing group being updated, the update will fail.</p>
     #[serde(rename = "expectedVersion")]
@@ -4354,7 +4354,7 @@ pub struct UpdateThingGroupRequest {
     pub thing_group_properties: ThingGroupProperties,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateThingGroupResponse {
     /// <p>The version of the updated thing group.</p>
     #[serde(rename = "version")]
@@ -4362,7 +4362,7 @@ pub struct UpdateThingGroupResponse {
     pub version: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateThingGroupsForThingRequest {
     /// <p>The groups to which the thing will be added.</p>
     #[serde(rename = "thingGroupsToAdd")]
@@ -4378,11 +4378,11 @@ pub struct UpdateThingGroupsForThingRequest {
     pub thing_name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateThingGroupsForThingResponse {}
 
 /// <p>The input for the UpdateThing operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateThingRequest {
     /// <p>A list of thing attributes, a JSON string containing name-value pairs. For example:</p> <p> <code>{\"attributes\":{\"name1\":\"value2\"}}</code> </p> <p>This data is used to add new attributes or update existing attributes.</p>
     #[serde(rename = "attributePayload")]
@@ -4406,7 +4406,7 @@ pub struct UpdateThingRequest {
 }
 
 /// <p>The output from the UpdateThing operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateThingResponse {}
 
 /// Errors returned by AcceptCertificateTransfer

--- a/rusoto/services/iot/src/generated.rs
+++ b/rusoto/services/iot/src/generated.rs
@@ -4440,7 +4440,8 @@ impl AcceptCertificateTransferError {
     pub fn from_body(body: &str) -> AcceptCertificateTransferError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4556,7 +4557,8 @@ impl AddThingToThingGroupError {
     pub fn from_body(body: &str) -> AddThingToThingGroupError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4656,7 +4658,8 @@ impl AssociateTargetsWithJobError {
     pub fn from_body(body: &str) -> AssociateTargetsWithJobError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4766,7 +4769,8 @@ impl AttachPolicyError {
     pub fn from_body(body: &str) -> AttachPolicyError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4880,7 +4884,8 @@ impl AttachPrincipalPolicyError {
     pub fn from_body(body: &str) -> AttachPrincipalPolicyError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4994,7 +4999,8 @@ impl AttachThingPrincipalError {
     pub fn from_body(body: &str) -> AttachThingPrincipalError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5106,7 +5112,8 @@ impl CancelCertificateTransferError {
     pub fn from_body(body: &str) -> CancelCertificateTransferError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5222,7 +5229,8 @@ impl CancelJobError {
     pub fn from_body(body: &str) -> CancelJobError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5320,7 +5328,8 @@ impl ClearDefaultAuthorizerError {
     pub fn from_body(body: &str) -> ClearDefaultAuthorizerError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5432,7 +5441,8 @@ impl CreateAuthorizerError {
     pub fn from_body(body: &str) -> CreateAuthorizerError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5542,7 +5552,8 @@ impl CreateCertificateFromCsrError {
     pub fn from_body(body: &str) -> CreateCertificateFromCsrError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5650,7 +5661,8 @@ impl CreateJobError {
     pub fn from_body(body: &str) -> CreateJobError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5754,7 +5766,8 @@ impl CreateKeysAndCertificateError {
     pub fn from_body(body: &str) -> CreateKeysAndCertificateError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5864,7 +5877,8 @@ impl CreateOTAUpdateError {
     pub fn from_body(body: &str) -> CreateOTAUpdateError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5978,7 +5992,8 @@ impl CreatePolicyError {
     pub fn from_body(body: &str) -> CreatePolicyError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6094,7 +6109,8 @@ impl CreatePolicyVersionError {
     pub fn from_body(body: &str) -> CreatePolicyVersionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6214,7 +6230,8 @@ impl CreateRoleAliasError {
     pub fn from_body(body: &str) -> CreateRoleAliasError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6328,7 +6345,8 @@ impl CreateStreamError {
     pub fn from_body(body: &str) -> CreateStreamError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6442,7 +6460,8 @@ impl CreateThingError {
     pub fn from_body(body: &str) -> CreateThingError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6550,7 +6569,8 @@ impl CreateThingGroupError {
     pub fn from_body(body: &str) -> CreateThingGroupError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6650,7 +6670,8 @@ impl CreateThingTypeError {
     pub fn from_body(body: &str) -> CreateThingTypeError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6756,7 +6777,8 @@ impl CreateTopicRuleError {
     pub fn from_body(body: &str) -> CreateTopicRuleError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6862,7 +6884,8 @@ impl DeleteAuthorizerError {
     pub fn from_body(body: &str) -> DeleteAuthorizerError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6976,7 +6999,8 @@ impl DeleteCACertificateError {
     pub fn from_body(body: &str) -> DeleteCACertificateError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7094,7 +7118,8 @@ impl DeleteCertificateError {
     pub fn from_body(body: &str) -> DeleteCertificateError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7212,7 +7237,8 @@ impl DeleteOTAUpdateError {
     pub fn from_body(body: &str) -> DeleteOTAUpdateError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7322,7 +7348,8 @@ impl DeletePolicyError {
     pub fn from_body(body: &str) -> DeletePolicyError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7436,7 +7463,8 @@ impl DeletePolicyVersionError {
     pub fn from_body(body: &str) -> DeletePolicyVersionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7548,7 +7576,8 @@ impl DeleteRegistrationCodeError {
     pub fn from_body(body: &str) -> DeleteRegistrationCodeError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7656,7 +7685,8 @@ impl DeleteRoleAliasError {
     pub fn from_body(body: &str) -> DeleteRoleAliasError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7770,7 +7800,8 @@ impl DeleteStreamError {
     pub fn from_body(body: &str) -> DeleteStreamError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7884,7 +7915,8 @@ impl DeleteThingError {
     pub fn from_body(body: &str) -> DeleteThingError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7992,7 +8024,8 @@ impl DeleteThingGroupError {
     pub fn from_body(body: &str) -> DeleteThingGroupError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8092,7 +8125,8 @@ impl DeleteThingTypeError {
     pub fn from_body(body: &str) -> DeleteThingTypeError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8196,7 +8230,8 @@ impl DeleteTopicRuleError {
     pub fn from_body(body: &str) -> DeleteTopicRuleError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8290,7 +8325,8 @@ impl DeleteV2LoggingLevelError {
     pub fn from_body(body: &str) -> DeleteV2LoggingLevelError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8388,7 +8424,8 @@ impl DeprecateThingTypeError {
     pub fn from_body(body: &str) -> DeprecateThingTypeError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8498,7 +8535,8 @@ impl DescribeAuthorizerError {
     pub fn from_body(body: &str) -> DescribeAuthorizerError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8608,7 +8646,8 @@ impl DescribeCACertificateError {
     pub fn from_body(body: &str) -> DescribeCACertificateError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8718,7 +8757,8 @@ impl DescribeCertificateError {
     pub fn from_body(body: &str) -> DescribeCertificateError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8828,7 +8868,8 @@ impl DescribeDefaultAuthorizerError {
     pub fn from_body(body: &str) -> DescribeDefaultAuthorizerError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8938,7 +8979,8 @@ impl DescribeEndpointError {
     pub fn from_body(body: &str) -> DescribeEndpointError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9030,7 +9072,8 @@ impl DescribeEventConfigurationsError {
     pub fn from_body(body: &str) -> DescribeEventConfigurationsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9126,7 +9169,8 @@ impl DescribeIndexError {
     pub fn from_body(body: &str) -> DescribeIndexError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9230,7 +9274,8 @@ impl DescribeJobError {
     pub fn from_body(body: &str) -> DescribeJobError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9326,7 +9371,8 @@ impl DescribeJobExecutionError {
     pub fn from_body(body: &str) -> DescribeJobExecutionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9428,7 +9474,8 @@ impl DescribeRoleAliasError {
     pub fn from_body(body: &str) -> DescribeRoleAliasError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9538,7 +9585,8 @@ impl DescribeStreamError {
     pub fn from_body(body: &str) -> DescribeStreamError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9646,7 +9694,8 @@ impl DescribeThingError {
     pub fn from_body(body: &str) -> DescribeThingError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9750,7 +9799,8 @@ impl DescribeThingGroupError {
     pub fn from_body(body: &str) -> DescribeThingGroupError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9850,7 +9900,8 @@ impl DescribeThingRegistrationTaskError {
     pub fn from_body(body: &str) -> DescribeThingRegistrationTaskError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9962,7 +10013,8 @@ impl DescribeThingTypeError {
     pub fn from_body(body: &str) -> DescribeThingTypeError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -10072,7 +10124,8 @@ impl DetachPolicyError {
     pub fn from_body(body: &str) -> DetachPolicyError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -10180,7 +10233,8 @@ impl DetachPrincipalPolicyError {
     pub fn from_body(body: &str) -> DetachPrincipalPolicyError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -10290,7 +10344,8 @@ impl DetachThingPrincipalError {
     pub fn from_body(body: &str) -> DetachThingPrincipalError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -10396,7 +10451,8 @@ impl DisableTopicRuleError {
     pub fn from_body(body: &str) -> DisableTopicRuleError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -10492,7 +10548,8 @@ impl EnableTopicRuleError {
     pub fn from_body(body: &str) -> EnableTopicRuleError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -10594,7 +10651,8 @@ impl GetEffectivePoliciesError {
     pub fn from_body(body: &str) -> GetEffectivePoliciesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -10706,7 +10764,8 @@ impl GetIndexingConfigurationError {
     pub fn from_body(body: &str) -> GetIndexingConfigurationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -10810,7 +10869,8 @@ impl GetJobDocumentError {
     pub fn from_body(body: &str) -> GetJobDocumentError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -10904,7 +10964,8 @@ impl GetLoggingOptionsError {
     pub fn from_body(body: &str) -> GetLoggingOptionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -11002,7 +11063,8 @@ impl GetOTAUpdateError {
     pub fn from_body(body: &str) -> GetOTAUpdateError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -11110,7 +11172,8 @@ impl GetPolicyError {
     pub fn from_body(body: &str) -> GetPolicyError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -11216,7 +11279,8 @@ impl GetPolicyVersionError {
     pub fn from_body(body: &str) -> GetPolicyVersionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -11322,7 +11386,8 @@ impl GetRegistrationCodeError {
     pub fn from_body(body: &str) -> GetRegistrationCodeError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -11424,7 +11489,8 @@ impl GetTopicRuleError {
     pub fn from_body(body: &str) -> GetTopicRuleError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -11516,7 +11582,8 @@ impl GetV2LoggingOptionsError {
     pub fn from_body(body: &str) -> GetV2LoggingOptionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -11616,7 +11683,8 @@ impl ListAttachedPoliciesError {
     pub fn from_body(body: &str) -> ListAttachedPoliciesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -11728,7 +11796,8 @@ impl ListAuthorizersError {
     pub fn from_body(body: &str) -> ListAuthorizersError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -11830,7 +11899,8 @@ impl ListCACertificatesError {
     pub fn from_body(body: &str) -> ListCACertificatesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -11934,7 +12004,8 @@ impl ListCertificatesError {
     pub fn from_body(body: &str) -> ListCertificatesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -12036,7 +12107,8 @@ impl ListCertificatesByCAError {
     pub fn from_body(body: &str) -> ListCertificatesByCAError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -12140,7 +12212,8 @@ impl ListIndicesError {
     pub fn from_body(body: &str) -> ListIndicesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -12240,7 +12313,8 @@ impl ListJobExecutionsForJobError {
     pub fn from_body(body: &str) -> ListJobExecutionsForJobError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -12340,7 +12414,8 @@ impl ListJobExecutionsForThingError {
     pub fn from_body(body: &str) -> ListJobExecutionsForThingError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -12442,7 +12517,8 @@ impl ListJobsError {
     pub fn from_body(body: &str) -> ListJobsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -12536,7 +12612,8 @@ impl ListOTAUpdatesError {
     pub fn from_body(body: &str) -> ListOTAUpdatesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -12638,7 +12715,8 @@ impl ListOutgoingCertificatesError {
     pub fn from_body(body: &str) -> ListOutgoingCertificatesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -12744,7 +12822,8 @@ impl ListPoliciesError {
     pub fn from_body(body: &str) -> ListPoliciesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -12848,7 +12927,8 @@ impl ListPolicyPrincipalsError {
     pub fn from_body(body: &str) -> ListPolicyPrincipalsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -12958,7 +13038,8 @@ impl ListPolicyVersionsError {
     pub fn from_body(body: &str) -> ListPolicyVersionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -13068,7 +13149,8 @@ impl ListPrincipalPoliciesError {
     pub fn from_body(body: &str) -> ListPrincipalPoliciesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -13178,7 +13260,8 @@ impl ListPrincipalThingsError {
     pub fn from_body(body: &str) -> ListPrincipalThingsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -13286,7 +13369,8 @@ impl ListRoleAliasesError {
     pub fn from_body(body: &str) -> ListRoleAliasesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -13388,7 +13472,8 @@ impl ListStreamsError {
     pub fn from_body(body: &str) -> ListStreamsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -13494,7 +13579,8 @@ impl ListTargetsForPolicyError {
     pub fn from_body(body: &str) -> ListTargetsForPolicyError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -13602,7 +13688,8 @@ impl ListThingGroupsError {
     pub fn from_body(body: &str) -> ListThingGroupsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -13692,7 +13779,8 @@ impl ListThingGroupsForThingError {
     pub fn from_body(body: &str) -> ListThingGroupsForThingError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -13790,7 +13878,8 @@ impl ListThingPrincipalsError {
     pub fn from_body(body: &str) -> ListThingPrincipalsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -13896,7 +13985,8 @@ impl ListThingRegistrationTaskReportsError {
     pub fn from_body(body: &str) -> ListThingRegistrationTaskReportsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -13998,7 +14088,8 @@ impl ListThingRegistrationTasksError {
     pub fn from_body(body: &str) -> ListThingRegistrationTasksError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -14098,7 +14189,8 @@ impl ListThingTypesError {
     pub fn from_body(body: &str) -> ListThingTypesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -14200,7 +14292,8 @@ impl ListThingsError {
     pub fn from_body(body: &str) -> ListThingsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -14296,7 +14389,8 @@ impl ListThingsInThingGroupError {
     pub fn from_body(body: &str) -> ListThingsInThingGroupError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -14388,7 +14482,8 @@ impl ListTopicRulesError {
     pub fn from_body(body: &str) -> ListTopicRulesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -14480,7 +14575,8 @@ impl ListV2LoggingLevelsError {
     pub fn from_body(body: &str) -> ListV2LoggingLevelsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -14588,7 +14684,8 @@ impl RegisterCACertificateError {
     pub fn from_body(body: &str) -> RegisterCACertificateError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -14722,7 +14819,8 @@ impl RegisterCertificateError {
     pub fn from_body(body: &str) -> RegisterCertificateError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -14846,7 +14944,8 @@ impl RegisterThingError {
     pub fn from_body(body: &str) -> RegisterThingError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -14960,7 +15059,8 @@ impl RejectCertificateTransferError {
     pub fn from_body(body: &str) -> RejectCertificateTransferError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -15076,7 +15176,8 @@ impl RemoveThingFromThingGroupError {
     pub fn from_body(body: &str) -> RemoveThingFromThingGroupError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -15178,7 +15279,8 @@ impl ReplaceTopicRuleError {
     pub fn from_body(body: &str) -> ReplaceTopicRuleError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -15286,7 +15388,8 @@ impl SearchIndexError {
     pub fn from_body(body: &str) -> SearchIndexError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -15404,7 +15507,8 @@ impl SetDefaultAuthorizerError {
     pub fn from_body(body: &str) -> SetDefaultAuthorizerError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -15520,7 +15624,8 @@ impl SetDefaultPolicyVersionError {
     pub fn from_body(body: &str) -> SetDefaultPolicyVersionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -15626,7 +15731,8 @@ impl SetLoggingOptionsError {
     pub fn from_body(body: &str) -> SetLoggingOptionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -15720,7 +15826,8 @@ impl SetV2LoggingLevelError {
     pub fn from_body(body: &str) -> SetV2LoggingLevelError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -15816,7 +15923,8 @@ impl SetV2LoggingOptionsError {
     pub fn from_body(body: &str) -> SetV2LoggingOptionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -15910,7 +16018,8 @@ impl StartThingRegistrationTaskError {
     pub fn from_body(body: &str) -> StartThingRegistrationTaskError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -16010,7 +16119,8 @@ impl StopThingRegistrationTaskError {
     pub fn from_body(body: &str) -> StopThingRegistrationTaskError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -16120,7 +16230,8 @@ impl TestAuthorizationError {
     pub fn from_body(body: &str) -> TestAuthorizationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -16236,7 +16347,8 @@ impl TestInvokeAuthorizerError {
     pub fn from_body(body: &str) -> TestInvokeAuthorizerError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -16354,7 +16466,8 @@ impl TransferCertificateError {
     pub fn from_body(body: &str) -> TransferCertificateError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -16474,7 +16587,8 @@ impl UpdateAuthorizerError {
     pub fn from_body(body: &str) -> UpdateAuthorizerError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -16586,7 +16700,8 @@ impl UpdateCACertificateError {
     pub fn from_body(body: &str) -> UpdateCACertificateError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -16698,7 +16813,8 @@ impl UpdateCertificateError {
     pub fn from_body(body: &str) -> UpdateCertificateError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -16806,7 +16922,8 @@ impl UpdateEventConfigurationsError {
     pub fn from_body(body: &str) -> UpdateEventConfigurationsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -16902,7 +17019,8 @@ impl UpdateIndexingConfigurationError {
     pub fn from_body(body: &str) -> UpdateIndexingConfigurationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -17012,7 +17130,8 @@ impl UpdateRoleAliasError {
     pub fn from_body(body: &str) -> UpdateRoleAliasError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -17120,7 +17239,8 @@ impl UpdateStreamError {
     pub fn from_body(body: &str) -> UpdateStreamError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -17230,7 +17350,8 @@ impl UpdateThingError {
     pub fn from_body(body: &str) -> UpdateThingError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -17340,7 +17461,8 @@ impl UpdateThingGroupError {
     pub fn from_body(body: &str) -> UpdateThingGroupError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -17440,7 +17562,8 @@ impl UpdateThingGroupsForThingError {
     pub fn from_body(body: &str) -> UpdateThingGroupsForThingError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/kinesis/src/generated.rs
+++ b/rusoto/services/kinesis/src/generated.rs
@@ -31,7 +31,7 @@ use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 /// <p>Represents the input for <code>AddTagsToStream</code>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AddTagsToStreamInput {
     /// <p>The name of the stream.</p>
     #[serde(rename = "StreamName")]
@@ -42,7 +42,7 @@ pub struct AddTagsToStreamInput {
 }
 
 /// <p>Represents the input for <code>CreateStream</code>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateStreamInput {
     /// <p>The number of shards that the stream will use. The throughput of the stream is a function of the number of shards; more shards are required for greater provisioned throughput.</p> <p>DefaultShardLimit;</p>
     #[serde(rename = "ShardCount")]
@@ -53,7 +53,7 @@ pub struct CreateStreamInput {
 }
 
 /// <p>Represents the input for <a>DecreaseStreamRetentionPeriod</a>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DecreaseStreamRetentionPeriodInput {
     /// <p>The new retention period of the stream, in hours. Must be less than the current retention period.</p>
     #[serde(rename = "RetentionPeriodHours")]
@@ -64,17 +64,17 @@ pub struct DecreaseStreamRetentionPeriodInput {
 }
 
 /// <p>Represents the input for <a>DeleteStream</a>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteStreamInput {
     /// <p>The name of the stream to delete.</p>
     #[serde(rename = "StreamName")]
     pub stream_name: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeLimitsInput {}
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeLimitsOutput {
     /// <p>The number of open shards.</p>
     #[serde(rename = "OpenShardCount")]
@@ -85,7 +85,7 @@ pub struct DescribeLimitsOutput {
 }
 
 /// <p>Represents the input for <code>DescribeStream</code>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeStreamInput {
     /// <p>The shard ID of the shard to start with.</p>
     #[serde(rename = "ExclusiveStartShardId")]
@@ -101,21 +101,21 @@ pub struct DescribeStreamInput {
 }
 
 /// <p>Represents the output for <code>DescribeStream</code>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeStreamOutput {
     /// <p>The current status of the stream, the stream Amazon Resource Name (ARN), an array of shard objects that comprise the stream, and whether there are more shards available.</p>
     #[serde(rename = "StreamDescription")]
     pub stream_description: StreamDescription,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeStreamSummaryInput {
     /// <p>The name of the stream to describe.</p>
     #[serde(rename = "StreamName")]
     pub stream_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeStreamSummaryOutput {
     /// <p>A <a>StreamDescriptionSummary</a> containing information about the stream.</p>
     #[serde(rename = "StreamDescriptionSummary")]
@@ -123,7 +123,7 @@ pub struct DescribeStreamSummaryOutput {
 }
 
 /// <p>Represents the input for <a>DisableEnhancedMonitoring</a>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DisableEnhancedMonitoringInput {
     /// <p>List of shard-level metrics to disable.</p> <p>The following are the valid shard-level metrics. The value "<code>ALL</code>" disables every metric.</p> <ul> <li> <p> <code>IncomingBytes</code> </p> </li> <li> <p> <code>IncomingRecords</code> </p> </li> <li> <p> <code>OutgoingBytes</code> </p> </li> <li> <p> <code>OutgoingRecords</code> </p> </li> <li> <p> <code>WriteProvisionedThroughputExceeded</code> </p> </li> <li> <p> <code>ReadProvisionedThroughputExceeded</code> </p> </li> <li> <p> <code>IteratorAgeMilliseconds</code> </p> </li> <li> <p> <code>ALL</code> </p> </li> </ul> <p>For more information, see <a href="http://docs.aws.amazon.com/kinesis/latest/dev/monitoring-with-cloudwatch.html">Monitoring the Amazon Kinesis Data Streams Service with Amazon CloudWatch</a> in the <i>Amazon Kinesis Data Streams Developer Guide</i>.</p>
     #[serde(rename = "ShardLevelMetrics")]
@@ -134,7 +134,7 @@ pub struct DisableEnhancedMonitoringInput {
 }
 
 /// <p>Represents the input for <a>EnableEnhancedMonitoring</a>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct EnableEnhancedMonitoringInput {
     /// <p>List of shard-level metrics to enable.</p> <p>The following are the valid shard-level metrics. The value "<code>ALL</code>" enables every metric.</p> <ul> <li> <p> <code>IncomingBytes</code> </p> </li> <li> <p> <code>IncomingRecords</code> </p> </li> <li> <p> <code>OutgoingBytes</code> </p> </li> <li> <p> <code>OutgoingRecords</code> </p> </li> <li> <p> <code>WriteProvisionedThroughputExceeded</code> </p> </li> <li> <p> <code>ReadProvisionedThroughputExceeded</code> </p> </li> <li> <p> <code>IteratorAgeMilliseconds</code> </p> </li> <li> <p> <code>ALL</code> </p> </li> </ul> <p>For more information, see <a href="http://docs.aws.amazon.com/kinesis/latest/dev/monitoring-with-cloudwatch.html">Monitoring the Amazon Kinesis Data Streams Service with Amazon CloudWatch</a> in the <i>Amazon Kinesis Data Streams Developer Guide</i>.</p>
     #[serde(rename = "ShardLevelMetrics")]
@@ -145,7 +145,7 @@ pub struct EnableEnhancedMonitoringInput {
 }
 
 /// <p>Represents enhanced metrics types.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct EnhancedMetrics {
     /// <p>List of shard-level metrics.</p> <p>The following are the valid shard-level metrics. The value "<code>ALL</code>" enhances every metric.</p> <ul> <li> <p> <code>IncomingBytes</code> </p> </li> <li> <p> <code>IncomingRecords</code> </p> </li> <li> <p> <code>OutgoingBytes</code> </p> </li> <li> <p> <code>OutgoingRecords</code> </p> </li> <li> <p> <code>WriteProvisionedThroughputExceeded</code> </p> </li> <li> <p> <code>ReadProvisionedThroughputExceeded</code> </p> </li> <li> <p> <code>IteratorAgeMilliseconds</code> </p> </li> <li> <p> <code>ALL</code> </p> </li> </ul> <p>For more information, see <a href="http://docs.aws.amazon.com/kinesis/latest/dev/monitoring-with-cloudwatch.html">Monitoring the Amazon Kinesis Data Streams Service with Amazon CloudWatch</a> in the <i>Amazon Kinesis Data Streams Developer Guide</i>.</p>
     #[serde(rename = "ShardLevelMetrics")]
@@ -154,7 +154,7 @@ pub struct EnhancedMetrics {
 }
 
 /// <p>Represents the output for <a>EnableEnhancedMonitoring</a> and <a>DisableEnhancedMonitoring</a>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct EnhancedMonitoringOutput {
     /// <p>Represents the current state of the metrics that are in the enhanced state before the operation.</p>
     #[serde(rename = "CurrentShardLevelMetrics")]
@@ -171,7 +171,7 @@ pub struct EnhancedMonitoringOutput {
 }
 
 /// <p>Represents the input for <a>GetRecords</a>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetRecordsInput {
     /// <p>The maximum number of records to return. Specify a value of up to 10,000. If you specify a value that is greater than 10,000, <a>GetRecords</a> throws <code>InvalidArgumentException</code>.</p>
     #[serde(rename = "Limit")]
@@ -183,7 +183,7 @@ pub struct GetRecordsInput {
 }
 
 /// <p>Represents the output for <a>GetRecords</a>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetRecordsOutput {
     /// <p>The number of milliseconds the <a>GetRecords</a> response is from the tip of the stream, indicating how far behind current time the consumer is. A value of zero indicates that record processing is caught up, and there are no new records to process at this moment.</p>
     #[serde(rename = "MillisBehindLatest")]
@@ -199,7 +199,7 @@ pub struct GetRecordsOutput {
 }
 
 /// <p>Represents the input for <code>GetShardIterator</code>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetShardIteratorInput {
     /// <p>The shard ID of the Kinesis Data Streams shard to get the iterator for.</p>
     #[serde(rename = "ShardId")]
@@ -221,7 +221,7 @@ pub struct GetShardIteratorInput {
 }
 
 /// <p>Represents the output for <code>GetShardIterator</code>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetShardIteratorOutput {
     /// <p>The position in the shard from which to start reading data records sequentially. A shard iterator specifies this position using the sequence number of a data record in a shard.</p>
     #[serde(rename = "ShardIterator")]
@@ -230,7 +230,7 @@ pub struct GetShardIteratorOutput {
 }
 
 /// <p>The range of possible hash key values for the shard, which is a set of ordered contiguous positive integers.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct HashKeyRange {
     /// <p>The ending hash key of the hash key range.</p>
     #[serde(rename = "EndingHashKey")]
@@ -241,7 +241,7 @@ pub struct HashKeyRange {
 }
 
 /// <p>Represents the input for <a>IncreaseStreamRetentionPeriod</a>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct IncreaseStreamRetentionPeriodInput {
     /// <p>The new retention period of the stream, in hours. Must be more than the current retention period.</p>
     #[serde(rename = "RetentionPeriodHours")]
@@ -251,7 +251,7 @@ pub struct IncreaseStreamRetentionPeriodInput {
     pub stream_name: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListShardsInput {
     /// <p>The ID of the shard to start the list with. </p> <p>If you don't specify this parameter, the default behavior is for <code>ListShards</code> to list the shards starting with the first one in the stream.</p> <p>You cannot specify this parameter if you specify <code>NextToken</code>.</p>
     #[serde(rename = "ExclusiveStartShardId")]
@@ -275,7 +275,7 @@ pub struct ListShardsInput {
     pub stream_name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListShardsOutput {
     /// <p><p>When the number of shards in the data stream is greater than the default value for the <code>MaxResults</code> parameter, or if you explicitly specify a value for <code>MaxResults</code> that is less than the number of shards in the data stream, the response includes a pagination token named <code>NextToken</code>. You can specify this <code>NextToken</code> value in a subsequent call to <code>ListShards</code> to list the next set of shards. For more information about the use of this pagination token when calling the <code>ListShards</code> operation, see <a>ListShardsInput$NextToken</a>.</p> <important> <p>Tokens expire after 300 seconds. When you obtain a value for <code>NextToken</code> in the response to a call to <code>ListShards</code>, you have 300 seconds to use that value. If you specify an expired token in a call to <code>ListShards</code>, you get <code>ExpiredNextTokenException</code>.</p> </important></p>
     #[serde(rename = "NextToken")]
@@ -288,7 +288,7 @@ pub struct ListShardsOutput {
 }
 
 /// <p>Represents the input for <code>ListStreams</code>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListStreamsInput {
     /// <p>The name of the stream to start the list with.</p>
     #[serde(rename = "ExclusiveStartStreamName")]
@@ -301,7 +301,7 @@ pub struct ListStreamsInput {
 }
 
 /// <p>Represents the output for <code>ListStreams</code>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListStreamsOutput {
     /// <p>If set to <code>true</code>, there are more streams available to list.</p>
     #[serde(rename = "HasMoreStreams")]
@@ -312,7 +312,7 @@ pub struct ListStreamsOutput {
 }
 
 /// <p>Represents the input for <code>ListTagsForStream</code>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListTagsForStreamInput {
     /// <p>The key to use as the starting point for the list of tags. If this parameter is set, <code>ListTagsForStream</code> gets all tags that occur after <code>ExclusiveStartTagKey</code>. </p>
     #[serde(rename = "ExclusiveStartTagKey")]
@@ -328,7 +328,7 @@ pub struct ListTagsForStreamInput {
 }
 
 /// <p>Represents the output for <code>ListTagsForStream</code>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListTagsForStreamOutput {
     /// <p>If set to <code>true</code>, more tags are available. To request additional tags, set <code>ExclusiveStartTagKey</code> to the key of the last tag returned.</p>
     #[serde(rename = "HasMoreTags")]
@@ -339,7 +339,7 @@ pub struct ListTagsForStreamOutput {
 }
 
 /// <p>Represents the input for <code>MergeShards</code>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct MergeShardsInput {
     /// <p>The shard ID of the adjacent shard for the merge.</p>
     #[serde(rename = "AdjacentShardToMerge")]
@@ -353,7 +353,7 @@ pub struct MergeShardsInput {
 }
 
 /// <p>Represents the input for <code>PutRecord</code>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PutRecordInput {
     /// <p>The data blob to put into the record, which is base64-encoded when the blob is serialized. When the data blob (the payload before base64-encoding) is added to the partition key size, the total size must not exceed the maximum record size (1 MB).</p>
     #[serde(rename = "Data")]
@@ -380,7 +380,7 @@ pub struct PutRecordInput {
 }
 
 /// <p>Represents the output for <code>PutRecord</code>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PutRecordOutput {
     /// <p><p>The encryption type to use on the record. This parameter can be one of the following values:</p> <ul> <li> <p> <code>NONE</code>: Do not encrypt the records in the stream.</p> </li> <li> <p> <code>KMS</code>: Use server-side encryption on the records in the stream using a customer-managed AWS KMS key.</p> </li> </ul></p>
     #[serde(rename = "EncryptionType")]
@@ -395,7 +395,7 @@ pub struct PutRecordOutput {
 }
 
 /// <p>A <code>PutRecords</code> request.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PutRecordsInput {
     /// <p>The records associated with the request.</p>
     #[serde(rename = "Records")]
@@ -406,7 +406,7 @@ pub struct PutRecordsInput {
 }
 
 /// <p> <code>PutRecords</code> results.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PutRecordsOutput {
     /// <p><p>The encryption type used on the records. This parameter can be one of the following values:</p> <ul> <li> <p> <code>NONE</code>: Do not encrypt the records.</p> </li> <li> <p> <code>KMS</code>: Use server-side encryption on the records using a customer-managed AWS KMS key.</p> </li> </ul></p>
     #[serde(rename = "EncryptionType")]
@@ -422,7 +422,7 @@ pub struct PutRecordsOutput {
 }
 
 /// <p>Represents the output for <code>PutRecords</code>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PutRecordsRequestEntry {
     /// <p>The data blob to put into the record, which is base64-encoded when the blob is serialized. When the data blob (the payload before base64-encoding) is added to the partition key size, the total size must not exceed the maximum record size (1 MB).</p>
     #[serde(rename = "Data")]
@@ -442,7 +442,7 @@ pub struct PutRecordsRequestEntry {
 }
 
 /// <p>Represents the result of an individual record from a <code>PutRecords</code> request. A record that is successfully added to a stream includes <code>SequenceNumber</code> and <code>ShardId</code> in the result. A record that fails to be added to the stream includes <code>ErrorCode</code> and <code>ErrorMessage</code> in the result.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PutRecordsResultEntry {
     /// <p>The error code for an individual record result. <code>ErrorCodes</code> can be either <code>ProvisionedThroughputExceededException</code> or <code>InternalFailure</code>.</p>
     #[serde(rename = "ErrorCode")]
@@ -463,7 +463,7 @@ pub struct PutRecordsResultEntry {
 }
 
 /// <p>The unit of data of the Kinesis data stream, which is composed of a sequence number, a partition key, and a data blob.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Record {
     /// <p>The approximate time that the record was inserted into the stream.</p>
     #[serde(rename = "ApproximateArrivalTimestamp")]
@@ -490,7 +490,7 @@ pub struct Record {
 }
 
 /// <p>Represents the input for <code>RemoveTagsFromStream</code>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RemoveTagsFromStreamInput {
     /// <p>The name of the stream.</p>
     #[serde(rename = "StreamName")]
@@ -501,7 +501,7 @@ pub struct RemoveTagsFromStreamInput {
 }
 
 /// <p>The range of possible sequence numbers for the shard.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SequenceNumberRange {
     /// <p>The ending sequence number for the range. Shards that are in the OPEN state have an ending sequence number of <code>null</code>.</p>
     #[serde(rename = "EndingSequenceNumber")]
@@ -513,7 +513,7 @@ pub struct SequenceNumberRange {
 }
 
 /// <p>A uniquely identified group of data records in a Kinesis data stream.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Shard {
     /// <p>The shard ID of the shard adjacent to the shard's parent.</p>
     #[serde(rename = "AdjacentParentShardId")]
@@ -535,7 +535,7 @@ pub struct Shard {
 }
 
 /// <p>Represents the input for <code>SplitShard</code>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SplitShardInput {
     /// <p>A hash key value for the starting hash key of one of the child shards created by the split. The hash key range for a given shard constitutes a set of ordered contiguous positive integers. The value for <code>NewStartingHashKey</code> must be in the range of hash keys being mapped into the shard. The <code>NewStartingHashKey</code> hash key value and all higher hash key values in hash key range are distributed to one of the child shards. All the lower hash key values in the range are distributed to the other child shard.</p>
     #[serde(rename = "NewStartingHashKey")]
@@ -548,7 +548,7 @@ pub struct SplitShardInput {
     pub stream_name: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StartStreamEncryptionInput {
     /// <p>The encryption type to use. The only valid value is <code>KMS</code>.</p>
     #[serde(rename = "EncryptionType")]
@@ -561,7 +561,7 @@ pub struct StartStreamEncryptionInput {
     pub stream_name: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StopStreamEncryptionInput {
     /// <p>The encryption type. The only valid value is <code>KMS</code>.</p>
     #[serde(rename = "EncryptionType")]
@@ -575,7 +575,7 @@ pub struct StopStreamEncryptionInput {
 }
 
 /// <p>Represents the output for <a>DescribeStream</a>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StreamDescription {
     /// <p><p>The server-side encryption type used on the stream. This parameter can be one of the following values:</p> <ul> <li> <p> <code>NONE</code>: Do not encrypt the records in the stream.</p> </li> <li> <p> <code>KMS</code>: Use server-side encryption on the records in the stream using a customer-managed AWS KMS key.</p> </li> </ul></p>
     #[serde(rename = "EncryptionType")]
@@ -612,7 +612,7 @@ pub struct StreamDescription {
 }
 
 /// <p>Represents the output for <a>DescribeStreamSummary</a> </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StreamDescriptionSummary {
     /// <p><p>The encryption type used. This value is one of the following:</p> <ul> <li> <p> <code>KMS</code> </p> </li> <li> <p> <code>NONE</code> </p> </li> </ul></p>
     #[serde(rename = "EncryptionType")]
@@ -646,7 +646,7 @@ pub struct StreamDescriptionSummary {
 }
 
 /// <p>Metadata assigned to the stream, consisting of a key-value pair.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Tag {
     /// <p>A unique identifier for the tag. Maximum length: 128 characters. Valid characters: Unicode letters, digits, white space, _ . / = + - % @</p>
     #[serde(rename = "Key")]
@@ -657,7 +657,7 @@ pub struct Tag {
     pub value: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateShardCountInput {
     /// <p>The scaling type. Uniform scaling creates shards of equal size.</p>
     #[serde(rename = "ScalingType")]
@@ -670,7 +670,7 @@ pub struct UpdateShardCountInput {
     pub target_shard_count: i64,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateShardCountOutput {
     /// <p>The current number of shards.</p>
     #[serde(rename = "CurrentShardCount")]

--- a/rusoto/services/kinesis/src/generated.rs
+++ b/rusoto/services/kinesis/src/generated.rs
@@ -711,7 +711,8 @@ impl AddTagsToStreamError {
     pub fn from_body(body: &str) -> AddTagsToStreamError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -805,7 +806,8 @@ impl CreateStreamError {
     pub fn from_body(body: &str) -> CreateStreamError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -897,7 +899,8 @@ impl DecreaseStreamRetentionPeriodError {
     pub fn from_body(body: &str) -> DecreaseStreamRetentionPeriodError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -995,7 +998,8 @@ impl DeleteStreamError {
     pub fn from_body(body: &str) -> DeleteStreamError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1077,7 +1081,8 @@ impl DescribeLimitsError {
     pub fn from_body(body: &str) -> DescribeLimitsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1157,7 +1162,8 @@ impl DescribeStreamError {
     pub fn from_body(body: &str) -> DescribeStreamError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1241,7 +1247,8 @@ impl DescribeStreamSummaryError {
     pub fn from_body(body: &str) -> DescribeStreamSummaryError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1331,7 +1338,8 @@ impl DisableEnhancedMonitoringError {
     pub fn from_body(body: &str) -> DisableEnhancedMonitoringError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1431,7 +1439,8 @@ impl EnableEnhancedMonitoringError {
     pub fn from_body(body: &str) -> EnableEnhancedMonitoringError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1541,7 +1550,8 @@ impl GetRecordsError {
     pub fn from_body(body: &str) -> GetRecordsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1657,7 +1667,8 @@ impl GetShardIteratorError {
     pub fn from_body(body: &str) -> GetShardIteratorError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1751,7 +1762,8 @@ impl IncreaseStreamRetentionPeriodError {
     pub fn from_body(body: &str) -> IncreaseStreamRetentionPeriodError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1855,7 +1867,8 @@ impl ListShardsError {
     pub fn from_body(body: &str) -> ListShardsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1947,7 +1960,8 @@ impl ListStreamsError {
     pub fn from_body(body: &str) -> ListStreamsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2029,7 +2043,8 @@ impl ListTagsForStreamError {
     pub fn from_body(body: &str) -> ListTagsForStreamError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2123,7 +2138,8 @@ impl MergeShardsError {
     pub fn from_body(body: &str) -> MergeShardsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2229,7 +2245,8 @@ impl PutRecordError {
     pub fn from_body(body: &str) -> PutRecordError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2353,7 +2370,8 @@ impl PutRecordsError {
     pub fn from_body(body: &str) -> PutRecordsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2467,7 +2485,8 @@ impl RemoveTagsFromStreamError {
     pub fn from_body(body: &str) -> RemoveTagsFromStreamError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2565,7 +2584,8 @@ impl SplitShardError {
     pub fn from_body(body: &str) -> SplitShardError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2671,7 +2691,8 @@ impl StartStreamEncryptionError {
     pub fn from_body(body: &str) -> StartStreamEncryptionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2793,7 +2814,8 @@ impl StopStreamEncryptionError {
     pub fn from_body(body: &str) -> StopStreamEncryptionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2891,7 +2913,8 @@ impl UpdateShardCountError {
     pub fn from_body(body: &str) -> UpdateShardCountError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/kinesisanalytics/src/generated.rs
+++ b/rusoto/services/kinesisanalytics/src/generated.rs
@@ -1196,7 +1196,8 @@ impl AddApplicationCloudWatchLoggingOptionError {
     pub fn from_body(body: &str) -> AddApplicationCloudWatchLoggingOptionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1306,7 +1307,8 @@ impl AddApplicationInputError {
     pub fn from_body(body: &str) -> AddApplicationInputError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1410,7 +1412,8 @@ impl AddApplicationInputProcessingConfigurationError {
     pub fn from_body(body: &str) -> AddApplicationInputProcessingConfigurationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1524,7 +1527,8 @@ impl AddApplicationOutputError {
     pub fn from_body(body: &str) -> AddApplicationOutputError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1624,7 +1628,8 @@ impl AddApplicationReferenceDataSourceError {
     pub fn from_body(body: &str) -> AddApplicationReferenceDataSourceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1730,7 +1735,8 @@ impl CreateApplicationError {
     pub fn from_body(body: &str) -> CreateApplicationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1826,7 +1832,8 @@ impl DeleteApplicationError {
     pub fn from_body(body: &str) -> DeleteApplicationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1920,7 +1927,8 @@ impl DeleteApplicationCloudWatchLoggingOptionError {
     pub fn from_body(body: &str) -> DeleteApplicationCloudWatchLoggingOptionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2032,7 +2040,8 @@ impl DeleteApplicationInputProcessingConfigurationError {
     pub fn from_body(body: &str) -> DeleteApplicationInputProcessingConfigurationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2152,7 +2161,8 @@ impl DeleteApplicationOutputError {
     pub fn from_body(body: &str) -> DeleteApplicationOutputError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2252,7 +2262,8 @@ impl DeleteApplicationReferenceDataSourceError {
     pub fn from_body(body: &str) -> DeleteApplicationReferenceDataSourceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2352,7 +2363,8 @@ impl DescribeApplicationError {
     pub fn from_body(body: &str) -> DescribeApplicationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2438,7 +2450,8 @@ impl DiscoverInputSchemaError {
     pub fn from_body(body: &str) -> DiscoverInputSchemaError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2530,7 +2543,8 @@ impl ListApplicationsError {
     pub fn from_body(body: &str) -> ListApplicationsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2610,7 +2624,8 @@ impl StartApplicationError {
     pub fn from_body(body: &str) -> StartApplicationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2704,7 +2719,8 @@ impl StopApplicationError {
     pub fn from_body(body: &str) -> StopApplicationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2794,7 +2810,8 @@ impl UpdateApplicationError {
     pub fn from_body(body: &str) -> UpdateApplicationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/kinesisanalytics/src/generated.rs
+++ b/rusoto/services/kinesisanalytics/src/generated.rs
@@ -30,7 +30,7 @@ use rusoto_core::signature::SignedRequest;
 use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AddApplicationCloudWatchLoggingOptionRequest {
     /// <p>The Kinesis Analytics application name.</p>
     #[serde(rename = "ApplicationName")]
@@ -43,10 +43,10 @@ pub struct AddApplicationCloudWatchLoggingOptionRequest {
     pub current_application_version_id: i64,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AddApplicationCloudWatchLoggingOptionResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AddApplicationInputProcessingConfigurationRequest {
     /// <p>Name of the application to which you want to add the input processing configuration.</p>
     #[serde(rename = "ApplicationName")]
@@ -62,11 +62,11 @@ pub struct AddApplicationInputProcessingConfigurationRequest {
     pub input_processing_configuration: InputProcessingConfiguration,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AddApplicationInputProcessingConfigurationResponse {}
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AddApplicationInputRequest {
     /// <p>Name of your existing Amazon Kinesis Analytics application to which you want to add the streaming source.</p>
     #[serde(rename = "ApplicationName")]
@@ -80,11 +80,11 @@ pub struct AddApplicationInputRequest {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AddApplicationInputResponse {}
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AddApplicationOutputRequest {
     /// <p>Name of the application to which you want to add the output configuration.</p>
     #[serde(rename = "ApplicationName")]
@@ -98,11 +98,11 @@ pub struct AddApplicationOutputRequest {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AddApplicationOutputResponse {}
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AddApplicationReferenceDataSourceRequest {
     /// <p>Name of an existing application.</p>
     #[serde(rename = "ApplicationName")]
@@ -116,11 +116,11 @@ pub struct AddApplicationReferenceDataSourceRequest {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AddApplicationReferenceDataSourceResponse {}
 
 /// <p>Provides a description of the application, including the application Amazon Resource Name (ARN), status, latest version, and input and output configuration.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ApplicationDetail {
     /// <p>ARN of the application.</p>
     #[serde(rename = "ApplicationARN")]
@@ -169,7 +169,7 @@ pub struct ApplicationDetail {
 }
 
 /// <p>Provides application summary information, including the application Amazon Resource Name (ARN), name, and status.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ApplicationSummary {
     /// <p>ARN of the application.</p>
     #[serde(rename = "ApplicationARN")]
@@ -183,7 +183,7 @@ pub struct ApplicationSummary {
 }
 
 /// <p>Describes updates to apply to an existing Amazon Kinesis Analytics application.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ApplicationUpdate {
     /// <p>Describes application code updates.</p>
     #[serde(rename = "ApplicationCodeUpdate")]
@@ -208,7 +208,7 @@ pub struct ApplicationUpdate {
 }
 
 /// <p>Provides additional mapping information when the record format uses delimiters, such as CSV. For example, the following sample records use CSV format, where the records use the <i>'\n'</i> as the row delimiter and a comma (",") as the column delimiter: </p> <p> <code>"name1", "address1" </code> </p> <p> <code>"name2, "address2"</code> </p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CSVMappingParameters {
     /// <p>Column delimiter. For example, in a CSV format, a comma (",") is the typical column delimiter.</p>
     #[serde(rename = "RecordColumnDelimiter")]
@@ -219,7 +219,7 @@ pub struct CSVMappingParameters {
 }
 
 /// <p>Provides a description of CloudWatch logging options, including the log stream Amazon Resource Name (ARN) and the role ARN.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CloudWatchLoggingOption {
     /// <p>ARN of the CloudWatch log to receive application messages.</p>
     #[serde(rename = "LogStreamARN")]
@@ -230,7 +230,7 @@ pub struct CloudWatchLoggingOption {
 }
 
 /// <p>Description of the CloudWatch logging option.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CloudWatchLoggingOptionDescription {
     /// <p>ID of the CloudWatch logging option description.</p>
     #[serde(rename = "CloudWatchLoggingOptionId")]
@@ -245,7 +245,7 @@ pub struct CloudWatchLoggingOptionDescription {
 }
 
 /// <p>Describes CloudWatch logging option updates.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CloudWatchLoggingOptionUpdate {
     /// <p>ID of the CloudWatch logging option to update</p>
     #[serde(rename = "CloudWatchLoggingOptionId")]
@@ -261,7 +261,7 @@ pub struct CloudWatchLoggingOptionUpdate {
 }
 
 /// <p>TBD</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateApplicationRequest {
     /// <p>One or more SQL statements that read input data, transform it, and generate output. For example, you can write a SQL statement that reads data from one in-application stream, generates a running average of the number of advertisement clicks by vendor, and insert resulting rows in another in-application stream using pumps. For more information about the typical pattern, see <a href="http://docs.aws.amazon.com/kinesisanalytics/latest/dev/how-it-works-app-code.html">Application Code</a>. </p> <p>You can provide such series of SQL statements, where output of one statement can be used as the input for the next statement. You store intermediate results by creating in-application streams and pumps.</p> <p>Note that the application code must create the streams with names specified in the <code>Outputs</code>. For example, if your <code>Outputs</code> defines output streams named <code>ExampleOutputStream1</code> and <code>ExampleOutputStream2</code>, then your application code must create these streams. </p>
     #[serde(rename = "ApplicationCode")]
@@ -289,14 +289,14 @@ pub struct CreateApplicationRequest {
 }
 
 /// <p>TBD</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateApplicationResponse {
     /// <p>In response to your <code>CreateApplication</code> request, Amazon Kinesis Analytics returns a response with a summary of the application it created, including the application Amazon Resource Name (ARN), name, and status.</p>
     #[serde(rename = "ApplicationSummary")]
     pub application_summary: ApplicationSummary,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteApplicationCloudWatchLoggingOptionRequest {
     /// <p>The Kinesis Analytics application name.</p>
     #[serde(rename = "ApplicationName")]
@@ -309,10 +309,10 @@ pub struct DeleteApplicationCloudWatchLoggingOptionRequest {
     pub current_application_version_id: i64,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteApplicationCloudWatchLoggingOptionResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteApplicationInputProcessingConfigurationRequest {
     /// <p>The Kinesis Analytics application name.</p>
     #[serde(rename = "ApplicationName")]
@@ -325,11 +325,11 @@ pub struct DeleteApplicationInputProcessingConfigurationRequest {
     pub input_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteApplicationInputProcessingConfigurationResponse {}
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteApplicationOutputRequest {
     /// <p>Amazon Kinesis Analytics application name.</p>
     #[serde(rename = "ApplicationName")]
@@ -343,10 +343,10 @@ pub struct DeleteApplicationOutputRequest {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteApplicationOutputResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteApplicationReferenceDataSourceRequest {
     /// <p>Name of an existing application.</p>
     #[serde(rename = "ApplicationName")]
@@ -359,11 +359,11 @@ pub struct DeleteApplicationReferenceDataSourceRequest {
     pub reference_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteApplicationReferenceDataSourceResponse {}
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteApplicationRequest {
     /// <p>Name of the Amazon Kinesis Analytics application to delete.</p>
     #[serde(rename = "ApplicationName")]
@@ -374,11 +374,11 @@ pub struct DeleteApplicationRequest {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteApplicationResponse {}
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeApplicationRequest {
     /// <p>Name of the application.</p>
     #[serde(rename = "ApplicationName")]
@@ -386,7 +386,7 @@ pub struct DescribeApplicationRequest {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeApplicationResponse {
     /// <p>Provides a description of the application, such as the application Amazon Resource Name (ARN), status, latest version, and input and output configuration details.</p>
     #[serde(rename = "ApplicationDetail")]
@@ -394,7 +394,7 @@ pub struct DescribeApplicationResponse {
 }
 
 /// <p>Describes the data format when records are written to the destination. For more information, see <a href="http://docs.aws.amazon.com/kinesisanalytics/latest/dev/how-it-works-output.html">Configuring Application Output</a>. </p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct DestinationSchema {
     /// <p>Specifies the format of the records on the output stream.</p>
     #[serde(rename = "RecordFormatType")]
@@ -402,7 +402,7 @@ pub struct DestinationSchema {
     pub record_format_type: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DiscoverInputSchemaRequest {
     /// <p>The <a>InputProcessingConfiguration</a> to use to preprocess the records before discovering the schema of the records.</p>
     #[serde(rename = "InputProcessingConfiguration")]
@@ -427,7 +427,7 @@ pub struct DiscoverInputSchemaRequest {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DiscoverInputSchemaResponse {
     /// <p>Schema inferred from the streaming source. It identifies the format of the data in the streaming source and how each data element maps to corresponding columns in the in-application stream that you can create.</p>
     #[serde(rename = "InputSchema")]
@@ -448,7 +448,7 @@ pub struct DiscoverInputSchemaResponse {
 }
 
 /// <p>When you configure the application input, you specify the streaming source, the in-application stream name that is created, and the mapping between the two. For more information, see <a href="http://docs.aws.amazon.com/kinesisanalytics/latest/dev/how-it-works-input.html">Configuring Application Input</a>. </p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct Input {
     /// <p>Describes the number of in-application streams to create. </p> <p>Data from your source is routed to these in-application input streams.</p> <p> (see <a href="http://docs.aws.amazon.com/kinesisanalytics/latest/dev/how-it-works-input.html">Configuring Application Input</a>.</p>
     #[serde(rename = "InputParallelism")]
@@ -475,7 +475,7 @@ pub struct Input {
 }
 
 /// <p>When you start your application, you provide this configuration, which identifies the input source and the point in the input source at which you want the application to start processing records.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct InputConfiguration {
     /// <p>Input source ID. You can get this ID by calling the <a>DescribeApplication</a> operation.</p>
     #[serde(rename = "Id")]
@@ -486,7 +486,7 @@ pub struct InputConfiguration {
 }
 
 /// <p>Describes the application input configuration. For more information, see <a href="http://docs.aws.amazon.com/kinesisanalytics/latest/dev/how-it-works-input.html">Configuring Application Input</a>. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct InputDescription {
     /// <p>Returns the in-application stream names that are mapped to the stream source.</p>
     #[serde(rename = "InAppStreamNames")]
@@ -527,7 +527,7 @@ pub struct InputDescription {
 }
 
 /// <p>An object that contains the Amazon Resource Name (ARN) of the <a href="https://aws.amazon.com/documentation/lambda/">AWS Lambda</a> function that is used to preprocess records in the stream, and the ARN of the IAM role that is used to access the AWS Lambda function. </p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct InputLambdaProcessor {
     /// <p>The ARN of the <a href="https://aws.amazon.com/documentation/lambda/">AWS Lambda</a> function that operates on records in the stream.</p>
     #[serde(rename = "ResourceARN")]
@@ -538,7 +538,7 @@ pub struct InputLambdaProcessor {
 }
 
 /// <p>An object that contains the Amazon Resource Name (ARN) of the <a href="https://aws.amazon.com/documentation/lambda/">AWS Lambda</a> function that is used to preprocess records in the stream, and the ARN of the IAM role that is used to access the AWS Lambda expression.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct InputLambdaProcessorDescription {
     /// <p>The ARN of the <a href="https://aws.amazon.com/documentation/lambda/">AWS Lambda</a> function that is used to preprocess the records in the stream.</p>
     #[serde(rename = "ResourceARN")]
@@ -551,7 +551,7 @@ pub struct InputLambdaProcessorDescription {
 }
 
 /// <p>Represents an update to the <a>InputLambdaProcessor</a> that is used to preprocess the records in the stream.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct InputLambdaProcessorUpdate {
     /// <p>The Amazon Resource Name (ARN) of the new <a href="https://aws.amazon.com/documentation/lambda/">AWS Lambda</a> function that is used to preprocess the records in the stream.</p>
     #[serde(rename = "ResourceARNUpdate")]
@@ -564,7 +564,7 @@ pub struct InputLambdaProcessorUpdate {
 }
 
 /// <p>Describes the number of in-application streams to create for a given streaming source. For information about parallelism, see <a href="http://docs.aws.amazon.com/kinesisanalytics/latest/dev/how-it-works-input.html">Configuring Application Input</a>. </p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct InputParallelism {
     /// <p>Number of in-application streams to create. For more information, see <a href="http://docs.aws.amazon.com/kinesisanalytics/latest/dev/limits.html">Limits</a>. </p>
     #[serde(rename = "Count")]
@@ -573,7 +573,7 @@ pub struct InputParallelism {
 }
 
 /// <p>Provides updates to the parallelism count.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct InputParallelismUpdate {
     /// <p>Number of in-application streams to create for the specified streaming source.</p>
     #[serde(rename = "CountUpdate")]
@@ -582,7 +582,7 @@ pub struct InputParallelismUpdate {
 }
 
 /// <p>Provides a description of a processor that is used to preprocess the records in the stream before being processed by your application code. Currently, the only input processor available is <a href="https://aws.amazon.com/documentation/lambda/">AWS Lambda</a>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct InputProcessingConfiguration {
     /// <p>The <a>InputLambdaProcessor</a> that is used to preprocess the records in the stream before being processed by your application code.</p>
     #[serde(rename = "InputLambdaProcessor")]
@@ -590,7 +590,7 @@ pub struct InputProcessingConfiguration {
 }
 
 /// <p>Provides configuration information about an input processor. Currently, the only input processor available is <a href="https://aws.amazon.com/documentation/lambda/">AWS Lambda</a>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct InputProcessingConfigurationDescription {
     /// <p>Provides configuration information about the associated <a>InputLambdaProcessorDescription</a>.</p>
     #[serde(rename = "InputLambdaProcessorDescription")]
@@ -599,7 +599,7 @@ pub struct InputProcessingConfigurationDescription {
 }
 
 /// <p>Describes updates to an <a>InputProcessingConfiguration</a>. </p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct InputProcessingConfigurationUpdate {
     /// <p>Provides update information for an <a>InputLambdaProcessor</a>.</p>
     #[serde(rename = "InputLambdaProcessorUpdate")]
@@ -607,7 +607,7 @@ pub struct InputProcessingConfigurationUpdate {
 }
 
 /// <p>Describes updates for the application's input schema.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct InputSchemaUpdate {
     /// <p>A list of <code>RecordColumn</code> objects. Each object describes the mapping of the streaming source element to the corresponding column in the in-application stream. </p>
     #[serde(rename = "RecordColumnUpdates")]
@@ -624,7 +624,7 @@ pub struct InputSchemaUpdate {
 }
 
 /// <p>Describes the point at which the application reads from the streaming source.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct InputStartingPositionConfiguration {
     /// <p><p>The starting position on the stream.</p> <ul> <li> <p> <code>NOW</code> - Start reading just after the most recent record in the stream, start at the request time stamp that the customer issued.</p> </li> <li> <p> <code>TRIM<em>HORIZON</code> - Start reading at the last untrimmed record in the stream, which is the oldest record available in the stream. This option is not available for an Amazon Kinesis Firehose delivery stream.</p> </li> <li> <p> <code>LAST</em>STOPPED_POINT</code> - Resume reading from where the application last stopped reading.</p> </li> </ul></p>
     #[serde(rename = "InputStartingPosition")]
@@ -633,7 +633,7 @@ pub struct InputStartingPositionConfiguration {
 }
 
 /// <p>Describes updates to a specific input configuration (identified by the <code>InputId</code> of an application). </p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct InputUpdate {
     /// <p>Input ID of the application input to be updated.</p>
     #[serde(rename = "InputId")]
@@ -665,7 +665,7 @@ pub struct InputUpdate {
 }
 
 /// <p>Provides additional mapping information when JSON is the record format on the streaming source.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct JSONMappingParameters {
     /// <p>Path to the top-level parent that contains the records.</p>
     #[serde(rename = "RecordRowPath")]
@@ -673,7 +673,7 @@ pub struct JSONMappingParameters {
 }
 
 /// <p> Identifies an Amazon Kinesis Firehose delivery stream as the streaming source. You provide the delivery stream's Amazon Resource Name (ARN) and an IAM role ARN that enables Amazon Kinesis Analytics to access the stream on your behalf.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct KinesisFirehoseInput {
     /// <p>ARN of the input delivery stream.</p>
     #[serde(rename = "ResourceARN")]
@@ -684,7 +684,7 @@ pub struct KinesisFirehoseInput {
 }
 
 /// <p> Describes the Amazon Kinesis Firehose delivery stream that is configured as the streaming source in the application input configuration. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct KinesisFirehoseInputDescription {
     /// <p>Amazon Resource Name (ARN) of the Amazon Kinesis Firehose delivery stream.</p>
     #[serde(rename = "ResourceARN")]
@@ -697,7 +697,7 @@ pub struct KinesisFirehoseInputDescription {
 }
 
 /// <p>When updating application input configuration, provides information about an Amazon Kinesis Firehose delivery stream as the streaming source.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct KinesisFirehoseInputUpdate {
     /// <p>Amazon Resource Name (ARN) of the input Amazon Kinesis Firehose delivery stream to read.</p>
     #[serde(rename = "ResourceARNUpdate")]
@@ -710,7 +710,7 @@ pub struct KinesisFirehoseInputUpdate {
 }
 
 /// <p>When configuring application output, identifies an Amazon Kinesis Firehose delivery stream as the destination. You provide the stream Amazon Resource Name (ARN) and an IAM role that enables Amazon Kinesis Analytics to write to the stream on your behalf.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct KinesisFirehoseOutput {
     /// <p>ARN of the destination Amazon Kinesis Firehose delivery stream to write to.</p>
     #[serde(rename = "ResourceARN")]
@@ -721,7 +721,7 @@ pub struct KinesisFirehoseOutput {
 }
 
 /// <p> For an application output, describes the Amazon Kinesis Firehose delivery stream configured as its destination. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct KinesisFirehoseOutputDescription {
     /// <p>Amazon Resource Name (ARN) of the Amazon Kinesis Firehose delivery stream.</p>
     #[serde(rename = "ResourceARN")]
@@ -734,7 +734,7 @@ pub struct KinesisFirehoseOutputDescription {
 }
 
 /// <p> When updating an output configuration using the <a>UpdateApplication</a> operation, provides information about an Amazon Kinesis Firehose delivery stream configured as the destination. </p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct KinesisFirehoseOutputUpdate {
     /// <p>Amazon Resource Name (ARN) of the Amazon Kinesis Firehose delivery stream to write to.</p>
     #[serde(rename = "ResourceARNUpdate")]
@@ -747,7 +747,7 @@ pub struct KinesisFirehoseOutputUpdate {
 }
 
 /// <p> Identifies an Amazon Kinesis stream as the streaming source. You provide the stream's Amazon Resource Name (ARN) and an IAM role ARN that enables Amazon Kinesis Analytics to access the stream on your behalf.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct KinesisStreamsInput {
     /// <p>ARN of the input Amazon Kinesis stream to read.</p>
     #[serde(rename = "ResourceARN")]
@@ -758,7 +758,7 @@ pub struct KinesisStreamsInput {
 }
 
 /// <p> Describes the Amazon Kinesis stream that is configured as the streaming source in the application input configuration. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct KinesisStreamsInputDescription {
     /// <p>Amazon Resource Name (ARN) of the Amazon Kinesis stream.</p>
     #[serde(rename = "ResourceARN")]
@@ -771,7 +771,7 @@ pub struct KinesisStreamsInputDescription {
 }
 
 /// <p>When updating application input configuration, provides information about an Amazon Kinesis stream as the streaming source.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct KinesisStreamsInputUpdate {
     /// <p>Amazon Resource Name (ARN) of the input Amazon Kinesis stream to read.</p>
     #[serde(rename = "ResourceARNUpdate")]
@@ -784,7 +784,7 @@ pub struct KinesisStreamsInputUpdate {
 }
 
 /// <p>When configuring application output, identifies an Amazon Kinesis stream as the destination. You provide the stream Amazon Resource Name (ARN) and also an IAM role ARN that Amazon Kinesis Analytics can use to write to the stream on your behalf.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct KinesisStreamsOutput {
     /// <p>ARN of the destination Amazon Kinesis stream to write to.</p>
     #[serde(rename = "ResourceARN")]
@@ -795,7 +795,7 @@ pub struct KinesisStreamsOutput {
 }
 
 /// <p> For an application output, describes the Amazon Kinesis stream configured as its destination. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct KinesisStreamsOutputDescription {
     /// <p>Amazon Resource Name (ARN) of the Amazon Kinesis stream.</p>
     #[serde(rename = "ResourceARN")]
@@ -808,7 +808,7 @@ pub struct KinesisStreamsOutputDescription {
 }
 
 /// <p> When updating an output configuration using the <a>UpdateApplication</a> operation, provides information about an Amazon Kinesis stream configured as the destination. </p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct KinesisStreamsOutputUpdate {
     /// <p>Amazon Resource Name (ARN) of the Amazon Kinesis stream where you want to write the output.</p>
     #[serde(rename = "ResourceARNUpdate")]
@@ -821,7 +821,7 @@ pub struct KinesisStreamsOutputUpdate {
 }
 
 /// <p>When configuring application output, identifies an AWS Lambda function as the destination. You provide the function Amazon Resource Name (ARN) and also an IAM role ARN that Amazon Kinesis Analytics can use to write to the function on your behalf. </p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct LambdaOutput {
     /// <p>Amazon Resource Name (ARN) of the destination Lambda function to write to.</p>
     #[serde(rename = "ResourceARN")]
@@ -832,7 +832,7 @@ pub struct LambdaOutput {
 }
 
 /// <p>For an application output, describes the AWS Lambda function configured as its destination. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct LambdaOutputDescription {
     /// <p>Amazon Resource Name (ARN) of the destination Lambda function.</p>
     #[serde(rename = "ResourceARN")]
@@ -845,7 +845,7 @@ pub struct LambdaOutputDescription {
 }
 
 /// <p>When updating an output configuration using the <a>UpdateApplication</a> operation, provides information about an AWS Lambda function configured as the destination.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct LambdaOutputUpdate {
     /// <p>Amazon Resource Name (ARN) of the destination Lambda function.</p>
     #[serde(rename = "ResourceARNUpdate")]
@@ -858,7 +858,7 @@ pub struct LambdaOutputUpdate {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListApplicationsRequest {
     /// <p>Name of the application to start the list with. When using pagination to retrieve the list, you don't need to specify this parameter in the first request. However, in subsequent requests, you add the last application name from the previous response to get the next page of applications.</p>
     #[serde(rename = "ExclusiveStartApplicationName")]
@@ -871,7 +871,7 @@ pub struct ListApplicationsRequest {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListApplicationsResponse {
     /// <p>List of <code>ApplicationSummary</code> objects. </p>
     #[serde(rename = "ApplicationSummaries")]
@@ -882,7 +882,7 @@ pub struct ListApplicationsResponse {
 }
 
 /// <p>When configuring application input at the time of creating or updating an application, provides additional mapping information specific to the record format (such as JSON, CSV, or record fields delimited by some delimiter) on the streaming source.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct MappingParameters {
     /// <p>Provides additional mapping information when the record format uses delimiters (for example, CSV).</p>
     #[serde(rename = "CSVMappingParameters")]
@@ -895,7 +895,7 @@ pub struct MappingParameters {
 }
 
 /// <p> Describes application output configuration in which you identify an in-application stream and a destination where you want the in-application stream data to be written. The destination can be an Amazon Kinesis stream or an Amazon Kinesis Firehose delivery stream. </p> <p/> <p>For limits on how many destinations an application can write and other limitations, see <a href="http://docs.aws.amazon.com/kinesisanalytics/latest/dev/limits.html">Limits</a>. </p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct Output {
     /// <p>Describes the data format when records are written to the destination. For more information, see <a href="http://docs.aws.amazon.com/kinesisanalytics/latest/dev/how-it-works-output.html">Configuring Application Output</a>.</p>
     #[serde(rename = "DestinationSchema")]
@@ -918,7 +918,7 @@ pub struct Output {
 }
 
 /// <p>Describes the application output configuration, which includes the in-application stream name and the destination where the stream data is written. The destination can be an Amazon Kinesis stream or an Amazon Kinesis Firehose delivery stream. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct OutputDescription {
     /// <p>Data format used for writing data to the destination.</p>
     #[serde(rename = "DestinationSchema")]
@@ -947,7 +947,7 @@ pub struct OutputDescription {
 }
 
 /// <p> Describes updates to the output configuration identified by the <code>OutputId</code>. </p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct OutputUpdate {
     /// <p>Describes the data format when records are written to the destination. For more information, see <a href="http://docs.aws.amazon.com/kinesisanalytics/latest/dev/how-it-works-output.html">Configuring Application Output</a>.</p>
     #[serde(rename = "DestinationSchemaUpdate")]
@@ -975,7 +975,7 @@ pub struct OutputUpdate {
 }
 
 /// <p>Describes the mapping of each data element in the streaming source to the corresponding column in the in-application stream.</p> <p>Also used to describe the format of the reference data source.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RecordColumn {
     /// <p>Reference to the data element in the streaming input of the reference data source.</p>
     #[serde(rename = "Mapping")]
@@ -990,7 +990,7 @@ pub struct RecordColumn {
 }
 
 /// <p> Describes the record format and relevant mapping information that should be applied to schematize the records on the stream. </p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RecordFormat {
     /// <p>When configuring application input at the time of creating or updating an application, provides additional mapping information specific to the record format (such as JSON, CSV, or record fields delimited by some delimiter) on the streaming source.</p>
     #[serde(rename = "MappingParameters")]
@@ -1002,7 +1002,7 @@ pub struct RecordFormat {
 }
 
 /// <p>Describes the reference data source by providing the source information (S3 bucket name and object key name), the resulting in-application table name that is created, and the necessary schema to map the data elements in the Amazon S3 object to the in-application table.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ReferenceDataSource {
     /// <p>Describes the format of the data in the streaming source, and how each data element maps to corresponding columns created in the in-application stream.</p>
     #[serde(rename = "ReferenceSchema")]
@@ -1017,7 +1017,7 @@ pub struct ReferenceDataSource {
 }
 
 /// <p>Describes the reference data source configured for an application.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ReferenceDataSourceDescription {
     /// <p>ID of the reference data source. This is the ID that Amazon Kinesis Analytics assigns when you add the reference data source to your application using the <a>AddApplicationReferenceDataSource</a> operation.</p>
     #[serde(rename = "ReferenceId")]
@@ -1035,7 +1035,7 @@ pub struct ReferenceDataSourceDescription {
 }
 
 /// <p>When you update a reference data source configuration for an application, this object provides all the updated values (such as the source bucket name and object key name), the in-application table name that is created, and updated mapping information that maps the data in the Amazon S3 object to the in-application reference table that is created.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ReferenceDataSourceUpdate {
     /// <p>ID of the reference data source being updated. You can use the <a>DescribeApplication</a> operation to get this value.</p>
     #[serde(rename = "ReferenceId")]
@@ -1055,7 +1055,7 @@ pub struct ReferenceDataSourceUpdate {
 }
 
 /// <p>Provides a description of an Amazon S3 data source, including the Amazon Resource Name (ARN) of the S3 bucket, the ARN of the IAM role that is used to access the bucket, and the name of the S3 object that contains the data.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct S3Configuration {
     /// <p>ARN of the S3 bucket that contains the data.</p>
     #[serde(rename = "BucketARN")]
@@ -1069,7 +1069,7 @@ pub struct S3Configuration {
 }
 
 /// <p>Identifies the S3 bucket and object that contains the reference data. Also identifies the IAM role Amazon Kinesis Analytics can assume to read this object on your behalf.</p> <p>An Amazon Kinesis Analytics application loads reference data only once. If the data changes, you call the <a>UpdateApplication</a> operation to trigger reloading of data into your application.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct S3ReferenceDataSource {
     /// <p>Amazon Resource Name (ARN) of the S3 bucket.</p>
     #[serde(rename = "BucketARN")]
@@ -1083,7 +1083,7 @@ pub struct S3ReferenceDataSource {
 }
 
 /// <p>Provides the bucket name and object key name that stores the reference data.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct S3ReferenceDataSourceDescription {
     /// <p>Amazon Resource Name (ARN) of the S3 bucket.</p>
     #[serde(rename = "BucketARN")]
@@ -1097,7 +1097,7 @@ pub struct S3ReferenceDataSourceDescription {
 }
 
 /// <p>Describes the S3 bucket name, object key name, and IAM role that Amazon Kinesis Analytics can assume to read the Amazon S3 object on your behalf and populate the in-application reference table.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct S3ReferenceDataSourceUpdate {
     /// <p>Amazon Resource Name (ARN) of the S3 bucket.</p>
     #[serde(rename = "BucketARNUpdate")]
@@ -1114,7 +1114,7 @@ pub struct S3ReferenceDataSourceUpdate {
 }
 
 /// <p>Describes the format of the data in the streaming source, and how each data element maps to corresponding columns created in the in-application stream.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SourceSchema {
     /// <p>A list of <code>RecordColumn</code> objects.</p>
     #[serde(rename = "RecordColumns")]
@@ -1129,7 +1129,7 @@ pub struct SourceSchema {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StartApplicationRequest {
     /// <p>Name of the application.</p>
     #[serde(rename = "ApplicationName")]
@@ -1140,11 +1140,11 @@ pub struct StartApplicationRequest {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StartApplicationResponse {}
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StopApplicationRequest {
     /// <p>Name of the running application to stop.</p>
     #[serde(rename = "ApplicationName")]
@@ -1152,10 +1152,10 @@ pub struct StopApplicationRequest {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StopApplicationResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateApplicationRequest {
     /// <p>Name of the Amazon Kinesis Analytics application to update.</p>
     #[serde(rename = "ApplicationName")]
@@ -1168,7 +1168,7 @@ pub struct UpdateApplicationRequest {
     pub current_application_version_id: i64,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateApplicationResponse {}
 
 /// Errors returned by AddApplicationCloudWatchLoggingOption

--- a/rusoto/services/kms/src/generated.rs
+++ b/rusoto/services/kms/src/generated.rs
@@ -977,7 +977,8 @@ impl CancelKeyDeletionError {
     pub fn from_body(body: &str) -> CancelKeyDeletionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1085,7 +1086,8 @@ impl CreateAliasError {
     pub fn from_body(body: &str) -> CreateAliasError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1199,7 +1201,8 @@ impl CreateGrantError {
     pub fn from_body(body: &str) -> CreateGrantError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1313,7 +1316,8 @@ impl CreateKeyError {
     pub fn from_body(body: &str) -> CreateKeyError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1425,7 +1429,8 @@ impl DecryptError {
     pub fn from_body(body: &str) -> DecryptError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1531,7 +1536,8 @@ impl DeleteAliasError {
     pub fn from_body(body: &str) -> DeleteAliasError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1629,7 +1635,8 @@ impl DeleteImportedKeyMaterialError {
     pub fn from_body(body: &str) -> DeleteImportedKeyMaterialError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1739,7 +1746,8 @@ impl DescribeKeyError {
     pub fn from_body(body: &str) -> DescribeKeyError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1835,7 +1843,8 @@ impl DisableKeyError {
     pub fn from_body(body: &str) -> DisableKeyError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1937,7 +1946,8 @@ impl DisableKeyRotationError {
     pub fn from_body(body: &str) -> DisableKeyRotationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2051,7 +2061,8 @@ impl EnableKeyError {
     pub fn from_body(body: &str) -> EnableKeyError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2157,7 +2168,8 @@ impl EnableKeyRotationError {
     pub fn from_body(body: &str) -> EnableKeyRotationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2275,7 +2287,8 @@ impl EncryptError {
     pub fn from_body(body: &str) -> EncryptError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2389,7 +2402,8 @@ impl GenerateDataKeyError {
     pub fn from_body(body: &str) -> GenerateDataKeyError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2509,7 +2523,8 @@ impl GenerateDataKeyWithoutPlaintextError {
     pub fn from_body(body: &str) -> GenerateDataKeyWithoutPlaintextError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2629,7 +2644,8 @@ impl GenerateRandomError {
     pub fn from_body(body: &str) -> GenerateRandomError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2719,7 +2735,8 @@ impl GetKeyPolicyError {
     pub fn from_body(body: &str) -> GetKeyPolicyError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2821,7 +2838,8 @@ impl GetKeyRotationStatusError {
     pub fn from_body(body: &str) -> GetKeyRotationStatusError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2931,7 +2949,8 @@ impl GetParametersForImportError {
     pub fn from_body(body: &str) -> GetParametersForImportError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3051,7 +3070,8 @@ impl ImportKeyMaterialError {
     pub fn from_body(body: &str) -> ImportKeyMaterialError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3171,7 +3191,8 @@ impl ListAliasesError {
     pub fn from_body(body: &str) -> ListAliasesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3267,7 +3288,8 @@ impl ListGrantsError {
     pub fn from_body(body: &str) -> ListGrantsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3369,7 +3391,8 @@ impl ListKeyPoliciesError {
     pub fn from_body(body: &str) -> ListKeyPoliciesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3467,7 +3490,8 @@ impl ListKeysError {
     pub fn from_body(body: &str) -> ListKeysError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3557,7 +3581,8 @@ impl ListResourceTagsError {
     pub fn from_body(body: &str) -> ListResourceTagsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3655,7 +3680,8 @@ impl ListRetirableGrantsError {
     pub fn from_body(body: &str) -> ListRetirableGrantsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3765,7 +3791,8 @@ impl PutKeyPolicyError {
     pub fn from_body(body: &str) -> PutKeyPolicyError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3885,7 +3912,8 @@ impl ReEncryptError {
     pub fn from_body(body: &str) -> ReEncryptError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4001,7 +4029,8 @@ impl RetireGrantError {
     pub fn from_body(body: &str) -> RetireGrantError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4111,7 +4140,8 @@ impl RevokeGrantError {
     pub fn from_body(body: &str) -> RevokeGrantError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4215,7 +4245,8 @@ impl ScheduleKeyDeletionError {
     pub fn from_body(body: &str) -> ScheduleKeyDeletionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4321,7 +4352,8 @@ impl TagResourceError {
     pub fn from_body(body: &str) -> TagResourceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4423,7 +4455,8 @@ impl UntagResourceError {
     pub fn from_body(body: &str) -> UntagResourceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4521,7 +4554,8 @@ impl UpdateAliasError {
     pub fn from_body(body: &str) -> UpdateAliasError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4617,7 +4651,8 @@ impl UpdateKeyDescriptionError {
     pub fn from_body(body: &str) -> UpdateKeyDescriptionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/kms/src/generated.rs
+++ b/rusoto/services/kms/src/generated.rs
@@ -31,7 +31,7 @@ use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 /// <p>Contains information about an alias.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AliasListEntry {
     /// <p>String that contains the key ARN.</p>
     #[serde(rename = "AliasArn")]
@@ -47,14 +47,14 @@ pub struct AliasListEntry {
     pub target_key_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CancelKeyDeletionRequest {
     /// <p>The unique identifier for the customer master key (CMK) for which to cancel deletion.</p> <p>Specify the key ID or the Amazon Resource Name (ARN) of the CMK.</p> <p>For example:</p> <ul> <li> <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> <li> <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> </ul> <p>To get the key ID and key ARN for a CMK, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>
     #[serde(rename = "KeyId")]
     pub key_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CancelKeyDeletionResponse {
     /// <p>The unique identifier of the master key for which deletion is canceled.</p>
     #[serde(rename = "KeyId")]
@@ -62,7 +62,7 @@ pub struct CancelKeyDeletionResponse {
     pub key_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateAliasRequest {
     /// <p>String that contains the display name. The name must start with the word "alias" followed by a forward slash (alias/). Aliases that begin with "alias/AWS" are reserved.</p>
     #[serde(rename = "AliasName")]
@@ -72,7 +72,7 @@ pub struct CreateAliasRequest {
     pub target_key_id: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateGrantRequest {
     /// <p>A structure that you can use to allow certain operations in the grant only when the desired encryption context is present. For more information about encryption context, see <a href="http://docs.aws.amazon.com/kms/latest/developerguide/encryption-context.html">Encryption Context</a> in the <i>AWS Key Management Service Developer Guide</i>.</p>
     #[serde(rename = "Constraints")]
@@ -101,7 +101,7 @@ pub struct CreateGrantRequest {
     pub retiring_principal: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateGrantResponse {
     /// <p>The unique identifier for the grant.</p> <p>You can use the <code>GrantId</code> in a subsequent <a>RetireGrant</a> or <a>RevokeGrant</a> operation.</p>
     #[serde(rename = "GrantId")]
@@ -113,7 +113,7 @@ pub struct CreateGrantResponse {
     pub grant_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateKeyRequest {
     /// <p>A flag to indicate whether to bypass the key policy lockout safety check.</p> <important> <p>Setting this value to true increases the risk that the CMK becomes unmanageable. Do not set this value to true indiscriminately.</p> <p>For more information, refer to the scenario in the <a href="http://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default-allow-root-enable-iam">Default Key Policy</a> section in the <i>AWS Key Management Service Developer Guide</i>.</p> </important> <p>Use this parameter only when you include a policy in the request and you intend to prevent the principal that is making the request from making a subsequent <a>PutKeyPolicy</a> request on the CMK.</p> <p>The default value is false.</p>
     #[serde(rename = "BypassPolicyLockoutSafetyCheck")]
@@ -141,7 +141,7 @@ pub struct CreateKeyRequest {
     pub tags: Option<Vec<Tag>>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateKeyResponse {
     /// <p>Metadata associated with the CMK.</p>
     #[serde(rename = "KeyMetadata")]
@@ -149,7 +149,7 @@ pub struct CreateKeyResponse {
     pub key_metadata: Option<KeyMetadata>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DecryptRequest {
     /// <p>Ciphertext to be decrypted. The blob includes metadata.</p>
     #[serde(rename = "CiphertextBlob")]
@@ -169,7 +169,7 @@ pub struct DecryptRequest {
     pub grant_tokens: Option<Vec<String>>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DecryptResponse {
     /// <p>ARN of the key used to perform the decryption. This value is returned if no errors are encountered during the operation.</p>
     #[serde(rename = "KeyId")]
@@ -185,21 +185,21 @@ pub struct DecryptResponse {
     pub plaintext: Option<Vec<u8>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteAliasRequest {
     /// <p>The alias to be deleted. The name must start with the word "alias" followed by a forward slash (alias/). Aliases that begin with "alias/aws" are reserved.</p>
     #[serde(rename = "AliasName")]
     pub alias_name: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteImportedKeyMaterialRequest {
     /// <p>The identifier of the CMK whose key material to delete. The CMK's <code>Origin</code> must be <code>EXTERNAL</code>.</p> <p>Specify the key ID or the Amazon Resource Name (ARN) of the CMK.</p> <p>For example:</p> <ul> <li> <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> <li> <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> </ul> <p>To get the key ID and key ARN for a CMK, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>
     #[serde(rename = "KeyId")]
     pub key_id: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeKeyRequest {
     /// <p>A list of grant tokens.</p> <p>For more information, see <a href="http://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#grant_token">Grant Tokens</a> in the <i>AWS Key Management Service Developer Guide</i>.</p>
     #[serde(rename = "GrantTokens")]
@@ -210,7 +210,7 @@ pub struct DescribeKeyRequest {
     pub key_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeKeyResponse {
     /// <p>Metadata associated with the key.</p>
     #[serde(rename = "KeyMetadata")]
@@ -218,35 +218,35 @@ pub struct DescribeKeyResponse {
     pub key_metadata: Option<KeyMetadata>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DisableKeyRequest {
     /// <p>A unique identifier for the customer master key (CMK).</p> <p>Specify the key ID or the Amazon Resource Name (ARN) of the CMK.</p> <p>For example:</p> <ul> <li> <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> <li> <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> </ul> <p>To get the key ID and key ARN for a CMK, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>
     #[serde(rename = "KeyId")]
     pub key_id: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DisableKeyRotationRequest {
     /// <p>A unique identifier for the customer master key (CMK).</p> <p>Specify the key ID or the Amazon Resource Name (ARN) of the CMK.</p> <p>For example:</p> <ul> <li> <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> <li> <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> </ul> <p>To get the key ID and key ARN for a CMK, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>
     #[serde(rename = "KeyId")]
     pub key_id: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct EnableKeyRequest {
     /// <p>A unique identifier for the customer master key (CMK).</p> <p>Specify the key ID or the Amazon Resource Name (ARN) of the CMK.</p> <p>For example:</p> <ul> <li> <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> <li> <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> </ul> <p>To get the key ID and key ARN for a CMK, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>
     #[serde(rename = "KeyId")]
     pub key_id: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct EnableKeyRotationRequest {
     /// <p>A unique identifier for the customer master key (CMK).</p> <p>Specify the key ID or the Amazon Resource Name (ARN) of the CMK.</p> <p>For example:</p> <ul> <li> <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> <li> <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> </ul> <p>To get the key ID and key ARN for a CMK, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>
     #[serde(rename = "KeyId")]
     pub key_id: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct EncryptRequest {
     /// <p>Name-value pair that specifies the encryption context to be used for authenticated encryption. If used here, the same value must be supplied to the <code>Decrypt</code> API or decryption will fail. For more information, see <a href="http://docs.aws.amazon.com/kms/latest/developerguide/encryption-context.html">Encryption Context</a>.</p>
     #[serde(rename = "EncryptionContext")]
@@ -269,7 +269,7 @@ pub struct EncryptRequest {
     pub plaintext: Vec<u8>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct EncryptResponse {
     /// <p>The encrypted plaintext. When you use the HTTP API or the AWS CLI, the value is Base64-encoded. Otherwise, it is not encoded.</p>
     #[serde(rename = "CiphertextBlob")]
@@ -285,7 +285,7 @@ pub struct EncryptResponse {
     pub key_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GenerateDataKeyRequest {
     /// <p>A set of key-value pairs that represents additional authenticated data.</p> <p>For more information, see <a href="http://docs.aws.amazon.com/kms/latest/developerguide/encryption-context.html">Encryption Context</a> in the <i>AWS Key Management Service Developer Guide</i>.</p>
     #[serde(rename = "EncryptionContext")]
@@ -308,7 +308,7 @@ pub struct GenerateDataKeyRequest {
     pub number_of_bytes: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GenerateDataKeyResponse {
     /// <p>The encrypted data encryption key. When you use the HTTP API or the AWS CLI, the value is Base64-encoded. Otherwise, it is not encoded.</p>
     #[serde(rename = "CiphertextBlob")]
@@ -332,7 +332,7 @@ pub struct GenerateDataKeyResponse {
     pub plaintext: Option<Vec<u8>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GenerateDataKeyWithoutPlaintextRequest {
     /// <p>A set of key-value pairs that represents additional authenticated data.</p> <p>For more information, see <a href="http://docs.aws.amazon.com/kms/latest/developerguide/encryption-context.html">Encryption Context</a> in the <i>AWS Key Management Service Developer Guide</i>.</p>
     #[serde(rename = "EncryptionContext")]
@@ -355,7 +355,7 @@ pub struct GenerateDataKeyWithoutPlaintextRequest {
     pub number_of_bytes: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GenerateDataKeyWithoutPlaintextResponse {
     /// <p>The encrypted data encryption key. When you use the HTTP API or the AWS CLI, the value is Base64-encoded. Otherwise, it is not encoded.</p>
     #[serde(rename = "CiphertextBlob")]
@@ -371,7 +371,7 @@ pub struct GenerateDataKeyWithoutPlaintextResponse {
     pub key_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GenerateRandomRequest {
     /// <p>The length of the byte string.</p>
     #[serde(rename = "NumberOfBytes")]
@@ -379,7 +379,7 @@ pub struct GenerateRandomRequest {
     pub number_of_bytes: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GenerateRandomResponse {
     /// <p>The random byte string. When you use the HTTP API or the AWS CLI, the value is Base64-encoded. Otherwise, it is not encoded.</p>
     #[serde(rename = "Plaintext")]
@@ -391,7 +391,7 @@ pub struct GenerateRandomResponse {
     pub plaintext: Option<Vec<u8>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetKeyPolicyRequest {
     /// <p>A unique identifier for the customer master key (CMK).</p> <p>Specify the key ID or the Amazon Resource Name (ARN) of the CMK.</p> <p>For example:</p> <ul> <li> <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> <li> <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> </ul> <p>To get the key ID and key ARN for a CMK, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>
     #[serde(rename = "KeyId")]
@@ -401,7 +401,7 @@ pub struct GetKeyPolicyRequest {
     pub policy_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetKeyPolicyResponse {
     /// <p>A key policy document in JSON format.</p>
     #[serde(rename = "Policy")]
@@ -409,14 +409,14 @@ pub struct GetKeyPolicyResponse {
     pub policy: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetKeyRotationStatusRequest {
     /// <p>A unique identifier for the customer master key (CMK).</p> <p>Specify the key ID or the Amazon Resource Name (ARN) of the CMK. To specify a CMK in a different AWS account, you must use the key ARN.</p> <p>For example:</p> <ul> <li> <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> <li> <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> </ul> <p>To get the key ID and key ARN for a CMK, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>
     #[serde(rename = "KeyId")]
     pub key_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetKeyRotationStatusResponse {
     /// <p>A Boolean value that specifies whether key rotation is enabled.</p>
     #[serde(rename = "KeyRotationEnabled")]
@@ -424,7 +424,7 @@ pub struct GetKeyRotationStatusResponse {
     pub key_rotation_enabled: Option<bool>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetParametersForImportRequest {
     /// <p>The identifier of the CMK into which you will import key material. The CMK's <code>Origin</code> must be <code>EXTERNAL</code>.</p> <p>Specify the key ID or the Amazon Resource Name (ARN) of the CMK.</p> <p>For example:</p> <ul> <li> <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> <li> <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> </ul> <p>To get the key ID and key ARN for a CMK, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>
     #[serde(rename = "KeyId")]
@@ -437,7 +437,7 @@ pub struct GetParametersForImportRequest {
     pub wrapping_key_spec: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetParametersForImportResponse {
     /// <p>The import token to send in a subsequent <a>ImportKeyMaterial</a> request.</p>
     #[serde(rename = "ImportToken")]
@@ -466,7 +466,7 @@ pub struct GetParametersForImportResponse {
 }
 
 /// <p>A structure that you can use to allow certain operations in the grant only when the desired encryption context is present. For more information about encryption context, see <a href="http://docs.aws.amazon.com/kms/latest/developerguide/encryption-context.html">Encryption Context</a> in the <i>AWS Key Management Service Developer Guide</i>.</p> <p>Grant constraints apply only to operations that accept encryption context as input. For example, the <code> <a>DescribeKey</a> </code> operation does not accept encryption context as input. A grant that allows the <code>DescribeKey</code> operation does so regardless of the grant constraints. In constrast, the <code> <a>Encrypt</a> </code> operation accepts encryption context as input. A grant that allows the <code>Encrypt</code> operation does so only when the encryption context of the <code>Encrypt</code> operation satisfies the grant constraints.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct GrantConstraints {
     /// <p>A list of key-value pairs that must be present in the encryption context of certain subsequent operations that the grant allows. When certain subsequent operations allowed by the grant include encryption context that matches this list, the grant allows the operation. Otherwise, the grant does not allow the operation.</p>
     #[serde(rename = "EncryptionContextEquals")]
@@ -479,7 +479,7 @@ pub struct GrantConstraints {
 }
 
 /// <p>Contains information about an entry in a list of grants.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GrantListEntry {
     /// <p>A list of key-value pairs that must be present in the encryption context of certain subsequent operations that the grant allows.</p>
     #[serde(rename = "Constraints")]
@@ -519,7 +519,7 @@ pub struct GrantListEntry {
     pub retiring_principal: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ImportKeyMaterialRequest {
     /// <p>The encrypted key material to import. It must be encrypted with the public key that you received in the response to a previous <a>GetParametersForImport</a> request, using the wrapping algorithm that you specified in that request.</p>
     #[serde(rename = "EncryptedKeyMaterial")]
@@ -550,11 +550,11 @@ pub struct ImportKeyMaterialRequest {
     pub valid_to: Option<f64>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ImportKeyMaterialResponse {}
 
 /// <p>Contains information about each entry in the key list.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct KeyListEntry {
     /// <p>ARN of the key.</p>
     #[serde(rename = "KeyArn")]
@@ -567,7 +567,7 @@ pub struct KeyListEntry {
 }
 
 /// <p>Contains metadata about a customer master key (CMK).</p> <p>This data type is used as a response element for the <a>CreateKey</a> and <a>DescribeKey</a> operations.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct KeyMetadata {
     /// <p>The twelve-digit account ID of the AWS account that owns the CMK.</p>
     #[serde(rename = "AWSAccountId")]
@@ -622,7 +622,7 @@ pub struct KeyMetadata {
     pub valid_to: Option<f64>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListAliasesRequest {
     /// <p>Use this parameter to specify the maximum number of items to return. When this value is present, AWS KMS does not return more than the specified number of items, but it might return fewer.</p> <p>This value is optional. If you include a value, it must be between 1 and 100, inclusive. If you do not include a value, it defaults to 50.</p>
     #[serde(rename = "Limit")]
@@ -634,7 +634,7 @@ pub struct ListAliasesRequest {
     pub marker: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListAliasesResponse {
     /// <p>A list of aliases.</p>
     #[serde(rename = "Aliases")]
@@ -650,7 +650,7 @@ pub struct ListAliasesResponse {
     pub truncated: Option<bool>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListGrantsRequest {
     /// <p>A unique identifier for the customer master key (CMK).</p> <p>Specify the key ID or the Amazon Resource Name (ARN) of the CMK. To specify a CMK in a different AWS account, you must use the key ARN.</p> <p>For example:</p> <ul> <li> <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> <li> <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> </ul> <p>To get the key ID and key ARN for a CMK, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>
     #[serde(rename = "KeyId")]
@@ -665,7 +665,7 @@ pub struct ListGrantsRequest {
     pub marker: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListGrantsResponse {
     /// <p>A list of grants.</p>
     #[serde(rename = "Grants")]
@@ -681,7 +681,7 @@ pub struct ListGrantsResponse {
     pub truncated: Option<bool>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListKeyPoliciesRequest {
     /// <p>A unique identifier for the customer master key (CMK).</p> <p>Specify the key ID or the Amazon Resource Name (ARN) of the CMK.</p> <p>For example:</p> <ul> <li> <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> <li> <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> </ul> <p>To get the key ID and key ARN for a CMK, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>
     #[serde(rename = "KeyId")]
@@ -696,7 +696,7 @@ pub struct ListKeyPoliciesRequest {
     pub marker: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListKeyPoliciesResponse {
     /// <p>When <code>Truncated</code> is true, this element is present and contains the value to use for the <code>Marker</code> parameter in a subsequent request.</p>
     #[serde(rename = "NextMarker")]
@@ -712,7 +712,7 @@ pub struct ListKeyPoliciesResponse {
     pub truncated: Option<bool>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListKeysRequest {
     /// <p>Use this parameter to specify the maximum number of items to return. When this value is present, AWS KMS does not return more than the specified number of items, but it might return fewer.</p> <p>This value is optional. If you include a value, it must be between 1 and 1000, inclusive. If you do not include a value, it defaults to 100.</p>
     #[serde(rename = "Limit")]
@@ -724,7 +724,7 @@ pub struct ListKeysRequest {
     pub marker: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListKeysResponse {
     /// <p>A list of customer master keys (CMKs).</p>
     #[serde(rename = "Keys")]
@@ -740,7 +740,7 @@ pub struct ListKeysResponse {
     pub truncated: Option<bool>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListResourceTagsRequest {
     /// <p>A unique identifier for the customer master key (CMK).</p> <p>Specify the key ID or the Amazon Resource Name (ARN) of the CMK.</p> <p>For example:</p> <ul> <li> <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> <li> <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> </ul> <p>To get the key ID and key ARN for a CMK, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>
     #[serde(rename = "KeyId")]
@@ -755,7 +755,7 @@ pub struct ListResourceTagsRequest {
     pub marker: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListResourceTagsResponse {
     /// <p>When <code>Truncated</code> is true, this element is present and contains the value to use for the <code>Marker</code> parameter in a subsequent request.</p> <p>Do not assume or infer any information from this value.</p>
     #[serde(rename = "NextMarker")]
@@ -771,7 +771,7 @@ pub struct ListResourceTagsResponse {
     pub truncated: Option<bool>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListRetirableGrantsRequest {
     /// <p>Use this parameter to specify the maximum number of items to return. When this value is present, AWS KMS does not return more than the specified number of items, but it might return fewer.</p> <p>This value is optional. If you include a value, it must be between 1 and 100, inclusive. If you do not include a value, it defaults to 50.</p>
     #[serde(rename = "Limit")]
@@ -786,7 +786,7 @@ pub struct ListRetirableGrantsRequest {
     pub retiring_principal: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PutKeyPolicyRequest {
     /// <p>A flag to indicate whether to bypass the key policy lockout safety check.</p> <important> <p>Setting this value to true increases the risk that the CMK becomes unmanageable. Do not set this value to true indiscriminately.</p> <p>For more information, refer to the scenario in the <a href="http://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default-allow-root-enable-iam">Default Key Policy</a> section in the <i>AWS Key Management Service Developer Guide</i>.</p> </important> <p>Use this parameter only when you intend to prevent the principal that is making the request from making a subsequent <code>PutKeyPolicy</code> request on the CMK.</p> <p>The default value is false.</p>
     #[serde(rename = "BypassPolicyLockoutSafetyCheck")]
@@ -803,7 +803,7 @@ pub struct PutKeyPolicyRequest {
     pub policy_name: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ReEncryptRequest {
     /// <p>Ciphertext of the data to reencrypt.</p>
     #[serde(rename = "CiphertextBlob")]
@@ -830,7 +830,7 @@ pub struct ReEncryptRequest {
     pub source_encryption_context: Option<::std::collections::HashMap<String, String>>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ReEncryptResponse {
     /// <p>The reencrypted data. When you use the HTTP API or the AWS CLI, the value is Base64-encoded. Otherwise, it is not encoded.</p>
     #[serde(rename = "CiphertextBlob")]
@@ -850,7 +850,7 @@ pub struct ReEncryptResponse {
     pub source_key_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RetireGrantRequest {
     /// <p><p>Unique identifier of the grant to retire. The grant ID is returned in the response to a <code>CreateGrant</code> operation.</p> <ul> <li> <p>Grant ID Example - 0123456789012345678901234567890123456789012345678901234567890123</p> </li> </ul></p>
     #[serde(rename = "GrantId")]
@@ -866,7 +866,7 @@ pub struct RetireGrantRequest {
     pub key_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RevokeGrantRequest {
     /// <p>Identifier of the grant to be revoked.</p>
     #[serde(rename = "GrantId")]
@@ -876,7 +876,7 @@ pub struct RevokeGrantRequest {
     pub key_id: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ScheduleKeyDeletionRequest {
     /// <p>The unique identifier of the customer master key (CMK) to delete.</p> <p>Specify the key ID or the Amazon Resource Name (ARN) of the CMK.</p> <p>For example:</p> <ul> <li> <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> <li> <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> </ul> <p>To get the key ID and key ARN for a CMK, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>
     #[serde(rename = "KeyId")]
@@ -887,7 +887,7 @@ pub struct ScheduleKeyDeletionRequest {
     pub pending_window_in_days: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ScheduleKeyDeletionResponse {
     /// <p>The date and time after which AWS KMS deletes the customer master key (CMK).</p>
     #[serde(rename = "DeletionDate")]
@@ -900,7 +900,7 @@ pub struct ScheduleKeyDeletionResponse {
 }
 
 /// <p>A key-value pair. A tag consists of a tag key and a tag value. Tag keys and tag values are both required, but tag values can be empty (null) strings.</p> <p>For information about the rules that apply to tag keys and tag values, see <a href="http://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/allocation-tag-restrictions.html">User-Defined Tag Restrictions</a> in the <i>AWS Billing and Cost Management User Guide</i>.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Tag {
     /// <p>The key of the tag.</p>
     #[serde(rename = "TagKey")]
@@ -910,7 +910,7 @@ pub struct Tag {
     pub tag_value: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct TagResourceRequest {
     /// <p>A unique identifier for the CMK you are tagging.</p> <p>Specify the key ID or the Amazon Resource Name (ARN) of the CMK.</p> <p>For example:</p> <ul> <li> <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> <li> <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> </ul> <p>To get the key ID and key ARN for a CMK, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>
     #[serde(rename = "KeyId")]
@@ -920,7 +920,7 @@ pub struct TagResourceRequest {
     pub tags: Vec<Tag>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UntagResourceRequest {
     /// <p>A unique identifier for the CMK from which you are removing tags.</p> <p>Specify the key ID or the Amazon Resource Name (ARN) of the CMK.</p> <p>For example:</p> <ul> <li> <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> <li> <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code> </p> </li> </ul> <p>To get the key ID and key ARN for a CMK, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>
     #[serde(rename = "KeyId")]
@@ -930,7 +930,7 @@ pub struct UntagResourceRequest {
     pub tag_keys: Vec<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateAliasRequest {
     /// <p>String that contains the name of the alias to be modified. The name must start with the word "alias" followed by a forward slash (alias/). Aliases that begin with "alias/aws" are reserved.</p>
     #[serde(rename = "AliasName")]
@@ -940,7 +940,7 @@ pub struct UpdateAliasRequest {
     pub target_key_id: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateKeyDescriptionRequest {
     /// <p>New description for the CMK.</p>
     #[serde(rename = "Description")]

--- a/rusoto/services/lambda/src/generated.rs
+++ b/rusoto/services/lambda/src/generated.rs
@@ -31,7 +31,7 @@ use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 /// <p>Provides limits of code size and concurrency associated with the current account and region.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AccountLimit {
     /// <p>Size, in bytes, of code/dependencies that you can zip into a deployment package (uncompressed zip/jar size) for uploading. The default limit is 250 MB.</p>
     #[serde(rename = "CodeSizeUnzipped")]
@@ -56,7 +56,7 @@ pub struct AccountLimit {
 }
 
 /// <p>Provides code size usage and function count associated with the current account and region.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AccountUsage {
     /// <p>The number of your account's existing functions per region.</p>
     #[serde(rename = "FunctionCount")]
@@ -69,7 +69,7 @@ pub struct AccountUsage {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AddPermissionRequest {
     /// <p>The AWS Lambda action you want to allow in this statement. Each Lambda action is a string starting with <code>lambda:</code> followed by the API name . For example, <code>lambda:CreateFunction</code>. You can use wildcard (<code>lambda:*</code>) to grant permission for all AWS Lambda actions. </p>
     #[serde(rename = "Action")]
@@ -106,7 +106,7 @@ pub struct AddPermissionRequest {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AddPermissionResponse {
     /// <p>The permission statement you specified in the request. The response returns the same as a string using a backslash ("\") as an escape character in the JSON.</p>
     #[serde(rename = "Statement")]
@@ -115,7 +115,7 @@ pub struct AddPermissionResponse {
 }
 
 /// <p>Provides configuration information about a Lambda function version alias.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AliasConfiguration {
     /// <p>Lambda function ARN that is qualified using the alias name as the suffix. For example, if you create an alias called <code>BETA</code> that points to a helloworld function version, the ARN is <code>arn:aws:lambda:aws-regions:acct-id:function:helloworld:BETA</code>.</p>
     #[serde(rename = "AliasArn")]
@@ -144,7 +144,7 @@ pub struct AliasConfiguration {
 }
 
 /// <p>The parent object that implements what percentage of traffic will invoke each function version. For more information, see <a>lambda-traffic-shifting-using-aliases</a>.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct AliasRoutingConfiguration {
     /// <p>Set this value to dictate what percentage of traffic will invoke the updated function version. If set to an empty string, 100 percent of traffic will invoke <code>function-version</code>. For more information, see <a>lambda-traffic-shifting-using-aliases</a>.</p>
     #[serde(rename = "AdditionalVersionWeights")]
@@ -152,7 +152,7 @@ pub struct AliasRoutingConfiguration {
     pub additional_version_weights: Option<::std::collections::HashMap<String, f64>>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Concurrency {
     /// <p>The number of concurrent executions reserved for this function. For more information, see <a>concurrent-executions</a>.</p>
     #[serde(rename = "ReservedConcurrentExecutions")]
@@ -160,7 +160,7 @@ pub struct Concurrency {
     pub reserved_concurrent_executions: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateAliasRequest {
     /// <p>Description of the alias.</p>
     #[serde(rename = "Description")]
@@ -182,7 +182,7 @@ pub struct CreateAliasRequest {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateEventSourceMappingRequest {
     /// <p>The largest number of records that AWS Lambda will retrieve from your event source at the time of invoking your function. Your function receives an event with all the retrieved records. The default is 100 records.</p>
     #[serde(rename = "BatchSize")]
@@ -208,7 +208,7 @@ pub struct CreateEventSourceMappingRequest {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateFunctionRequest {
     /// <p>The code for the Lambda function.</p>
     #[serde(rename = "Code")]
@@ -267,7 +267,7 @@ pub struct CreateFunctionRequest {
 }
 
 /// <p>The Amazon Resource Name (ARN) of an Amazon SQS queue or Amazon SNS topic you specify as your Dead Letter Queue (DLQ). For more information, see <a>dlq</a>. </p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct DeadLetterConfig {
     /// <p>The Amazon Resource Name (ARN) of an Amazon SQS queue or Amazon SNS topic you specify as your Dead Letter Queue (DLQ). <a>dlq</a>. For more information, see <a>dlq</a>. </p>
     #[serde(rename = "TargetArn")]
@@ -275,7 +275,7 @@ pub struct DeadLetterConfig {
     pub target_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteAliasRequest {
     /// <p>The Lambda function name for which the alias is created. Deleting an alias does not delete the function version to which it is pointing. Note that the length constraint applies only to the ARN. If you specify only the function name, it is limited to 64 characters in length.</p>
     #[serde(rename = "FunctionName")]
@@ -286,21 +286,21 @@ pub struct DeleteAliasRequest {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteEventSourceMappingRequest {
     /// <p>The event source mapping ID.</p>
     #[serde(rename = "UUID")]
     pub uuid: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteFunctionConcurrencyRequest {
     /// <p>The name of the function you are removing concurrent execution limits from. For more information, see <a>concurrent-executions</a>.</p>
     #[serde(rename = "FunctionName")]
     pub function_name: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteFunctionRequest {
     /// <p>The Lambda function to delete.</p> <p> You can specify the function name (for example, <code>Thumbnail</code>) or you can specify Amazon Resource Name (ARN) of the function (for example, <code>arn:aws:lambda:us-west-2:account-id:function:ThumbNail</code>). If you are using versioning, you can also provide a qualified function ARN (ARN that is qualified with function version or alias name as suffix). AWS Lambda also allows you to specify only the function name with the account ID qualifier (for example, <code>account-id:Thumbnail</code>). Note that the length constraint applies only to the ARN. If you specify only the function name, it is limited to 64 characters in length. </p>
     #[serde(rename = "FunctionName")]
@@ -312,7 +312,7 @@ pub struct DeleteFunctionRequest {
 }
 
 /// <p>The parent object that contains your environment's configuration settings.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct Environment {
     /// <p>The key-value pairs that represent your environment's configuration settings.</p>
     #[serde(rename = "Variables")]
@@ -321,7 +321,7 @@ pub struct Environment {
 }
 
 /// <p>The parent object that contains error information associated with your configuration settings.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct EnvironmentError {
     /// <p>The error code returned by the environment error object.</p>
     #[serde(rename = "ErrorCode")]
@@ -334,7 +334,7 @@ pub struct EnvironmentError {
 }
 
 /// <p>The parent object returned that contains your environment's configuration settings or any error information associated with your configuration settings.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct EnvironmentResponse {
     #[serde(rename = "Error")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -346,7 +346,7 @@ pub struct EnvironmentResponse {
 }
 
 /// <p>Describes mapping between an Amazon Kinesis stream and a Lambda function.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct EventSourceMappingConfiguration {
     /// <p>The largest number of records that AWS Lambda will retrieve from your event source at the time of invoking your function. Your function receives an event with all the retrieved records.</p>
     #[serde(rename = "BatchSize")]
@@ -383,7 +383,7 @@ pub struct EventSourceMappingConfiguration {
 }
 
 /// <p>The code for the Lambda function.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct FunctionCode {
     /// <p>Amazon S3 bucket name where the .zip file containing your deployment package is stored. This bucket must reside in the same AWS region where you are creating the Lambda function.</p>
     #[serde(rename = "S3Bucket")]
@@ -408,7 +408,7 @@ pub struct FunctionCode {
 }
 
 /// <p>The object for the Lambda function location.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct FunctionCodeLocation {
     /// <p>The presigned URL you can use to download the function's .zip file that you previously uploaded. The URL is valid for up to 10 minutes.</p>
     #[serde(rename = "Location")]
@@ -421,7 +421,7 @@ pub struct FunctionCodeLocation {
 }
 
 /// <p>A complex type that describes function metadata.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct FunctionConfiguration {
     /// <p>It is the SHA256 hash of your function deployment package.</p>
     #[serde(rename = "CodeSha256")]
@@ -501,10 +501,10 @@ pub struct FunctionConfiguration {
     pub vpc_config: Option<VpcConfigResponse>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetAccountSettingsRequest {}
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetAccountSettingsResponse {
     #[serde(rename = "AccountLimit")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -514,7 +514,7 @@ pub struct GetAccountSettingsResponse {
     pub account_usage: Option<AccountUsage>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetAliasRequest {
     /// <p>Function name for which the alias is created. An alias is a subresource that exists only in the context of an existing Lambda function so you must specify the function name. Note that the length constraint applies only to the ARN. If you specify only the function name, it is limited to 64 characters in length.</p>
     #[serde(rename = "FunctionName")]
@@ -525,7 +525,7 @@ pub struct GetAliasRequest {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetEventSourceMappingRequest {
     /// <p>The AWS Lambda assigned ID of the event source mapping.</p>
     #[serde(rename = "UUID")]
@@ -533,7 +533,7 @@ pub struct GetEventSourceMappingRequest {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetFunctionConfigurationRequest {
     /// <p>The name of the Lambda function for which you want to retrieve the configuration information.</p> <p> You can specify a function name (for example, <code>Thumbnail</code>) or you can specify Amazon Resource Name (ARN) of the function (for example, <code>arn:aws:lambda:us-west-2:account-id:function:ThumbNail</code>). AWS Lambda also allows you to specify a partial ARN (for example, <code>account-id:Thumbnail</code>). Note that the length constraint applies only to the ARN. If you specify only the function name, it is limited to 64 characters in length. </p>
     #[serde(rename = "FunctionName")]
@@ -545,7 +545,7 @@ pub struct GetFunctionConfigurationRequest {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetFunctionRequest {
     /// <p>The Lambda function name.</p> <p> You can specify a function name (for example, <code>Thumbnail</code>) or you can specify Amazon Resource Name (ARN) of the function (for example, <code>arn:aws:lambda:us-west-2:account-id:function:ThumbNail</code>). AWS Lambda also allows you to specify a partial ARN (for example, <code>account-id:Thumbnail</code>). Note that the length constraint applies only to the ARN. If you specify only the function name, it is limited to 64 characters in length. </p>
     #[serde(rename = "FunctionName")]
@@ -557,7 +557,7 @@ pub struct GetFunctionRequest {
 }
 
 /// <p>This response contains the object for the Lambda function location (see <a>FunctionCodeLocation</a>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetFunctionResponse {
     #[serde(rename = "Code")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -576,7 +576,7 @@ pub struct GetFunctionResponse {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetPolicyRequest {
     /// <p>Function name whose resource policy you want to retrieve.</p> <p> You can specify the function name (for example, <code>Thumbnail</code>) or you can specify Amazon Resource Name (ARN) of the function (for example, <code>arn:aws:lambda:us-west-2:account-id:function:ThumbNail</code>). If you are using versioning, you can also provide a qualified function ARN (ARN that is qualified with function version or alias name as suffix). AWS Lambda also allows you to specify only the function name with the account ID qualifier (for example, <code>account-id:Thumbnail</code>). Note that the length constraint applies only to the ARN. If you specify only the function name, it is limited to 64 characters in length. </p>
     #[serde(rename = "FunctionName")]
@@ -588,7 +588,7 @@ pub struct GetPolicyRequest {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetPolicyResponse {
     /// <p>The resource policy associated with the specified function. The response returns the same as a string using a backslash ("\") as an escape character in the JSON.</p>
     #[serde(rename = "Policy")]
@@ -601,7 +601,7 @@ pub struct GetPolicyResponse {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct InvocationRequest {
     /// <p>Using the <code>ClientContext</code> you can pass client-specific information to the Lambda function you are invoking. You can then process the client information in your Lambda function as you choose through the context variable. For an example of a <code>ClientContext</code> JSON, see <a href="http://docs.aws.amazon.com/mobileanalytics/latest/ug/PutEvents.html">PutEvents</a> in the <i>Amazon Mobile Analytics API Reference and User Guide</i>.</p> <p>The ClientContext JSON must be base64-encoded and has a maximum size of 3583 bytes.</p>
     #[serde(rename = "ClientContext")]
@@ -633,7 +633,7 @@ pub struct InvocationRequest {
 }
 
 /// <p>Upon success, returns an empty response. Otherwise, throws an exception.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct InvocationResponse {
     /// <p>The function version that has been executed. This value is returned only if the invocation type is <code>RequestResponse</code>. For more information, see <a>lambda-traffic-shifting-using-aliases</a>.</p>
     pub executed_version: Option<String>,
@@ -648,7 +648,7 @@ pub struct InvocationResponse {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct InvokeAsyncRequest {
     /// <p>The Lambda function name. Note that the length constraint applies only to the ARN. If you specify only the function name, it is limited to 64 characters in length.</p>
     #[serde(rename = "FunctionName")]
@@ -664,7 +664,7 @@ pub struct InvokeAsyncRequest {
 }
 
 /// <p>Upon success, it returns empty response. Otherwise, throws an exception.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct InvokeAsyncResponse {
     /// <p>It will be 202 upon success.</p>
     #[serde(rename = "Status")]
@@ -672,7 +672,7 @@ pub struct InvokeAsyncResponse {
     pub status: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListAliasesRequest {
     /// <p>Lambda function name for which the alias is created. Note that the length constraint applies only to the ARN. If you specify only the function name, it is limited to 64 characters in length.</p>
     #[serde(rename = "FunctionName")]
@@ -691,7 +691,7 @@ pub struct ListAliasesRequest {
     pub max_items: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListAliasesResponse {
     /// <p>A list of aliases.</p>
     #[serde(rename = "Aliases")]
@@ -704,7 +704,7 @@ pub struct ListAliasesResponse {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListEventSourceMappingsRequest {
     /// <p>The Amazon Resource Name (ARN) of the Amazon Kinesis stream. (This parameter is optional.)</p>
     #[serde(rename = "EventSourceArn")]
@@ -725,7 +725,7 @@ pub struct ListEventSourceMappingsRequest {
 }
 
 /// <p>Contains a list of event sources (see <a>EventSourceMappingConfiguration</a>)</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListEventSourceMappingsResponse {
     /// <p>An array of <code>EventSourceMappingConfiguration</code> objects.</p>
     #[serde(rename = "EventSourceMappings")]
@@ -738,7 +738,7 @@ pub struct ListEventSourceMappingsResponse {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListFunctionsRequest {
     /// <p>Optional string. If not specified, only the unqualified functions ARNs (Amazon Resource Names) will be returned.</p> <p>Valid value:</p> <p> <code>ALL</code>: Will return all versions, including <code>$LATEST</code> which will have fully qualified ARNs (Amazon Resource Names).</p>
     #[serde(rename = "FunctionVersion")]
@@ -759,7 +759,7 @@ pub struct ListFunctionsRequest {
 }
 
 /// <p>Contains a list of AWS Lambda function configurations (see <a>FunctionConfiguration</a>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListFunctionsResponse {
     /// <p>A list of Lambda functions.</p>
     #[serde(rename = "Functions")]
@@ -771,14 +771,14 @@ pub struct ListFunctionsResponse {
     pub next_marker: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListTagsRequest {
     /// <p>The ARN (Amazon Resource Name) of the function. For more information, see <a href="http://docs.aws.amazon.com/lambda/latest/dg/tagging.html">Tagging Lambda Functions</a> in the <b>AWS Lambda Developer Guide</b>.</p>
     #[serde(rename = "Resource")]
     pub resource: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListTagsResponse {
     /// <p>The list of tags assigned to the function. For more information, see <a href="http://docs.aws.amazon.com/lambda/latest/dg/tagging.html">Tagging Lambda Functions</a> in the <b>AWS Lambda Developer Guide</b>.</p>
     #[serde(rename = "Tags")]
@@ -787,7 +787,7 @@ pub struct ListTagsResponse {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListVersionsByFunctionRequest {
     /// <p>Function name whose versions to list. You can specify a function name (for example, <code>Thumbnail</code>) or you can specify Amazon Resource Name (ARN) of the function (for example, <code>arn:aws:lambda:us-west-2:account-id:function:ThumbNail</code>). AWS Lambda also allows you to specify a partial ARN (for example, <code>account-id:Thumbnail</code>). Note that the length constraint applies only to the ARN. If you specify only the function name, it is limited to 64 characters in length. </p>
     #[serde(rename = "FunctionName")]
@@ -803,7 +803,7 @@ pub struct ListVersionsByFunctionRequest {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListVersionsByFunctionResponse {
     /// <p>A string, present if there are more function versions.</p>
     #[serde(rename = "NextMarker")]
@@ -816,7 +816,7 @@ pub struct ListVersionsByFunctionResponse {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PublishVersionRequest {
     /// <p>The SHA256 hash of the deployment package you want to publish. This provides validation on the code you are publishing. If you provide this parameter, the value must match the SHA256 of the $LATEST version for the publication to succeed. You can use the <b>DryRun</b> parameter of <a>UpdateFunctionCode</a> to verify the hash value that will be returned before publishing your new version.</p>
     #[serde(rename = "CodeSha256")]
@@ -835,7 +835,7 @@ pub struct PublishVersionRequest {
     pub revision_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PutFunctionConcurrencyRequest {
     /// <p>The name of the function you are setting concurrent execution limits on. For more information, see <a>concurrent-executions</a>.</p>
     #[serde(rename = "FunctionName")]
@@ -846,7 +846,7 @@ pub struct PutFunctionConcurrencyRequest {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RemovePermissionRequest {
     /// <p>Lambda function whose resource policy you want to remove a permission from.</p> <p> You can specify a function name (for example, <code>Thumbnail</code>) or you can specify Amazon Resource Name (ARN) of the function (for example, <code>arn:aws:lambda:us-west-2:account-id:function:ThumbNail</code>). AWS Lambda also allows you to specify a partial ARN (for example, <code>account-id:Thumbnail</code>). Note that the length constraint applies only to the ARN. If you specify only the function name, it is limited to 64 characters in length. </p>
     #[serde(rename = "FunctionName")]
@@ -864,7 +864,7 @@ pub struct RemovePermissionRequest {
     pub statement_id: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct TagResourceRequest {
     /// <p>The ARN (Amazon Resource Name) of the Lambda function. For more information, see <a href="http://docs.aws.amazon.com/lambda/latest/dg/tagging.html">Tagging Lambda Functions</a> in the <b>AWS Lambda Developer Guide</b>.</p>
     #[serde(rename = "Resource")]
@@ -875,7 +875,7 @@ pub struct TagResourceRequest {
 }
 
 /// <p>The parent object that contains your function's tracing settings.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct TracingConfig {
     /// <p>Can be either PassThrough or Active. If PassThrough, Lambda will only trace the request from an upstream service if it contains a tracing header with "sampled=1". If Active, Lambda will respect any tracing header it receives from an upstream service. If no tracing header is received, Lambda will call X-Ray for a tracing decision.</p>
     #[serde(rename = "Mode")]
@@ -884,7 +884,7 @@ pub struct TracingConfig {
 }
 
 /// <p>Parent object of the tracing information associated with your Lambda function.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct TracingConfigResponse {
     /// <p>The tracing mode associated with your Lambda function.</p>
     #[serde(rename = "Mode")]
@@ -892,7 +892,7 @@ pub struct TracingConfigResponse {
     pub mode: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UntagResourceRequest {
     /// <p>The ARN (Amazon Resource Name) of the function. For more information, see <a href="http://docs.aws.amazon.com/lambda/latest/dg/tagging.html">Tagging Lambda Functions</a> in the <b>AWS Lambda Developer Guide</b>.</p>
     #[serde(rename = "Resource")]
@@ -902,7 +902,7 @@ pub struct UntagResourceRequest {
     pub tag_keys: Vec<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateAliasRequest {
     /// <p>You can change the description of the alias using this parameter.</p>
     #[serde(rename = "Description")]
@@ -929,7 +929,7 @@ pub struct UpdateAliasRequest {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateEventSourceMappingRequest {
     /// <p>The maximum number of stream records that can be sent to your Lambda function for a single invocation.</p>
     #[serde(rename = "BatchSize")]
@@ -949,7 +949,7 @@ pub struct UpdateEventSourceMappingRequest {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateFunctionCodeRequest {
     /// <p>This boolean parameter can be used to test your request to AWS Lambda to update the Lambda function and publish a version as an atomic operation. It will do all necessary computation and validation of your code but will not upload it or a publish a version. Each time this operation is invoked, the <code>CodeSha256</code> hash value of the provided code will also be computed and returned in the response.</p>
     #[serde(rename = "DryRun")]
@@ -989,7 +989,7 @@ pub struct UpdateFunctionCodeRequest {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateFunctionConfigurationRequest {
     /// <p>The parent object that contains the target ARN (Amazon Resource Name) of an Amazon SQS queue or Amazon SNS topic. For more information, see <a>dlq</a>. </p>
     #[serde(rename = "DeadLetterConfig")]
@@ -1044,7 +1044,7 @@ pub struct UpdateFunctionConfigurationRequest {
 }
 
 /// <p>If your Lambda function accesses resources in a VPC, you provide this parameter identifying the list of security group IDs and subnet IDs. These must belong to the same VPC. You must provide at least one security group and one subnet ID.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct VpcConfig {
     /// <p>A list of one or more security groups IDs in your VPC.</p>
     #[serde(rename = "SecurityGroupIds")]
@@ -1057,7 +1057,7 @@ pub struct VpcConfig {
 }
 
 /// <p>VPC configuration associated with your Lambda function.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct VpcConfigResponse {
     /// <p>A list of security group IDs associated with the Lambda function.</p>
     #[serde(rename = "SecurityGroupIds")]

--- a/rusoto/services/lambda/src/generated.rs
+++ b/rusoto/services/lambda/src/generated.rs
@@ -1104,7 +1104,8 @@ impl AddPermissionError {
     pub fn from_body(body: &str) -> AddPermissionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1212,7 +1213,8 @@ impl CreateAliasError {
     pub fn from_body(body: &str) -> CreateAliasError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1312,7 +1314,8 @@ impl CreateEventSourceMappingError {
     pub fn from_body(body: &str) -> CreateEventSourceMappingError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1420,7 +1423,8 @@ impl CreateFunctionError {
     pub fn from_body(body: &str) -> CreateFunctionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1520,7 +1524,8 @@ impl DeleteAliasError {
     pub fn from_body(body: &str) -> DeleteAliasError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1610,7 +1615,8 @@ impl DeleteEventSourceMappingError {
     pub fn from_body(body: &str) -> DeleteEventSourceMappingError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1712,7 +1718,8 @@ impl DeleteFunctionError {
     pub fn from_body(body: &str) -> DeleteFunctionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1810,7 +1817,8 @@ impl DeleteFunctionConcurrencyError {
     pub fn from_body(body: &str) -> DeleteFunctionConcurrencyError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1908,7 +1916,8 @@ impl GetAccountSettingsError {
     pub fn from_body(body: &str) -> GetAccountSettingsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1998,7 +2007,8 @@ impl GetAliasError {
     pub fn from_body(body: &str) -> GetAliasError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2090,7 +2100,8 @@ impl GetEventSourceMappingError {
     pub fn from_body(body: &str) -> GetEventSourceMappingError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2190,7 +2201,8 @@ impl GetFunctionError {
     pub fn from_body(body: &str) -> GetFunctionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2284,7 +2296,8 @@ impl GetFunctionConfigurationError {
     pub fn from_body(body: &str) -> GetFunctionConfigurationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2384,7 +2397,8 @@ impl GetPolicyError {
     pub fn from_body(body: &str) -> GetPolicyError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2508,7 +2522,8 @@ impl InvokeError {
     pub fn from_body(body: &str) -> InvokeError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2660,7 +2675,8 @@ impl InvokeAsyncError {
     pub fn from_body(body: &str) -> InvokeAsyncError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2754,7 +2770,8 @@ impl ListAliasesError {
     pub fn from_body(body: &str) -> ListAliasesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2848,7 +2865,8 @@ impl ListEventSourceMappingsError {
     pub fn from_body(body: &str) -> ListEventSourceMappingsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2946,7 +2964,8 @@ impl ListFunctionsError {
     pub fn from_body(body: &str) -> ListFunctionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3036,7 +3055,8 @@ impl ListTagsError {
     pub fn from_body(body: &str) -> ListTagsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3128,7 +3148,8 @@ impl ListVersionsByFunctionError {
     pub fn from_body(body: &str) -> ListVersionsByFunctionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3232,7 +3253,8 @@ impl PublishVersionError {
     pub fn from_body(body: &str) -> PublishVersionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3334,7 +3356,8 @@ impl PutFunctionConcurrencyError {
     pub fn from_body(body: &str) -> PutFunctionConcurrencyError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3436,7 +3459,8 @@ impl RemovePermissionError {
     pub fn from_body(body: &str) -> RemovePermissionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3536,7 +3560,8 @@ impl TagResourceError {
     pub fn from_body(body: &str) -> TagResourceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3630,7 +3655,8 @@ impl UntagResourceError {
     pub fn from_body(body: &str) -> UntagResourceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3726,7 +3752,8 @@ impl UpdateAliasError {
     pub fn from_body(body: &str) -> UpdateAliasError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3826,7 +3853,8 @@ impl UpdateEventSourceMappingError {
     pub fn from_body(body: &str) -> UpdateEventSourceMappingError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3934,7 +3962,8 @@ impl UpdateFunctionCodeError {
     pub fn from_body(body: &str) -> UpdateFunctionCodeError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4044,7 +4073,8 @@ impl UpdateFunctionConfigurationError {
     pub fn from_body(body: &str) -> UpdateFunctionConfigurationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/lex-models/src/generated.rs
+++ b/rusoto/services/lex-models/src/generated.rs
@@ -31,7 +31,7 @@ use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 /// <p>Provides information about a bot alias.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BotAliasMetadata {
     /// <p>The name of the bot to which the alias points.</p>
     #[serde(rename = "botName")]
@@ -64,7 +64,7 @@ pub struct BotAliasMetadata {
 }
 
 /// <p>Represents an association between an Amazon Lex bot and an external messaging platform.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BotChannelAssociation {
     /// <p>An alias pointing to the specific version of the Amazon Lex bot to which this association is being made. </p>
     #[serde(rename = "botAlias")]
@@ -105,7 +105,7 @@ pub struct BotChannelAssociation {
 }
 
 /// <p>Provides information about a bot. .</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BotMetadata {
     /// <p>The date that the bot was created.</p>
     #[serde(rename = "createdDate")]
@@ -134,7 +134,7 @@ pub struct BotMetadata {
 }
 
 /// <p>Provides metadata for a built-in intent.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BuiltinIntentMetadata {
     /// <p>A unique identifier for the built-in intent. To find the signature for an intent, see <a href="https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/built-in-intent-ref/standard-intents">Standard Built-in Intents</a> in the <i>Alexa Skills Kit</i>.</p>
     #[serde(rename = "signature")]
@@ -147,7 +147,7 @@ pub struct BuiltinIntentMetadata {
 }
 
 /// <p>Provides information about a slot used in a built-in intent.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BuiltinIntentSlot {
     /// <p>A list of the slots defined for the intent.</p>
     #[serde(rename = "name")]
@@ -156,7 +156,7 @@ pub struct BuiltinIntentSlot {
 }
 
 /// <p>Provides information about a built in slot type.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BuiltinSlotTypeMetadata {
     /// <p>A unique identifier for the built-in slot type. To find the signature for a slot type, see <a href="https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/built-in-intent-ref/slot-type-reference">Slot Type Reference</a> in the <i>Alexa Skills Kit</i>.</p>
     #[serde(rename = "signature")]
@@ -169,7 +169,7 @@ pub struct BuiltinSlotTypeMetadata {
 }
 
 /// <p>Specifies a Lambda function that verifies requests to a bot or fulfills the user's request to a bot..</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CodeHook {
     /// <p>The version of the request-response that you want Amazon Lex to use to invoke your Lambda function. For more information, see <a>using-lambda</a>.</p>
     #[serde(rename = "messageVersion")]
@@ -179,7 +179,7 @@ pub struct CodeHook {
     pub uri: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateBotVersionRequest {
     /// <p>Identifies a specific revision of the <code>$LATEST</code> version of the bot. If you specify a checksum and the <code>$LATEST</code> version of the bot has a different checksum, a <code>PreconditionFailedException</code> exception is returned and Amazon Lex doesn't publish a new version. If you don't specify a checksum, Amazon Lex publishes the <code>$LATEST</code> version.</p>
     #[serde(rename = "checksum")]
@@ -190,7 +190,7 @@ pub struct CreateBotVersionRequest {
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateBotVersionResponse {
     /// <p>The message that Amazon Lex uses to abort a conversation. For more information, see <a>PutBot</a>.</p>
     #[serde(rename = "abortStatement")]
@@ -254,7 +254,7 @@ pub struct CreateBotVersionResponse {
     pub voice_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateIntentVersionRequest {
     /// <p>Checksum of the <code>$LATEST</code> version of the intent that should be used to create the new version. If you specify a checksum and the <code>$LATEST</code> version of the intent has a different checksum, Amazon Lex returns a <code>PreconditionFailedException</code> exception and doesn't publish a new version. If you don't specify a checksum, Amazon Lex publishes the <code>$LATEST</code> version.</p>
     #[serde(rename = "checksum")]
@@ -265,7 +265,7 @@ pub struct CreateIntentVersionRequest {
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateIntentVersionResponse {
     /// <p>Checksum of the intent version created.</p>
     #[serde(rename = "checksum")]
@@ -329,7 +329,7 @@ pub struct CreateIntentVersionResponse {
     pub version: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateSlotTypeVersionRequest {
     /// <p>Checksum for the <code>$LATEST</code> version of the slot type that you want to publish. If you specify a checksum and the <code>$LATEST</code> version of the slot type has a different checksum, Amazon Lex returns a <code>PreconditionFailedException</code> exception and doesn't publish the new version. If you don't specify a checksum, Amazon Lex publishes the <code>$LATEST</code> version.</p>
     #[serde(rename = "checksum")]
@@ -340,7 +340,7 @@ pub struct CreateSlotTypeVersionRequest {
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateSlotTypeVersionResponse {
     /// <p>Checksum of the <code>$LATEST</code> version of the slot type.</p>
     #[serde(rename = "checksum")]
@@ -376,7 +376,7 @@ pub struct CreateSlotTypeVersionResponse {
     pub version: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteBotAliasRequest {
     /// <p>The name of the bot that the alias points to.</p>
     #[serde(rename = "botName")]
@@ -386,7 +386,7 @@ pub struct DeleteBotAliasRequest {
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteBotChannelAssociationRequest {
     /// <p>An alias that points to the specific version of the Amazon Lex bot to which this association is being made.</p>
     #[serde(rename = "botAlias")]
@@ -399,14 +399,14 @@ pub struct DeleteBotChannelAssociationRequest {
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteBotRequest {
     /// <p>The name of the bot. The name is case sensitive. </p>
     #[serde(rename = "name")]
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteBotVersionRequest {
     /// <p>The name of the bot.</p>
     #[serde(rename = "name")]
@@ -416,14 +416,14 @@ pub struct DeleteBotVersionRequest {
     pub version: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteIntentRequest {
     /// <p>The name of the intent. The name is case sensitive. </p>
     #[serde(rename = "name")]
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteIntentVersionRequest {
     /// <p>The name of the intent.</p>
     #[serde(rename = "name")]
@@ -433,14 +433,14 @@ pub struct DeleteIntentVersionRequest {
     pub version: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteSlotTypeRequest {
     /// <p>The name of the slot type. The name is case sensitive. </p>
     #[serde(rename = "name")]
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteSlotTypeVersionRequest {
     /// <p>The name of the slot type.</p>
     #[serde(rename = "name")]
@@ -450,7 +450,7 @@ pub struct DeleteSlotTypeVersionRequest {
     pub version: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteUtterancesRequest {
     /// <p>The name of the bot that stored the utterances.</p>
     #[serde(rename = "botName")]
@@ -461,7 +461,7 @@ pub struct DeleteUtterancesRequest {
 }
 
 /// <p><p>Each slot type can have a set of values. Each enumeration value represents a value the slot type can take. </p> <p>For example, a pizza ordering bot could have a slot type that specifies the type of crust that the pizza should have. The slot type could include the values </p> <ul> <li> <p>thick</p> </li> <li> <p>thin</p> </li> <li> <p>stuffed</p> </li> </ul></p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct EnumerationValue {
     /// <p>Additional values related to the slot type value.</p>
     #[serde(rename = "synonyms")]
@@ -473,7 +473,7 @@ pub struct EnumerationValue {
 }
 
 /// <p>A prompt for additional activity after an intent is fulfilled. For example, after the <code>OrderPizza</code> intent is fulfilled, you might prompt the user to find out whether the user wants to order drinks.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct FollowUpPrompt {
     /// <p>Prompts for information from the user. </p>
     #[serde(rename = "prompt")]
@@ -484,7 +484,7 @@ pub struct FollowUpPrompt {
 }
 
 /// <p><p> Describes how the intent is fulfilled after the user provides all of the information required for the intent. You can provide a Lambda function to process the intent, or you can return the intent information to the client application. We recommend that you use a Lambda function so that the relevant logic lives in the Cloud and limit the client-side code primarily to presentation. If you need to update the logic, you only update the Lambda function; you don&#39;t need to upgrade your client application. </p> <p>Consider the following examples:</p> <ul> <li> <p>In a pizza ordering application, after the user provides all of the information for placing an order, you use a Lambda function to place an order with a pizzeria. </p> </li> <li> <p>In a gaming application, when a user says &quot;pick up a rock,&quot; this information must go back to the client application so that it can perform the operation and update the graphics. In this case, you want Amazon Lex to return the intent data to the client. </p> </li> </ul></p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct FulfillmentActivity {
     /// <p> A description of the Lambda function that is run to fulfill the intent. </p>
     #[serde(rename = "codeHook")]
@@ -495,7 +495,7 @@ pub struct FulfillmentActivity {
     pub type_: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetBotAliasRequest {
     /// <p>The name of the bot.</p>
     #[serde(rename = "botName")]
@@ -505,7 +505,7 @@ pub struct GetBotAliasRequest {
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetBotAliasResponse {
     /// <p>The name of the bot that the alias points to.</p>
     #[serde(rename = "botName")]
@@ -537,7 +537,7 @@ pub struct GetBotAliasResponse {
     pub name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetBotAliasesRequest {
     /// <p>The name of the bot.</p>
     #[serde(rename = "botName")]
@@ -556,7 +556,7 @@ pub struct GetBotAliasesRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetBotAliasesResponse {
     /// <p>An array of <code>BotAliasMetadata</code> objects, each describing a bot alias.</p>
     #[serde(rename = "BotAliases")]
@@ -568,7 +568,7 @@ pub struct GetBotAliasesResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetBotChannelAssociationRequest {
     /// <p>An alias pointing to the specific version of the Amazon Lex bot to which this association is being made.</p>
     #[serde(rename = "botAlias")]
@@ -581,7 +581,7 @@ pub struct GetBotChannelAssociationRequest {
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetBotChannelAssociationResponse {
     /// <p>An alias pointing to the specific version of the Amazon Lex bot to which this association is being made.</p>
     #[serde(rename = "botAlias")]
@@ -621,7 +621,7 @@ pub struct GetBotChannelAssociationResponse {
     pub type_: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetBotChannelAssociationsRequest {
     /// <p>An alias pointing to the specific version of the Amazon Lex bot to which this association is being made.</p>
     #[serde(rename = "botAlias")]
@@ -643,7 +643,7 @@ pub struct GetBotChannelAssociationsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetBotChannelAssociationsResponse {
     /// <p>An array of objects, one for each association, that provides information about the Amazon Lex bot and its association with the channel. </p>
     #[serde(rename = "botChannelAssociations")]
@@ -655,7 +655,7 @@ pub struct GetBotChannelAssociationsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetBotRequest {
     /// <p>The name of the bot. The name is case sensitive. </p>
     #[serde(rename = "name")]
@@ -665,7 +665,7 @@ pub struct GetBotRequest {
     pub version_or_alias: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetBotResponse {
     /// <p>The message that Amazon Lex returns when the user elects to end the conversation without completing it. For more information, see <a>PutBot</a>.</p>
     #[serde(rename = "abortStatement")]
@@ -729,7 +729,7 @@ pub struct GetBotResponse {
     pub voice_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetBotVersionsRequest {
     /// <p>The maximum number of bot versions to return in the response. The default is 10.</p>
     #[serde(rename = "maxResults")]
@@ -744,7 +744,7 @@ pub struct GetBotVersionsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetBotVersionsResponse {
     /// <p>An array of <code>BotMetadata</code> objects, one for each numbered version of the bot plus one for the <code>$LATEST</code> version.</p>
     #[serde(rename = "bots")]
@@ -756,7 +756,7 @@ pub struct GetBotVersionsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetBotsRequest {
     /// <p>The maximum number of bots to return in the response that the request will return. The default is 10.</p>
     #[serde(rename = "maxResults")]
@@ -772,7 +772,7 @@ pub struct GetBotsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetBotsResponse {
     /// <p>An array of <code>botMetadata</code> objects, with one entry for each bot. </p>
     #[serde(rename = "bots")]
@@ -784,14 +784,14 @@ pub struct GetBotsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetBuiltinIntentRequest {
     /// <p>The unique identifier for a built-in intent. To find the signature for an intent, see <a href="https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/built-in-intent-ref/standard-intents">Standard Built-in Intents</a> in the <i>Alexa Skills Kit</i>.</p>
     #[serde(rename = "signature")]
     pub signature: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetBuiltinIntentResponse {
     /// <p>The unique identifier for a built-in intent.</p>
     #[serde(rename = "signature")]
@@ -807,7 +807,7 @@ pub struct GetBuiltinIntentResponse {
     pub supported_locales: Option<Vec<String>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetBuiltinIntentsRequest {
     /// <p>A list of locales that the intent supports.</p>
     #[serde(rename = "locale")]
@@ -827,7 +827,7 @@ pub struct GetBuiltinIntentsRequest {
     pub signature_contains: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetBuiltinIntentsResponse {
     /// <p>An array of <code>builtinIntentMetadata</code> objects, one for each intent in the response.</p>
     #[serde(rename = "intents")]
@@ -839,7 +839,7 @@ pub struct GetBuiltinIntentsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetBuiltinSlotTypesRequest {
     /// <p>A list of locales that the slot type supports.</p>
     #[serde(rename = "locale")]
@@ -859,7 +859,7 @@ pub struct GetBuiltinSlotTypesRequest {
     pub signature_contains: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetBuiltinSlotTypesResponse {
     /// <p>If the response is truncated, the response includes a pagination token that you can use in your next request to fetch the next page of slot types.</p>
     #[serde(rename = "nextToken")]
@@ -871,7 +871,7 @@ pub struct GetBuiltinSlotTypesResponse {
     pub slot_types: Option<Vec<BuiltinSlotTypeMetadata>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetExportRequest {
     /// <p>The format of the exported data.</p>
     #[serde(rename = "exportType")]
@@ -887,7 +887,7 @@ pub struct GetExportRequest {
     pub version: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetExportResponse {
     /// <p><p>The status of the export. </p> <ul> <li> <p> <code>IN_PROGRESS</code> - The export is in progress.</p> </li> <li> <p> <code>READY</code> - The export is complete.</p> </li> <li> <p> <code>FAILED</code> - The export could not be completed.</p> </li> </ul></p>
     #[serde(rename = "exportStatus")]
@@ -919,14 +919,14 @@ pub struct GetExportResponse {
     pub version: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetImportRequest {
     /// <p>The identifier of the import job information to return.</p>
     #[serde(rename = "importId")]
     pub import_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetImportResponse {
     /// <p>A timestamp for the date and time that the import job was created.</p>
     #[serde(rename = "createdDate")]
@@ -958,7 +958,7 @@ pub struct GetImportResponse {
     pub resource_type: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetIntentRequest {
     /// <p>The name of the intent. The name is case sensitive. </p>
     #[serde(rename = "name")]
@@ -968,7 +968,7 @@ pub struct GetIntentRequest {
     pub version: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetIntentResponse {
     /// <p>Checksum of the intent.</p>
     #[serde(rename = "checksum")]
@@ -1032,7 +1032,7 @@ pub struct GetIntentResponse {
     pub version: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetIntentVersionsRequest {
     /// <p>The maximum number of intent versions to return in the response. The default is 10.</p>
     #[serde(rename = "maxResults")]
@@ -1047,7 +1047,7 @@ pub struct GetIntentVersionsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetIntentVersionsResponse {
     /// <p>An array of <code>IntentMetadata</code> objects, one for each numbered version of the intent plus one for the <code>$LATEST</code> version.</p>
     #[serde(rename = "intents")]
@@ -1059,7 +1059,7 @@ pub struct GetIntentVersionsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetIntentsRequest {
     /// <p>The maximum number of intents to return in the response. The default is 10.</p>
     #[serde(rename = "maxResults")]
@@ -1075,7 +1075,7 @@ pub struct GetIntentsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetIntentsResponse {
     /// <p>An array of <code>Intent</code> objects. For more information, see <a>PutBot</a>.</p>
     #[serde(rename = "intents")]
@@ -1087,7 +1087,7 @@ pub struct GetIntentsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetSlotTypeRequest {
     /// <p>The name of the slot type. The name is case sensitive. </p>
     #[serde(rename = "name")]
@@ -1097,7 +1097,7 @@ pub struct GetSlotTypeRequest {
     pub version: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetSlotTypeResponse {
     /// <p>Checksum of the <code>$LATEST</code> version of the slot type.</p>
     #[serde(rename = "checksum")]
@@ -1133,7 +1133,7 @@ pub struct GetSlotTypeResponse {
     pub version: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetSlotTypeVersionsRequest {
     /// <p>The maximum number of slot type versions to return in the response. The default is 10.</p>
     #[serde(rename = "maxResults")]
@@ -1148,7 +1148,7 @@ pub struct GetSlotTypeVersionsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetSlotTypeVersionsResponse {
     /// <p>A pagination token for fetching the next page of slot type versions. If the response to this call is truncated, Amazon Lex returns a pagination token in the response. To fetch the next page of versions, specify the pagination token in the next request. </p>
     #[serde(rename = "nextToken")]
@@ -1160,7 +1160,7 @@ pub struct GetSlotTypeVersionsResponse {
     pub slot_types: Option<Vec<SlotTypeMetadata>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetSlotTypesRequest {
     /// <p>The maximum number of slot types to return in the response. The default is 10.</p>
     #[serde(rename = "maxResults")]
@@ -1176,7 +1176,7 @@ pub struct GetSlotTypesRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetSlotTypesResponse {
     /// <p>If the response is truncated, it includes a pagination token that you can specify in your next request to fetch the next page of slot types.</p>
     #[serde(rename = "nextToken")]
@@ -1188,7 +1188,7 @@ pub struct GetSlotTypesResponse {
     pub slot_types: Option<Vec<SlotTypeMetadata>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetUtterancesViewRequest {
     /// <p>The name of the bot for which utterance information should be returned.</p>
     #[serde(rename = "botName")]
@@ -1201,7 +1201,7 @@ pub struct GetUtterancesViewRequest {
     pub status_type: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetUtterancesViewResponse {
     /// <p>The name of the bot for which utterance information was returned.</p>
     #[serde(rename = "botName")]
@@ -1214,7 +1214,7 @@ pub struct GetUtterancesViewResponse {
 }
 
 /// <p>Identifies the specific version of an intent.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Intent {
     /// <p>The name of the intent.</p>
     #[serde(rename = "intentName")]
@@ -1225,7 +1225,7 @@ pub struct Intent {
 }
 
 /// <p>Provides information about an intent.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct IntentMetadata {
     /// <p>The date that the intent was created.</p>
     #[serde(rename = "createdDate")]
@@ -1250,7 +1250,7 @@ pub struct IntentMetadata {
 }
 
 /// <p>The message object that provides the message text and its type.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Message {
     /// <p>The text of the message.</p>
     #[serde(rename = "content")]
@@ -1265,7 +1265,7 @@ pub struct Message {
 }
 
 /// <p>Obtains information from the user. To define a prompt, provide one or more messages and specify the number of attempts to get information from the user. If you provide more than one message, Amazon Lex chooses one of the messages to use to prompt the user. For more information, see <a>how-it-works</a>.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Prompt {
     /// <p>The number of times to prompt the user for information.</p>
     #[serde(rename = "maxAttempts")]
@@ -1279,7 +1279,7 @@ pub struct Prompt {
     pub response_card: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PutBotAliasRequest {
     /// <p>The name of the bot.</p>
     #[serde(rename = "botName")]
@@ -1300,7 +1300,7 @@ pub struct PutBotAliasRequest {
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PutBotAliasResponse {
     /// <p>The name of the bot that the alias points to.</p>
     #[serde(rename = "botName")]
@@ -1332,7 +1332,7 @@ pub struct PutBotAliasResponse {
     pub name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PutBotRequest {
     /// <p>When Amazon Lex can't understand the user's input in context, it tries to elicit the information a few times. After that, Amazon Lex sends the message defined in <code>abortStatement</code> to the user, and then aborts the conversation. To set the number of retries, use the <code>valueElicitationPrompt</code> field for the slot type. </p> <p>For example, in a pizza ordering bot, Amazon Lex might ask a user "What type of crust would you like?" If the user's response is not one of the expected responses (for example, "thin crust, "deep dish," etc.), Amazon Lex tries to elicit a correct response a few more times. </p> <p>For example, in a pizza ordering application, <code>OrderPizza</code> might be one of the intents. This intent might require the <code>CrustType</code> slot. You specify the <code>valueElicitationPrompt</code> field when you create the <code>CrustType</code> slot.</p>
     #[serde(rename = "abortStatement")]
@@ -1380,7 +1380,7 @@ pub struct PutBotRequest {
     pub voice_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PutBotResponse {
     /// <p>The message that Amazon Lex uses to abort a conversation. For more information, see <a>PutBot</a>.</p>
     #[serde(rename = "abortStatement")]
@@ -1447,7 +1447,7 @@ pub struct PutBotResponse {
     pub voice_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PutIntentRequest {
     /// <p>Identifies a specific revision of the <code>$LATEST</code> version.</p> <p>When you create a new intent, leave the <code>checksum</code> field blank. If you specify a checksum you get a <code>BadRequestException</code> exception.</p> <p>When you want to update a intent, set the <code>checksum</code> field to the checksum of the most recent revision of the <code>$LATEST</code> version. If you don't specify the <code> checksum</code> field, or if the checksum does not match the <code>$LATEST</code> version, you get a <code>PreconditionFailedException</code> exception.</p>
     #[serde(rename = "checksum")]
@@ -1501,7 +1501,7 @@ pub struct PutIntentRequest {
     pub slots: Option<Vec<Slot>>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PutIntentResponse {
     /// <p>Checksum of the <code>$LATEST</code>version of the intent created or updated.</p>
     #[serde(rename = "checksum")]
@@ -1568,7 +1568,7 @@ pub struct PutIntentResponse {
     pub version: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PutSlotTypeRequest {
     /// <p>Identifies a specific revision of the <code>$LATEST</code> version.</p> <p>When you create a new slot type, leave the <code>checksum</code> field blank. If you specify a checksum you get a <code>BadRequestException</code> exception.</p> <p>When you want to update a slot type, set the <code>checksum</code> field to the checksum of the most recent revision of the <code>$LATEST</code> version. If you don't specify the <code> checksum</code> field, or if the checksum does not match the <code>$LATEST</code> version, you get a <code>PreconditionFailedException</code> exception.</p>
     #[serde(rename = "checksum")]
@@ -1594,7 +1594,7 @@ pub struct PutSlotTypeRequest {
     pub value_selection_strategy: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PutSlotTypeResponse {
     /// <p>Checksum of the <code>$LATEST</code> version of the slot type.</p>
     #[serde(rename = "checksum")]
@@ -1634,7 +1634,7 @@ pub struct PutSlotTypeResponse {
 }
 
 /// <p>Describes the resource that refers to the resource that you are attempting to delete. This object is returned as part of the <code>ResourceInUseException</code> exception. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ResourceReference {
     /// <p>The name of the resource that is using the resource that you are trying to delete.</p>
     pub name: Option<String>,
@@ -1643,7 +1643,7 @@ pub struct ResourceReference {
 }
 
 /// <p>Identifies the version of a specific slot.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Slot {
     /// <p>A description of the slot.</p>
     #[serde(rename = "description")]
@@ -1682,7 +1682,7 @@ pub struct Slot {
 }
 
 /// <p>Provides information about a slot type..</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SlotTypeMetadata {
     /// <p>The date that the slot type was created.</p>
     #[serde(rename = "createdDate")]
@@ -1706,7 +1706,7 @@ pub struct SlotTypeMetadata {
     pub version: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StartImportRequest {
     /// <p><p>Specifies the action that the <code>StartImport</code> operation should take when there is an existing resource with the same name.</p> <ul> <li> <p>FAIL<em>ON</em>CONFLICT - The import operation is stopped on the first conflict between a resource in the import file and an existing resource. The name of the resource causing the conflict is in the <code>failureReason</code> field of the response to the <code>GetImport</code> operation.</p> <p>OVERWRITE_LATEST - The import operation proceeds even if there is a conflict with an existing resource. The $LASTEST version of the existing resource is overwritten with the data from the import file.</p> </li> </ul></p>
     #[serde(rename = "mergeStrategy")]
@@ -1724,7 +1724,7 @@ pub struct StartImportRequest {
     pub resource_type: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StartImportResponse {
     /// <p>A timestamp for the date and time that the import job was requested.</p>
     #[serde(rename = "createdDate")]
@@ -1753,7 +1753,7 @@ pub struct StartImportResponse {
 }
 
 /// <p>A collection of messages that convey information to the user. At runtime, Amazon Lex selects the message to convey. </p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Statement {
     /// <p>A collection of message objects.</p>
     #[serde(rename = "messages")]
@@ -1765,7 +1765,7 @@ pub struct Statement {
 }
 
 /// <p>Provides information about a single utterance that was made to your bot. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UtteranceData {
     /// <p>The number of times that the utterance was processed.</p>
     #[serde(rename = "count")]
@@ -1790,7 +1790,7 @@ pub struct UtteranceData {
 }
 
 /// <p>Provides a list of utterances that have been made to a specific version of your bot. The list contains a maximum of 100 utterances.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UtteranceList {
     /// <p>The version of the bot that processed the list.</p>
     #[serde(rename = "botVersion")]

--- a/rusoto/services/lex-models/src/generated.rs
+++ b/rusoto/services/lex-models/src/generated.rs
@@ -1831,7 +1831,8 @@ impl CreateBotVersionError {
     pub fn from_body(body: &str) -> CreateBotVersionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1939,7 +1940,8 @@ impl CreateIntentVersionError {
     pub fn from_body(body: &str) -> CreateIntentVersionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2049,7 +2051,8 @@ impl CreateSlotTypeVersionError {
     pub fn from_body(body: &str) -> CreateSlotTypeVersionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2159,7 +2162,8 @@ impl DeleteBotError {
     pub fn from_body(body: &str) -> DeleteBotError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2261,7 +2265,8 @@ impl DeleteBotAliasError {
     pub fn from_body(body: &str) -> DeleteBotAliasError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2367,7 +2372,8 @@ impl DeleteBotChannelAssociationError {
     pub fn from_body(body: &str) -> DeleteBotChannelAssociationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2475,7 +2481,8 @@ impl DeleteBotVersionError {
     pub fn from_body(body: &str) -> DeleteBotVersionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2583,7 +2590,8 @@ impl DeleteIntentError {
     pub fn from_body(body: &str) -> DeleteIntentError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2687,7 +2695,8 @@ impl DeleteIntentVersionError {
     pub fn from_body(body: &str) -> DeleteIntentVersionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2797,7 +2806,8 @@ impl DeleteSlotTypeError {
     pub fn from_body(body: &str) -> DeleteSlotTypeError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2905,7 +2915,8 @@ impl DeleteSlotTypeVersionError {
     pub fn from_body(body: &str) -> DeleteSlotTypeVersionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3011,7 +3022,8 @@ impl DeleteUtterancesError {
     pub fn from_body(body: &str) -> DeleteUtterancesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3107,7 +3119,8 @@ impl GetBotError {
     pub fn from_body(body: &str) -> GetBotError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3197,7 +3210,8 @@ impl GetBotAliasError {
     pub fn from_body(body: &str) -> GetBotAliasError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3289,7 +3303,8 @@ impl GetBotAliasesError {
     pub fn from_body(body: &str) -> GetBotAliasesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3381,7 +3396,8 @@ impl GetBotChannelAssociationError {
     pub fn from_body(body: &str) -> GetBotChannelAssociationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3477,7 +3493,8 @@ impl GetBotChannelAssociationsError {
     pub fn from_body(body: &str) -> GetBotChannelAssociationsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3571,7 +3588,8 @@ impl GetBotVersionsError {
     pub fn from_body(body: &str) -> GetBotVersionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3667,7 +3685,8 @@ impl GetBotsError {
     pub fn from_body(body: &str) -> GetBotsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3757,7 +3776,8 @@ impl GetBuiltinIntentError {
     pub fn from_body(body: &str) -> GetBuiltinIntentError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3851,7 +3871,8 @@ impl GetBuiltinIntentsError {
     pub fn from_body(body: &str) -> GetBuiltinIntentsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3943,7 +3964,8 @@ impl GetBuiltinSlotTypesError {
     pub fn from_body(body: &str) -> GetBuiltinSlotTypesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4037,7 +4059,8 @@ impl GetExportError {
     pub fn from_body(body: &str) -> GetExportError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4129,7 +4152,8 @@ impl GetImportError {
     pub fn from_body(body: &str) -> GetImportError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4221,7 +4245,8 @@ impl GetIntentError {
     pub fn from_body(body: &str) -> GetIntentError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4313,7 +4338,8 @@ impl GetIntentVersionsError {
     pub fn from_body(body: &str) -> GetIntentVersionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4411,7 +4437,8 @@ impl GetIntentsError {
     pub fn from_body(body: &str) -> GetIntentsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4503,7 +4530,8 @@ impl GetSlotTypeError {
     pub fn from_body(body: &str) -> GetSlotTypeError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4597,7 +4625,8 @@ impl GetSlotTypeVersionsError {
     pub fn from_body(body: &str) -> GetSlotTypeVersionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4695,7 +4724,8 @@ impl GetSlotTypesError {
     pub fn from_body(body: &str) -> GetSlotTypesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4787,7 +4817,8 @@ impl GetUtterancesViewError {
     pub fn from_body(body: &str) -> GetUtterancesViewError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4883,7 +4914,8 @@ impl PutBotError {
     pub fn from_body(body: &str) -> PutBotError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4979,7 +5011,8 @@ impl PutBotAliasError {
     pub fn from_body(body: &str) -> PutBotAliasError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5079,7 +5112,8 @@ impl PutIntentError {
     pub fn from_body(body: &str) -> PutIntentError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5177,7 +5211,8 @@ impl PutSlotTypeError {
     pub fn from_body(body: &str) -> PutSlotTypeError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5273,7 +5308,8 @@ impl StartImportError {
     pub fn from_body(body: &str) -> StartImportError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/lex-runtime/src/generated.rs
+++ b/rusoto/services/lex-runtime/src/generated.rs
@@ -30,7 +30,7 @@ use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 /// <p>Represents an option to be shown on the client platform (Facebook, Slack, etc.)</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Button {
     /// <p>Text that is visible to the user on the button.</p>
     #[serde(rename = "text")]
@@ -41,7 +41,7 @@ pub struct Button {
 }
 
 /// <p>Represents an option rendered to the user when a prompt is shown. It could be an image, a button, a link, or text. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GenericAttachment {
     /// <p>The URL of an attachment to the response card.</p>
     #[serde(rename = "attachmentLinkUrl")]
@@ -65,7 +65,7 @@ pub struct GenericAttachment {
     pub title: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PostContentRequest {
     /// <p><p> You pass this value as the <code>Accept</code> HTTP header. </p> <p> The message Amazon Lex returns in the response can be either text or speech based on the <code>Accept</code> HTTP header value in the request. </p> <ul> <li> <p> If the value is <code>text/plain; charset=utf-8</code>, Amazon Lex returns text in the response. </p> </li> <li> <p> If the value begins with <code>audio/</code>, Amazon Lex returns speech in the response. Amazon Lex uses Amazon Polly to generate the speech (using the configuration you specified in the <code>Accept</code> header). For example, if you specify <code>audio/mpeg</code> as the value, Amazon Lex returns speech in the MPEG format.</p> <p>The following are the accepted values:</p> <ul> <li> <p>audio/mpeg</p> </li> <li> <p>audio/ogg</p> </li> <li> <p>audio/pcm</p> </li> <li> <p>text/plain; charset=utf-8</p> </li> <li> <p>audio/* (defaults to mpeg)</p> </li> </ul> </li> </ul></p>
     #[serde(rename = "accept")]
@@ -101,7 +101,7 @@ pub struct PostContentRequest {
     pub user_id: String,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PostContentResponse {
     /// <p>The prompt (or statement) to convey to the user. This is based on the bot configuration and context. For example, if Amazon Lex did not understand the user intent, it sends the <code>clarificationPrompt</code> configured for the bot. If the intent requires confirmation before taking the fulfillment action, it sends the <code>confirmationPrompt</code>. Another example: Suppose that the Lambda function successfully fulfilled the intent, and sent a message to convey to the user. Then Amazon Lex sends that message in the response. </p>
     pub audio_stream: Option<Vec<u8>>,
@@ -125,7 +125,7 @@ pub struct PostContentResponse {
     pub slots: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PostTextRequest {
     /// <p>The alias of the Amazon Lex bot.</p>
     #[serde(rename = "botAlias")]
@@ -149,7 +149,7 @@ pub struct PostTextRequest {
     pub user_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PostTextResponse {
     /// <p><p> Identifies the current state of the user interaction. Amazon Lex returns one of the following values as <code>dialogState</code>. The client can optionally use this information to customize the user interface. </p> <ul> <li> <p> <code>ElicitIntent</code> - Amazon Lex wants to elicit user intent. </p> <p>For example, a user might utter an intent (&quot;I want to order a pizza&quot;). If Amazon Lex cannot infer the user intent from this utterance, it will return this dialogState.</p> </li> <li> <p> <code>ConfirmIntent</code> - Amazon Lex is expecting a &quot;yes&quot; or &quot;no&quot; response. </p> <p> For example, Amazon Lex wants user confirmation before fulfilling an intent. </p> <p>Instead of a simple &quot;yes&quot; or &quot;no,&quot; a user might respond with additional information. For example, &quot;yes, but make it thick crust pizza&quot; or &quot;no, I want to order a drink&quot;. Amazon Lex can process such additional information (in these examples, update the crust type slot value, or change intent from OrderPizza to OrderDrink).</p> </li> <li> <p> <code>ElicitSlot</code> - Amazon Lex is expecting a slot value for the current intent. </p> <p>For example, suppose that in the response Amazon Lex sends this message: &quot;What size pizza would you like?&quot;. A user might reply with the slot value (e.g., &quot;medium&quot;). The user might also provide additional information in the response (e.g., &quot;medium thick crust pizza&quot;). Amazon Lex can process such additional information appropriately. </p> </li> <li> <p> <code>Fulfilled</code> - Conveys that the Lambda function configured for the intent has successfully fulfilled the intent. </p> </li> <li> <p> <code>ReadyForFulfillment</code> - Conveys that the client has to fulfill the intent. </p> </li> <li> <p> <code>Failed</code> - Conveys that the conversation with the user failed. </p> <p> This can happen for various reasons including that the user did not provide an appropriate response to prompts from the service (you can configure how many times Amazon Lex can prompt a user for specific information), or the Lambda function failed to fulfill the intent. </p> </li> </ul></p>
     #[serde(rename = "dialogState")]
@@ -186,7 +186,7 @@ pub struct PostTextResponse {
 }
 
 /// <p>If you configure a response card when creating your bots, Amazon Lex substitutes the session attributes and slot values that are available, and then returns it. The response card can also come from a Lambda function ( <code>dialogCodeHook</code> and <code>fulfillmentActivity</code> on an intent).</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ResponseCard {
     /// <p>The content type of the response.</p>
     #[serde(rename = "contentType")]

--- a/rusoto/services/lex-runtime/src/generated.rs
+++ b/rusoto/services/lex-runtime/src/generated.rs
@@ -241,7 +241,8 @@ impl PostContentError {
     pub fn from_body(body: &str) -> PostContentError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -369,7 +370,8 @@ impl PostTextError {
     pub fn from_body(body: &str) -> PostTextError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/lightsail/src/generated.rs
+++ b/rusoto/services/lightsail/src/generated.rs
@@ -30,14 +30,14 @@ use rusoto_core::signature::SignedRequest;
 use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AllocateStaticIpRequest {
     /// <p>The name of the static IP address.</p>
     #[serde(rename = "staticIpName")]
     pub static_ip_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AllocateStaticIpResult {
     /// <p>An array of key-value pairs containing information about the static IP address you allocated.</p>
     #[serde(rename = "operations")]
@@ -45,7 +45,7 @@ pub struct AllocateStaticIpResult {
     pub operations: Option<Vec<Operation>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AttachDiskRequest {
     /// <p>The unique Lightsail disk name (e.g., <code>my-disk</code>).</p>
     #[serde(rename = "diskName")]
@@ -58,7 +58,7 @@ pub struct AttachDiskRequest {
     pub instance_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AttachDiskResult {
     /// <p>An object describing the API operations.</p>
     #[serde(rename = "operations")]
@@ -66,7 +66,7 @@ pub struct AttachDiskResult {
     pub operations: Option<Vec<Operation>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AttachInstancesToLoadBalancerRequest {
     /// <p>An array of strings representing the instance name(s) you want to attach to your load balancer.</p> <p>An instance must be <code>running</code> before you can attach it to your load balancer.</p> <p>There are no additional limits on the number of instances you can attach to your load balancer, aside from the limit of Lightsail instances you can create in your account (20).</p>
     #[serde(rename = "instanceNames")]
@@ -76,7 +76,7 @@ pub struct AttachInstancesToLoadBalancerRequest {
     pub load_balancer_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AttachInstancesToLoadBalancerResult {
     /// <p>An object representing the API operations.</p>
     #[serde(rename = "operations")]
@@ -84,7 +84,7 @@ pub struct AttachInstancesToLoadBalancerResult {
     pub operations: Option<Vec<Operation>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AttachLoadBalancerTlsCertificateRequest {
     /// <p>The name of your SSL/TLS certificate.</p>
     #[serde(rename = "certificateName")]
@@ -94,7 +94,7 @@ pub struct AttachLoadBalancerTlsCertificateRequest {
     pub load_balancer_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AttachLoadBalancerTlsCertificateResult {
     /// <p>An object representing the API operations.</p> <p>These SSL/TLS certificates are only usable by Lightsail load balancers. You can't get the certificate and use it for another purpose.</p>
     #[serde(rename = "operations")]
@@ -102,7 +102,7 @@ pub struct AttachLoadBalancerTlsCertificateResult {
     pub operations: Option<Vec<Operation>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AttachStaticIpRequest {
     /// <p>The instance name to which you want to attach the static IP address.</p>
     #[serde(rename = "instanceName")]
@@ -112,7 +112,7 @@ pub struct AttachStaticIpRequest {
     pub static_ip_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AttachStaticIpResult {
     /// <p>An array of key-value pairs containing information about your API operations.</p>
     #[serde(rename = "operations")]
@@ -121,7 +121,7 @@ pub struct AttachStaticIpResult {
 }
 
 /// <p>Describes an Availability Zone.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AvailabilityZone {
     /// <p>The state of the Availability Zone.</p>
     #[serde(rename = "state")]
@@ -134,7 +134,7 @@ pub struct AvailabilityZone {
 }
 
 /// <p>Describes a blueprint (a virtual private server image).</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Blueprint {
     /// <p>The ID for the virtual private server image (e.g., <code>app_wordpress_4_4</code> or <code>app_lamp_7_0</code>).</p>
     #[serde(rename = "blueprintId")]
@@ -187,7 +187,7 @@ pub struct Blueprint {
 }
 
 /// <p>Describes a bundle, which is a set of specs describing your virtual private server (or <i>instance</i>).</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Bundle {
     /// <p>The bundle ID (e.g., <code>micro_1_0</code>).</p>
     #[serde(rename = "bundleId")]
@@ -235,7 +235,7 @@ pub struct Bundle {
     pub transfer_per_month_in_gb: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CloseInstancePublicPortsRequest {
     /// <p>The name of the instance on which you're attempting to close the public ports.</p>
     #[serde(rename = "instanceName")]
@@ -245,7 +245,7 @@ pub struct CloseInstancePublicPortsRequest {
     pub port_info: PortInfo,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CloseInstancePublicPortsResult {
     /// <p>An array of key-value pairs that contains information about the operation.</p>
     #[serde(rename = "operation")]
@@ -253,7 +253,7 @@ pub struct CloseInstancePublicPortsResult {
     pub operation: Option<Operation>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateDiskFromSnapshotRequest {
     /// <p>The Availability Zone where you want to create the disk (e.g., <code>us-east-2a</code>). Choose the same Availability Zone as the Lightsail instance where you want to create the disk.</p> <p>Use the GetRegions operation to list the Availability Zones where Lightsail is currently available.</p>
     #[serde(rename = "availabilityZone")]
@@ -269,7 +269,7 @@ pub struct CreateDiskFromSnapshotRequest {
     pub size_in_gb: i64,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateDiskFromSnapshotResult {
     /// <p>An object describing the API operations.</p>
     #[serde(rename = "operations")]
@@ -277,7 +277,7 @@ pub struct CreateDiskFromSnapshotResult {
     pub operations: Option<Vec<Operation>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateDiskRequest {
     /// <p>The Availability Zone where you want to create the disk (e.g., <code>us-east-2a</code>). Choose the same Availability Zone as the Lightsail instance where you want to create the disk.</p> <p>Use the GetRegions operation to list the Availability Zones where Lightsail is currently available.</p>
     #[serde(rename = "availabilityZone")]
@@ -290,7 +290,7 @@ pub struct CreateDiskRequest {
     pub size_in_gb: i64,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateDiskResult {
     /// <p>An object describing the API operations.</p>
     #[serde(rename = "operations")]
@@ -298,7 +298,7 @@ pub struct CreateDiskResult {
     pub operations: Option<Vec<Operation>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateDiskSnapshotRequest {
     /// <p>The unique name of the source disk (e.g., <code>my-source-disk</code>).</p>
     #[serde(rename = "diskName")]
@@ -308,7 +308,7 @@ pub struct CreateDiskSnapshotRequest {
     pub disk_snapshot_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateDiskSnapshotResult {
     /// <p>An object describing the API operations.</p>
     #[serde(rename = "operations")]
@@ -316,7 +316,7 @@ pub struct CreateDiskSnapshotResult {
     pub operations: Option<Vec<Operation>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateDomainEntryRequest {
     /// <p>An array of key-value pairs containing information about the domain entry request.</p>
     #[serde(rename = "domainEntry")]
@@ -326,7 +326,7 @@ pub struct CreateDomainEntryRequest {
     pub domain_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateDomainEntryResult {
     /// <p>An array of key-value pairs containing information about the operation.</p>
     #[serde(rename = "operation")]
@@ -334,14 +334,14 @@ pub struct CreateDomainEntryResult {
     pub operation: Option<Operation>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateDomainRequest {
     /// <p><p>The domain name to manage (e.g., <code>example.com</code>).</p> <note> <p>You cannot register a new domain name using Lightsail. You must register a domain name using Amazon Route 53 or another domain name registrar. If you have already registered your domain, you can enter its name in this parameter to manage the DNS records for that domain.</p> </note></p>
     #[serde(rename = "domainName")]
     pub domain_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateDomainResult {
     /// <p>An array of key-value pairs containing information about the domain resource you created.</p>
     #[serde(rename = "operation")]
@@ -349,7 +349,7 @@ pub struct CreateDomainResult {
     pub operation: Option<Operation>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateInstanceSnapshotRequest {
     /// <p>The Lightsail instance on which to base your snapshot.</p>
     #[serde(rename = "instanceName")]
@@ -359,7 +359,7 @@ pub struct CreateInstanceSnapshotRequest {
     pub instance_snapshot_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateInstanceSnapshotResult {
     /// <p>An array of key-value pairs containing information about the results of your create instances snapshot request.</p>
     #[serde(rename = "operations")]
@@ -367,7 +367,7 @@ pub struct CreateInstanceSnapshotResult {
     pub operations: Option<Vec<Operation>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateInstancesFromSnapshotRequest {
     /// <p>An object containing information about one or more disk mappings.</p>
     #[serde(rename = "attachedDiskMapping")]
@@ -395,7 +395,7 @@ pub struct CreateInstancesFromSnapshotRequest {
     pub user_data: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateInstancesFromSnapshotResult {
     /// <p>An array of key-value pairs containing information about the results of your create instances from snapshot request.</p>
     #[serde(rename = "operations")]
@@ -403,7 +403,7 @@ pub struct CreateInstancesFromSnapshotResult {
     pub operations: Option<Vec<Operation>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateInstancesRequest {
     /// <p>The Availability Zone in which to create your instance. Use the following format: <code>us-east-2a</code> (case sensitive). You can get a list of availability zones by using the <a href="http://docs.aws.amazon.com/lightsail/2016-11-28/api-reference/API_GetRegions.html">get regions</a> operation. Be sure to add the <code>include availability zones</code> parameter to your request.</p>
     #[serde(rename = "availabilityZone")]
@@ -427,7 +427,7 @@ pub struct CreateInstancesRequest {
     pub user_data: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateInstancesResult {
     /// <p>An array of key-value pairs containing information about the results of your create instances request.</p>
     #[serde(rename = "operations")]
@@ -435,14 +435,14 @@ pub struct CreateInstancesResult {
     pub operations: Option<Vec<Operation>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateKeyPairRequest {
     /// <p>The name for your new key pair.</p>
     #[serde(rename = "keyPairName")]
     pub key_pair_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateKeyPairResult {
     /// <p>An array of key-value pairs containing information about the new key pair you just created.</p>
     #[serde(rename = "keyPair")]
@@ -462,7 +462,7 @@ pub struct CreateKeyPairResult {
     pub public_key_base_64: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateLoadBalancerRequest {
     /// <p>The optional alternative domains and subdomains to use with your SSL/TLS certificate (e.g., <code>www.example.com</code>, <code>example.com</code>, <code>m.example.com</code>, <code>blog.example.com</code>).</p>
     #[serde(rename = "certificateAlternativeNames")]
@@ -488,7 +488,7 @@ pub struct CreateLoadBalancerRequest {
     pub load_balancer_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateLoadBalancerResult {
     /// <p>An object containing information about the API operations.</p>
     #[serde(rename = "operations")]
@@ -496,7 +496,7 @@ pub struct CreateLoadBalancerResult {
     pub operations: Option<Vec<Operation>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateLoadBalancerTlsCertificateRequest {
     /// <p>An array of strings listing alternative domains and subdomains for your SSL/TLS certificate. Lightsail will de-dupe the names for you. You can have a maximum of 9 alternative names (in addition to the 1 primary domain). We do not support wildcards (e.g., <code>*.example.com</code>).</p>
     #[serde(rename = "certificateAlternativeNames")]
@@ -513,7 +513,7 @@ pub struct CreateLoadBalancerTlsCertificateRequest {
     pub load_balancer_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateLoadBalancerTlsCertificateResult {
     /// <p>An object containing information about the API operations.</p>
     #[serde(rename = "operations")]
@@ -521,14 +521,14 @@ pub struct CreateLoadBalancerTlsCertificateResult {
     pub operations: Option<Vec<Operation>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteDiskRequest {
     /// <p>The unique name of the disk you want to delete (e.g., <code>my-disk</code>).</p>
     #[serde(rename = "diskName")]
     pub disk_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteDiskResult {
     /// <p>An object describing the API operations.</p>
     #[serde(rename = "operations")]
@@ -536,14 +536,14 @@ pub struct DeleteDiskResult {
     pub operations: Option<Vec<Operation>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteDiskSnapshotRequest {
     /// <p>The name of the disk snapshot you want to delete (e.g., <code>my-disk-snapshot</code>).</p>
     #[serde(rename = "diskSnapshotName")]
     pub disk_snapshot_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteDiskSnapshotResult {
     /// <p>An object describing the API operations.</p>
     #[serde(rename = "operations")]
@@ -551,7 +551,7 @@ pub struct DeleteDiskSnapshotResult {
     pub operations: Option<Vec<Operation>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteDomainEntryRequest {
     /// <p>An array of key-value pairs containing information about your domain entries.</p>
     #[serde(rename = "domainEntry")]
@@ -561,7 +561,7 @@ pub struct DeleteDomainEntryRequest {
     pub domain_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteDomainEntryResult {
     /// <p>An array of key-value pairs containing information about the results of your delete domain entry request.</p>
     #[serde(rename = "operation")]
@@ -569,14 +569,14 @@ pub struct DeleteDomainEntryResult {
     pub operation: Option<Operation>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteDomainRequest {
     /// <p>The specific domain name to delete.</p>
     #[serde(rename = "domainName")]
     pub domain_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteDomainResult {
     /// <p>An array of key-value pairs containing information about the results of your delete domain request.</p>
     #[serde(rename = "operation")]
@@ -584,14 +584,14 @@ pub struct DeleteDomainResult {
     pub operation: Option<Operation>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteInstanceRequest {
     /// <p>The name of the instance to delete.</p>
     #[serde(rename = "instanceName")]
     pub instance_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteInstanceResult {
     /// <p>An array of key-value pairs containing information about the results of your delete instance request.</p>
     #[serde(rename = "operations")]
@@ -599,14 +599,14 @@ pub struct DeleteInstanceResult {
     pub operations: Option<Vec<Operation>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteInstanceSnapshotRequest {
     /// <p>The name of the snapshot to delete.</p>
     #[serde(rename = "instanceSnapshotName")]
     pub instance_snapshot_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteInstanceSnapshotResult {
     /// <p>An array of key-value pairs containing information about the results of your delete instance snapshot request.</p>
     #[serde(rename = "operations")]
@@ -614,14 +614,14 @@ pub struct DeleteInstanceSnapshotResult {
     pub operations: Option<Vec<Operation>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteKeyPairRequest {
     /// <p>The name of the key pair to delete.</p>
     #[serde(rename = "keyPairName")]
     pub key_pair_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteKeyPairResult {
     /// <p>An array of key-value pairs containing information about the results of your delete key pair request.</p>
     #[serde(rename = "operation")]
@@ -629,14 +629,14 @@ pub struct DeleteKeyPairResult {
     pub operation: Option<Operation>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteLoadBalancerRequest {
     /// <p>The name of the load balancer you want to delete.</p>
     #[serde(rename = "loadBalancerName")]
     pub load_balancer_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteLoadBalancerResult {
     /// <p>An object describing the API operations.</p>
     #[serde(rename = "operations")]
@@ -644,7 +644,7 @@ pub struct DeleteLoadBalancerResult {
     pub operations: Option<Vec<Operation>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteLoadBalancerTlsCertificateRequest {
     /// <p>The SSL/TLS certificate name.</p>
     #[serde(rename = "certificateName")]
@@ -658,7 +658,7 @@ pub struct DeleteLoadBalancerTlsCertificateRequest {
     pub load_balancer_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteLoadBalancerTlsCertificateResult {
     /// <p>An object describing the API operations.</p>
     #[serde(rename = "operations")]
@@ -666,14 +666,14 @@ pub struct DeleteLoadBalancerTlsCertificateResult {
     pub operations: Option<Vec<Operation>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DetachDiskRequest {
     /// <p>The unique name of the disk you want to detach from your instance (e.g., <code>my-disk</code>).</p>
     #[serde(rename = "diskName")]
     pub disk_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DetachDiskResult {
     /// <p>An object describing the API operations.</p>
     #[serde(rename = "operations")]
@@ -681,7 +681,7 @@ pub struct DetachDiskResult {
     pub operations: Option<Vec<Operation>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DetachInstancesFromLoadBalancerRequest {
     /// <p>An array of strings containing the names of the instances you want to detach from the load balancer.</p>
     #[serde(rename = "instanceNames")]
@@ -691,7 +691,7 @@ pub struct DetachInstancesFromLoadBalancerRequest {
     pub load_balancer_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DetachInstancesFromLoadBalancerResult {
     /// <p>An object describing the API operations.</p>
     #[serde(rename = "operations")]
@@ -699,14 +699,14 @@ pub struct DetachInstancesFromLoadBalancerResult {
     pub operations: Option<Vec<Operation>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DetachStaticIpRequest {
     /// <p>The name of the static IP to detach from the instance.</p>
     #[serde(rename = "staticIpName")]
     pub static_ip_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DetachStaticIpResult {
     /// <p>An array of key-value pairs containing information about the results of your detach static IP request.</p>
     #[serde(rename = "operations")]
@@ -715,7 +715,7 @@ pub struct DetachStaticIpResult {
 }
 
 /// <p>Describes a system disk or an block storage disk.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Disk {
     /// <p>The Amazon Resource Name (ARN) of the disk.</p>
     #[serde(rename = "arn")]
@@ -772,7 +772,7 @@ pub struct Disk {
 }
 
 /// <p>Describes a block storage disk mapping.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DiskMap {
     /// <p>The new disk name (e.g., <code>my-new-disk</code>).</p>
     #[serde(rename = "newDiskName")]
@@ -785,7 +785,7 @@ pub struct DiskMap {
 }
 
 /// <p>Describes a block storage disk snapshot.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DiskSnapshot {
     /// <p>The Amazon Resource Name (ARN) of the disk snapshot.</p>
     #[serde(rename = "arn")]
@@ -834,7 +834,7 @@ pub struct DiskSnapshot {
 }
 
 /// <p>Describes a domain where you are storing recordsets in Lightsail.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Domain {
     /// <p>The Amazon Resource Name (ARN) of the domain recordset (e.g., <code>arn:aws:lightsail:global:123456789101:Domain/824cede0-abc7-4f84-8dbc-12345EXAMPLE</code>).</p>
     #[serde(rename = "arn")]
@@ -867,7 +867,7 @@ pub struct Domain {
 }
 
 /// <p>Describes a domain recordset entry.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct DomainEntry {
     /// <p>The ID of the domain recordset entry.</p>
     #[serde(rename = "id")]
@@ -891,10 +891,10 @@ pub struct DomainEntry {
     pub type_: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DownloadDefaultKeyPairRequest {}
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DownloadDefaultKeyPairResult {
     /// <p>A base64-encoded RSA private key.</p>
     #[serde(rename = "privateKeyBase64")]
@@ -906,7 +906,7 @@ pub struct DownloadDefaultKeyPairResult {
     pub public_key_base_64: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetActiveNamesRequest {
     /// <p>A token used for paginating results from your get active names request.</p>
     #[serde(rename = "pageToken")]
@@ -914,7 +914,7 @@ pub struct GetActiveNamesRequest {
     pub page_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetActiveNamesResult {
     /// <p>The list of active names returned by the get active names request.</p>
     #[serde(rename = "activeNames")]
@@ -926,7 +926,7 @@ pub struct GetActiveNamesResult {
     pub next_page_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetBlueprintsRequest {
     /// <p>A Boolean value indicating whether to include inactive results in your request.</p>
     #[serde(rename = "includeInactive")]
@@ -938,7 +938,7 @@ pub struct GetBlueprintsRequest {
     pub page_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetBlueprintsResult {
     /// <p>An array of key-value pairs that contains information about the available blueprints.</p>
     #[serde(rename = "blueprints")]
@@ -950,7 +950,7 @@ pub struct GetBlueprintsResult {
     pub next_page_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetBundlesRequest {
     /// <p>A Boolean value that indicates whether to include inactive bundle results in your request.</p>
     #[serde(rename = "includeInactive")]
@@ -962,7 +962,7 @@ pub struct GetBundlesRequest {
     pub page_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetBundlesResult {
     /// <p>An array of key-value pairs that contains information about the available bundles.</p>
     #[serde(rename = "bundles")]
@@ -974,14 +974,14 @@ pub struct GetBundlesResult {
     pub next_page_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetDiskRequest {
     /// <p>The name of the disk (e.g., <code>my-disk</code>).</p>
     #[serde(rename = "diskName")]
     pub disk_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetDiskResult {
     /// <p>An object containing information about the disk.</p>
     #[serde(rename = "disk")]
@@ -989,14 +989,14 @@ pub struct GetDiskResult {
     pub disk: Option<Disk>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetDiskSnapshotRequest {
     /// <p>The name of the disk snapshot (e.g., <code>my-disk-snapshot</code>).</p>
     #[serde(rename = "diskSnapshotName")]
     pub disk_snapshot_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetDiskSnapshotResult {
     /// <p>An object containing information about the disk snapshot.</p>
     #[serde(rename = "diskSnapshot")]
@@ -1004,7 +1004,7 @@ pub struct GetDiskSnapshotResult {
     pub disk_snapshot: Option<DiskSnapshot>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetDiskSnapshotsRequest {
     /// <p>A token used for advancing to the next page of results from your GetDiskSnapshots request.</p>
     #[serde(rename = "pageToken")]
@@ -1012,7 +1012,7 @@ pub struct GetDiskSnapshotsRequest {
     pub page_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetDiskSnapshotsResult {
     /// <p>An array of objects containing information about all block storage disk snapshots.</p>
     #[serde(rename = "diskSnapshots")]
@@ -1024,7 +1024,7 @@ pub struct GetDiskSnapshotsResult {
     pub next_page_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetDisksRequest {
     /// <p>A token used for advancing to the next page of results from your GetDisks request.</p>
     #[serde(rename = "pageToken")]
@@ -1032,7 +1032,7 @@ pub struct GetDisksRequest {
     pub page_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetDisksResult {
     /// <p>An array of objects containing information about all block storage disks.</p>
     #[serde(rename = "disks")]
@@ -1044,14 +1044,14 @@ pub struct GetDisksResult {
     pub next_page_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetDomainRequest {
     /// <p>The domain name for which your want to return information about.</p>
     #[serde(rename = "domainName")]
     pub domain_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetDomainResult {
     /// <p>An array of key-value pairs containing information about your get domain request.</p>
     #[serde(rename = "domain")]
@@ -1059,7 +1059,7 @@ pub struct GetDomainResult {
     pub domain: Option<Domain>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetDomainsRequest {
     /// <p>A token used for advancing to the next page of results from your get domains request.</p>
     #[serde(rename = "pageToken")]
@@ -1067,7 +1067,7 @@ pub struct GetDomainsRequest {
     pub page_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetDomainsResult {
     /// <p>An array of key-value pairs containing information about each of the domain entries in the user's account.</p>
     #[serde(rename = "domains")]
@@ -1079,7 +1079,7 @@ pub struct GetDomainsResult {
     pub next_page_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetInstanceAccessDetailsRequest {
     /// <p>The name of the instance to access.</p>
     #[serde(rename = "instanceName")]
@@ -1090,7 +1090,7 @@ pub struct GetInstanceAccessDetailsRequest {
     pub protocol: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetInstanceAccessDetailsResult {
     /// <p>An array of key-value pairs containing information about a get instance access request.</p>
     #[serde(rename = "accessDetails")]
@@ -1098,7 +1098,7 @@ pub struct GetInstanceAccessDetailsResult {
     pub access_details: Option<InstanceAccessDetails>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetInstanceMetricDataRequest {
     /// <p>The end time of the time period.</p>
     #[serde(rename = "endTime")]
@@ -1123,7 +1123,7 @@ pub struct GetInstanceMetricDataRequest {
     pub unit: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetInstanceMetricDataResult {
     /// <p>An array of key-value pairs containing information about the results of your get instance metric data request.</p>
     #[serde(rename = "metricData")]
@@ -1135,14 +1135,14 @@ pub struct GetInstanceMetricDataResult {
     pub metric_name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetInstancePortStatesRequest {
     /// <p>The name of the instance.</p>
     #[serde(rename = "instanceName")]
     pub instance_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetInstancePortStatesResult {
     /// <p>Information about the port states resulting from your request.</p>
     #[serde(rename = "portStates")]
@@ -1150,14 +1150,14 @@ pub struct GetInstancePortStatesResult {
     pub port_states: Option<Vec<InstancePortState>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetInstanceRequest {
     /// <p>The name of the instance.</p>
     #[serde(rename = "instanceName")]
     pub instance_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetInstanceResult {
     /// <p>An array of key-value pairs containing information about the specified instance.</p>
     #[serde(rename = "instance")]
@@ -1165,14 +1165,14 @@ pub struct GetInstanceResult {
     pub instance: Option<Instance>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetInstanceSnapshotRequest {
     /// <p>The name of the snapshot for which you are requesting information.</p>
     #[serde(rename = "instanceSnapshotName")]
     pub instance_snapshot_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetInstanceSnapshotResult {
     /// <p>An array of key-value pairs containing information about the results of your get instance snapshot request.</p>
     #[serde(rename = "instanceSnapshot")]
@@ -1180,7 +1180,7 @@ pub struct GetInstanceSnapshotResult {
     pub instance_snapshot: Option<InstanceSnapshot>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetInstanceSnapshotsRequest {
     /// <p>A token used for advancing to the next page of results from your get instance snapshots request.</p>
     #[serde(rename = "pageToken")]
@@ -1188,7 +1188,7 @@ pub struct GetInstanceSnapshotsRequest {
     pub page_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetInstanceSnapshotsResult {
     /// <p>An array of key-value pairs containing information about the results of your get instance snapshots request.</p>
     #[serde(rename = "instanceSnapshots")]
@@ -1200,14 +1200,14 @@ pub struct GetInstanceSnapshotsResult {
     pub next_page_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetInstanceStateRequest {
     /// <p>The name of the instance to get state information about.</p>
     #[serde(rename = "instanceName")]
     pub instance_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetInstanceStateResult {
     /// <p>The state of the instance.</p>
     #[serde(rename = "state")]
@@ -1215,7 +1215,7 @@ pub struct GetInstanceStateResult {
     pub state: Option<InstanceState>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetInstancesRequest {
     /// <p>A token used for advancing to the next page of results from your get instances request.</p>
     #[serde(rename = "pageToken")]
@@ -1223,7 +1223,7 @@ pub struct GetInstancesRequest {
     pub page_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetInstancesResult {
     /// <p>An array of key-value pairs containing information about your instances.</p>
     #[serde(rename = "instances")]
@@ -1235,14 +1235,14 @@ pub struct GetInstancesResult {
     pub next_page_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetKeyPairRequest {
     /// <p>The name of the key pair for which you are requesting information.</p>
     #[serde(rename = "keyPairName")]
     pub key_pair_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetKeyPairResult {
     /// <p>An array of key-value pairs containing information about the key pair.</p>
     #[serde(rename = "keyPair")]
@@ -1250,7 +1250,7 @@ pub struct GetKeyPairResult {
     pub key_pair: Option<KeyPair>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetKeyPairsRequest {
     /// <p>A token used for advancing to the next page of results from your get key pairs request.</p>
     #[serde(rename = "pageToken")]
@@ -1258,7 +1258,7 @@ pub struct GetKeyPairsRequest {
     pub page_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetKeyPairsResult {
     /// <p>An array of key-value pairs containing information about the key pairs.</p>
     #[serde(rename = "keyPairs")]
@@ -1270,7 +1270,7 @@ pub struct GetKeyPairsResult {
     pub next_page_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetLoadBalancerMetricDataRequest {
     /// <p>The end time of the period.</p>
     #[serde(rename = "endTime")]
@@ -1295,7 +1295,7 @@ pub struct GetLoadBalancerMetricDataRequest {
     pub unit: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetLoadBalancerMetricDataResult {
     /// <p>An array of metric datapoint objects.</p>
     #[serde(rename = "metricData")]
@@ -1307,14 +1307,14 @@ pub struct GetLoadBalancerMetricDataResult {
     pub metric_name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetLoadBalancerRequest {
     /// <p>The name of the load balancer.</p>
     #[serde(rename = "loadBalancerName")]
     pub load_balancer_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetLoadBalancerResult {
     /// <p>An object containing information about your load balancer.</p>
     #[serde(rename = "loadBalancer")]
@@ -1322,14 +1322,14 @@ pub struct GetLoadBalancerResult {
     pub load_balancer: Option<LoadBalancer>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetLoadBalancerTlsCertificatesRequest {
     /// <p>The name of the load balancer you associated with your SSL/TLS certificate.</p>
     #[serde(rename = "loadBalancerName")]
     pub load_balancer_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetLoadBalancerTlsCertificatesResult {
     /// <p>An array of LoadBalancerTlsCertificate objects describing your SSL/TLS certificates.</p>
     #[serde(rename = "tlsCertificates")]
@@ -1337,7 +1337,7 @@ pub struct GetLoadBalancerTlsCertificatesResult {
     pub tls_certificates: Option<Vec<LoadBalancerTlsCertificate>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetLoadBalancersRequest {
     /// <p>A token used for paginating the results from your GetLoadBalancers request.</p>
     #[serde(rename = "pageToken")]
@@ -1345,7 +1345,7 @@ pub struct GetLoadBalancersRequest {
     pub page_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetLoadBalancersResult {
     /// <p>An array of LoadBalancer objects describing your load balancers.</p>
     #[serde(rename = "loadBalancers")]
@@ -1357,14 +1357,14 @@ pub struct GetLoadBalancersResult {
     pub next_page_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetOperationRequest {
     /// <p>A GUID used to identify the operation.</p>
     #[serde(rename = "operationId")]
     pub operation_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetOperationResult {
     /// <p>An array of key-value pairs containing information about the results of your get operation request.</p>
     #[serde(rename = "operation")]
@@ -1372,7 +1372,7 @@ pub struct GetOperationResult {
     pub operation: Option<Operation>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetOperationsForResourceRequest {
     /// <p>A token used for advancing to the next page of results from your get operations for resource request.</p>
     #[serde(rename = "pageToken")]
@@ -1383,7 +1383,7 @@ pub struct GetOperationsForResourceRequest {
     pub resource_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetOperationsForResourceResult {
     /// <p>An identifier that was returned from the previous call to this operation, which can be used to return the next set of items in the list.</p>
     #[serde(rename = "nextPageToken")]
@@ -1395,7 +1395,7 @@ pub struct GetOperationsForResourceResult {
     pub operations: Option<Vec<Operation>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetOperationsRequest {
     /// <p>A token used for advancing to the next page of results from your get operations request.</p>
     #[serde(rename = "pageToken")]
@@ -1403,7 +1403,7 @@ pub struct GetOperationsRequest {
     pub page_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetOperationsResult {
     /// <p>A token used for advancing to the next page of results from your get operations request.</p>
     #[serde(rename = "nextPageToken")]
@@ -1415,7 +1415,7 @@ pub struct GetOperationsResult {
     pub operations: Option<Vec<Operation>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetRegionsRequest {
     /// <p>A Boolean value indicating whether to also include Availability Zones in your get regions request. Availability Zones are indicated with a letter: e.g., <code>us-east-2a</code>.</p>
     #[serde(rename = "includeAvailabilityZones")]
@@ -1423,7 +1423,7 @@ pub struct GetRegionsRequest {
     pub include_availability_zones: Option<bool>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetRegionsResult {
     /// <p>An array of key-value pairs containing information about your get regions request.</p>
     #[serde(rename = "regions")]
@@ -1431,14 +1431,14 @@ pub struct GetRegionsResult {
     pub regions: Option<Vec<Region>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetStaticIpRequest {
     /// <p>The name of the static IP in Lightsail.</p>
     #[serde(rename = "staticIpName")]
     pub static_ip_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetStaticIpResult {
     /// <p>An array of key-value pairs containing information about the requested static IP.</p>
     #[serde(rename = "staticIp")]
@@ -1446,7 +1446,7 @@ pub struct GetStaticIpResult {
     pub static_ip: Option<StaticIp>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetStaticIpsRequest {
     /// <p>A token used for advancing to the next page of results from your get static IPs request.</p>
     #[serde(rename = "pageToken")]
@@ -1454,7 +1454,7 @@ pub struct GetStaticIpsRequest {
     pub page_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetStaticIpsResult {
     /// <p>A token used for advancing to the next page of results from your get static IPs request.</p>
     #[serde(rename = "nextPageToken")]
@@ -1466,7 +1466,7 @@ pub struct GetStaticIpsResult {
     pub static_ips: Option<Vec<StaticIp>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ImportKeyPairRequest {
     /// <p>The name of the key pair for which you want to import the public key.</p>
     #[serde(rename = "keyPairName")]
@@ -1476,7 +1476,7 @@ pub struct ImportKeyPairRequest {
     pub public_key_base_64: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ImportKeyPairResult {
     /// <p>An array of key-value pairs containing information about the request operation.</p>
     #[serde(rename = "operation")]
@@ -1485,7 +1485,7 @@ pub struct ImportKeyPairResult {
 }
 
 /// <p>Describes an instance (a virtual private server).</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Instance {
     /// <p>The Amazon Resource Name (ARN) of the instance (e.g., <code>arn:aws:lightsail:us-east-2:123456789101:Instance/244ad76f-8aad-4741-809f-12345EXAMPLE</code>).</p>
     #[serde(rename = "arn")]
@@ -1562,7 +1562,7 @@ pub struct Instance {
 }
 
 /// <p>The parameters for gaining temporary access to one of your Amazon Lightsail instances.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct InstanceAccessDetails {
     /// <p>For SSH access, the public key to use when accessing your instance For OpenSSH clients (e.g., command line SSH), you should save this value to <code>tempkey-cert.pub</code>.</p>
     #[serde(rename = "certKey")]
@@ -1603,7 +1603,7 @@ pub struct InstanceAccessDetails {
 }
 
 /// <p>Describes the hardware for the instance.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct InstanceHardware {
     /// <p>The number of vCPUs the instance has.</p>
     #[serde(rename = "cpuCount")]
@@ -1620,7 +1620,7 @@ pub struct InstanceHardware {
 }
 
 /// <p>Describes information about the health of the instance.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct InstanceHealthSummary {
     /// <p>Describes the overall instance health. Valid values are below.</p>
     #[serde(rename = "instanceHealth")]
@@ -1637,7 +1637,7 @@ pub struct InstanceHealthSummary {
 }
 
 /// <p>Describes monthly data transfer rates and port information for an instance.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct InstanceNetworking {
     /// <p>The amount of data in GB allocated for monthly data transfers.</p>
     #[serde(rename = "monthlyTransfer")]
@@ -1650,7 +1650,7 @@ pub struct InstanceNetworking {
 }
 
 /// <p>Describes information about the instance ports.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct InstancePortInfo {
     /// <p>The access direction (<code>inbound</code> or <code>outbound</code>).</p>
     #[serde(rename = "accessDirection")]
@@ -1683,7 +1683,7 @@ pub struct InstancePortInfo {
 }
 
 /// <p>Describes the port state.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct InstancePortState {
     /// <p>The first port in the range.</p>
     #[serde(rename = "fromPort")]
@@ -1704,7 +1704,7 @@ pub struct InstancePortState {
 }
 
 /// <p>Describes the snapshot of the virtual private server, or <i>instance</i>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct InstanceSnapshot {
     /// <p>The Amazon Resource Name (ARN) of the snapshot (e.g., <code>arn:aws:lightsail:us-east-2:123456789101:InstanceSnapshot/d23b5706-3322-4d83-81e5-12345EXAMPLE</code>).</p>
     #[serde(rename = "arn")]
@@ -1765,7 +1765,7 @@ pub struct InstanceSnapshot {
 }
 
 /// <p>Describes the virtual private server (or <i>instance</i>) status.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct InstanceState {
     /// <p>The status code for the instance.</p>
     #[serde(rename = "code")]
@@ -1777,10 +1777,10 @@ pub struct InstanceState {
     pub name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct IsVpcPeeredRequest {}
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct IsVpcPeeredResult {
     /// <p>Returns <code>true</code> if the Lightsail VPC is peered; otherwise, <code>false</code>.</p>
     #[serde(rename = "isPeered")]
@@ -1789,7 +1789,7 @@ pub struct IsVpcPeeredResult {
 }
 
 /// <p>Describes the SSH key pair.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct KeyPair {
     /// <p>The Amazon Resource Name (ARN) of the key pair (e.g., <code>arn:aws:lightsail:us-east-2:123456789101:KeyPair/05859e3d-331d-48ba-9034-12345EXAMPLE</code>).</p>
     #[serde(rename = "arn")]
@@ -1822,7 +1822,7 @@ pub struct KeyPair {
 }
 
 /// <p>Describes the Lightsail load balancer.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct LoadBalancer {
     /// <p>The Amazon Resource Name (ARN) of the load balancer.</p>
     #[serde(rename = "arn")]
@@ -1887,7 +1887,7 @@ pub struct LoadBalancer {
 }
 
 /// <p>Describes a load balancer SSL/TLS certificate.</p> <p>TLS is just an updated, more secure version of Secure Socket Layer (SSL).</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct LoadBalancerTlsCertificate {
     /// <p>The Amazon Resource Name (ARN) of the SSL/TLS certificate.</p>
     #[serde(rename = "arn")]
@@ -1988,7 +1988,7 @@ pub struct LoadBalancerTlsCertificate {
 }
 
 /// <p>Contains information about the domain names on an SSL/TLS certificate that you will use to validate domain ownership.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct LoadBalancerTlsCertificateDomainValidationOption {
     /// <p>The fully qualified domain name in the certificate request.</p>
     #[serde(rename = "domainName")]
@@ -2001,7 +2001,7 @@ pub struct LoadBalancerTlsCertificateDomainValidationOption {
 }
 
 /// <p>Describes the validation record of each domain name in the SSL/TLS certificate.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct LoadBalancerTlsCertificateDomainValidationRecord {
     /// <p>The domain name against which your SSL/TLS certificate was validated.</p>
     #[serde(rename = "domainName")]
@@ -2026,7 +2026,7 @@ pub struct LoadBalancerTlsCertificateDomainValidationRecord {
 }
 
 /// <p>Contains information about the status of Lightsail's managed renewal for the certificate.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct LoadBalancerTlsCertificateRenewalSummary {
     /// <p>Contains information about the validation of each domain name in the certificate, as it pertains to Lightsail's managed renewal. This is different from the initial validation that occurs as a result of the RequestCertificate request.</p>
     #[serde(rename = "domainValidationOptions")]
@@ -2039,7 +2039,7 @@ pub struct LoadBalancerTlsCertificateRenewalSummary {
 }
 
 /// <p>Provides a summary of SSL/TLS certificate metadata.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct LoadBalancerTlsCertificateSummary {
     /// <p>When <code>true</code>, the SSL/TLS certificate is attached to the Lightsail load balancer.</p>
     #[serde(rename = "isAttached")]
@@ -2052,7 +2052,7 @@ pub struct LoadBalancerTlsCertificateSummary {
 }
 
 /// <p>Describes the metric data point.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct MetricDatapoint {
     /// <p>The average.</p>
     #[serde(rename = "average")]
@@ -2085,7 +2085,7 @@ pub struct MetricDatapoint {
 }
 
 /// <p>Describes the monthly data transfer in and out of your virtual private server (or <i>instance</i>).</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct MonthlyTransfer {
     /// <p>The amount allocated per month (in GB).</p>
     #[serde(rename = "gbPerMonthAllocated")]
@@ -2093,7 +2093,7 @@ pub struct MonthlyTransfer {
     pub gb_per_month_allocated: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct OpenInstancePublicPortsRequest {
     /// <p>The name of the instance for which you want to open the public ports.</p>
     #[serde(rename = "instanceName")]
@@ -2103,7 +2103,7 @@ pub struct OpenInstancePublicPortsRequest {
     pub port_info: PortInfo,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct OpenInstancePublicPortsResult {
     /// <p>An array of key-value pairs containing information about the request operation.</p>
     #[serde(rename = "operation")]
@@ -2112,7 +2112,7 @@ pub struct OpenInstancePublicPortsResult {
 }
 
 /// <p>Describes the API operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Operation {
     /// <p>The timestamp when the operation was initialized (e.g., <code>1479816991.349</code>).</p>
     #[serde(rename = "createdAt")]
@@ -2165,7 +2165,7 @@ pub struct Operation {
 }
 
 /// <p>The password data for the Windows Server-based instance, including the ciphertext and the key pair name.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PasswordData {
     /// <p><p>The encrypted password. Ciphertext will be an empty string if access to your new instance is not ready yet. When you create an instance, it can take up to 15 minutes for the instance to be ready.</p> <note> <p>If you use the default key pair (<code>LightsailDefaultKeyPair</code>), the decrypted password will be available in the password field.</p> <p>If you are using a custom key pair, you need to use your own means of decryption.</p> <p>If you change the Administrator password on the instance, Lightsail will continue to return the original ciphertext value. When accessing the instance using RDP, you need to manually enter the Administrator password after changing it from the default.</p> </note></p>
     #[serde(rename = "ciphertext")]
@@ -2177,10 +2177,10 @@ pub struct PasswordData {
     pub key_pair_name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PeerVpcRequest {}
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PeerVpcResult {
     /// <p>An array of key-value pairs containing information about the request operation.</p>
     #[serde(rename = "operation")]
@@ -2189,7 +2189,7 @@ pub struct PeerVpcResult {
 }
 
 /// <p>Describes information about the ports on your virtual private server (or <i>instance</i>).</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PortInfo {
     /// <p>The first port in the range.</p>
     #[serde(rename = "fromPort")]
@@ -2205,7 +2205,7 @@ pub struct PortInfo {
     pub to_port: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PutInstancePublicPortsRequest {
     /// <p>The Lightsail instance name of the public port(s) you are setting.</p>
     #[serde(rename = "instanceName")]
@@ -2215,7 +2215,7 @@ pub struct PutInstancePublicPortsRequest {
     pub port_infos: Vec<PortInfo>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PutInstancePublicPortsResult {
     /// <p>Describes metadata about the operation you just executed.</p>
     #[serde(rename = "operation")]
@@ -2223,14 +2223,14 @@ pub struct PutInstancePublicPortsResult {
     pub operation: Option<Operation>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RebootInstanceRequest {
     /// <p>The name of the instance to reboot.</p>
     #[serde(rename = "instanceName")]
     pub instance_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RebootInstanceResult {
     /// <p>An array of key-value pairs containing information about the request operations.</p>
     #[serde(rename = "operations")]
@@ -2239,7 +2239,7 @@ pub struct RebootInstanceResult {
 }
 
 /// <p>Describes the AWS Region.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Region {
     /// <p>The Availability Zones. Follows the format <code>us-east-2a</code> (case-sensitive).</p>
     #[serde(rename = "availabilityZones")]
@@ -2263,14 +2263,14 @@ pub struct Region {
     pub name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ReleaseStaticIpRequest {
     /// <p>The name of the static IP to delete.</p>
     #[serde(rename = "staticIpName")]
     pub static_ip_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ReleaseStaticIpResult {
     /// <p>An array of key-value pairs containing information about the request operation.</p>
     #[serde(rename = "operations")]
@@ -2279,7 +2279,7 @@ pub struct ReleaseStaticIpResult {
 }
 
 /// <p>Describes the resource location.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ResourceLocation {
     /// <p>The Availability Zone. Follows the format <code>us-east-2a</code> (case-sensitive).</p>
     #[serde(rename = "availabilityZone")]
@@ -2291,14 +2291,14 @@ pub struct ResourceLocation {
     pub region_name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StartInstanceRequest {
     /// <p>The name of the instance (a virtual private server) to start.</p>
     #[serde(rename = "instanceName")]
     pub instance_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StartInstanceResult {
     /// <p>An array of key-value pairs containing information about the request operation.</p>
     #[serde(rename = "operations")]
@@ -2307,7 +2307,7 @@ pub struct StartInstanceResult {
 }
 
 /// <p>Describes the static IP.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StaticIp {
     /// <p>The Amazon Resource Name (ARN) of the static IP (e.g., <code>arn:aws:lightsail:us-east-2:123456789101:StaticIp/9cbb4a9e-f8e3-4dfe-b57e-12345EXAMPLE</code>).</p>
     #[serde(rename = "arn")]
@@ -2347,7 +2347,7 @@ pub struct StaticIp {
     pub support_code: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StopInstanceRequest {
     /// <p><p>When set to <code>True</code>, forces a Lightsail instance that is stuck in a <code>stopping</code> state to stop.</p> <important> <p>Only use the <code>force</code> parameter if your instance is stuck in the <code>stopping</code> state. In any other state, your instance should stop normally without adding this parameter to your API request.</p> </important></p>
     #[serde(rename = "force")]
@@ -2358,7 +2358,7 @@ pub struct StopInstanceRequest {
     pub instance_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StopInstanceResult {
     /// <p>An array of key-value pairs containing information about the request operation.</p>
     #[serde(rename = "operations")]
@@ -2366,10 +2366,10 @@ pub struct StopInstanceResult {
     pub operations: Option<Vec<Operation>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UnpeerVpcRequest {}
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UnpeerVpcResult {
     /// <p>An array of key-value pairs containing information about the request operation.</p>
     #[serde(rename = "operation")]
@@ -2377,7 +2377,7 @@ pub struct UnpeerVpcResult {
     pub operation: Option<Operation>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateDomainEntryRequest {
     /// <p>An array of key-value pairs containing information about the domain entry.</p>
     #[serde(rename = "domainEntry")]
@@ -2387,7 +2387,7 @@ pub struct UpdateDomainEntryRequest {
     pub domain_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateDomainEntryResult {
     /// <p>An array of key-value pairs containing information about the request operation.</p>
     #[serde(rename = "operations")]
@@ -2395,7 +2395,7 @@ pub struct UpdateDomainEntryResult {
     pub operations: Option<Vec<Operation>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateLoadBalancerAttributeRequest {
     /// <p>The name of the attribute you want to update. Valid values are below.</p>
     #[serde(rename = "attributeName")]
@@ -2408,7 +2408,7 @@ pub struct UpdateLoadBalancerAttributeRequest {
     pub load_balancer_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateLoadBalancerAttributeResult {
     /// <p>An object describing the API operations.</p>
     #[serde(rename = "operations")]

--- a/rusoto/services/lightsail/src/generated.rs
+++ b/rusoto/services/lightsail/src/generated.rs
@@ -2447,7 +2447,8 @@ impl AllocateStaticIpError {
     pub fn from_body(body: &str) -> AllocateStaticIpError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2561,7 +2562,8 @@ impl AttachDiskError {
     pub fn from_body(body: &str) -> AttachDiskError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2669,7 +2671,8 @@ impl AttachInstancesToLoadBalancerError {
     pub fn from_body(body: &str) -> AttachInstancesToLoadBalancerError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2791,7 +2794,8 @@ impl AttachLoadBalancerTlsCertificateError {
     pub fn from_body(body: &str) -> AttachLoadBalancerTlsCertificateError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2913,7 +2917,8 @@ impl AttachStaticIpError {
     pub fn from_body(body: &str) -> AttachStaticIpError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3025,7 +3030,8 @@ impl CloseInstancePublicPortsError {
     pub fn from_body(body: &str) -> CloseInstancePublicPortsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3143,7 +3149,8 @@ impl CreateDiskError {
     pub fn from_body(body: &str) -> CreateDiskError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3251,7 +3258,8 @@ impl CreateDiskFromSnapshotError {
     pub fn from_body(body: &str) -> CreateDiskFromSnapshotError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3369,7 +3377,8 @@ impl CreateDiskSnapshotError {
     pub fn from_body(body: &str) -> CreateDiskSnapshotError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3485,7 +3494,8 @@ impl CreateDomainError {
     pub fn from_body(body: &str) -> CreateDomainError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3595,7 +3605,8 @@ impl CreateDomainEntryError {
     pub fn from_body(body: &str) -> CreateDomainEntryError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3711,7 +3722,8 @@ impl CreateInstanceSnapshotError {
     pub fn from_body(body: &str) -> CreateInstanceSnapshotError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3829,7 +3841,8 @@ impl CreateInstancesError {
     pub fn from_body(body: &str) -> CreateInstancesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3943,7 +3956,8 @@ impl CreateInstancesFromSnapshotError {
     pub fn from_body(body: &str) -> CreateInstancesFromSnapshotError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4065,7 +4079,8 @@ impl CreateKeyPairError {
     pub fn from_body(body: &str) -> CreateKeyPairError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4177,7 +4192,8 @@ impl CreateLoadBalancerError {
     pub fn from_body(body: &str) -> CreateLoadBalancerError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4293,7 +4309,8 @@ impl CreateLoadBalancerTlsCertificateError {
     pub fn from_body(body: &str) -> CreateLoadBalancerTlsCertificateError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4415,7 +4432,8 @@ impl DeleteDiskError {
     pub fn from_body(body: &str) -> DeleteDiskError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4523,7 +4541,8 @@ impl DeleteDiskSnapshotError {
     pub fn from_body(body: &str) -> DeleteDiskSnapshotError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4639,7 +4658,8 @@ impl DeleteDomainError {
     pub fn from_body(body: &str) -> DeleteDomainError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4749,7 +4769,8 @@ impl DeleteDomainEntryError {
     pub fn from_body(body: &str) -> DeleteDomainEntryError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4865,7 +4886,8 @@ impl DeleteInstanceError {
     pub fn from_body(body: &str) -> DeleteInstanceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4977,7 +4999,8 @@ impl DeleteInstanceSnapshotError {
     pub fn from_body(body: &str) -> DeleteInstanceSnapshotError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5095,7 +5118,8 @@ impl DeleteKeyPairError {
     pub fn from_body(body: &str) -> DeleteKeyPairError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5207,7 +5231,8 @@ impl DeleteLoadBalancerError {
     pub fn from_body(body: &str) -> DeleteLoadBalancerError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5323,7 +5348,8 @@ impl DeleteLoadBalancerTlsCertificateError {
     pub fn from_body(body: &str) -> DeleteLoadBalancerTlsCertificateError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5445,7 +5471,8 @@ impl DetachDiskError {
     pub fn from_body(body: &str) -> DetachDiskError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5553,7 +5580,8 @@ impl DetachInstancesFromLoadBalancerError {
     pub fn from_body(body: &str) -> DetachInstancesFromLoadBalancerError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5675,7 +5703,8 @@ impl DetachStaticIpError {
     pub fn from_body(body: &str) -> DetachStaticIpError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5787,7 +5816,8 @@ impl DownloadDefaultKeyPairError {
     pub fn from_body(body: &str) -> DownloadDefaultKeyPairError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5905,7 +5935,8 @@ impl GetActiveNamesError {
     pub fn from_body(body: &str) -> GetActiveNamesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6017,7 +6048,8 @@ impl GetBlueprintsError {
     pub fn from_body(body: &str) -> GetBlueprintsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6129,7 +6161,8 @@ impl GetBundlesError {
     pub fn from_body(body: &str) -> GetBundlesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6237,7 +6270,8 @@ impl GetDiskError {
     pub fn from_body(body: &str) -> GetDiskError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6345,7 +6379,8 @@ impl GetDiskSnapshotError {
     pub fn from_body(body: &str) -> GetDiskSnapshotError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6459,7 +6494,8 @@ impl GetDiskSnapshotsError {
     pub fn from_body(body: &str) -> GetDiskSnapshotsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6573,7 +6609,8 @@ impl GetDisksError {
     pub fn from_body(body: &str) -> GetDisksError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6681,7 +6718,8 @@ impl GetDomainError {
     pub fn from_body(body: &str) -> GetDomainError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6789,7 +6827,8 @@ impl GetDomainsError {
     pub fn from_body(body: &str) -> GetDomainsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6897,7 +6936,8 @@ impl GetInstanceError {
     pub fn from_body(body: &str) -> GetInstanceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7007,7 +7047,8 @@ impl GetInstanceAccessDetailsError {
     pub fn from_body(body: &str) -> GetInstanceAccessDetailsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7125,7 +7166,8 @@ impl GetInstanceMetricDataError {
     pub fn from_body(body: &str) -> GetInstanceMetricDataError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7243,7 +7285,8 @@ impl GetInstancePortStatesError {
     pub fn from_body(body: &str) -> GetInstancePortStatesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7361,7 +7404,8 @@ impl GetInstanceSnapshotError {
     pub fn from_body(body: &str) -> GetInstanceSnapshotError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7479,7 +7523,8 @@ impl GetInstanceSnapshotsError {
     pub fn from_body(body: &str) -> GetInstanceSnapshotsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7597,7 +7642,8 @@ impl GetInstanceStateError {
     pub fn from_body(body: &str) -> GetInstanceStateError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7711,7 +7757,8 @@ impl GetInstancesError {
     pub fn from_body(body: &str) -> GetInstancesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7821,7 +7868,8 @@ impl GetKeyPairError {
     pub fn from_body(body: &str) -> GetKeyPairError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7929,7 +7977,8 @@ impl GetKeyPairsError {
     pub fn from_body(body: &str) -> GetKeyPairsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8039,7 +8088,8 @@ impl GetLoadBalancerError {
     pub fn from_body(body: &str) -> GetLoadBalancerError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8153,7 +8203,8 @@ impl GetLoadBalancerMetricDataError {
     pub fn from_body(body: &str) -> GetLoadBalancerMetricDataError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8273,7 +8324,8 @@ impl GetLoadBalancerTlsCertificatesError {
     pub fn from_body(body: &str) -> GetLoadBalancerTlsCertificatesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8395,7 +8447,8 @@ impl GetLoadBalancersError {
     pub fn from_body(body: &str) -> GetLoadBalancersError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8509,7 +8562,8 @@ impl GetOperationError {
     pub fn from_body(body: &str) -> GetOperationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8619,7 +8673,8 @@ impl GetOperationsError {
     pub fn from_body(body: &str) -> GetOperationsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8731,7 +8786,8 @@ impl GetOperationsForResourceError {
     pub fn from_body(body: &str) -> GetOperationsForResourceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8849,7 +8905,8 @@ impl GetRegionsError {
     pub fn from_body(body: &str) -> GetRegionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8957,7 +9014,8 @@ impl GetStaticIpError {
     pub fn from_body(body: &str) -> GetStaticIpError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9067,7 +9125,8 @@ impl GetStaticIpsError {
     pub fn from_body(body: &str) -> GetStaticIpsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9177,7 +9236,8 @@ impl ImportKeyPairError {
     pub fn from_body(body: &str) -> ImportKeyPairError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9289,7 +9349,8 @@ impl IsVpcPeeredError {
     pub fn from_body(body: &str) -> IsVpcPeeredError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9399,7 +9460,8 @@ impl OpenInstancePublicPortsError {
     pub fn from_body(body: &str) -> OpenInstancePublicPortsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9517,7 +9579,8 @@ impl PeerVpcError {
     pub fn from_body(body: &str) -> PeerVpcError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9625,7 +9688,8 @@ impl PutInstancePublicPortsError {
     pub fn from_body(body: &str) -> PutInstancePublicPortsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9743,7 +9807,8 @@ impl RebootInstanceError {
     pub fn from_body(body: &str) -> RebootInstanceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9855,7 +9920,8 @@ impl ReleaseStaticIpError {
     pub fn from_body(body: &str) -> ReleaseStaticIpError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9969,7 +10035,8 @@ impl StartInstanceError {
     pub fn from_body(body: &str) -> StartInstanceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -10081,7 +10148,8 @@ impl StopInstanceError {
     pub fn from_body(body: &str) -> StopInstanceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -10191,7 +10259,8 @@ impl UnpeerVpcError {
     pub fn from_body(body: &str) -> UnpeerVpcError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -10299,7 +10368,8 @@ impl UpdateDomainEntryError {
     pub fn from_body(body: &str) -> UpdateDomainEntryError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -10415,7 +10485,8 @@ impl UpdateLoadBalancerAttributeError {
     pub fn from_body(body: &str) -> UpdateLoadBalancerAttributeError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/logs/src/generated.rs
+++ b/rusoto/services/logs/src/generated.rs
@@ -1045,7 +1045,8 @@ impl AssociateKmsKeyError {
     pub fn from_body(body: &str) -> AssociateKmsKeyError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1141,7 +1142,8 @@ impl CancelExportTaskError {
     pub fn from_body(body: &str) -> CancelExportTaskError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1241,7 +1243,8 @@ impl CreateExportTaskError {
     pub fn from_body(body: &str) -> CreateExportTaskError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1347,7 +1350,8 @@ impl CreateLogGroupError {
     pub fn from_body(body: &str) -> CreateLogGroupError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1447,7 +1451,8 @@ impl CreateLogStreamError {
     pub fn from_body(body: &str) -> CreateLogStreamError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1543,7 +1548,8 @@ impl DeleteDestinationError {
     pub fn from_body(body: &str) -> DeleteDestinationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1641,7 +1647,8 @@ impl DeleteLogGroupError {
     pub fn from_body(body: &str) -> DeleteLogGroupError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1737,7 +1744,8 @@ impl DeleteLogStreamError {
     pub fn from_body(body: &str) -> DeleteLogStreamError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1833,7 +1841,8 @@ impl DeleteMetricFilterError {
     pub fn from_body(body: &str) -> DeleteMetricFilterError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1929,7 +1938,8 @@ impl DeleteResourcePolicyError {
     pub fn from_body(body: &str) -> DeleteResourcePolicyError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2023,7 +2033,8 @@ impl DeleteRetentionPolicyError {
     pub fn from_body(body: &str) -> DeleteRetentionPolicyError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2121,7 +2132,8 @@ impl DeleteSubscriptionFilterError {
     pub fn from_body(body: &str) -> DeleteSubscriptionFilterError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2217,7 +2229,8 @@ impl DescribeDestinationsError {
     pub fn from_body(body: &str) -> DescribeDestinationsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2303,7 +2316,8 @@ impl DescribeExportTasksError {
     pub fn from_body(body: &str) -> DescribeExportTasksError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2389,7 +2403,8 @@ impl DescribeLogGroupsError {
     pub fn from_body(body: &str) -> DescribeLogGroupsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2477,7 +2492,8 @@ impl DescribeLogStreamsError {
     pub fn from_body(body: &str) -> DescribeLogStreamsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2569,7 +2585,8 @@ impl DescribeMetricFiltersError {
     pub fn from_body(body: &str) -> DescribeMetricFiltersError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2659,7 +2676,8 @@ impl DescribeResourcePoliciesError {
     pub fn from_body(body: &str) -> DescribeResourcePoliciesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2749,7 +2767,8 @@ impl DescribeSubscriptionFiltersError {
     pub fn from_body(body: &str) -> DescribeSubscriptionFiltersError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2849,7 +2868,8 @@ impl DisassociateKmsKeyError {
     pub fn from_body(body: &str) -> DisassociateKmsKeyError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2945,7 +2965,8 @@ impl FilterLogEventsError {
     pub fn from_body(body: &str) -> FilterLogEventsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3035,7 +3056,8 @@ impl GetLogEventsError {
     pub fn from_body(body: &str) -> GetLogEventsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3123,7 +3145,8 @@ impl ListTagsLogGroupError {
     pub fn from_body(body: &str) -> ListTagsLogGroupError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3209,7 +3232,8 @@ impl PutDestinationError {
     pub fn from_body(body: &str) -> PutDestinationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3299,7 +3323,8 @@ impl PutDestinationPolicyError {
     pub fn from_body(body: &str) -> PutDestinationPolicyError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3395,7 +3420,8 @@ impl PutLogEventsError {
     pub fn from_body(body: &str) -> PutLogEventsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3497,7 +3523,8 @@ impl PutMetricFilterError {
     pub fn from_body(body: &str) -> PutMetricFilterError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3595,7 +3622,8 @@ impl PutResourcePolicyError {
     pub fn from_body(body: &str) -> PutResourcePolicyError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3689,7 +3717,8 @@ impl PutRetentionPolicyError {
     pub fn from_body(body: &str) -> PutRetentionPolicyError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3789,7 +3818,8 @@ impl PutSubscriptionFilterError {
     pub fn from_body(body: &str) -> PutSubscriptionFilterError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3887,7 +3917,8 @@ impl TagLogGroupError {
     pub fn from_body(body: &str) -> TagLogGroupError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3971,7 +4002,8 @@ impl TestMetricFilterError {
     pub fn from_body(body: &str) -> TestMetricFilterError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4053,7 +4085,8 @@ impl UntagLogGroupError {
     pub fn from_body(body: &str) -> UntagLogGroupError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/logs/src/generated.rs
+++ b/rusoto/services/logs/src/generated.rs
@@ -30,7 +30,7 @@ use rusoto_core::signature::SignedRequest;
 use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AssociateKmsKeyRequest {
     /// <p>The Amazon Resource Name (ARN) of the CMK to use when encrypting log data. For more information, see <a href="http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arn-syntax-kms">Amazon Resource Names - AWS Key Management Service (AWS KMS)</a>.</p>
     #[serde(rename = "kmsKeyId")]
@@ -40,14 +40,14 @@ pub struct AssociateKmsKeyRequest {
     pub log_group_name: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CancelExportTaskRequest {
     /// <p>The ID of the export task.</p>
     #[serde(rename = "taskId")]
     pub task_id: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateExportTaskRequest {
     /// <p>The name of S3 bucket for the exported log data. The bucket must be in the same AWS region.</p>
     #[serde(rename = "destination")]
@@ -75,7 +75,7 @@ pub struct CreateExportTaskRequest {
     pub to: i64,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateExportTaskResponse {
     /// <p>The ID of the export task.</p>
     #[serde(rename = "taskId")]
@@ -83,7 +83,7 @@ pub struct CreateExportTaskResponse {
     pub task_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateLogGroupRequest {
     /// <p>The Amazon Resource Name (ARN) of the CMK to use when encrypting log data. For more information, see <a href="http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arn-syntax-kms">Amazon Resource Names - AWS Key Management Service (AWS KMS)</a>.</p>
     #[serde(rename = "kmsKeyId")]
@@ -98,7 +98,7 @@ pub struct CreateLogGroupRequest {
     pub tags: Option<::std::collections::HashMap<String, String>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateLogStreamRequest {
     /// <p>The name of the log group.</p>
     #[serde(rename = "logGroupName")]
@@ -108,21 +108,21 @@ pub struct CreateLogStreamRequest {
     pub log_stream_name: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteDestinationRequest {
     /// <p>The name of the destination.</p>
     #[serde(rename = "destinationName")]
     pub destination_name: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteLogGroupRequest {
     /// <p>The name of the log group.</p>
     #[serde(rename = "logGroupName")]
     pub log_group_name: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteLogStreamRequest {
     /// <p>The name of the log group.</p>
     #[serde(rename = "logGroupName")]
@@ -132,7 +132,7 @@ pub struct DeleteLogStreamRequest {
     pub log_stream_name: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteMetricFilterRequest {
     /// <p>The name of the metric filter.</p>
     #[serde(rename = "filterName")]
@@ -142,7 +142,7 @@ pub struct DeleteMetricFilterRequest {
     pub log_group_name: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteResourcePolicyRequest {
     /// <p>The name of the policy to be revoked. This parameter is required.</p>
     #[serde(rename = "policyName")]
@@ -150,14 +150,14 @@ pub struct DeleteResourcePolicyRequest {
     pub policy_name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteRetentionPolicyRequest {
     /// <p>The name of the log group.</p>
     #[serde(rename = "logGroupName")]
     pub log_group_name: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteSubscriptionFilterRequest {
     /// <p>The name of the subscription filter.</p>
     #[serde(rename = "filterName")]
@@ -167,7 +167,7 @@ pub struct DeleteSubscriptionFilterRequest {
     pub log_group_name: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeDestinationsRequest {
     /// <p>The prefix to match. If you don't specify a value, no prefix filter is applied.</p>
     #[serde(rename = "DestinationNamePrefix")]
@@ -183,7 +183,7 @@ pub struct DescribeDestinationsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeDestinationsResponse {
     /// <p>The destinations.</p>
     #[serde(rename = "destinations")]
@@ -194,7 +194,7 @@ pub struct DescribeDestinationsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeExportTasksRequest {
     /// <p>The maximum number of items returned. If you don't specify a value, the default is up to 50 items.</p>
     #[serde(rename = "limit")]
@@ -214,7 +214,7 @@ pub struct DescribeExportTasksRequest {
     pub task_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeExportTasksResponse {
     /// <p>The export tasks.</p>
     #[serde(rename = "exportTasks")]
@@ -225,7 +225,7 @@ pub struct DescribeExportTasksResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeLogGroupsRequest {
     /// <p>The maximum number of items returned. If you don't specify a value, the default is up to 50 items.</p>
     #[serde(rename = "limit")]
@@ -241,7 +241,7 @@ pub struct DescribeLogGroupsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeLogGroupsResponse {
     /// <p>The log groups.</p>
     #[serde(rename = "logGroups")]
@@ -252,7 +252,7 @@ pub struct DescribeLogGroupsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeLogStreamsRequest {
     /// <p>If the value is true, results are returned in descending order. If the value is to false, results are returned in ascending order. The default value is false.</p>
     #[serde(rename = "descending")]
@@ -279,7 +279,7 @@ pub struct DescribeLogStreamsRequest {
     pub order_by: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeLogStreamsResponse {
     /// <p>The log streams.</p>
     #[serde(rename = "logStreams")]
@@ -290,7 +290,7 @@ pub struct DescribeLogStreamsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeMetricFiltersRequest {
     /// <p>The prefix to match.</p>
     #[serde(rename = "filterNamePrefix")]
@@ -317,7 +317,7 @@ pub struct DescribeMetricFiltersRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeMetricFiltersResponse {
     /// <p>The metric filters.</p>
     #[serde(rename = "metricFilters")]
@@ -328,7 +328,7 @@ pub struct DescribeMetricFiltersResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeResourcePoliciesRequest {
     /// <p>The maximum number of resource policies to be displayed with one call of this API.</p>
     #[serde(rename = "limit")]
@@ -339,7 +339,7 @@ pub struct DescribeResourcePoliciesRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeResourcePoliciesResponse {
     #[serde(rename = "nextToken")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -350,7 +350,7 @@ pub struct DescribeResourcePoliciesResponse {
     pub resource_policies: Option<Vec<ResourcePolicy>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeSubscriptionFiltersRequest {
     /// <p>The prefix to match. If you don't specify a value, no prefix filter is applied.</p>
     #[serde(rename = "filterNamePrefix")]
@@ -369,7 +369,7 @@ pub struct DescribeSubscriptionFiltersRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeSubscriptionFiltersResponse {
     #[serde(rename = "nextToken")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -381,7 +381,7 @@ pub struct DescribeSubscriptionFiltersResponse {
 }
 
 /// <p>Represents a cross-account destination that receives subscription log events.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Destination {
     /// <p>An IAM policy document that governs which AWS accounts can create subscription filters against this destination.</p>
     #[serde(rename = "accessPolicy")]
@@ -409,7 +409,7 @@ pub struct Destination {
     pub target_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DisassociateKmsKeyRequest {
     /// <p>The name of the log group.</p>
     #[serde(rename = "logGroupName")]
@@ -417,7 +417,7 @@ pub struct DisassociateKmsKeyRequest {
 }
 
 /// <p>Represents an export task.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ExportTask {
     /// <p>The name of Amazon S3 bucket to which the log data was exported.</p>
     #[serde(rename = "destination")]
@@ -458,7 +458,7 @@ pub struct ExportTask {
 }
 
 /// <p>Represents the status of an export task.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ExportTaskExecutionInfo {
     /// <p>The completion time of the export task, expressed as the number of milliseconds after Jan 1, 1970 00:00:00 UTC.</p>
     #[serde(rename = "completionTime")]
@@ -471,7 +471,7 @@ pub struct ExportTaskExecutionInfo {
 }
 
 /// <p>Represents the status of an export task.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ExportTaskStatus {
     /// <p>The status code of the export task.</p>
     #[serde(rename = "code")]
@@ -483,7 +483,7 @@ pub struct ExportTaskStatus {
     pub message: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct FilterLogEventsRequest {
     /// <p>The end of the time range, expressed as the number of milliseconds after Jan 1, 1970 00:00:00 UTC. Events with a time stamp later than this time are not returned.</p>
     #[serde(rename = "endTime")]
@@ -518,7 +518,7 @@ pub struct FilterLogEventsRequest {
     pub start_time: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct FilterLogEventsResponse {
     /// <p>The matched events.</p>
     #[serde(rename = "events")]
@@ -535,7 +535,7 @@ pub struct FilterLogEventsResponse {
 }
 
 /// <p>Represents a matched event.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct FilteredLogEvent {
     /// <p>The ID of the event.</p>
     #[serde(rename = "eventId")]
@@ -559,7 +559,7 @@ pub struct FilteredLogEvent {
     pub timestamp: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetLogEventsRequest {
     /// <p>The end of the time range, expressed as the number of milliseconds after Jan 1, 1970 00:00:00 UTC. Events with a time stamp later than this time are not included.</p>
     #[serde(rename = "endTime")]
@@ -589,7 +589,7 @@ pub struct GetLogEventsRequest {
     pub start_time: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetLogEventsResponse {
     /// <p>The events.</p>
     #[serde(rename = "events")]
@@ -606,7 +606,7 @@ pub struct GetLogEventsResponse {
 }
 
 /// <p>Represents a log event, which is a record of activity that was recorded by the application or resource being monitored.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct InputLogEvent {
     /// <p>The raw event message.</p>
     #[serde(rename = "message")]
@@ -616,14 +616,14 @@ pub struct InputLogEvent {
     pub timestamp: i64,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListTagsLogGroupRequest {
     /// <p>The name of the log group.</p>
     #[serde(rename = "logGroupName")]
     pub log_group_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListTagsLogGroupResponse {
     /// <p>The tags for the log group.</p>
     #[serde(rename = "tags")]
@@ -632,7 +632,7 @@ pub struct ListTagsLogGroupResponse {
 }
 
 /// <p>Represents a log group.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct LogGroup {
     /// <p>The Amazon Resource Name (ARN) of the log group.</p>
     #[serde(rename = "arn")]
@@ -664,7 +664,7 @@ pub struct LogGroup {
 }
 
 /// <p>Represents a log stream, which is a sequence of log events from a single emitter of logs.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct LogStream {
     /// <p>The Amazon Resource Name (ARN) of the log stream.</p>
     #[serde(rename = "arn")]
@@ -701,7 +701,7 @@ pub struct LogStream {
 }
 
 /// <p>Metric filters express how CloudWatch Logs would extract metric observations from ingested log events and transform them into metric data in a CloudWatch metric.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct MetricFilter {
     /// <p>The creation time of the metric filter, expressed as the number of milliseconds after Jan 1, 1970 00:00:00 UTC.</p>
     #[serde(rename = "creationTime")]
@@ -725,7 +725,7 @@ pub struct MetricFilter {
 }
 
 /// <p>Represents a matched event.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct MetricFilterMatchRecord {
     /// <p>The raw event data.</p>
     #[serde(rename = "eventMessage")]
@@ -742,7 +742,7 @@ pub struct MetricFilterMatchRecord {
 }
 
 /// <p>Indicates how to transform ingested log events in to metric data in a CloudWatch metric.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct MetricTransformation {
     /// <p>(Optional) The value to emit when a filter pattern does not match a log event. This value can be null.</p>
     #[serde(rename = "defaultValue")]
@@ -760,7 +760,7 @@ pub struct MetricTransformation {
 }
 
 /// <p>Represents a log event.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct OutputLogEvent {
     /// <p>The time the event was ingested, expressed as the number of milliseconds after Jan 1, 1970 00:00:00 UTC.</p>
     #[serde(rename = "ingestionTime")]
@@ -776,7 +776,7 @@ pub struct OutputLogEvent {
     pub timestamp: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PutDestinationPolicyRequest {
     /// <p>An IAM policy document that authorizes cross-account users to deliver their log events to the associated destination.</p>
     #[serde(rename = "accessPolicy")]
@@ -786,7 +786,7 @@ pub struct PutDestinationPolicyRequest {
     pub destination_name: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PutDestinationRequest {
     /// <p>A name for the destination.</p>
     #[serde(rename = "destinationName")]
@@ -799,7 +799,7 @@ pub struct PutDestinationRequest {
     pub target_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PutDestinationResponse {
     /// <p>The destination.</p>
     #[serde(rename = "destination")]
@@ -807,7 +807,7 @@ pub struct PutDestinationResponse {
     pub destination: Option<Destination>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PutLogEventsRequest {
     /// <p>The log events.</p>
     #[serde(rename = "logEvents")]
@@ -824,7 +824,7 @@ pub struct PutLogEventsRequest {
     pub sequence_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PutLogEventsResponse {
     /// <p>The next sequence token.</p>
     #[serde(rename = "nextSequenceToken")]
@@ -836,7 +836,7 @@ pub struct PutLogEventsResponse {
     pub rejected_log_events_info: Option<RejectedLogEventsInfo>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PutMetricFilterRequest {
     /// <p>A name for the metric filter.</p>
     #[serde(rename = "filterName")]
@@ -852,7 +852,7 @@ pub struct PutMetricFilterRequest {
     pub metric_transformations: Vec<MetricTransformation>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PutResourcePolicyRequest {
     /// <p>Details of the new policy, including the identity of the principal that is enabled to put logs to this account. This is formatted as a JSON string.</p> <p>The following example creates a resource policy enabling the Route 53 service to put DNS query logs in to the specified log group. Replace "logArn" with the ARN of your CloudWatch Logs resource, such as a log group or log stream.</p> <p> { "Version": "2012-10-17" "Statement": [ { "Sid": "Route53LogsToCloudWatchLogs", "Effect": "Allow", "Principal": { "Service": [ "route53.amazonaws.com" ] }, "Action":"logs:PutLogEvents", "Resource": logArn } ] } </p>
     #[serde(rename = "policyDocument")]
@@ -864,7 +864,7 @@ pub struct PutResourcePolicyRequest {
     pub policy_name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PutResourcePolicyResponse {
     /// <p>The new policy.</p>
     #[serde(rename = "resourcePolicy")]
@@ -872,7 +872,7 @@ pub struct PutResourcePolicyResponse {
     pub resource_policy: Option<ResourcePolicy>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PutRetentionPolicyRequest {
     /// <p>The name of the log group.</p>
     #[serde(rename = "logGroupName")]
@@ -881,7 +881,7 @@ pub struct PutRetentionPolicyRequest {
     pub retention_in_days: i64,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PutSubscriptionFilterRequest {
     /// <p><p>The ARN of the destination to deliver matching log events to. Currently, the supported destinations are:</p> <ul> <li> <p>An Amazon Kinesis stream belonging to the same account as the subscription filter, for same-account delivery.</p> </li> <li> <p>A logical destination (specified using an ARN) belonging to a different account, for cross-account delivery.</p> </li> <li> <p>An Amazon Kinesis Firehose delivery stream belonging to the same account as the subscription filter, for same-account delivery.</p> </li> <li> <p>An AWS Lambda function belonging to the same account as the subscription filter, for same-account delivery.</p> </li> </ul></p>
     #[serde(rename = "destinationArn")]
@@ -906,7 +906,7 @@ pub struct PutSubscriptionFilterRequest {
 }
 
 /// <p>Represents the rejected events.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RejectedLogEventsInfo {
     /// <p>The expired log events.</p>
     #[serde(rename = "expiredLogEventEndIndex")]
@@ -923,7 +923,7 @@ pub struct RejectedLogEventsInfo {
 }
 
 /// <p>A policy enabling one or more entities to put logs to a log group in this account.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ResourcePolicy {
     /// <p>Time stamp showing when this policy was last updated, expressed as the number of milliseconds after Jan 1, 1970 00:00:00 UTC.</p>
     #[serde(rename = "lastUpdatedTime")]
@@ -940,7 +940,7 @@ pub struct ResourcePolicy {
 }
 
 /// <p>Represents the search status of a log stream.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SearchedLogStream {
     /// <p>The name of the log stream.</p>
     #[serde(rename = "logStreamName")]
@@ -953,7 +953,7 @@ pub struct SearchedLogStream {
 }
 
 /// <p>Represents a subscription filter.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SubscriptionFilter {
     /// <p>The creation time of the subscription filter, expressed as the number of milliseconds after Jan 1, 1970 00:00:00 UTC.</p>
     #[serde(rename = "creationTime")]
@@ -983,7 +983,7 @@ pub struct SubscriptionFilter {
     pub role_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct TagLogGroupRequest {
     /// <p>The name of the log group.</p>
     #[serde(rename = "logGroupName")]
@@ -993,7 +993,7 @@ pub struct TagLogGroupRequest {
     pub tags: ::std::collections::HashMap<String, String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct TestMetricFilterRequest {
     #[serde(rename = "filterPattern")]
     pub filter_pattern: String,
@@ -1002,7 +1002,7 @@ pub struct TestMetricFilterRequest {
     pub log_event_messages: Vec<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct TestMetricFilterResponse {
     /// <p>The matched events.</p>
     #[serde(rename = "matches")]
@@ -1010,7 +1010,7 @@ pub struct TestMetricFilterResponse {
     pub matches: Option<Vec<MetricFilterMatchRecord>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UntagLogGroupRequest {
     /// <p>The name of the log group.</p>
     #[serde(rename = "logGroupName")]

--- a/rusoto/services/machinelearning/src/generated.rs
+++ b/rusoto/services/machinelearning/src/generated.rs
@@ -1607,7 +1607,8 @@ impl AddTagsError {
     pub fn from_body(body: &str) -> AddTagsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1701,7 +1702,8 @@ impl CreateBatchPredictionError {
     pub fn from_body(body: &str) -> CreateBatchPredictionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1795,7 +1797,8 @@ impl CreateDataSourceFromRDSError {
     pub fn from_body(body: &str) -> CreateDataSourceFromRDSError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1889,7 +1892,8 @@ impl CreateDataSourceFromRedshiftError {
     pub fn from_body(body: &str) -> CreateDataSourceFromRedshiftError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1983,7 +1987,8 @@ impl CreateDataSourceFromS3Error {
     pub fn from_body(body: &str) -> CreateDataSourceFromS3Error {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2077,7 +2082,8 @@ impl CreateEvaluationError {
     pub fn from_body(body: &str) -> CreateEvaluationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2169,7 +2175,8 @@ impl CreateMLModelError {
     pub fn from_body(body: &str) -> CreateMLModelError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2259,7 +2266,8 @@ impl CreateRealtimeEndpointError {
     pub fn from_body(body: &str) -> CreateRealtimeEndpointError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2351,7 +2359,8 @@ impl DeleteBatchPredictionError {
     pub fn from_body(body: &str) -> DeleteBatchPredictionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2443,7 +2452,8 @@ impl DeleteDataSourceError {
     pub fn from_body(body: &str) -> DeleteDataSourceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2533,7 +2543,8 @@ impl DeleteEvaluationError {
     pub fn from_body(body: &str) -> DeleteEvaluationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2623,7 +2634,8 @@ impl DeleteMLModelError {
     pub fn from_body(body: &str) -> DeleteMLModelError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2713,7 +2725,8 @@ impl DeleteRealtimeEndpointError {
     pub fn from_body(body: &str) -> DeleteRealtimeEndpointError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2807,7 +2820,8 @@ impl DeleteTagsError {
     pub fn from_body(body: &str) -> DeleteTagsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2897,7 +2911,8 @@ impl DescribeBatchPredictionsError {
     pub fn from_body(body: &str) -> DescribeBatchPredictionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2983,7 +2998,8 @@ impl DescribeDataSourcesError {
     pub fn from_body(body: &str) -> DescribeDataSourcesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3069,7 +3085,8 @@ impl DescribeEvaluationsError {
     pub fn from_body(body: &str) -> DescribeEvaluationsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3155,7 +3172,8 @@ impl DescribeMLModelsError {
     pub fn from_body(body: &str) -> DescribeMLModelsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3241,7 +3259,8 @@ impl DescribeTagsError {
     pub fn from_body(body: &str) -> DescribeTagsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3331,7 +3350,8 @@ impl GetBatchPredictionError {
     pub fn from_body(body: &str) -> GetBatchPredictionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3423,7 +3443,8 @@ impl GetDataSourceError {
     pub fn from_body(body: &str) -> GetDataSourceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3513,7 +3534,8 @@ impl GetEvaluationError {
     pub fn from_body(body: &str) -> GetEvaluationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3603,7 +3625,8 @@ impl GetMLModelError {
     pub fn from_body(body: &str) -> GetMLModelError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3695,7 +3718,8 @@ impl PredictError {
     pub fn from_body(body: &str) -> PredictError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3791,7 +3815,8 @@ impl UpdateBatchPredictionError {
     pub fn from_body(body: &str) -> UpdateBatchPredictionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3883,7 +3908,8 @@ impl UpdateDataSourceError {
     pub fn from_body(body: &str) -> UpdateDataSourceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3973,7 +3999,8 @@ impl UpdateEvaluationError {
     pub fn from_body(body: &str) -> UpdateEvaluationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4063,7 +4090,8 @@ impl UpdateMLModelError {
     pub fn from_body(body: &str) -> UpdateMLModelError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/machinelearning/src/generated.rs
+++ b/rusoto/services/machinelearning/src/generated.rs
@@ -30,7 +30,7 @@ use rusoto_core::signature::SignedRequest;
 use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AddTagsInput {
     /// <p>The ID of the ML object to tag. For example, <code>exampleModelId</code>.</p>
     #[serde(rename = "ResourceId")]
@@ -44,7 +44,7 @@ pub struct AddTagsInput {
 }
 
 /// <p>Amazon ML returns the following elements. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AddTagsOutput {
     /// <p>The ID of the ML object that was tagged.</p>
     #[serde(rename = "ResourceId")]
@@ -57,7 +57,7 @@ pub struct AddTagsOutput {
 }
 
 /// <p> Represents the output of a <code>GetBatchPrediction</code> operation.</p> <p> The content consists of the detailed metadata, the status, and the data file information of a <code>Batch Prediction</code>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BatchPrediction {
     /// <p>The ID of the <code>DataSource</code> that points to the group of observations to predict.</p>
     #[serde(rename = "BatchPredictionDataSourceId")]
@@ -120,7 +120,7 @@ pub struct BatchPrediction {
     pub total_record_count: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateBatchPredictionInput {
     /// <p>The ID of the <code>DataSource</code> that points to the group of observations to predict.</p>
     #[serde(rename = "BatchPredictionDataSourceId")]
@@ -141,7 +141,7 @@ pub struct CreateBatchPredictionInput {
 }
 
 /// <p> Represents the output of a <code>CreateBatchPrediction</code> operation, and is an acknowledgement that Amazon ML received the request.</p> <p>The <code>CreateBatchPrediction</code> operation is asynchronous. You can poll for status updates by using the <code>&gt;GetBatchPrediction</code> operation and checking the <code>Status</code> parameter of the result. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateBatchPredictionOutput {
     /// <p>A user-supplied ID that uniquely identifies the <code>BatchPrediction</code>. This value is identical to the value of the <code>BatchPredictionId</code> in the request.</p>
     #[serde(rename = "BatchPredictionId")]
@@ -149,7 +149,7 @@ pub struct CreateBatchPredictionOutput {
     pub batch_prediction_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateDataSourceFromRDSInput {
     /// <p>The compute statistics for a <code>DataSource</code>. The statistics are generated from the observation data referenced by a <code>DataSource</code>. Amazon ML uses the statistics internally during <code>MLModel</code> training. This parameter must be set to <code>true</code> if the <code></code>DataSource<code></code> needs to be used for <code>MLModel</code> training. </p>
     #[serde(rename = "ComputeStatistics")]
@@ -171,7 +171,7 @@ pub struct CreateDataSourceFromRDSInput {
 }
 
 /// <p> Represents the output of a <code>CreateDataSourceFromRDS</code> operation, and is an acknowledgement that Amazon ML received the request.</p> <p>The <code>CreateDataSourceFromRDS</code>&gt; operation is asynchronous. You can poll for updates by using the <code>GetBatchPrediction</code> operation and checking the <code>Status</code> parameter. You can inspect the <code>Message</code> when <code>Status</code> shows up as <code>FAILED</code>. You can also check the progress of the copy operation by going to the <code>DataPipeline</code> console and looking up the pipeline using the <code>pipelineId </code> from the describe call.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateDataSourceFromRDSOutput {
     /// <p>A user-supplied ID that uniquely identifies the datasource. This value should be identical to the value of the <code>DataSourceID</code> in the request. </p>
     #[serde(rename = "DataSourceId")]
@@ -179,7 +179,7 @@ pub struct CreateDataSourceFromRDSOutput {
     pub data_source_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateDataSourceFromRedshiftInput {
     /// <p>The compute statistics for a <code>DataSource</code>. The statistics are generated from the observation data referenced by a <code>DataSource</code>. Amazon ML uses the statistics internally during <code>MLModel</code> training. This parameter must be set to <code>true</code> if the <code>DataSource</code> needs to be used for <code>MLModel</code> training.</p>
     #[serde(rename = "ComputeStatistics")]
@@ -201,7 +201,7 @@ pub struct CreateDataSourceFromRedshiftInput {
 }
 
 /// <p> Represents the output of a <code>CreateDataSourceFromRedshift</code> operation, and is an acknowledgement that Amazon ML received the request.</p> <p>The <code>CreateDataSourceFromRedshift</code> operation is asynchronous. You can poll for updates by using the <code>GetBatchPrediction</code> operation and checking the <code>Status</code> parameter. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateDataSourceFromRedshiftOutput {
     /// <p>A user-supplied ID that uniquely identifies the datasource. This value should be identical to the value of the <code>DataSourceID</code> in the request. </p>
     #[serde(rename = "DataSourceId")]
@@ -209,7 +209,7 @@ pub struct CreateDataSourceFromRedshiftOutput {
     pub data_source_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateDataSourceFromS3Input {
     /// <p>The compute statistics for a <code>DataSource</code>. The statistics are generated from the observation data referenced by a <code>DataSource</code>. Amazon ML uses the statistics internally during <code>MLModel</code> training. This parameter must be set to <code>true</code> if the <code></code>DataSource<code></code> needs to be used for <code>MLModel</code> training.</p>
     #[serde(rename = "ComputeStatistics")]
@@ -228,7 +228,7 @@ pub struct CreateDataSourceFromS3Input {
 }
 
 /// <p> Represents the output of a <code>CreateDataSourceFromS3</code> operation, and is an acknowledgement that Amazon ML received the request.</p> <p>The <code>CreateDataSourceFromS3</code> operation is asynchronous. You can poll for updates by using the <code>GetBatchPrediction</code> operation and checking the <code>Status</code> parameter. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateDataSourceFromS3Output {
     /// <p>A user-supplied ID that uniquely identifies the <code>DataSource</code>. This value should be identical to the value of the <code>DataSourceID</code> in the request. </p>
     #[serde(rename = "DataSourceId")]
@@ -236,7 +236,7 @@ pub struct CreateDataSourceFromS3Output {
     pub data_source_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateEvaluationInput {
     /// <p>The ID of the <code>DataSource</code> for the evaluation. The schema of the <code>DataSource</code> must match the schema used to create the <code>MLModel</code>.</p>
     #[serde(rename = "EvaluationDataSourceId")]
@@ -254,7 +254,7 @@ pub struct CreateEvaluationInput {
 }
 
 /// <p> Represents the output of a <code>CreateEvaluation</code> operation, and is an acknowledgement that Amazon ML received the request.</p> <p><code>CreateEvaluation</code> operation is asynchronous. You can poll for status updates by using the <code>GetEvcaluation</code> operation and checking the <code>Status</code> parameter. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateEvaluationOutput {
     /// <p>The user-supplied ID that uniquely identifies the <code>Evaluation</code>. This value should be identical to the value of the <code>EvaluationId</code> in the request.</p>
     #[serde(rename = "EvaluationId")]
@@ -262,7 +262,7 @@ pub struct CreateEvaluationOutput {
     pub evaluation_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateMLModelInput {
     /// <p>A user-supplied ID that uniquely identifies the <code>MLModel</code>.</p>
     #[serde(rename = "MLModelId")]
@@ -292,7 +292,7 @@ pub struct CreateMLModelInput {
 }
 
 /// <p> Represents the output of a <code>CreateMLModel</code> operation, and is an acknowledgement that Amazon ML received the request.</p> <p>The <code>CreateMLModel</code> operation is asynchronous. You can poll for status updates by using the <code>GetMLModel</code> operation and checking the <code>Status</code> parameter. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateMLModelOutput {
     /// <p>A user-supplied ID that uniquely identifies the <code>MLModel</code>. This value should be identical to the value of the <code>MLModelId</code> in the request. </p>
     #[serde(rename = "MLModelId")]
@@ -300,7 +300,7 @@ pub struct CreateMLModelOutput {
     pub ml_model_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateRealtimeEndpointInput {
     /// <p>The ID assigned to the <code>MLModel</code> during creation.</p>
     #[serde(rename = "MLModelId")]
@@ -308,7 +308,7 @@ pub struct CreateRealtimeEndpointInput {
 }
 
 /// <p><p>Represents the output of an <code>CreateRealtimeEndpoint</code> operation.</p> <p>The result contains the <code>MLModelId</code> and the endpoint information for the <code>MLModel</code>.</p> <note> <p>The endpoint information includes the URI of the <code>MLModel</code>; that is, the location to send online prediction requests for the specified <code>MLModel</code>.</p> </note></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateRealtimeEndpointOutput {
     /// <p>A user-supplied ID that uniquely identifies the <code>MLModel</code>. This value should be identical to the value of the <code>MLModelId</code> in the request.</p>
     #[serde(rename = "MLModelId")]
@@ -321,7 +321,7 @@ pub struct CreateRealtimeEndpointOutput {
 }
 
 /// <p> Represents the output of the <code>GetDataSource</code> operation. </p> <p> The content consists of the detailed metadata and data file information and the current status of the <code>DataSource</code>. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DataSource {
     /// <p> The parameter is <code>true</code> if statistics need to be generated from the observation data. </p>
     #[serde(rename = "ComputeStatistics")]
@@ -391,7 +391,7 @@ pub struct DataSource {
     pub status: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteBatchPredictionInput {
     /// <p>A user-supplied ID that uniquely identifies the <code>BatchPrediction</code>.</p>
     #[serde(rename = "BatchPredictionId")]
@@ -399,7 +399,7 @@ pub struct DeleteBatchPredictionInput {
 }
 
 /// <p> Represents the output of a <code>DeleteBatchPrediction</code> operation.</p> <p>You can use the <code>GetBatchPrediction</code> operation and check the value of the <code>Status</code> parameter to see whether a <code>BatchPrediction</code> is marked as <code>DELETED</code>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteBatchPredictionOutput {
     /// <p>A user-supplied ID that uniquely identifies the <code>BatchPrediction</code>. This value should be identical to the value of the <code>BatchPredictionID</code> in the request.</p>
     #[serde(rename = "BatchPredictionId")]
@@ -407,7 +407,7 @@ pub struct DeleteBatchPredictionOutput {
     pub batch_prediction_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteDataSourceInput {
     /// <p>A user-supplied ID that uniquely identifies the <code>DataSource</code>.</p>
     #[serde(rename = "DataSourceId")]
@@ -415,7 +415,7 @@ pub struct DeleteDataSourceInput {
 }
 
 /// <p> Represents the output of a <code>DeleteDataSource</code> operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteDataSourceOutput {
     /// <p>A user-supplied ID that uniquely identifies the <code>DataSource</code>. This value should be identical to the value of the <code>DataSourceID</code> in the request.</p>
     #[serde(rename = "DataSourceId")]
@@ -423,7 +423,7 @@ pub struct DeleteDataSourceOutput {
     pub data_source_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteEvaluationInput {
     /// <p>A user-supplied ID that uniquely identifies the <code>Evaluation</code> to delete.</p>
     #[serde(rename = "EvaluationId")]
@@ -431,7 +431,7 @@ pub struct DeleteEvaluationInput {
 }
 
 /// <p> Represents the output of a <code>DeleteEvaluation</code> operation. The output indicates that Amazon Machine Learning (Amazon ML) received the request.</p> <p>You can use the <code>GetEvaluation</code> operation and check the value of the <code>Status</code> parameter to see whether an <code>Evaluation</code> is marked as <code>DELETED</code>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteEvaluationOutput {
     /// <p>A user-supplied ID that uniquely identifies the <code>Evaluation</code>. This value should be identical to the value of the <code>EvaluationId</code> in the request.</p>
     #[serde(rename = "EvaluationId")]
@@ -439,7 +439,7 @@ pub struct DeleteEvaluationOutput {
     pub evaluation_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteMLModelInput {
     /// <p>A user-supplied ID that uniquely identifies the <code>MLModel</code>.</p>
     #[serde(rename = "MLModelId")]
@@ -447,7 +447,7 @@ pub struct DeleteMLModelInput {
 }
 
 /// <p>Represents the output of a <code>DeleteMLModel</code> operation.</p> <p>You can use the <code>GetMLModel</code> operation and check the value of the <code>Status</code> parameter to see whether an <code>MLModel</code> is marked as <code>DELETED</code>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteMLModelOutput {
     /// <p>A user-supplied ID that uniquely identifies the <code>MLModel</code>. This value should be identical to the value of the <code>MLModelID</code> in the request.</p>
     #[serde(rename = "MLModelId")]
@@ -455,7 +455,7 @@ pub struct DeleteMLModelOutput {
     pub ml_model_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteRealtimeEndpointInput {
     /// <p>The ID assigned to the <code>MLModel</code> during creation.</p>
     #[serde(rename = "MLModelId")]
@@ -463,7 +463,7 @@ pub struct DeleteRealtimeEndpointInput {
 }
 
 /// <p>Represents the output of an <code>DeleteRealtimeEndpoint</code> operation.</p> <p>The result contains the <code>MLModelId</code> and the endpoint information for the <code>MLModel</code>. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteRealtimeEndpointOutput {
     /// <p>A user-supplied ID that uniquely identifies the <code>MLModel</code>. This value should be identical to the value of the <code>MLModelId</code> in the request.</p>
     #[serde(rename = "MLModelId")]
@@ -475,7 +475,7 @@ pub struct DeleteRealtimeEndpointOutput {
     pub realtime_endpoint_info: Option<RealtimeEndpointInfo>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteTagsInput {
     /// <p>The ID of the tagged ML object. For example, <code>exampleModelId</code>.</p>
     #[serde(rename = "ResourceId")]
@@ -489,7 +489,7 @@ pub struct DeleteTagsInput {
 }
 
 /// <p>Amazon ML returns the following elements. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteTagsOutput {
     /// <p>The ID of the ML object from which tags were deleted.</p>
     #[serde(rename = "ResourceId")]
@@ -501,7 +501,7 @@ pub struct DeleteTagsOutput {
     pub resource_type: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeBatchPredictionsInput {
     /// <p>The equal to operator. The <code>BatchPrediction</code> results will have <code>FilterVariable</code> values that exactly match the value specified with <code>EQ</code>.</p>
     #[serde(rename = "EQ")]
@@ -550,7 +550,7 @@ pub struct DescribeBatchPredictionsInput {
 }
 
 /// <p>Represents the output of a <code>DescribeBatchPredictions</code> operation. The content is essentially a list of <code>BatchPrediction</code>s.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeBatchPredictionsOutput {
     /// <p>The ID of the next page in the paginated results that indicates at least one more page follows.</p>
     #[serde(rename = "NextToken")]
@@ -562,7 +562,7 @@ pub struct DescribeBatchPredictionsOutput {
     pub results: Option<Vec<BatchPrediction>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeDataSourcesInput {
     /// <p>The equal to operator. The <code>DataSource</code> results will have <code>FilterVariable</code> values that exactly match the value specified with <code>EQ</code>.</p>
     #[serde(rename = "EQ")]
@@ -611,7 +611,7 @@ pub struct DescribeDataSourcesInput {
 }
 
 /// <p>Represents the query results from a <a>DescribeDataSources</a> operation. The content is essentially a list of <code>DataSource</code>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeDataSourcesOutput {
     /// <p>An ID of the next page in the paginated results that indicates at least one more page follows.</p>
     #[serde(rename = "NextToken")]
@@ -623,7 +623,7 @@ pub struct DescribeDataSourcesOutput {
     pub results: Option<Vec<DataSource>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeEvaluationsInput {
     /// <p>The equal to operator. The <code>Evaluation</code> results will have <code>FilterVariable</code> values that exactly match the value specified with <code>EQ</code>.</p>
     #[serde(rename = "EQ")]
@@ -672,7 +672,7 @@ pub struct DescribeEvaluationsInput {
 }
 
 /// <p>Represents the query results from a <code>DescribeEvaluations</code> operation. The content is essentially a list of <code>Evaluation</code>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeEvaluationsOutput {
     /// <p>The ID of the next page in the paginated results that indicates at least one more page follows.</p>
     #[serde(rename = "NextToken")]
@@ -684,7 +684,7 @@ pub struct DescribeEvaluationsOutput {
     pub results: Option<Vec<Evaluation>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeMLModelsInput {
     /// <p>The equal to operator. The <code>MLModel</code> results will have <code>FilterVariable</code> values that exactly match the value specified with <code>EQ</code>.</p>
     #[serde(rename = "EQ")]
@@ -733,7 +733,7 @@ pub struct DescribeMLModelsInput {
 }
 
 /// <p>Represents the output of a <code>DescribeMLModels</code> operation. The content is essentially a list of <code>MLModel</code>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeMLModelsOutput {
     /// <p>The ID of the next page in the paginated results that indicates at least one more page follows.</p>
     #[serde(rename = "NextToken")]
@@ -745,7 +745,7 @@ pub struct DescribeMLModelsOutput {
     pub results: Option<Vec<MLModel>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeTagsInput {
     /// <p>The ID of the ML object. For example, <code>exampleModelId</code>. </p>
     #[serde(rename = "ResourceId")]
@@ -756,7 +756,7 @@ pub struct DescribeTagsInput {
 }
 
 /// <p>Amazon ML returns the following elements. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeTagsOutput {
     /// <p>The ID of the tagged ML object.</p>
     #[serde(rename = "ResourceId")]
@@ -773,7 +773,7 @@ pub struct DescribeTagsOutput {
 }
 
 /// <p> Represents the output of <code>GetEvaluation</code> operation. </p> <p>The content consists of the detailed metadata and data file information and the current status of the <code>Evaluation</code>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Evaluation {
     #[serde(rename = "ComputeTime")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -830,7 +830,7 @@ pub struct Evaluation {
     pub status: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetBatchPredictionInput {
     /// <p>An ID assigned to the <code>BatchPrediction</code> at creation.</p>
     #[serde(rename = "BatchPredictionId")]
@@ -838,7 +838,7 @@ pub struct GetBatchPredictionInput {
 }
 
 /// <p>Represents the output of a <code>GetBatchPrediction</code> operation and describes a <code>BatchPrediction</code>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetBatchPredictionOutput {
     /// <p>The ID of the <code>DataSource</code> that was used to create the <code>BatchPrediction</code>. </p>
     #[serde(rename = "BatchPredictionDataSourceId")]
@@ -910,7 +910,7 @@ pub struct GetBatchPredictionOutput {
     pub total_record_count: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetDataSourceInput {
     /// <p>The ID assigned to the <code>DataSource</code> at creation.</p>
     #[serde(rename = "DataSourceId")]
@@ -922,7 +922,7 @@ pub struct GetDataSourceInput {
 }
 
 /// <p>Represents the output of a <code>GetDataSource</code> operation and describes a <code>DataSource</code>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetDataSourceOutput {
     /// <p> The parameter is <code>true</code> if statistics need to be generated from the observation data. </p>
     #[serde(rename = "ComputeStatistics")]
@@ -1003,7 +1003,7 @@ pub struct GetDataSourceOutput {
     pub status: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetEvaluationInput {
     /// <p>The ID of the <code>Evaluation</code> to retrieve. The evaluation of each <code>MLModel</code> is recorded and cataloged. The ID provides the means to access the information. </p>
     #[serde(rename = "EvaluationId")]
@@ -1011,7 +1011,7 @@ pub struct GetEvaluationInput {
 }
 
 /// <p>Represents the output of a <code>GetEvaluation</code> operation and describes an <code>Evaluation</code>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetEvaluationOutput {
     /// <p>The approximate CPU time in milliseconds that Amazon Machine Learning spent processing the <code>Evaluation</code>, normalized and scaled on computation resources. <code>ComputeTime</code> is only available if the <code>Evaluation</code> is in the <code>COMPLETED</code> state.</p>
     #[serde(rename = "ComputeTime")]
@@ -1075,7 +1075,7 @@ pub struct GetEvaluationOutput {
     pub status: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetMLModelInput {
     /// <p>The ID assigned to the <code>MLModel</code> at creation.</p>
     #[serde(rename = "MLModelId")]
@@ -1087,7 +1087,7 @@ pub struct GetMLModelInput {
 }
 
 /// <p>Represents the output of a <code>GetMLModel</code> operation, and provides detailed information about a <code>MLModel</code>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetMLModelOutput {
     /// <p>The approximate CPU time in milliseconds that Amazon Machine Learning spent processing the <code>MLModel</code>, normalized and scaled on computation resources. <code>ComputeTime</code> is only available if the <code>MLModel</code> is in the <code>COMPLETED</code> state.</p>
     #[serde(rename = "ComputeTime")]
@@ -1175,7 +1175,7 @@ pub struct GetMLModelOutput {
 }
 
 /// <p> Represents the output of a <code>GetMLModel</code> operation. </p> <p>The content consists of the detailed metadata and the current status of the <code>MLModel</code>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct MLModel {
     /// <p><p>The algorithm used to train the <code>MLModel</code>. The following algorithm is supported:</p> <ul> <li> <code>SGD</code> -- Stochastic gradient descent. The goal of <code>SGD</code> is to minimize the gradient of the loss function. </li> </ul></p>
     #[serde(rename = "Algorithm")]
@@ -1251,14 +1251,14 @@ pub struct MLModel {
 }
 
 /// <p>Measurements of how well the <code>MLModel</code> performed on known observations. One of the following metrics is returned, based on the type of the <code>MLModel</code>: </p> <ul> <li> <p>BinaryAUC: The binary <code>MLModel</code> uses the Area Under the Curve (AUC) technique to measure performance. </p> </li> <li> <p>RegressionRMSE: The regression <code>MLModel</code> uses the Root Mean Square Error (RMSE) technique to measure performance. RMSE measures the difference between predicted and actual values for a single variable.</p> </li> <li> <p>MulticlassAvgFScore: The multiclass <code>MLModel</code> uses the F1 score technique to measure performance. </p> </li> </ul> <p> For more information about performance metrics, please see the <a href="http://docs.aws.amazon.com/machine-learning/latest/dg">Amazon Machine Learning Developer Guide</a>. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PerformanceMetrics {
     #[serde(rename = "Properties")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub properties: Option<::std::collections::HashMap<String, String>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PredictInput {
     /// <p>A unique identifier of the <code>MLModel</code>.</p>
     #[serde(rename = "MLModelId")]
@@ -1269,7 +1269,7 @@ pub struct PredictInput {
     pub record: ::std::collections::HashMap<String, String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PredictOutput {
     #[serde(rename = "Prediction")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1277,7 +1277,7 @@ pub struct PredictOutput {
 }
 
 /// <p><p>The output from a <code>Predict</code> operation: </p> <ul> <li> <p> <code>Details</code> - Contains the following attributes: <code>DetailsAttributes.PREDICTIVE<em>MODEL</em>TYPE - REGRESSION | BINARY | MULTICLASS</code> <code>DetailsAttributes.ALGORITHM - SGD</code> </p> </li> <li> <p> <code>PredictedLabel</code> - Present for either a <code>BINARY</code> or <code>MULTICLASS</code> <code>MLModel</code> request. </p> </li> <li> <p> <code>PredictedScores</code> - Contains the raw classification score corresponding to each label. </p> </li> <li> <p> <code>PredictedValue</code> - Present for a <code>REGRESSION</code> <code>MLModel</code> request. </p> </li> </ul></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Prediction {
     #[serde(rename = "details")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1296,7 +1296,7 @@ pub struct Prediction {
 }
 
 /// <p>The data specification of an Amazon Relational Database Service (Amazon RDS) <code>DataSource</code>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RDSDataSpec {
     /// <p><p>A JSON string that represents the splitting and rearrangement processing to be applied to a <code>DataSource</code>. If the <code>DataRearrangement</code> parameter is not provided, all of the input data is used to create the <code>Datasource</code>.</p> <p>There are multiple parameters that control what data is used to create a datasource:</p> <ul> <li><p><b><code>percentBegin</code></b></p> <p>Use <code>percentBegin</code> to indicate the beginning of the range of the data used to create the Datasource. If you do not include <code>percentBegin</code> and <code>percentEnd</code>, Amazon ML includes all of the data when creating the datasource.</p></li> <li><p><b><code>percentEnd</code></b></p> <p>Use <code>percentEnd</code> to indicate the end of the range of the data used to create the Datasource. If you do not include <code>percentBegin</code> and <code>percentEnd</code>, Amazon ML includes all of the data when creating the datasource.</p></li> <li><p><b><code>complement</code></b></p> <p>The <code>complement</code> parameter instructs Amazon ML to use the data that is not included in the range of <code>percentBegin</code> to <code>percentEnd</code> to create a datasource. The <code>complement</code> parameter is useful if you need to create complementary datasources for training and evaluation. To create a complementary datasource, use the same values for <code>percentBegin</code> and <code>percentEnd</code>, along with the <code>complement</code> parameter.</p> <p>For example, the following two datasources do not share any data, and can be used to train and evaluate a model. The first datasource has 25 percent of the data, and the second one has 75 percent of the data.</p> <p>Datasource for evaluation: <code>{&quot;splitting&quot;:{&quot;percentBegin&quot;:0, &quot;percentEnd&quot;:25}}</code></p> <p>Datasource for training: <code>{&quot;splitting&quot;:{&quot;percentBegin&quot;:0, &quot;percentEnd&quot;:25, &quot;complement&quot;:&quot;true&quot;}}</code></p> </li> <li><p><b><code>strategy</code></b></p> <p>To change how Amazon ML splits the data for a datasource, use the <code>strategy</code> parameter.</p> <p>The default value for the <code>strategy</code> parameter is <code>sequential</code>, meaning that Amazon ML takes all of the data records between the <code>percentBegin</code> and <code>percentEnd</code> parameters for the datasource, in the order that the records appear in the input data.</p> <p>The following two <code>DataRearrangement</code> lines are examples of sequentially ordered training and evaluation datasources:</p> <p>Datasource for evaluation: <code>{&quot;splitting&quot;:{&quot;percentBegin&quot;:70, &quot;percentEnd&quot;:100, &quot;strategy&quot;:&quot;sequential&quot;}}</code></p> <p>Datasource for training: <code>{&quot;splitting&quot;:{&quot;percentBegin&quot;:70, &quot;percentEnd&quot;:100, &quot;strategy&quot;:&quot;sequential&quot;, &quot;complement&quot;:&quot;true&quot;}}</code></p> <p>To randomly split the input data into the proportions indicated by the percentBegin and percentEnd parameters, set the <code>strategy</code> parameter to <code>random</code> and provide a string that is used as the seed value for the random data splitting (for example, you can use the S3 path to your data as the random seed string). If you choose the random split strategy, Amazon ML assigns each row of data a pseudo-random number between 0 and 100, and then selects the rows that have an assigned number between <code>percentBegin</code> and <code>percentEnd</code>. Pseudo-random numbers are assigned using both the input seed string value and the byte offset as a seed, so changing the data results in a different split. Any existing ordering is preserved. The random splitting strategy ensures that variables in the training and evaluation data are distributed similarly. It is useful in the cases where the input data may have an implicit sort order, which would otherwise result in training and evaluation datasources containing non-similar data records.</p> <p>The following two <code>DataRearrangement</code> lines are examples of non-sequentially ordered training and evaluation datasources:</p> <p>Datasource for evaluation: <code>{&quot;splitting&quot;:{&quot;percentBegin&quot;:70, &quot;percentEnd&quot;:100, &quot;strategy&quot;:&quot;random&quot;, &quot;randomSeed&quot;=&quot;s3://my<em>s3</em>path/bucket/file.csv&quot;}}</code></p> <p>Datasource for training: <code>{&quot;splitting&quot;:{&quot;percentBegin&quot;:70, &quot;percentEnd&quot;:100, &quot;strategy&quot;:&quot;random&quot;, &quot;randomSeed&quot;=&quot;s3://my<em>s3</em>path/bucket/file.csv&quot;, &quot;complement&quot;:&quot;true&quot;}}</code></p> </li> </ul></p>
     #[serde(rename = "DataRearrangement")]
@@ -1337,7 +1337,7 @@ pub struct RDSDataSpec {
 }
 
 /// <p>The database details of an Amazon RDS database.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RDSDatabase {
     #[serde(rename = "DatabaseName")]
     pub database_name: String,
@@ -1347,7 +1347,7 @@ pub struct RDSDatabase {
 }
 
 /// <p>The database credentials to connect to a database on an RDS DB instance.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RDSDatabaseCredentials {
     #[serde(rename = "Password")]
     pub password: String,
@@ -1356,7 +1356,7 @@ pub struct RDSDatabaseCredentials {
 }
 
 /// <p>The datasource details that are specific to Amazon RDS.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RDSMetadata {
     /// <p>The ID of the Data Pipeline instance that is used to carry to copy data from Amazon RDS to Amazon S3. You can use the ID to find details about the instance in the Data Pipeline console.</p>
     #[serde(rename = "DataPipelineId")]
@@ -1384,7 +1384,7 @@ pub struct RDSMetadata {
 }
 
 /// <p> Describes the real-time endpoint information for an <code>MLModel</code>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RealtimeEndpointInfo {
     /// <p>The time that the request to create the real-time endpoint for the <code>MLModel</code> was received. The time is expressed in epoch time.</p>
     #[serde(rename = "CreatedAt")]
@@ -1405,7 +1405,7 @@ pub struct RealtimeEndpointInfo {
 }
 
 /// <p>Describes the data specification of an Amazon Redshift <code>DataSource</code>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RedshiftDataSpec {
     /// <p><p>A JSON string that represents the splitting and rearrangement processing to be applied to a <code>DataSource</code>. If the <code>DataRearrangement</code> parameter is not provided, all of the input data is used to create the <code>Datasource</code>.</p> <p>There are multiple parameters that control what data is used to create a datasource:</p> <ul> <li><p><b><code>percentBegin</code></b></p> <p>Use <code>percentBegin</code> to indicate the beginning of the range of the data used to create the Datasource. If you do not include <code>percentBegin</code> and <code>percentEnd</code>, Amazon ML includes all of the data when creating the datasource.</p></li> <li><p><b><code>percentEnd</code></b></p> <p>Use <code>percentEnd</code> to indicate the end of the range of the data used to create the Datasource. If you do not include <code>percentBegin</code> and <code>percentEnd</code>, Amazon ML includes all of the data when creating the datasource.</p></li> <li><p><b><code>complement</code></b></p> <p>The <code>complement</code> parameter instructs Amazon ML to use the data that is not included in the range of <code>percentBegin</code> to <code>percentEnd</code> to create a datasource. The <code>complement</code> parameter is useful if you need to create complementary datasources for training and evaluation. To create a complementary datasource, use the same values for <code>percentBegin</code> and <code>percentEnd</code>, along with the <code>complement</code> parameter.</p> <p>For example, the following two datasources do not share any data, and can be used to train and evaluate a model. The first datasource has 25 percent of the data, and the second one has 75 percent of the data.</p> <p>Datasource for evaluation: <code>{&quot;splitting&quot;:{&quot;percentBegin&quot;:0, &quot;percentEnd&quot;:25}}</code></p> <p>Datasource for training: <code>{&quot;splitting&quot;:{&quot;percentBegin&quot;:0, &quot;percentEnd&quot;:25, &quot;complement&quot;:&quot;true&quot;}}</code></p> </li> <li><p><b><code>strategy</code></b></p> <p>To change how Amazon ML splits the data for a datasource, use the <code>strategy</code> parameter.</p> <p>The default value for the <code>strategy</code> parameter is <code>sequential</code>, meaning that Amazon ML takes all of the data records between the <code>percentBegin</code> and <code>percentEnd</code> parameters for the datasource, in the order that the records appear in the input data.</p> <p>The following two <code>DataRearrangement</code> lines are examples of sequentially ordered training and evaluation datasources:</p> <p>Datasource for evaluation: <code>{&quot;splitting&quot;:{&quot;percentBegin&quot;:70, &quot;percentEnd&quot;:100, &quot;strategy&quot;:&quot;sequential&quot;}}</code></p> <p>Datasource for training: <code>{&quot;splitting&quot;:{&quot;percentBegin&quot;:70, &quot;percentEnd&quot;:100, &quot;strategy&quot;:&quot;sequential&quot;, &quot;complement&quot;:&quot;true&quot;}}</code></p> <p>To randomly split the input data into the proportions indicated by the percentBegin and percentEnd parameters, set the <code>strategy</code> parameter to <code>random</code> and provide a string that is used as the seed value for the random data splitting (for example, you can use the S3 path to your data as the random seed string). If you choose the random split strategy, Amazon ML assigns each row of data a pseudo-random number between 0 and 100, and then selects the rows that have an assigned number between <code>percentBegin</code> and <code>percentEnd</code>. Pseudo-random numbers are assigned using both the input seed string value and the byte offset as a seed, so changing the data results in a different split. Any existing ordering is preserved. The random splitting strategy ensures that variables in the training and evaluation data are distributed similarly. It is useful in the cases where the input data may have an implicit sort order, which would otherwise result in training and evaluation datasources containing non-similar data records.</p> <p>The following two <code>DataRearrangement</code> lines are examples of non-sequentially ordered training and evaluation datasources:</p> <p>Datasource for evaluation: <code>{&quot;splitting&quot;:{&quot;percentBegin&quot;:70, &quot;percentEnd&quot;:100, &quot;strategy&quot;:&quot;random&quot;, &quot;randomSeed&quot;=&quot;s3://my<em>s3</em>path/bucket/file.csv&quot;}}</code></p> <p>Datasource for training: <code>{&quot;splitting&quot;:{&quot;percentBegin&quot;:70, &quot;percentEnd&quot;:100, &quot;strategy&quot;:&quot;random&quot;, &quot;randomSeed&quot;=&quot;s3://my<em>s3</em>path/bucket/file.csv&quot;, &quot;complement&quot;:&quot;true&quot;}}</code></p> </li> </ul></p>
     #[serde(rename = "DataRearrangement")]
@@ -1434,7 +1434,7 @@ pub struct RedshiftDataSpec {
 }
 
 /// <p>Describes the database details required to connect to an Amazon Redshift database.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RedshiftDatabase {
     #[serde(rename = "ClusterIdentifier")]
     pub cluster_identifier: String,
@@ -1443,7 +1443,7 @@ pub struct RedshiftDatabase {
 }
 
 /// <p> Describes the database credentials for connecting to a database on an Amazon Redshift cluster.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RedshiftDatabaseCredentials {
     #[serde(rename = "Password")]
     pub password: String,
@@ -1452,7 +1452,7 @@ pub struct RedshiftDatabaseCredentials {
 }
 
 /// <p>Describes the <code>DataSource</code> details specific to Amazon Redshift.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RedshiftMetadata {
     #[serde(rename = "DatabaseUserName")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1467,7 +1467,7 @@ pub struct RedshiftMetadata {
 }
 
 /// <p> Describes the data specification of a <code>DataSource</code>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct S3DataSpec {
     /// <p>The location of the data file(s) used by a <code>DataSource</code>. The URI specifies a data file or an Amazon Simple Storage Service (Amazon S3) directory or bucket containing data files.</p>
     #[serde(rename = "DataLocationS3")]
@@ -1487,7 +1487,7 @@ pub struct S3DataSpec {
 }
 
 /// <p>A custom key-value pair associated with an ML object, such as an ML model.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Tag {
     /// <p>A unique identifier for the tag. Valid characters include Unicode letters, digits, white space, _, ., /, =, +, -, %, and @.</p>
     #[serde(rename = "Key")]
@@ -1499,7 +1499,7 @@ pub struct Tag {
     pub value: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateBatchPredictionInput {
     /// <p>The ID assigned to the <code>BatchPrediction</code> during creation.</p>
     #[serde(rename = "BatchPredictionId")]
@@ -1510,7 +1510,7 @@ pub struct UpdateBatchPredictionInput {
 }
 
 /// <p>Represents the output of an <code>UpdateBatchPrediction</code> operation.</p> <p>You can see the updated content by using the <code>GetBatchPrediction</code> operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateBatchPredictionOutput {
     /// <p>The ID assigned to the <code>BatchPrediction</code> during creation. This value should be identical to the value of the <code>BatchPredictionId</code> in the request.</p>
     #[serde(rename = "BatchPredictionId")]
@@ -1518,7 +1518,7 @@ pub struct UpdateBatchPredictionOutput {
     pub batch_prediction_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateDataSourceInput {
     /// <p>The ID assigned to the <code>DataSource</code> during creation.</p>
     #[serde(rename = "DataSourceId")]
@@ -1529,7 +1529,7 @@ pub struct UpdateDataSourceInput {
 }
 
 /// <p>Represents the output of an <code>UpdateDataSource</code> operation.</p> <p>You can see the updated content by using the <code>GetBatchPrediction</code> operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateDataSourceOutput {
     /// <p>The ID assigned to the <code>DataSource</code> during creation. This value should be identical to the value of the <code>DataSourceID</code> in the request.</p>
     #[serde(rename = "DataSourceId")]
@@ -1537,7 +1537,7 @@ pub struct UpdateDataSourceOutput {
     pub data_source_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateEvaluationInput {
     /// <p>The ID assigned to the <code>Evaluation</code> during creation.</p>
     #[serde(rename = "EvaluationId")]
@@ -1548,7 +1548,7 @@ pub struct UpdateEvaluationInput {
 }
 
 /// <p>Represents the output of an <code>UpdateEvaluation</code> operation.</p> <p>You can see the updated content by using the <code>GetEvaluation</code> operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateEvaluationOutput {
     /// <p>The ID assigned to the <code>Evaluation</code> during creation. This value should be identical to the value of the <code>Evaluation</code> in the request.</p>
     #[serde(rename = "EvaluationId")]
@@ -1556,7 +1556,7 @@ pub struct UpdateEvaluationOutput {
     pub evaluation_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateMLModelInput {
     /// <p>The ID assigned to the <code>MLModel</code> during creation.</p>
     #[serde(rename = "MLModelId")]
@@ -1572,7 +1572,7 @@ pub struct UpdateMLModelInput {
 }
 
 /// <p>Represents the output of an <code>UpdateMLModel</code> operation.</p> <p>You can see the updated content by using the <code>GetMLModel</code> operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateMLModelOutput {
     /// <p>The ID assigned to the <code>MLModel</code> during creation. This value should be identical to the value of the <code>MLModelID</code> in the request.</p>
     #[serde(rename = "MLModelId")]

--- a/rusoto/services/marketplace-entitlement/src/generated.rs
+++ b/rusoto/services/marketplace-entitlement/src/generated.rs
@@ -132,7 +132,8 @@ impl GetEntitlementsError {
     pub fn from_body(body: &str) -> GetEntitlementsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/marketplace-entitlement/src/generated.rs
+++ b/rusoto/services/marketplace-entitlement/src/generated.rs
@@ -31,7 +31,7 @@ use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 /// <p>An entitlement represents capacity in a product owned by the customer. For example, a customer might own some number of users or seats in an SaaS application or some amount of data capacity in a multi-tenant database.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Entitlement {
     /// <p>The customer identifier is a handle to each unique customer in an application. Customer identifiers are obtained through the ResolveCustomer operation in AWS Marketplace Metering Service.</p>
     #[serde(rename = "CustomerIdentifier")]
@@ -56,7 +56,7 @@ pub struct Entitlement {
 }
 
 /// <p>The EntitlementValue represents the amount of capacity that the customer is entitled to for the product.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct EntitlementValue {
     /// <p>The BooleanValue field will be populated with a boolean value when the entitlement is a boolean type. Otherwise, the field will not be set.</p>
     #[serde(rename = "BooleanValue")]
@@ -77,7 +77,7 @@ pub struct EntitlementValue {
 }
 
 /// <p>The GetEntitlementsRequest contains parameters for the GetEntitlements operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetEntitlementsRequest {
     /// <p>Filter is used to return entitlements for a specific customer or for a specific dimension. Filters are described as keys mapped to a lists of values. Filtered requests are <i>unioned</i> for each value in the value list, and then <i>intersected</i> for each filter key.</p>
     #[serde(rename = "Filter")]
@@ -97,7 +97,7 @@ pub struct GetEntitlementsRequest {
 }
 
 /// <p>The GetEntitlementsRequest contains results from the GetEntitlements operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetEntitlementsResult {
     /// <p>The set of entitlements found through the GetEntitlements operation. If the result contains an empty set of entitlements, NextToken might still be present and should be used.</p>
     #[serde(rename = "Entitlements")]

--- a/rusoto/services/marketplacecommerceanalytics/src/generated.rs
+++ b/rusoto/services/marketplacecommerceanalytics/src/generated.rs
@@ -123,7 +123,8 @@ impl GenerateDataSetError {
     pub fn from_body(body: &str) -> GenerateDataSetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -203,7 +204,8 @@ impl StartSupportDataExportError {
     pub fn from_body(body: &str) -> StartSupportDataExportError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/marketplacecommerceanalytics/src/generated.rs
+++ b/rusoto/services/marketplacecommerceanalytics/src/generated.rs
@@ -31,7 +31,7 @@ use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 /// <p>Container for the parameters to the GenerateDataSet operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GenerateDataSetRequest {
     /// <p>(Optional) Key-value pairs which will be returned, unmodified, in the Amazon SNS notification message and the data set metadata file. These key-value pairs can be used to correlated responses with tracking information from other systems.</p>
     #[serde(rename = "customerDefinedValues")]
@@ -59,7 +59,7 @@ pub struct GenerateDataSetRequest {
 }
 
 /// <p>Container for the result of the GenerateDataSet operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GenerateDataSetResult {
     /// <p>A unique identifier representing a specific request to the GenerateDataSet operation. This identifier can be used to correlate a request with notifications from the SNS topic.</p>
     #[serde(rename = "dataSetRequestId")]
@@ -68,7 +68,7 @@ pub struct GenerateDataSetResult {
 }
 
 /// <p>Container for the parameters to the StartSupportDataExport operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StartSupportDataExportRequest {
     /// <p>(Optional) Key-value pairs which will be returned, unmodified, in the Amazon SNS notification message and the data set metadata file.</p>
     #[serde(rename = "customerDefinedValues")]
@@ -96,7 +96,7 @@ pub struct StartSupportDataExportRequest {
 }
 
 /// <p>Container for the result of the StartSupportDataExport operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StartSupportDataExportResult {
     /// <p>A unique identifier representing a specific request to the StartSupportDataExport operation. This identifier can be used to correlate a request with notifications from the SNS topic.</p>
     #[serde(rename = "dataSetRequestId")]

--- a/rusoto/services/meteringmarketplace/src/generated.rs
+++ b/rusoto/services/meteringmarketplace/src/generated.rs
@@ -31,7 +31,7 @@ use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 /// <p>A BatchMeterUsageRequest contains UsageRecords, which indicate quantities of usage within your application.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct BatchMeterUsageRequest {
     /// <p>Product code is used to uniquely identify a product in AWS Marketplace. The product code should be the same as the one used during the publishing of a new product.</p>
     #[serde(rename = "ProductCode")]
@@ -42,7 +42,7 @@ pub struct BatchMeterUsageRequest {
 }
 
 /// <p>Contains the UsageRecords processed by BatchMeterUsage and any records that have failed due to transient error.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BatchMeterUsageResult {
     /// <p>Contains all UsageRecords processed by BatchMeterUsage. These records were either honored by AWS Marketplace Metering Service or were invalid.</p>
     #[serde(rename = "Results")]
@@ -54,7 +54,7 @@ pub struct BatchMeterUsageResult {
     pub unprocessed_records: Option<Vec<UsageRecord>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct MeterUsageRequest {
     /// <p>Checks whether you have the permissions required for the action, but does not make the request. If you have the permissions, the request returns DryRunOperation; otherwise, it returns UnauthorizedException.</p>
     #[serde(rename = "DryRun")]
@@ -73,7 +73,7 @@ pub struct MeterUsageRequest {
     pub usage_quantity: i64,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct MeterUsageResult {
     #[serde(rename = "MeteringRecordId")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -81,7 +81,7 @@ pub struct MeterUsageResult {
 }
 
 /// <p>Contains input to the ResolveCustomer operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ResolveCustomerRequest {
     /// <p>When a buyer visits your website during the registration process, the buyer submits a registration token through the browser. The registration token is resolved to obtain a CustomerIdentifier and product code.</p>
     #[serde(rename = "RegistrationToken")]
@@ -89,7 +89,7 @@ pub struct ResolveCustomerRequest {
 }
 
 /// <p>The result of the ResolveCustomer operation. Contains the CustomerIdentifier and product code.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ResolveCustomerResult {
     /// <p>The CustomerIdentifier is used to identify an individual customer in your application. Calls to BatchMeterUsage require CustomerIdentifiers for each UsageRecord.</p>
     #[serde(rename = "CustomerIdentifier")]
@@ -102,7 +102,7 @@ pub struct ResolveCustomerResult {
 }
 
 /// <p>A UsageRecord indicates a quantity of usage for a given product, customer, dimension and time.</p> <p>Multiple requests with the same UsageRecords as input will be deduplicated to prevent double charges.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct UsageRecord {
     /// <p>The CustomerIdentifier is obtained through the ResolveCustomer operation and represents an individual buyer in your application.</p>
     #[serde(rename = "CustomerIdentifier")]
@@ -119,7 +119,7 @@ pub struct UsageRecord {
 }
 
 /// <p>A UsageRecordResult indicates the status of a given UsageRecord processed by BatchMeterUsage.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UsageRecordResult {
     /// <p>The MeteringRecordId is a unique identifier for this metering event.</p>
     #[serde(rename = "MeteringRecordId")]

--- a/rusoto/services/meteringmarketplace/src/generated.rs
+++ b/rusoto/services/meteringmarketplace/src/generated.rs
@@ -164,7 +164,8 @@ impl BatchMeterUsageError {
     pub fn from_body(body: &str) -> BatchMeterUsageError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -274,7 +275,8 @@ impl MeterUsageError {
     pub fn from_body(body: &str) -> MeterUsageError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -380,7 +382,8 @@ impl ResolveCustomerError {
     pub fn from_body(body: &str) -> ResolveCustomerError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/mgh/src/generated.rs
+++ b/rusoto/services/mgh/src/generated.rs
@@ -512,7 +512,8 @@ impl AssociateCreatedArtifactError {
     pub fn from_body(body: &str) -> AssociateCreatedArtifactError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -634,7 +635,8 @@ impl AssociateDiscoveredResourceError {
     pub fn from_body(body: &str) -> AssociateDiscoveredResourceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -758,7 +760,8 @@ impl CreateProgressUpdateStreamError {
     pub fn from_body(body: &str) -> CreateProgressUpdateStreamError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -874,7 +877,8 @@ impl DeleteProgressUpdateStreamError {
     pub fn from_body(body: &str) -> DeleteProgressUpdateStreamError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -994,7 +998,8 @@ impl DescribeApplicationStateError {
     pub fn from_body(body: &str) -> DescribeApplicationStateError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1104,7 +1109,8 @@ impl DescribeMigrationTaskError {
     pub fn from_body(body: &str) -> DescribeMigrationTaskError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1212,7 +1218,8 @@ impl DisassociateCreatedArtifactError {
     pub fn from_body(body: &str) -> DisassociateCreatedArtifactError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1334,7 +1341,8 @@ impl DisassociateDiscoveredResourceError {
     pub fn from_body(body: &str) -> DisassociateDiscoveredResourceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1458,7 +1466,8 @@ impl ImportMigrationTaskError {
     pub fn from_body(body: &str) -> ImportMigrationTaskError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1570,7 +1579,8 @@ impl ListCreatedArtifactsError {
     pub fn from_body(body: &str) -> ListCreatedArtifactsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1674,7 +1684,8 @@ impl ListDiscoveredResourcesError {
     pub fn from_body(body: &str) -> ListDiscoveredResourcesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1782,7 +1793,8 @@ impl ListMigrationTasksError {
     pub fn from_body(body: &str) -> ListMigrationTasksError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1888,7 +1900,8 @@ impl ListProgressUpdateStreamsError {
     pub fn from_body(body: &str) -> ListProgressUpdateStreamsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1996,7 +2009,8 @@ impl NotifyApplicationStateError {
     pub fn from_body(body: &str) -> NotifyApplicationStateError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2116,7 +2130,8 @@ impl NotifyMigrationTaskStateError {
     pub fn from_body(body: &str) -> NotifyMigrationTaskStateError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2236,7 +2251,8 @@ impl PutResourceAttributesError {
     pub fn from_body(body: &str) -> PutResourceAttributesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/mgh/src/generated.rs
+++ b/rusoto/services/mgh/src/generated.rs
@@ -30,7 +30,7 @@ use rusoto_core::signature::SignedRequest;
 use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AssociateCreatedArtifactRequest {
     /// <p>An ARN of the AWS resource related to the migration (e.g., AMI, EC2 instance, RDS instance, etc.) </p>
     #[serde(rename = "CreatedArtifact")]
@@ -47,10 +47,10 @@ pub struct AssociateCreatedArtifactRequest {
     pub progress_update_stream: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AssociateCreatedArtifactResult {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AssociateDiscoveredResourceRequest {
     /// <p>Object representing a Resource.</p>
     #[serde(rename = "DiscoveredResource")]
@@ -67,10 +67,10 @@ pub struct AssociateDiscoveredResourceRequest {
     pub progress_update_stream: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AssociateDiscoveredResourceResult {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateProgressUpdateStreamRequest {
     /// <p>Optional boolean flag to indicate whether any effect should take place. Used to test if the caller has permission to make the call.</p>
     #[serde(rename = "DryRun")]
@@ -81,11 +81,11 @@ pub struct CreateProgressUpdateStreamRequest {
     pub progress_update_stream_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateProgressUpdateStreamResult {}
 
 /// <p>An ARN of the AWS cloud resource target receiving the migration (e.g., AMI, EC2 instance, RDS instance, etc.).</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CreatedArtifact {
     /// <p>A description that can be free-form text to record additional detail about the artifact for clarity or for later reference.</p>
     #[serde(rename = "Description")]
@@ -96,7 +96,7 @@ pub struct CreatedArtifact {
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteProgressUpdateStreamRequest {
     /// <p>Optional boolean flag to indicate whether any effect should take place. Used to test if the caller has permission to make the call.</p>
     #[serde(rename = "DryRun")]
@@ -107,17 +107,17 @@ pub struct DeleteProgressUpdateStreamRequest {
     pub progress_update_stream_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteProgressUpdateStreamResult {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeApplicationStateRequest {
     /// <p>The configurationId in ADS that uniquely identifies the grouped application.</p>
     #[serde(rename = "ApplicationId")]
     pub application_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeApplicationStateResult {
     /// <p>Status of the application - Not Started, In-Progress, Complete.</p>
     #[serde(rename = "ApplicationStatus")]
@@ -129,7 +129,7 @@ pub struct DescribeApplicationStateResult {
     pub last_updated_time: Option<f64>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeMigrationTaskRequest {
     /// <p>The identifier given to the MigrationTask.</p>
     #[serde(rename = "MigrationTaskName")]
@@ -139,7 +139,7 @@ pub struct DescribeMigrationTaskRequest {
     pub progress_update_stream: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeMigrationTaskResult {
     /// <p>Object encapsulating information about the migration task.</p>
     #[serde(rename = "MigrationTask")]
@@ -147,7 +147,7 @@ pub struct DescribeMigrationTaskResult {
     pub migration_task: Option<MigrationTask>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DisassociateCreatedArtifactRequest {
     /// <p>An ARN of the AWS resource related to the migration (e.g., AMI, EC2 instance, RDS instance, etc.)</p>
     #[serde(rename = "CreatedArtifactName")]
@@ -164,10 +164,10 @@ pub struct DisassociateCreatedArtifactRequest {
     pub progress_update_stream: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DisassociateCreatedArtifactResult {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DisassociateDiscoveredResourceRequest {
     /// <p>ConfigurationId of the ADS resource to be disassociated.</p>
     #[serde(rename = "ConfigurationId")]
@@ -184,11 +184,11 @@ pub struct DisassociateDiscoveredResourceRequest {
     pub progress_update_stream: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DisassociateDiscoveredResourceResult {}
 
 /// <p>Object representing the on-premises resource being migrated.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct DiscoveredResource {
     /// <p>The configurationId in ADS that uniquely identifies the on-premise resource.</p>
     #[serde(rename = "ConfigurationId")]
@@ -199,7 +199,7 @@ pub struct DiscoveredResource {
     pub description: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ImportMigrationTaskRequest {
     /// <p>Optional boolean flag to indicate whether any effect should take place. Used to test if the caller has permission to make the call.</p>
     #[serde(rename = "DryRun")]
@@ -213,10 +213,10 @@ pub struct ImportMigrationTaskRequest {
     pub progress_update_stream: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ImportMigrationTaskResult {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListCreatedArtifactsRequest {
     /// <p>Maximum number of results to be returned per page.</p>
     #[serde(rename = "MaxResults")]
@@ -234,7 +234,7 @@ pub struct ListCreatedArtifactsRequest {
     pub progress_update_stream: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListCreatedArtifactsResult {
     /// <p>List of created artifacts up to the maximum number of results specified in the request.</p>
     #[serde(rename = "CreatedArtifactList")]
@@ -246,7 +246,7 @@ pub struct ListCreatedArtifactsResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListDiscoveredResourcesRequest {
     /// <p>The maximum number of results returned per page.</p>
     #[serde(rename = "MaxResults")]
@@ -264,7 +264,7 @@ pub struct ListDiscoveredResourcesRequest {
     pub progress_update_stream: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListDiscoveredResourcesResult {
     /// <p>Returned list of discovered resources associated with the given MigrationTask.</p>
     #[serde(rename = "DiscoveredResourceList")]
@@ -276,7 +276,7 @@ pub struct ListDiscoveredResourcesResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListMigrationTasksRequest {
     /// <p>Value to specify how many results are returned per page.</p>
     #[serde(rename = "MaxResults")]
@@ -292,7 +292,7 @@ pub struct ListMigrationTasksRequest {
     pub resource_name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListMigrationTasksResult {
     /// <p>Lists the migration task's summary which includes: <code>MigrationTaskName</code>, <code>ProgressPercent</code>, <code>ProgressUpdateStream</code>, <code>Status</code>, and the <code>UpdateDateTime</code> for each task.</p>
     #[serde(rename = "MigrationTaskSummaryList")]
@@ -304,7 +304,7 @@ pub struct ListMigrationTasksResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListProgressUpdateStreamsRequest {
     /// <p>Filter to limit the maximum number of results to list per page.</p>
     #[serde(rename = "MaxResults")]
@@ -316,7 +316,7 @@ pub struct ListProgressUpdateStreamsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListProgressUpdateStreamsResult {
     /// <p>If there are more streams created than the max result, return the next token to be passed to the next call as a bookmark of where to start from.</p>
     #[serde(rename = "NextToken")]
@@ -329,7 +329,7 @@ pub struct ListProgressUpdateStreamsResult {
 }
 
 /// <p>Represents a migration task in a migration tool.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct MigrationTask {
     /// <p>Unique identifier that references the migration task.</p>
     #[serde(rename = "MigrationTaskName")]
@@ -354,7 +354,7 @@ pub struct MigrationTask {
 }
 
 /// <p>MigrationTaskSummary includes <code>MigrationTaskName</code>, <code>ProgressPercent</code>, <code>ProgressUpdateStream</code>, <code>Status</code>, and <code>UpdateDateTime</code> for each task.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct MigrationTaskSummary {
     /// <p>Unique identifier that references the migration task.</p>
     #[serde(rename = "MigrationTaskName")]
@@ -382,7 +382,7 @@ pub struct MigrationTaskSummary {
     pub update_date_time: Option<f64>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct NotifyApplicationStateRequest {
     /// <p>The configurationId in ADS that uniquely identifies the grouped application.</p>
     #[serde(rename = "ApplicationId")]
@@ -396,10 +396,10 @@ pub struct NotifyApplicationStateRequest {
     pub status: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct NotifyApplicationStateResult {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct NotifyMigrationTaskStateRequest {
     /// <p>Optional boolean flag to indicate whether any effect should take place. Used to test if the caller has permission to make the call.</p>
     #[serde(rename = "DryRun")]
@@ -422,11 +422,11 @@ pub struct NotifyMigrationTaskStateRequest {
     pub update_date_time: f64,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct NotifyMigrationTaskStateResult {}
 
 /// <p>Summary of the AWS resource used for access control that is implicitly linked to your AWS account.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ProgressUpdateStreamSummary {
     /// <p>The name of the ProgressUpdateStream. </p>
     #[serde(rename = "ProgressUpdateStreamName")]
@@ -434,7 +434,7 @@ pub struct ProgressUpdateStreamSummary {
     pub progress_update_stream_name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PutResourceAttributesRequest {
     /// <p>Optional boolean flag to indicate whether any effect should take place. Used to test if the caller has permission to make the call.</p>
     #[serde(rename = "DryRun")]
@@ -451,11 +451,11 @@ pub struct PutResourceAttributesRequest {
     pub resource_attribute_list: Vec<ResourceAttribute>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PutResourceAttributesResult {}
 
 /// <p><p>Attribute associated with a resource.</p> <p>Note the corresponding format required per type listed below:</p> <dl> <dt>IPV4</dt> <dd> <p> <code>x.x.x.x</code> </p> <p> <i>where x is an integer in the range [0,255]</i> </p> </dd> <dt>IPV6</dt> <dd> <p> <code>y : y : y : y : y : y : y : y</code> </p> <p> <i>where y is a hexadecimal between 0 and FFFF. [0, FFFF]</i> </p> </dd> <dt>MAC_ADDRESS</dt> <dd> <p> <code>^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$</code> </p> </dd> <dt>FQDN</dt> <dd> <p> <code>^[^&lt;&gt;{}\\/?,=\p{Cntrl}]{1,256}$</code> </p> </dd> </dl></p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ResourceAttribute {
     /// <p>Type of resource.</p>
     #[serde(rename = "Type")]
@@ -466,7 +466,7 @@ pub struct ResourceAttribute {
 }
 
 /// <p>Task object encapsulating task information.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Task {
     /// <p>Indication of the percentage completion of the task.</p>
     #[serde(rename = "ProgressPercent")]

--- a/rusoto/services/mturk/src/generated.rs
+++ b/rusoto/services/mturk/src/generated.rs
@@ -1510,7 +1510,8 @@ impl AcceptQualificationRequestError {
     pub fn from_body(body: &str) -> AcceptQualificationRequestError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1596,7 +1597,8 @@ impl ApproveAssignmentError {
     pub fn from_body(body: &str) -> ApproveAssignmentError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1682,7 +1684,8 @@ impl AssociateQualificationWithWorkerError {
     pub fn from_body(body: &str) -> AssociateQualificationWithWorkerError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1768,7 +1771,8 @@ impl CreateAdditionalAssignmentsForHITError {
     pub fn from_body(body: &str) -> CreateAdditionalAssignmentsForHITError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1854,7 +1858,8 @@ impl CreateHITError {
     pub fn from_body(body: &str) -> CreateHITError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1932,7 +1937,8 @@ impl CreateHITTypeError {
     pub fn from_body(body: &str) -> CreateHITTypeError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2012,7 +2018,8 @@ impl CreateHITWithHITTypeError {
     pub fn from_body(body: &str) -> CreateHITWithHITTypeError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2098,7 +2105,8 @@ impl CreateQualificationTypeError {
     pub fn from_body(body: &str) -> CreateQualificationTypeError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2184,7 +2192,8 @@ impl CreateWorkerBlockError {
     pub fn from_body(body: &str) -> CreateWorkerBlockError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2270,7 +2279,8 @@ impl DeleteHITError {
     pub fn from_body(body: &str) -> DeleteHITError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2348,7 +2358,8 @@ impl DeleteQualificationTypeError {
     pub fn from_body(body: &str) -> DeleteQualificationTypeError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2434,7 +2445,8 @@ impl DeleteWorkerBlockError {
     pub fn from_body(body: &str) -> DeleteWorkerBlockError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2520,7 +2532,8 @@ impl DisassociateQualificationFromWorkerError {
     pub fn from_body(body: &str) -> DisassociateQualificationFromWorkerError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2606,7 +2619,8 @@ impl GetAccountBalanceError {
     pub fn from_body(body: &str) -> GetAccountBalanceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2692,7 +2706,8 @@ impl GetAssignmentError {
     pub fn from_body(body: &str) -> GetAssignmentError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2772,7 +2787,8 @@ impl GetFileUploadURLError {
     pub fn from_body(body: &str) -> GetFileUploadURLError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2856,7 +2872,8 @@ impl GetHITError {
     pub fn from_body(body: &str) -> GetHITError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2934,7 +2951,8 @@ impl GetQualificationScoreError {
     pub fn from_body(body: &str) -> GetQualificationScoreError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3020,7 +3038,8 @@ impl GetQualificationTypeError {
     pub fn from_body(body: &str) -> GetQualificationTypeError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3106,7 +3125,8 @@ impl ListAssignmentsForHITError {
     pub fn from_body(body: &str) -> ListAssignmentsForHITError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3192,7 +3212,8 @@ impl ListBonusPaymentsError {
     pub fn from_body(body: &str) -> ListBonusPaymentsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3278,7 +3299,8 @@ impl ListHITsError {
     pub fn from_body(body: &str) -> ListHITsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3356,7 +3378,8 @@ impl ListHITsForQualificationTypeError {
     pub fn from_body(body: &str) -> ListHITsForQualificationTypeError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3442,7 +3465,8 @@ impl ListQualificationRequestsError {
     pub fn from_body(body: &str) -> ListQualificationRequestsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3528,7 +3552,8 @@ impl ListQualificationTypesError {
     pub fn from_body(body: &str) -> ListQualificationTypesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3614,7 +3639,8 @@ impl ListReviewPolicyResultsForHITError {
     pub fn from_body(body: &str) -> ListReviewPolicyResultsForHITError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3700,7 +3726,8 @@ impl ListReviewableHITsError {
     pub fn from_body(body: &str) -> ListReviewableHITsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3786,7 +3813,8 @@ impl ListWorkerBlocksError {
     pub fn from_body(body: &str) -> ListWorkerBlocksError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3870,7 +3898,8 @@ impl ListWorkersWithQualificationTypeError {
     pub fn from_body(body: &str) -> ListWorkersWithQualificationTypeError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3956,7 +3985,8 @@ impl NotifyWorkersError {
     pub fn from_body(body: &str) -> NotifyWorkersError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4036,7 +4066,8 @@ impl RejectAssignmentError {
     pub fn from_body(body: &str) -> RejectAssignmentError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4120,7 +4151,8 @@ impl RejectQualificationRequestError {
     pub fn from_body(body: &str) -> RejectQualificationRequestError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4206,7 +4238,8 @@ impl SendBonusError {
     pub fn from_body(body: &str) -> SendBonusError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4284,7 +4317,8 @@ impl SendTestEventNotificationError {
     pub fn from_body(body: &str) -> SendTestEventNotificationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4370,7 +4404,8 @@ impl UpdateExpirationForHITError {
     pub fn from_body(body: &str) -> UpdateExpirationForHITError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4456,7 +4491,8 @@ impl UpdateHITReviewStatusError {
     pub fn from_body(body: &str) -> UpdateHITReviewStatusError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4542,7 +4578,8 @@ impl UpdateHITTypeOfHITError {
     pub fn from_body(body: &str) -> UpdateHITTypeOfHITError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4628,7 +4665,8 @@ impl UpdateNotificationSettingsError {
     pub fn from_body(body: &str) -> UpdateNotificationSettingsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4714,7 +4752,8 @@ impl UpdateQualificationTypeError {
     pub fn from_body(body: &str) -> UpdateQualificationTypeError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/mturk/src/generated.rs
+++ b/rusoto/services/mturk/src/generated.rs
@@ -30,7 +30,7 @@ use rusoto_core::signature::SignedRequest;
 use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AcceptQualificationRequestRequest {
     /// <p> The value of the Qualification. You can omit this value if you are using the presence or absence of the Qualification as the basis for a HIT requirement. </p>
     #[serde(rename = "IntegerValue")]
@@ -41,10 +41,10 @@ pub struct AcceptQualificationRequestRequest {
     pub qualification_request_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AcceptQualificationRequestResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ApproveAssignmentRequest {
     /// <p> The ID of the assignment. The assignment must correspond to a HIT created by the Requester. </p>
     #[serde(rename = "AssignmentId")]
@@ -59,11 +59,11 @@ pub struct ApproveAssignmentRequest {
     pub requester_feedback: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ApproveAssignmentResponse {}
 
 /// <p> The Assignment data structure represents a single assignment of a HIT to a Worker. The assignment tracks the Worker's efforts to complete the HIT, and contains the results for later retrieval. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Assignment {
     /// <p> The date and time the Worker accepted the assignment.</p>
     #[serde(rename = "AcceptTime")]
@@ -115,7 +115,7 @@ pub struct Assignment {
     pub worker_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AssociateQualificationWithWorkerRequest {
     /// <p>The value of the Qualification to assign.</p>
     #[serde(rename = "IntegerValue")]
@@ -133,11 +133,11 @@ pub struct AssociateQualificationWithWorkerRequest {
     pub worker_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AssociateQualificationWithWorkerResponse {}
 
 /// <p>An object representing a Bonus payment paid to a Worker.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BonusPayment {
     /// <p>The ID of the assignment associated with this bonus payment.</p>
     #[serde(rename = "AssignmentId")]
@@ -160,7 +160,7 @@ pub struct BonusPayment {
     pub worker_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateAdditionalAssignmentsForHITRequest {
     /// <p>The ID of the HIT to extend.</p>
     #[serde(rename = "HITId")]
@@ -174,10 +174,10 @@ pub struct CreateAdditionalAssignmentsForHITRequest {
     pub unique_request_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateAdditionalAssignmentsForHITResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateHITRequest {
     /// <p> The amount of time, in seconds, that a Worker has to complete the HIT after accepting it. If a Worker does not complete the assignment within the specified duration, the assignment is considered abandoned. If the HIT is still active (that is, its lifetime has not elapsed), the assignment becomes available for other users to find and accept. </p>
     #[serde(rename = "AssignmentDurationInSeconds")]
@@ -240,7 +240,7 @@ pub struct CreateHITRequest {
     pub unique_request_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateHITResponse {
     /// <p> Contains the newly created HIT data. For a description of the HIT data structure as it appears in responses, see the HIT Data Structure documentation. </p>
     #[serde(rename = "HIT")]
@@ -248,7 +248,7 @@ pub struct CreateHITResponse {
     pub hit: Option<HIT>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateHITTypeRequest {
     /// <p> The amount of time, in seconds, that a Worker has to complete the HIT after accepting it. If a Worker does not complete the assignment within the specified duration, the assignment is considered abandoned. If the HIT is still active (that is, its lifetime has not elapsed), the assignment becomes available for other users to find and accept. </p>
     #[serde(rename = "AssignmentDurationInSeconds")]
@@ -276,7 +276,7 @@ pub struct CreateHITTypeRequest {
     pub title: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateHITTypeResponse {
     /// <p> The ID of the newly registered HIT type.</p>
     #[serde(rename = "HITTypeId")]
@@ -284,7 +284,7 @@ pub struct CreateHITTypeResponse {
     pub hit_type_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateHITWithHITTypeRequest {
     /// <p> The Assignment-level Review Policy applies to the assignments under the HIT. You can specify for Mechanical Turk to take various actions based on the policy. </p>
     #[serde(rename = "AssignmentReviewPolicy")]
@@ -326,7 +326,7 @@ pub struct CreateHITWithHITTypeRequest {
     pub unique_request_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateHITWithHITTypeResponse {
     /// <p> Contains the newly created HIT data. For a description of the HIT data structure as it appears in responses, see the HIT Data Structure documentation. </p>
     #[serde(rename = "HIT")]
@@ -334,7 +334,7 @@ pub struct CreateHITWithHITTypeResponse {
     pub hit: Option<HIT>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateQualificationTypeRequest {
     /// <p>The answers to the Qualification test specified in the Test parameter, in the form of an AnswerKey data structure.</p> <p>Constraints: Must not be longer than 65535 bytes.</p> <p>Constraints: None. If not specified, you must process Qualification requests manually.</p>
     #[serde(rename = "AnswerKey")]
@@ -375,7 +375,7 @@ pub struct CreateQualificationTypeRequest {
     pub test_duration_in_seconds: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateQualificationTypeResponse {
     /// <p>The created Qualification type, returned as a QualificationType data structure.</p>
     #[serde(rename = "QualificationType")]
@@ -383,7 +383,7 @@ pub struct CreateQualificationTypeResponse {
     pub qualification_type: Option<QualificationType>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateWorkerBlockRequest {
     /// <p>A message explaining the reason for blocking the Worker. This parameter enables you to keep track of your Workers. The Worker does not see this message.</p>
     #[serde(rename = "Reason")]
@@ -393,30 +393,30 @@ pub struct CreateWorkerBlockRequest {
     pub worker_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateWorkerBlockResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteHITRequest {
     /// <p>The ID of the HIT to be deleted.</p>
     #[serde(rename = "HITId")]
     pub hit_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteHITResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteQualificationTypeRequest {
     /// <p>The ID of the QualificationType to dispose.</p>
     #[serde(rename = "QualificationTypeId")]
     pub qualification_type_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteQualificationTypeResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteWorkerBlockRequest {
     /// <p>A message that explains the reason for unblocking the Worker. The Worker does not see this message.</p>
     #[serde(rename = "Reason")]
@@ -427,10 +427,10 @@ pub struct DeleteWorkerBlockRequest {
     pub worker_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteWorkerBlockResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DisassociateQualificationFromWorkerRequest {
     /// <p>The ID of the Qualification type of the Qualification to be revoked.</p>
     #[serde(rename = "QualificationTypeId")]
@@ -444,13 +444,13 @@ pub struct DisassociateQualificationFromWorkerRequest {
     pub worker_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DisassociateQualificationFromWorkerResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetAccountBalanceRequest {}
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetAccountBalanceResponse {
     #[serde(rename = "AvailableBalance")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -460,14 +460,14 @@ pub struct GetAccountBalanceResponse {
     pub on_hold_balance: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetAssignmentRequest {
     /// <p>The ID of the Assignment to be retrieved.</p>
     #[serde(rename = "AssignmentId")]
     pub assignment_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetAssignmentResponse {
     /// <p> The assignment. The response includes one Assignment element. </p>
     #[serde(rename = "Assignment")]
@@ -479,7 +479,7 @@ pub struct GetAssignmentResponse {
     pub hit: Option<HIT>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetFileUploadURLRequest {
     /// <p>The ID of the assignment that contains the question with a FileUploadAnswer.</p>
     #[serde(rename = "AssignmentId")]
@@ -489,7 +489,7 @@ pub struct GetFileUploadURLRequest {
     pub question_identifier: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetFileUploadURLResponse {
     /// <p> A temporary URL for the file that the Worker uploaded for the answer. </p>
     #[serde(rename = "FileUploadURL")]
@@ -497,14 +497,14 @@ pub struct GetFileUploadURLResponse {
     pub file_upload_url: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetHITRequest {
     /// <p>The ID of the HIT to be retrieved.</p>
     #[serde(rename = "HITId")]
     pub hit_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetHITResponse {
     /// <p> Contains the requested HIT data.</p>
     #[serde(rename = "HIT")]
@@ -512,7 +512,7 @@ pub struct GetHITResponse {
     pub hit: Option<HIT>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetQualificationScoreRequest {
     /// <p>The ID of the QualificationType.</p>
     #[serde(rename = "QualificationTypeId")]
@@ -522,7 +522,7 @@ pub struct GetQualificationScoreRequest {
     pub worker_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetQualificationScoreResponse {
     /// <p> The Qualification data structure of the Qualification assigned to a user, including the Qualification type and the value (score). </p>
     #[serde(rename = "Qualification")]
@@ -530,14 +530,14 @@ pub struct GetQualificationScoreResponse {
     pub qualification: Option<Qualification>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetQualificationTypeRequest {
     /// <p>The ID of the QualificationType.</p>
     #[serde(rename = "QualificationTypeId")]
     pub qualification_type_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetQualificationTypeResponse {
     /// <p> The returned Qualification Type</p>
     #[serde(rename = "QualificationType")]
@@ -546,7 +546,7 @@ pub struct GetQualificationTypeResponse {
 }
 
 /// <p> The HIT data structure represents a single HIT, including all the information necessary for a Worker to accept and complete the HIT.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct HIT {
     /// <p> The length of time, in seconds, that a Worker has to complete the HIT after accepting it.</p>
     #[serde(rename = "AssignmentDurationInSeconds")]
@@ -634,7 +634,7 @@ pub struct HIT {
 }
 
 /// <p> The HITLayoutParameter data structure defines parameter values used with a HITLayout. A HITLayout is a reusable Amazon Mechanical Turk project template used to provide Human Intelligence Task (HIT) question data for CreateHIT. </p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct HITLayoutParameter {
     /// <p> The name of the parameter in the HITLayout. </p>
     #[serde(rename = "Name")]
@@ -644,7 +644,7 @@ pub struct HITLayoutParameter {
     pub value: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListAssignmentsForHITRequest {
     /// <p>The status of the assignments to return: Submitted | Approved | Rejected</p>
     #[serde(rename = "AssignmentStatuses")]
@@ -662,7 +662,7 @@ pub struct ListAssignmentsForHITRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListAssignmentsForHITResponse {
     /// <p> The collection of Assignment data structures returned by this call.</p>
     #[serde(rename = "Assignments")]
@@ -677,7 +677,7 @@ pub struct ListAssignmentsForHITResponse {
     pub num_results: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListBonusPaymentsRequest {
     /// <p>The ID of the assignment associated with the bonus payments to retrieve. If specified, only bonus payments for the given assignment are returned. Either the HITId parameter or the AssignmentId parameter must be specified</p>
     #[serde(rename = "AssignmentId")]
@@ -696,7 +696,7 @@ pub struct ListBonusPaymentsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListBonusPaymentsResponse {
     /// <p>A successful request to the ListBonusPayments operation returns a list of BonusPayment objects. </p>
     #[serde(rename = "BonusPayments")]
@@ -711,7 +711,7 @@ pub struct ListBonusPaymentsResponse {
     pub num_results: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListHITsForQualificationTypeRequest {
     /// <p> Limit the number of results returned. </p>
     #[serde(rename = "MaxResults")]
@@ -726,7 +726,7 @@ pub struct ListHITsForQualificationTypeRequest {
     pub qualification_type_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListHITsForQualificationTypeResponse {
     /// <p> The list of HIT elements returned by the query.</p>
     #[serde(rename = "HITs")]
@@ -741,7 +741,7 @@ pub struct ListHITsForQualificationTypeResponse {
     pub num_results: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListHITsRequest {
     #[serde(rename = "MaxResults")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -752,7 +752,7 @@ pub struct ListHITsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListHITsResponse {
     /// <p> The list of HIT elements returned by the query.</p>
     #[serde(rename = "HITs")]
@@ -767,7 +767,7 @@ pub struct ListHITsResponse {
     pub num_results: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListQualificationRequestsRequest {
     /// <p> The maximum number of results to return in a single call. </p>
     #[serde(rename = "MaxResults")]
@@ -782,7 +782,7 @@ pub struct ListQualificationRequestsRequest {
     pub qualification_type_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListQualificationRequestsResponse {
     #[serde(rename = "NextToken")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -797,7 +797,7 @@ pub struct ListQualificationRequestsResponse {
     pub qualification_requests: Option<Vec<QualificationRequest>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListQualificationTypesRequest {
     /// <p> The maximum number of results to return in a single call. </p>
     #[serde(rename = "MaxResults")]
@@ -819,7 +819,7 @@ pub struct ListQualificationTypesRequest {
     pub query: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListQualificationTypesResponse {
     #[serde(rename = "NextToken")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -834,7 +834,7 @@ pub struct ListQualificationTypesResponse {
     pub qualification_types: Option<Vec<QualificationType>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListReviewPolicyResultsForHITRequest {
     /// <p>The unique identifier of the HIT to retrieve review results for.</p>
     #[serde(rename = "HITId")]
@@ -861,7 +861,7 @@ pub struct ListReviewPolicyResultsForHITRequest {
     pub retrieve_results: Option<bool>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListReviewPolicyResultsForHITResponse {
     /// <p> The name of the Assignment-level Review Policy. This contains only the PolicyName element. </p>
     #[serde(rename = "AssignmentReviewPolicy")]
@@ -888,7 +888,7 @@ pub struct ListReviewPolicyResultsForHITResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListReviewableHITsRequest {
     /// <p> The ID of the HIT type of the HITs to consider for the query. If not specified, all HITs for the Reviewer are considered </p>
     #[serde(rename = "HITTypeId")]
@@ -908,7 +908,7 @@ pub struct ListReviewableHITsRequest {
     pub status: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListReviewableHITsResponse {
     /// <p> The list of HIT elements returned by the query.</p>
     #[serde(rename = "HITs")]
@@ -923,7 +923,7 @@ pub struct ListReviewableHITsResponse {
     pub num_results: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListWorkerBlocksRequest {
     #[serde(rename = "MaxResults")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -934,7 +934,7 @@ pub struct ListWorkerBlocksRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListWorkerBlocksResponse {
     #[serde(rename = "NextToken")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -949,7 +949,7 @@ pub struct ListWorkerBlocksResponse {
     pub worker_blocks: Option<Vec<WorkerBlock>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListWorkersWithQualificationTypeRequest {
     /// <p> Limit the number of results returned. </p>
     #[serde(rename = "MaxResults")]
@@ -968,7 +968,7 @@ pub struct ListWorkersWithQualificationTypeRequest {
     pub status: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListWorkersWithQualificationTypeResponse {
     #[serde(rename = "NextToken")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -984,7 +984,7 @@ pub struct ListWorkersWithQualificationTypeResponse {
 }
 
 /// <p>The Locale data structure represents a geographical region or location.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Locale {
     /// <p> The country of the locale. Must be a valid ISO 3166 country code. For example, the code US refers to the United States of America. </p>
     #[serde(rename = "Country")]
@@ -996,7 +996,7 @@ pub struct Locale {
 }
 
 /// <p>The NotificationSpecification data structure describes a HIT event notification for a HIT type.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct NotificationSpecification {
     /// <p><p> The target for notification messages. The Destination’s format is determined by the specified Transport: </p> <ul> <li> <p>When Transport is Email, the Destination is your email address.</p> </li> <li> <p>When Transport is SQS, the Destination is your queue URL.</p> </li> <li> <p>When Transport is SNS, the Destination is the ARN of your topic.</p> </li> </ul></p>
     #[serde(rename = "Destination")]
@@ -1013,7 +1013,7 @@ pub struct NotificationSpecification {
 }
 
 /// <p> When MTurk encounters an issue with notifying the Workers you specified, it returns back this object with failure details. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct NotifyWorkersFailureStatus {
     /// <p> Encoded value for the failure type. </p>
     #[serde(rename = "NotifyWorkersFailureCode")]
@@ -1029,7 +1029,7 @@ pub struct NotifyWorkersFailureStatus {
     pub worker_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct NotifyWorkersRequest {
     /// <p>The text of the email message to send. Can include up to 4,096 characters</p>
     #[serde(rename = "MessageText")]
@@ -1042,7 +1042,7 @@ pub struct NotifyWorkersRequest {
     pub worker_ids: Vec<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct NotifyWorkersResponse {
     /// <p> When MTurk sends notifications to the list of Workers, it returns back any failures it encounters in this list of NotifyWorkersFailureStatus objects. </p>
     #[serde(rename = "NotifyWorkersFailureStatuses")]
@@ -1051,7 +1051,7 @@ pub struct NotifyWorkersResponse {
 }
 
 /// <p> This data structure is the data type for the AnswerKey parameter of the ScoreMyKnownAnswers/2011-09-01 Review Policy. </p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ParameterMapEntry {
     /// <p> The QuestionID from the HIT that is used to identify which question requires Mechanical Turk to score as part of the ScoreMyKnownAnswers/2011-09-01 Review Policy. </p>
     #[serde(rename = "Key")]
@@ -1064,7 +1064,7 @@ pub struct ParameterMapEntry {
 }
 
 /// <p> Name of the parameter from the Review policy. </p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct PolicyParameter {
     /// <p> Name of the parameter from the list of Review Polices. </p>
     #[serde(rename = "Key")]
@@ -1081,7 +1081,7 @@ pub struct PolicyParameter {
 }
 
 /// <p>The Qualification data structure represents a Qualification assigned to a user, including the Qualification type and the value (score).</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Qualification {
     /// <p> The date and time the Qualification was granted to the Worker. If the Worker's Qualification was revoked, and then re-granted based on a new Qualification request, GrantTime is the date and time of the last call to the AcceptQualificationRequest operation.</p>
     #[serde(rename = "GrantTime")]
@@ -1109,7 +1109,7 @@ pub struct Qualification {
 }
 
 /// <p> The QualificationRequest data structure represents a request a Worker has made for a Qualification. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct QualificationRequest {
     /// <p> The Worker's answers for the Qualification type's test contained in a QuestionFormAnswers document, if the type has a test and the Worker has submitted answers. If the Worker does not provide any answers, Answer may be empty. </p>
     #[serde(rename = "Answer")]
@@ -1138,7 +1138,7 @@ pub struct QualificationRequest {
 }
 
 /// <p> The QualificationRequirement data structure describes a Qualification that a Worker must have before the Worker is allowed to accept a HIT. A requirement may optionally state that a Worker must have the Qualification in order to preview the HIT, or see the HIT in search results. </p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct QualificationRequirement {
     /// <p> Setting this attribute prevents Workers whose Qualifications do not meet this QualificationRequirement from taking the specified action. Valid arguments include "Accept" (Worker cannot accept the HIT, but can preview the HIT and see it in their search results), "PreviewAndAccept" (Worker cannot accept or preview the HIT, but can see the HIT in their search results), and "DiscoverPreviewAndAccept" (Worker cannot accept, preview, or see the HIT in their search results). It's possible for you to create a HIT with multiple QualificationRequirements (which can have different values for the ActionGuarded attribute). In this case, the Worker is only permitted to perform an action when they have met all QualificationRequirements guarding the action. The actions in the order of least restrictive to most restrictive are Discover, Preview and Accept. For example, if a Worker meets all QualificationRequirements that are set to DiscoverPreviewAndAccept, but do not meet all requirements that are set with PreviewAndAccept, then the Worker will be able to Discover, i.e. see the HIT in their search result, but will not be able to Preview or Accept the HIT. ActionsGuarded should not be used in combination with the <code>RequiredToPreview</code> field. </p>
     #[serde(rename = "ActionsGuarded")]
@@ -1161,7 +1161,7 @@ pub struct QualificationRequirement {
 }
 
 /// <p> The QualificationType data structure represents a Qualification type, a description of a property of a Worker that must match the requirements of a HIT for the Worker to be able to accept the HIT. The type also describes how a Worker can obtain a Qualification of that type, such as through a Qualification test. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct QualificationType {
     /// <p>The answers to the Qualification test specified in the Test parameter.</p>
     #[serde(rename = "AnswerKey")]
@@ -1217,7 +1217,7 @@ pub struct QualificationType {
     pub test_duration_in_seconds: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RejectAssignmentRequest {
     /// <p> The ID of the assignment. The assignment must correspond to a HIT created by the Requester. </p>
     #[serde(rename = "AssignmentId")]
@@ -1227,10 +1227,10 @@ pub struct RejectAssignmentRequest {
     pub requester_feedback: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RejectAssignmentResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RejectQualificationRequestRequest {
     /// <p> The ID of the Qualification request, as returned by the <code>ListQualificationRequests</code> operation. </p>
     #[serde(rename = "QualificationRequestId")]
@@ -1241,11 +1241,11 @@ pub struct RejectQualificationRequestRequest {
     pub reason: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RejectQualificationRequestResponse {}
 
 /// <p> Both the AssignmentReviewReport and the HITReviewReport elements contains the ReviewActionDetail data structure. This structure is returned multiple times for each action specified in the Review Policy. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ReviewActionDetail {
     /// <p>The unique identifier for the action.</p>
     #[serde(rename = "ActionId")]
@@ -1282,7 +1282,7 @@ pub struct ReviewActionDetail {
 }
 
 /// <p> HIT Review Policy data structures represent HIT review policies, which you specify when you create a HIT. </p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ReviewPolicy {
     /// <p>Name of the parameter from the Review policy.</p>
     #[serde(rename = "Parameters")]
@@ -1294,7 +1294,7 @@ pub struct ReviewPolicy {
 }
 
 /// <p> Contains both ReviewResult and ReviewAction elements for a particular HIT. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ReviewReport {
     /// <p> A list of ReviewAction objects for each action specified in the Review Policy. </p>
     #[serde(rename = "ReviewActions")]
@@ -1307,7 +1307,7 @@ pub struct ReviewReport {
 }
 
 /// <p> This data structure is returned multiple times for each result specified in the Review Policy. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ReviewResultDetail {
     /// <p> A unique identifier of the Review action result. </p>
     #[serde(rename = "ActionId")]
@@ -1335,7 +1335,7 @@ pub struct ReviewResultDetail {
     pub value: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SendBonusRequest {
     /// <p>The ID of the assignment for which this bonus is paid.</p>
     #[serde(rename = "AssignmentId")]
@@ -1355,10 +1355,10 @@ pub struct SendBonusRequest {
     pub worker_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SendBonusResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SendTestEventNotificationRequest {
     /// <p> The notification specification to test. This value is identical to the value you would provide to the UpdateNotificationSettings operation when you establish the notification specification for a HIT type. </p>
     #[serde(rename = "Notification")]
@@ -1368,10 +1368,10 @@ pub struct SendTestEventNotificationRequest {
     pub test_event_type: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SendTestEventNotificationResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateExpirationForHITRequest {
     /// <p> The date and time at which you want the HIT to expire </p>
     #[serde(rename = "ExpireAt")]
@@ -1381,10 +1381,10 @@ pub struct UpdateExpirationForHITRequest {
     pub hit_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateExpirationForHITResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateHITReviewStatusRequest {
     /// <p> The ID of the HIT to update. </p>
     #[serde(rename = "HITId")]
@@ -1395,10 +1395,10 @@ pub struct UpdateHITReviewStatusRequest {
     pub revert: Option<bool>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateHITReviewStatusResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateHITTypeOfHITRequest {
     /// <p>The HIT to update.</p>
     #[serde(rename = "HITId")]
@@ -1408,10 +1408,10 @@ pub struct UpdateHITTypeOfHITRequest {
     pub hit_type_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateHITTypeOfHITResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateNotificationSettingsRequest {
     /// <p> Specifies whether notifications are sent for HITs of this HIT type, according to the notification specification. You must specify either the Notification parameter or the Active parameter for the call to UpdateNotificationSettings to succeed. </p>
     #[serde(rename = "Active")]
@@ -1426,10 +1426,10 @@ pub struct UpdateNotificationSettingsRequest {
     pub notification: Option<NotificationSpecification>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateNotificationSettingsResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateQualificationTypeRequest {
     /// <p>The answers to the Qualification test specified in the Test parameter, in the form of an AnswerKey data structure.</p>
     #[serde(rename = "AnswerKey")]
@@ -1468,7 +1468,7 @@ pub struct UpdateQualificationTypeRequest {
     pub test_duration_in_seconds: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateQualificationTypeResponse {
     /// <p> Contains a QualificationType data structure.</p>
     #[serde(rename = "QualificationType")]
@@ -1477,7 +1477,7 @@ pub struct UpdateQualificationTypeResponse {
 }
 
 /// <p> The WorkerBlock data structure represents a Worker who has been blocked. It has two elements: the WorkerId and the Reason for the block. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct WorkerBlock {
     /// <p> A message explaining the reason the Worker was blocked. </p>
     #[serde(rename = "Reason")]

--- a/rusoto/services/opsworks/src/generated.rs
+++ b/rusoto/services/opsworks/src/generated.rs
@@ -3209,7 +3209,8 @@ impl AssignInstanceError {
     pub fn from_body(body: &str) -> AssignInstanceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3287,7 +3288,8 @@ impl AssignVolumeError {
     pub fn from_body(body: &str) -> AssignVolumeError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3365,7 +3367,8 @@ impl AssociateElasticIpError {
     pub fn from_body(body: &str) -> AssociateElasticIpError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3445,7 +3448,8 @@ impl AttachElasticLoadBalancerError {
     pub fn from_body(body: &str) -> AttachElasticLoadBalancerError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3527,7 +3531,8 @@ impl CloneStackError {
     pub fn from_body(body: &str) -> CloneStackError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3603,7 +3608,8 @@ impl CreateAppError {
     pub fn from_body(body: &str) -> CreateAppError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3679,7 +3685,8 @@ impl CreateDeploymentError {
     pub fn from_body(body: &str) -> CreateDeploymentError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3757,7 +3764,8 @@ impl CreateInstanceError {
     pub fn from_body(body: &str) -> CreateInstanceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3835,7 +3843,8 @@ impl CreateLayerError {
     pub fn from_body(body: &str) -> CreateLayerError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3911,7 +3920,8 @@ impl CreateStackError {
     pub fn from_body(body: &str) -> CreateStackError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3983,7 +3993,8 @@ impl CreateUserProfileError {
     pub fn from_body(body: &str) -> CreateUserProfileError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4059,7 +4070,8 @@ impl DeleteAppError {
     pub fn from_body(body: &str) -> DeleteAppError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4135,7 +4147,8 @@ impl DeleteInstanceError {
     pub fn from_body(body: &str) -> DeleteInstanceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4213,7 +4226,8 @@ impl DeleteLayerError {
     pub fn from_body(body: &str) -> DeleteLayerError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4291,7 +4305,8 @@ impl DeleteStackError {
     pub fn from_body(body: &str) -> DeleteStackError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4369,7 +4384,8 @@ impl DeleteUserProfileError {
     pub fn from_body(body: &str) -> DeleteUserProfileError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4449,7 +4465,8 @@ impl DeregisterEcsClusterError {
     pub fn from_body(body: &str) -> DeregisterEcsClusterError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4529,7 +4546,8 @@ impl DeregisterElasticIpError {
     pub fn from_body(body: &str) -> DeregisterElasticIpError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4609,7 +4627,8 @@ impl DeregisterInstanceError {
     pub fn from_body(body: &str) -> DeregisterInstanceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4689,7 +4708,8 @@ impl DeregisterRdsDbInstanceError {
     pub fn from_body(body: &str) -> DeregisterRdsDbInstanceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4769,7 +4789,8 @@ impl DeregisterVolumeError {
     pub fn from_body(body: &str) -> DeregisterVolumeError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4847,7 +4868,8 @@ impl DescribeAgentVersionsError {
     pub fn from_body(body: &str) -> DescribeAgentVersionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4927,7 +4949,8 @@ impl DescribeAppsError {
     pub fn from_body(body: &str) -> DescribeAppsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5005,7 +5028,8 @@ impl DescribeCommandsError {
     pub fn from_body(body: &str) -> DescribeCommandsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5083,7 +5107,8 @@ impl DescribeDeploymentsError {
     pub fn from_body(body: &str) -> DescribeDeploymentsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5163,7 +5188,8 @@ impl DescribeEcsClustersError {
     pub fn from_body(body: &str) -> DescribeEcsClustersError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5243,7 +5269,8 @@ impl DescribeElasticIpsError {
     pub fn from_body(body: &str) -> DescribeElasticIpsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5323,7 +5350,8 @@ impl DescribeElasticLoadBalancersError {
     pub fn from_body(body: &str) -> DescribeElasticLoadBalancersError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5405,7 +5433,8 @@ impl DescribeInstancesError {
     pub fn from_body(body: &str) -> DescribeInstancesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5485,7 +5514,8 @@ impl DescribeLayersError {
     pub fn from_body(body: &str) -> DescribeLayersError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5563,7 +5593,8 @@ impl DescribeLoadBasedAutoScalingError {
     pub fn from_body(body: &str) -> DescribeLoadBasedAutoScalingError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5643,7 +5674,8 @@ impl DescribeMyUserProfileError {
     pub fn from_body(body: &str) -> DescribeMyUserProfileError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5717,7 +5749,8 @@ impl DescribeOperatingSystemsError {
     pub fn from_body(body: &str) -> DescribeOperatingSystemsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5793,7 +5826,8 @@ impl DescribePermissionsError {
     pub fn from_body(body: &str) -> DescribePermissionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5873,7 +5907,8 @@ impl DescribeRaidArraysError {
     pub fn from_body(body: &str) -> DescribeRaidArraysError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5953,7 +5988,8 @@ impl DescribeRdsDbInstancesError {
     pub fn from_body(body: &str) -> DescribeRdsDbInstancesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6033,7 +6069,8 @@ impl DescribeServiceErrorsError {
     pub fn from_body(body: &str) -> DescribeServiceErrorsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6113,7 +6150,8 @@ impl DescribeStackProvisioningParametersError {
     pub fn from_body(body: &str) -> DescribeStackProvisioningParametersError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6195,7 +6233,8 @@ impl DescribeStackSummaryError {
     pub fn from_body(body: &str) -> DescribeStackSummaryError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6275,7 +6314,8 @@ impl DescribeStacksError {
     pub fn from_body(body: &str) -> DescribeStacksError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6353,7 +6393,8 @@ impl DescribeTimeBasedAutoScalingError {
     pub fn from_body(body: &str) -> DescribeTimeBasedAutoScalingError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6435,7 +6476,8 @@ impl DescribeUserProfilesError {
     pub fn from_body(body: &str) -> DescribeUserProfilesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6515,7 +6557,8 @@ impl DescribeVolumesError {
     pub fn from_body(body: &str) -> DescribeVolumesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6593,7 +6636,8 @@ impl DetachElasticLoadBalancerError {
     pub fn from_body(body: &str) -> DetachElasticLoadBalancerError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6675,7 +6719,8 @@ impl DisassociateElasticIpError {
     pub fn from_body(body: &str) -> DisassociateElasticIpError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6755,7 +6800,8 @@ impl GetHostnameSuggestionError {
     pub fn from_body(body: &str) -> GetHostnameSuggestionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6835,7 +6881,8 @@ impl GrantAccessError {
     pub fn from_body(body: &str) -> GrantAccessError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6913,7 +6960,8 @@ impl ListTagsError {
     pub fn from_body(body: &str) -> ListTagsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6989,7 +7037,8 @@ impl RebootInstanceError {
     pub fn from_body(body: &str) -> RebootInstanceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7067,7 +7116,8 @@ impl RegisterEcsClusterError {
     pub fn from_body(body: &str) -> RegisterEcsClusterError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7147,7 +7197,8 @@ impl RegisterElasticIpError {
     pub fn from_body(body: &str) -> RegisterElasticIpError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7227,7 +7278,8 @@ impl RegisterInstanceError {
     pub fn from_body(body: &str) -> RegisterInstanceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7305,7 +7357,8 @@ impl RegisterRdsDbInstanceError {
     pub fn from_body(body: &str) -> RegisterRdsDbInstanceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7385,7 +7438,8 @@ impl RegisterVolumeError {
     pub fn from_body(body: &str) -> RegisterVolumeError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7463,7 +7517,8 @@ impl SetLoadBasedAutoScalingError {
     pub fn from_body(body: &str) -> SetLoadBasedAutoScalingError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7543,7 +7598,8 @@ impl SetPermissionError {
     pub fn from_body(body: &str) -> SetPermissionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7621,7 +7677,8 @@ impl SetTimeBasedAutoScalingError {
     pub fn from_body(body: &str) -> SetTimeBasedAutoScalingError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7701,7 +7758,8 @@ impl StartInstanceError {
     pub fn from_body(body: &str) -> StartInstanceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7779,7 +7837,8 @@ impl StartStackError {
     pub fn from_body(body: &str) -> StartStackError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7855,7 +7914,8 @@ impl StopInstanceError {
     pub fn from_body(body: &str) -> StopInstanceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7933,7 +7993,8 @@ impl StopStackError {
     pub fn from_body(body: &str) -> StopStackError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8009,7 +8070,8 @@ impl TagResourceError {
     pub fn from_body(body: &str) -> TagResourceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8087,7 +8149,8 @@ impl UnassignInstanceError {
     pub fn from_body(body: &str) -> UnassignInstanceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8165,7 +8228,8 @@ impl UnassignVolumeError {
     pub fn from_body(body: &str) -> UnassignVolumeError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8243,7 +8307,8 @@ impl UntagResourceError {
     pub fn from_body(body: &str) -> UntagResourceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8321,7 +8386,8 @@ impl UpdateAppError {
     pub fn from_body(body: &str) -> UpdateAppError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8397,7 +8463,8 @@ impl UpdateElasticIpError {
     pub fn from_body(body: &str) -> UpdateElasticIpError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8475,7 +8542,8 @@ impl UpdateInstanceError {
     pub fn from_body(body: &str) -> UpdateInstanceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8553,7 +8621,8 @@ impl UpdateLayerError {
     pub fn from_body(body: &str) -> UpdateLayerError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8629,7 +8698,8 @@ impl UpdateMyUserProfileError {
     pub fn from_body(body: &str) -> UpdateMyUserProfileError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8705,7 +8775,8 @@ impl UpdateRdsDbInstanceError {
     pub fn from_body(body: &str) -> UpdateRdsDbInstanceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8785,7 +8856,8 @@ impl UpdateStackError {
     pub fn from_body(body: &str) -> UpdateStackError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8863,7 +8935,8 @@ impl UpdateUserProfileError {
     pub fn from_body(body: &str) -> UpdateUserProfileError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8943,7 +9016,8 @@ impl UpdateVolumeError {
     pub fn from_body(body: &str) -> UpdateVolumeError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/opsworks/src/generated.rs
+++ b/rusoto/services/opsworks/src/generated.rs
@@ -31,7 +31,7 @@ use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 /// <p>Describes an agent version.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AgentVersion {
     /// <p>The configuration manager.</p>
     #[serde(rename = "ConfigurationManager")]
@@ -44,7 +44,7 @@ pub struct AgentVersion {
 }
 
 /// <p>A description of the app.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct App {
     /// <p>The app ID.</p>
     #[serde(rename = "AppId")]
@@ -104,7 +104,7 @@ pub struct App {
     pub type_: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AssignInstanceRequest {
     /// <p>The instance ID.</p>
     #[serde(rename = "InstanceId")]
@@ -114,7 +114,7 @@ pub struct AssignInstanceRequest {
     pub layer_ids: Vec<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AssignVolumeRequest {
     /// <p>The instance ID.</p>
     #[serde(rename = "InstanceId")]
@@ -125,7 +125,7 @@ pub struct AssignVolumeRequest {
     pub volume_id: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AssociateElasticIpRequest {
     /// <p>The Elastic IP address.</p>
     #[serde(rename = "ElasticIp")]
@@ -136,7 +136,7 @@ pub struct AssociateElasticIpRequest {
     pub instance_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AttachElasticLoadBalancerRequest {
     /// <p>The Elastic Load Balancing instance's name.</p>
     #[serde(rename = "ElasticLoadBalancerName")]
@@ -147,7 +147,7 @@ pub struct AttachElasticLoadBalancerRequest {
 }
 
 /// <p>Describes a load-based auto scaling upscaling or downscaling threshold configuration, which specifies when AWS OpsWorks Stacks starts or stops load-based instances.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct AutoScalingThresholds {
     /// <p><p>Custom Cloudwatch auto scaling alarms, to be used as thresholds. This parameter takes a list of up to five alarm names, which are case sensitive and must be in the same region as the stack.</p> <note> <p>To use custom alarms, you must update your service role to allow <code>cloudwatch:DescribeAlarms</code>. You can either have AWS OpsWorks Stacks update the role for you when you first use this feature or you can edit the role manually. For more information, see <a href="http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-servicerole.html">Allowing AWS OpsWorks Stacks to Act on Your Behalf</a>.</p> </note></p>
     #[serde(rename = "Alarms")]
@@ -180,7 +180,7 @@ pub struct AutoScalingThresholds {
 }
 
 /// <p>Describes a block device mapping. This data type maps directly to the Amazon EC2 <a href="http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_BlockDeviceMapping.html">BlockDeviceMapping</a> data type. </p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct BlockDeviceMapping {
     /// <p>The device name that is exposed to the instance, such as <code>/dev/sdh</code>. For the root device, you can use the explicit device name or you can set this parameter to <code>ROOT_DEVICE</code> and AWS OpsWorks Stacks will provide the correct device name.</p>
     #[serde(rename = "DeviceName")]
@@ -201,7 +201,7 @@ pub struct BlockDeviceMapping {
 }
 
 /// <p>Describes the Chef configuration.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ChefConfiguration {
     /// <p>The Berkshelf version.</p>
     #[serde(rename = "BerkshelfVersion")]
@@ -213,7 +213,7 @@ pub struct ChefConfiguration {
     pub manage_berkshelf: Option<bool>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CloneStackRequest {
     /// <p><p>The default AWS OpsWorks Stacks agent version. You have the following options:</p> <ul> <li> <p>Auto-update - Set this parameter to <code>LATEST</code>. AWS OpsWorks Stacks automatically installs new agent versions on the stack&#39;s instances as soon as they are available.</p> </li> <li> <p>Fixed version - Set this parameter to your preferred agent version. To update the agent version, you must edit the stack configuration and specify a new version. AWS OpsWorks Stacks then automatically installs that version on the stack&#39;s instances.</p> </li> </ul> <p>The default setting is <code>LATEST</code>. To specify an agent version, you must use the complete version number, not the abbreviated number shown on the console. For a list of available agent version numbers, call <a>DescribeAgentVersions</a>. AgentVersion cannot be set to Chef 12.2.</p> <note> <p>You can also specify an agent version when you create or update an instance, which overrides the stack&#39;s default setting.</p> </note></p>
     #[serde(rename = "AgentVersion")]
@@ -303,7 +303,7 @@ pub struct CloneStackRequest {
 }
 
 /// <p>Contains the response to a <code>CloneStack</code> request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CloneStackResult {
     /// <p>The cloned stack ID.</p>
     #[serde(rename = "StackId")]
@@ -312,7 +312,7 @@ pub struct CloneStackResult {
 }
 
 /// <p>Describes the Amazon CloudWatch logs configuration for a layer.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CloudWatchLogsConfiguration {
     /// <p>Whether CloudWatch Logs is enabled for a layer.</p>
     #[serde(rename = "Enabled")]
@@ -325,7 +325,7 @@ pub struct CloudWatchLogsConfiguration {
 }
 
 /// <p>Describes the Amazon CloudWatch logs configuration for a layer. For detailed information about members of this data type, see the <a href="http://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AgentReference.html">CloudWatch Logs Agent Reference</a>.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CloudWatchLogsLogStream {
     /// <p>Specifies the max number of log events in a batch, up to 10000. The default value is 1000.</p>
     #[serde(rename = "BatchCount")]
@@ -374,7 +374,7 @@ pub struct CloudWatchLogsLogStream {
 }
 
 /// <p>Describes a command.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Command {
     /// <p>Date and time when the command was acknowledged.</p>
     #[serde(rename = "AcknowledgedAt")]
@@ -418,7 +418,7 @@ pub struct Command {
     pub type_: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateAppRequest {
     /// <p>A <code>Source</code> object that specifies the app repository.</p>
     #[serde(rename = "AppSource")]
@@ -468,7 +468,7 @@ pub struct CreateAppRequest {
 }
 
 /// <p>Contains the response to a <code>CreateApp</code> request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateAppResult {
     /// <p>The app ID.</p>
     #[serde(rename = "AppId")]
@@ -476,7 +476,7 @@ pub struct CreateAppResult {
     pub app_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateDeploymentRequest {
     /// <p>The app ID. This parameter is required for app deployments, but not for other deployment commands.</p>
     #[serde(rename = "AppId")]
@@ -507,7 +507,7 @@ pub struct CreateDeploymentRequest {
 }
 
 /// <p>Contains the response to a <code>CreateDeployment</code> request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateDeploymentResult {
     /// <p>The deployment ID, which can be used with other requests to identify the deployment.</p>
     #[serde(rename = "DeploymentId")]
@@ -515,7 +515,7 @@ pub struct CreateDeploymentResult {
     pub deployment_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateInstanceRequest {
     /// <p>The default AWS OpsWorks Stacks agent version. You have the following options:</p> <ul> <li> <p> <code>INHERIT</code> - Use the stack's default agent version setting.</p> </li> <li> <p> <i>version_number</i> - Use the specified agent version. This value overrides the stack's default setting. To update the agent version, edit the instance configuration and specify a new version. AWS OpsWorks Stacks then automatically installs that version on the instance.</p> </li> </ul> <p>The default setting is <code>INHERIT</code>. To specify an agent version, you must use the complete version number, not the abbreviated number shown on the console. For a list of available agent version numbers, call <a>DescribeAgentVersions</a>. AgentVersion cannot be set to Chef 12.2.</p>
     #[serde(rename = "AgentVersion")]
@@ -589,7 +589,7 @@ pub struct CreateInstanceRequest {
 }
 
 /// <p>Contains the response to a <code>CreateInstance</code> request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateInstanceResult {
     /// <p>The instance ID.</p>
     #[serde(rename = "InstanceId")]
@@ -597,7 +597,7 @@ pub struct CreateInstanceResult {
     pub instance_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateLayerRequest {
     /// <p>One or more user-defined key-value pairs to be added to the stack attributes.</p> <p>To create a cluster layer, set the <code>EcsClusterArn</code> attribute to the cluster's ARN.</p>
     #[serde(rename = "Attributes")]
@@ -670,7 +670,7 @@ pub struct CreateLayerRequest {
 }
 
 /// <p>Contains the response to a <code>CreateLayer</code> request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateLayerResult {
     /// <p>The layer ID.</p>
     #[serde(rename = "LayerId")]
@@ -678,7 +678,7 @@ pub struct CreateLayerResult {
     pub layer_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateStackRequest {
     /// <p><p>The default AWS OpsWorks Stacks agent version. You have the following options:</p> <ul> <li> <p>Auto-update - Set this parameter to <code>LATEST</code>. AWS OpsWorks Stacks automatically installs new agent versions on the stack&#39;s instances as soon as they are available.</p> </li> <li> <p>Fixed version - Set this parameter to your preferred agent version. To update the agent version, you must edit the stack configuration and specify a new version. AWS OpsWorks Stacks then automatically installs that version on the stack&#39;s instances.</p> </li> </ul> <p>The default setting is the most recent release of the agent. To specify an agent version, you must use the complete version number, not the abbreviated number shown on the console. For a list of available agent version numbers, call <a>DescribeAgentVersions</a>. AgentVersion cannot be set to Chef 12.2.</p> <note> <p>You can also specify an agent version when you create or update an instance, which overrides the stack&#39;s default setting.</p> </note></p>
     #[serde(rename = "AgentVersion")]
@@ -754,7 +754,7 @@ pub struct CreateStackRequest {
 }
 
 /// <p>Contains the response to a <code>CreateStack</code> request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateStackResult {
     /// <p>The stack ID, which is an opaque string that you use to identify the stack when performing actions such as <code>DescribeStacks</code>.</p>
     #[serde(rename = "StackId")]
@@ -762,7 +762,7 @@ pub struct CreateStackResult {
     pub stack_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateUserProfileRequest {
     /// <p>Whether users can specify their own SSH public key through the My Settings page. For more information, see <a href="http://docs.aws.amazon.com/opsworks/latest/userguide/security-settingsshkey.html">Setting an IAM User's Public SSH Key</a>.</p>
     #[serde(rename = "AllowSelfManagement")]
@@ -782,7 +782,7 @@ pub struct CreateUserProfileRequest {
 }
 
 /// <p>Contains the response to a <code>CreateUserProfile</code> request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateUserProfileResult {
     /// <p>The user's IAM ARN.</p>
     #[serde(rename = "IamUserArn")]
@@ -791,7 +791,7 @@ pub struct CreateUserProfileResult {
 }
 
 /// <p>Describes an app's data source.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct DataSource {
     /// <p>The data source's ARN.</p>
     #[serde(rename = "Arn")]
@@ -807,14 +807,14 @@ pub struct DataSource {
     pub type_: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteAppRequest {
     /// <p>The app ID.</p>
     #[serde(rename = "AppId")]
     pub app_id: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteInstanceRequest {
     /// <p>Whether to delete the instance Elastic IP address.</p>
     #[serde(rename = "DeleteElasticIp")]
@@ -829,21 +829,21 @@ pub struct DeleteInstanceRequest {
     pub instance_id: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteLayerRequest {
     /// <p>The layer ID.</p>
     #[serde(rename = "LayerId")]
     pub layer_id: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteStackRequest {
     /// <p>The stack ID.</p>
     #[serde(rename = "StackId")]
     pub stack_id: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteUserProfileRequest {
     /// <p>The user's IAM ARN. This can also be a federated user's ARN.</p>
     #[serde(rename = "IamUserArn")]
@@ -851,7 +851,7 @@ pub struct DeleteUserProfileRequest {
 }
 
 /// <p>Describes a deployment of a stack or app.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Deployment {
     /// <p>The app ID.</p>
     #[serde(rename = "AppId")]
@@ -903,7 +903,7 @@ pub struct Deployment {
 }
 
 /// <p>Used to specify a stack or deployment command.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct DeploymentCommand {
     /// <p>The arguments of those commands that take arguments. It should be set to a JSON object with the following format:</p> <p> <code>{"arg_name1" : ["value1", "value2", ...], "arg_name2" : ["value1", "value2", ...], ...}</code> </p> <p>The <code>update_dependencies</code> command takes two arguments:</p> <ul> <li> <p> <code>upgrade_os_to</code> - Specifies the desired Amazon Linux version for instances whose OS you want to upgrade, such as <code>Amazon Linux 2016.09</code>. You must also set the <code>allow_reboot</code> argument to true.</p> </li> <li> <p> <code>allow_reboot</code> - Specifies whether to allow AWS OpsWorks Stacks to reboot the instances if necessary, after installing the updates. This argument can be set to either <code>true</code> or <code>false</code>. The default value is <code>false</code>.</p> </li> </ul> <p>For example, to upgrade an instance to Amazon Linux 2016.09, set <code>Args</code> to the following.</p> <p> <code> { "upgrade_os_to":["Amazon Linux 2016.09"], "allow_reboot":["true"] } </code> </p>
     #[serde(rename = "Args")]
@@ -914,42 +914,42 @@ pub struct DeploymentCommand {
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeregisterEcsClusterRequest {
     /// <p>The cluster's ARN.</p>
     #[serde(rename = "EcsClusterArn")]
     pub ecs_cluster_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeregisterElasticIpRequest {
     /// <p>The Elastic IP address.</p>
     #[serde(rename = "ElasticIp")]
     pub elastic_ip: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeregisterInstanceRequest {
     /// <p>The instance ID.</p>
     #[serde(rename = "InstanceId")]
     pub instance_id: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeregisterRdsDbInstanceRequest {
     /// <p>The Amazon RDS instance's ARN.</p>
     #[serde(rename = "RdsDbInstanceArn")]
     pub rds_db_instance_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeregisterVolumeRequest {
     /// <p>The AWS OpsWorks Stacks volume ID, which is the GUID that AWS OpsWorks Stacks assigned to the instance when you registered the volume with the stack, not the Amazon EC2 volume ID.</p>
     #[serde(rename = "VolumeId")]
     pub volume_id: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeAgentVersionsRequest {
     /// <p>The configuration manager.</p>
     #[serde(rename = "ConfigurationManager")]
@@ -962,7 +962,7 @@ pub struct DescribeAgentVersionsRequest {
 }
 
 /// <p>Contains the response to a <code>DescribeAgentVersions</code> request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeAgentVersionsResult {
     /// <p>The agent versions for the specified stack or configuration manager. Note that this value is the complete version number, not the abbreviated number used by the console.</p>
     #[serde(rename = "AgentVersions")]
@@ -970,7 +970,7 @@ pub struct DescribeAgentVersionsResult {
     pub agent_versions: Option<Vec<AgentVersion>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeAppsRequest {
     /// <p>An array of app IDs for the apps to be described. If you use this parameter, <code>DescribeApps</code> returns a description of the specified apps. Otherwise, it returns a description of every app.</p>
     #[serde(rename = "AppIds")]
@@ -983,7 +983,7 @@ pub struct DescribeAppsRequest {
 }
 
 /// <p>Contains the response to a <code>DescribeApps</code> request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeAppsResult {
     /// <p>An array of <code>App</code> objects that describe the specified apps. </p>
     #[serde(rename = "Apps")]
@@ -991,7 +991,7 @@ pub struct DescribeAppsResult {
     pub apps: Option<Vec<App>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeCommandsRequest {
     /// <p>An array of command IDs. If you include this parameter, <code>DescribeCommands</code> returns a description of the specified commands. Otherwise, it returns a description of every command.</p>
     #[serde(rename = "CommandIds")]
@@ -1008,7 +1008,7 @@ pub struct DescribeCommandsRequest {
 }
 
 /// <p>Contains the response to a <code>DescribeCommands</code> request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeCommandsResult {
     /// <p>An array of <code>Command</code> objects that describe each of the specified commands.</p>
     #[serde(rename = "Commands")]
@@ -1016,7 +1016,7 @@ pub struct DescribeCommandsResult {
     pub commands: Option<Vec<Command>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeDeploymentsRequest {
     /// <p>The app ID. If you include this parameter, the command returns a description of the commands associated with the specified app.</p>
     #[serde(rename = "AppId")]
@@ -1033,7 +1033,7 @@ pub struct DescribeDeploymentsRequest {
 }
 
 /// <p>Contains the response to a <code>DescribeDeployments</code> request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeDeploymentsResult {
     /// <p>An array of <code>Deployment</code> objects that describe the deployments.</p>
     #[serde(rename = "Deployments")]
@@ -1041,7 +1041,7 @@ pub struct DescribeDeploymentsResult {
     pub deployments: Option<Vec<Deployment>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeEcsClustersRequest {
     /// <p>A list of ARNs, one for each cluster to be described.</p>
     #[serde(rename = "EcsClusterArns")]
@@ -1062,7 +1062,7 @@ pub struct DescribeEcsClustersRequest {
 }
 
 /// <p>Contains the response to a <code>DescribeEcsClusters</code> request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeEcsClustersResult {
     /// <p>A list of <code>EcsCluster</code> objects containing the cluster descriptions.</p>
     #[serde(rename = "EcsClusters")]
@@ -1074,7 +1074,7 @@ pub struct DescribeEcsClustersResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeElasticIpsRequest {
     /// <p>The instance ID. If you include this parameter, <code>DescribeElasticIps</code> returns a description of the Elastic IP addresses associated with the specified instance.</p>
     #[serde(rename = "InstanceId")]
@@ -1091,7 +1091,7 @@ pub struct DescribeElasticIpsRequest {
 }
 
 /// <p>Contains the response to a <code>DescribeElasticIps</code> request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeElasticIpsResult {
     /// <p>An <code>ElasticIps</code> object that describes the specified Elastic IP addresses.</p>
     #[serde(rename = "ElasticIps")]
@@ -1099,7 +1099,7 @@ pub struct DescribeElasticIpsResult {
     pub elastic_ips: Option<Vec<ElasticIp>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeElasticLoadBalancersRequest {
     /// <p>A list of layer IDs. The action describes the Elastic Load Balancing instances for the specified layers.</p>
     #[serde(rename = "LayerIds")]
@@ -1112,7 +1112,7 @@ pub struct DescribeElasticLoadBalancersRequest {
 }
 
 /// <p>Contains the response to a <code>DescribeElasticLoadBalancers</code> request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeElasticLoadBalancersResult {
     /// <p>A list of <code>ElasticLoadBalancer</code> objects that describe the specified Elastic Load Balancing instances.</p>
     #[serde(rename = "ElasticLoadBalancers")]
@@ -1120,7 +1120,7 @@ pub struct DescribeElasticLoadBalancersResult {
     pub elastic_load_balancers: Option<Vec<ElasticLoadBalancer>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeInstancesRequest {
     /// <p>An array of instance IDs to be described. If you use this parameter, <code>DescribeInstances</code> returns a description of the specified instances. Otherwise, it returns a description of every instance.</p>
     #[serde(rename = "InstanceIds")]
@@ -1137,7 +1137,7 @@ pub struct DescribeInstancesRequest {
 }
 
 /// <p>Contains the response to a <code>DescribeInstances</code> request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeInstancesResult {
     /// <p>An array of <code>Instance</code> objects that describe the instances.</p>
     #[serde(rename = "Instances")]
@@ -1145,7 +1145,7 @@ pub struct DescribeInstancesResult {
     pub instances: Option<Vec<Instance>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeLayersRequest {
     /// <p>An array of layer IDs that specify the layers to be described. If you omit this parameter, <code>DescribeLayers</code> returns a description of every layer in the specified stack.</p>
     #[serde(rename = "LayerIds")]
@@ -1158,7 +1158,7 @@ pub struct DescribeLayersRequest {
 }
 
 /// <p>Contains the response to a <code>DescribeLayers</code> request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeLayersResult {
     /// <p>An array of <code>Layer</code> objects that describe the layers.</p>
     #[serde(rename = "Layers")]
@@ -1166,7 +1166,7 @@ pub struct DescribeLayersResult {
     pub layers: Option<Vec<Layer>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeLoadBasedAutoScalingRequest {
     /// <p>An array of layer IDs.</p>
     #[serde(rename = "LayerIds")]
@@ -1174,7 +1174,7 @@ pub struct DescribeLoadBasedAutoScalingRequest {
 }
 
 /// <p>Contains the response to a <code>DescribeLoadBasedAutoScaling</code> request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeLoadBasedAutoScalingResult {
     /// <p>An array of <code>LoadBasedAutoScalingConfiguration</code> objects that describe each layer's configuration.</p>
     #[serde(rename = "LoadBasedAutoScalingConfigurations")]
@@ -1183,7 +1183,7 @@ pub struct DescribeLoadBasedAutoScalingResult {
 }
 
 /// <p>Contains the response to a <code>DescribeMyUserProfile</code> request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeMyUserProfileResult {
     /// <p>A <code>UserProfile</code> object that describes the user's SSH information.</p>
     #[serde(rename = "UserProfile")]
@@ -1192,14 +1192,14 @@ pub struct DescribeMyUserProfileResult {
 }
 
 /// <p>The response to a <code>DescribeOperatingSystems</code> request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeOperatingSystemsResponse {
     #[serde(rename = "OperatingSystems")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub operating_systems: Option<Vec<OperatingSystem>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribePermissionsRequest {
     /// <p>The user's IAM ARN. This can also be a federated user's ARN. For more information about IAM ARNs, see <a href="http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html">Using Identifiers</a>.</p>
     #[serde(rename = "IamUserArn")]
@@ -1212,7 +1212,7 @@ pub struct DescribePermissionsRequest {
 }
 
 /// <p>Contains the response to a <code>DescribePermissions</code> request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribePermissionsResult {
     /// <p><p>An array of <code>Permission</code> objects that describe the stack permissions.</p> <ul> <li> <p>If the request object contains only a stack ID, the array contains a <code>Permission</code> object with permissions for each of the stack IAM ARNs.</p> </li> <li> <p>If the request object contains only an IAM ARN, the array contains a <code>Permission</code> object with permissions for each of the user&#39;s stack IDs.</p> </li> <li> <p>If the request contains a stack ID and an IAM ARN, the array contains a single <code>Permission</code> object with permissions for the specified stack and IAM ARN.</p> </li> </ul></p>
     #[serde(rename = "Permissions")]
@@ -1220,7 +1220,7 @@ pub struct DescribePermissionsResult {
     pub permissions: Option<Vec<Permission>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeRaidArraysRequest {
     /// <p>The instance ID. If you use this parameter, <code>DescribeRaidArrays</code> returns descriptions of the RAID arrays associated with the specified instance. </p>
     #[serde(rename = "InstanceId")]
@@ -1237,7 +1237,7 @@ pub struct DescribeRaidArraysRequest {
 }
 
 /// <p>Contains the response to a <code>DescribeRaidArrays</code> request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeRaidArraysResult {
     /// <p>A <code>RaidArrays</code> object that describes the specified RAID arrays.</p>
     #[serde(rename = "RaidArrays")]
@@ -1245,7 +1245,7 @@ pub struct DescribeRaidArraysResult {
     pub raid_arrays: Option<Vec<RaidArray>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeRdsDbInstancesRequest {
     /// <p>An array containing the ARNs of the instances to be described.</p>
     #[serde(rename = "RdsDbInstanceArns")]
@@ -1257,7 +1257,7 @@ pub struct DescribeRdsDbInstancesRequest {
 }
 
 /// <p>Contains the response to a <code>DescribeRdsDbInstances</code> request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeRdsDbInstancesResult {
     /// <p>An a array of <code>RdsDbInstance</code> objects that describe the instances.</p>
     #[serde(rename = "RdsDbInstances")]
@@ -1265,7 +1265,7 @@ pub struct DescribeRdsDbInstancesResult {
     pub rds_db_instances: Option<Vec<RdsDbInstance>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeServiceErrorsRequest {
     /// <p>The instance ID. If you use this parameter, <code>DescribeServiceErrors</code> returns descriptions of the errors associated with the specified instance.</p>
     #[serde(rename = "InstanceId")]
@@ -1282,7 +1282,7 @@ pub struct DescribeServiceErrorsRequest {
 }
 
 /// <p>Contains the response to a <code>DescribeServiceErrors</code> request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeServiceErrorsResult {
     /// <p>An array of <code>ServiceError</code> objects that describe the specified service errors.</p>
     #[serde(rename = "ServiceErrors")]
@@ -1290,7 +1290,7 @@ pub struct DescribeServiceErrorsResult {
     pub service_errors: Option<Vec<ServiceError>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeStackProvisioningParametersRequest {
     /// <p>The stack ID</p>
     #[serde(rename = "StackId")]
@@ -1298,7 +1298,7 @@ pub struct DescribeStackProvisioningParametersRequest {
 }
 
 /// <p>Contains the response to a <code>DescribeStackProvisioningParameters</code> request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeStackProvisioningParametersResult {
     /// <p>The AWS OpsWorks Stacks agent installer's URL.</p>
     #[serde(rename = "AgentInstallerUrl")]
@@ -1310,7 +1310,7 @@ pub struct DescribeStackProvisioningParametersResult {
     pub parameters: Option<::std::collections::HashMap<String, String>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeStackSummaryRequest {
     /// <p>The stack ID.</p>
     #[serde(rename = "StackId")]
@@ -1318,7 +1318,7 @@ pub struct DescribeStackSummaryRequest {
 }
 
 /// <p>Contains the response to a <code>DescribeStackSummary</code> request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeStackSummaryResult {
     /// <p>A <code>StackSummary</code> object that contains the results.</p>
     #[serde(rename = "StackSummary")]
@@ -1326,7 +1326,7 @@ pub struct DescribeStackSummaryResult {
     pub stack_summary: Option<StackSummary>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeStacksRequest {
     /// <p>An array of stack IDs that specify the stacks to be described. If you omit this parameter, <code>DescribeStacks</code> returns a description of every stack.</p>
     #[serde(rename = "StackIds")]
@@ -1335,7 +1335,7 @@ pub struct DescribeStacksRequest {
 }
 
 /// <p>Contains the response to a <code>DescribeStacks</code> request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeStacksResult {
     /// <p>An array of <code>Stack</code> objects that describe the stacks.</p>
     #[serde(rename = "Stacks")]
@@ -1343,7 +1343,7 @@ pub struct DescribeStacksResult {
     pub stacks: Option<Vec<Stack>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeTimeBasedAutoScalingRequest {
     /// <p>An array of instance IDs.</p>
     #[serde(rename = "InstanceIds")]
@@ -1351,7 +1351,7 @@ pub struct DescribeTimeBasedAutoScalingRequest {
 }
 
 /// <p>Contains the response to a <code>DescribeTimeBasedAutoScaling</code> request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeTimeBasedAutoScalingResult {
     /// <p>An array of <code>TimeBasedAutoScalingConfiguration</code> objects that describe the configuration for the specified instances.</p>
     #[serde(rename = "TimeBasedAutoScalingConfigurations")]
@@ -1359,7 +1359,7 @@ pub struct DescribeTimeBasedAutoScalingResult {
     pub time_based_auto_scaling_configurations: Option<Vec<TimeBasedAutoScalingConfiguration>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeUserProfilesRequest {
     /// <p>An array of IAM or federated user ARNs that identify the users to be described.</p>
     #[serde(rename = "IamUserArns")]
@@ -1368,7 +1368,7 @@ pub struct DescribeUserProfilesRequest {
 }
 
 /// <p>Contains the response to a <code>DescribeUserProfiles</code> request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeUserProfilesResult {
     /// <p>A <code>Users</code> object that describes the specified users.</p>
     #[serde(rename = "UserProfiles")]
@@ -1376,7 +1376,7 @@ pub struct DescribeUserProfilesResult {
     pub user_profiles: Option<Vec<UserProfile>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeVolumesRequest {
     /// <p>The instance ID. If you use this parameter, <code>DescribeVolumes</code> returns descriptions of the volumes associated with the specified instance.</p>
     #[serde(rename = "InstanceId")]
@@ -1397,7 +1397,7 @@ pub struct DescribeVolumesRequest {
 }
 
 /// <p>Contains the response to a <code>DescribeVolumes</code> request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeVolumesResult {
     /// <p>An array of volume IDs.</p>
     #[serde(rename = "Volumes")]
@@ -1405,7 +1405,7 @@ pub struct DescribeVolumesResult {
     pub volumes: Option<Vec<Volume>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DetachElasticLoadBalancerRequest {
     /// <p>The Elastic Load Balancing instance's name.</p>
     #[serde(rename = "ElasticLoadBalancerName")]
@@ -1415,7 +1415,7 @@ pub struct DetachElasticLoadBalancerRequest {
     pub layer_id: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DisassociateElasticIpRequest {
     /// <p>The Elastic IP address.</p>
     #[serde(rename = "ElasticIp")]
@@ -1423,7 +1423,7 @@ pub struct DisassociateElasticIpRequest {
 }
 
 /// <p>Describes an Amazon EBS volume. This data type maps directly to the Amazon EC2 <a href="http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_EbsBlockDevice.html">EbsBlockDevice</a> data type.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct EbsBlockDevice {
     /// <p>Whether the volume is deleted on instance termination.</p>
     #[serde(rename = "DeleteOnTermination")]
@@ -1448,7 +1448,7 @@ pub struct EbsBlockDevice {
 }
 
 /// <p>Describes a registered Amazon ECS cluster.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct EcsCluster {
     /// <p>The cluster's ARN.</p>
     #[serde(rename = "EcsClusterArn")]
@@ -1469,7 +1469,7 @@ pub struct EcsCluster {
 }
 
 /// <p>Describes an Elastic IP address.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ElasticIp {
     /// <p>The domain.</p>
     #[serde(rename = "Domain")]
@@ -1494,7 +1494,7 @@ pub struct ElasticIp {
 }
 
 /// <p>Describes an Elastic Load Balancing instance.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ElasticLoadBalancer {
     /// <p>A list of Availability Zones.</p>
     #[serde(rename = "AvailabilityZones")]
@@ -1535,7 +1535,7 @@ pub struct ElasticLoadBalancer {
 }
 
 /// <p>Represents an app's environment variable.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct EnvironmentVariable {
     /// <p>(Required) The environment variable's name, which can consist of up to 64 characters and must be specified. The name can contain upper- and lowercase letters, numbers, and underscores (_), but it must start with a letter or underscore.</p>
     #[serde(rename = "Key")]
@@ -1549,7 +1549,7 @@ pub struct EnvironmentVariable {
     pub value: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetHostnameSuggestionRequest {
     /// <p>The layer ID.</p>
     #[serde(rename = "LayerId")]
@@ -1557,7 +1557,7 @@ pub struct GetHostnameSuggestionRequest {
 }
 
 /// <p>Contains the response to a <code>GetHostnameSuggestion</code> request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetHostnameSuggestionResult {
     /// <p>The generated host name.</p>
     #[serde(rename = "Hostname")]
@@ -1569,7 +1569,7 @@ pub struct GetHostnameSuggestionResult {
     pub layer_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GrantAccessRequest {
     /// <p>The instance's AWS OpsWorks Stacks ID.</p>
     #[serde(rename = "InstanceId")]
@@ -1581,7 +1581,7 @@ pub struct GrantAccessRequest {
 }
 
 /// <p>Contains the response to a <code>GrantAccess</code> request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GrantAccessResult {
     /// <p>A <code>TemporaryCredential</code> object that contains the data needed to log in to the instance by RDP clients, such as the Microsoft Remote Desktop Connection.</p>
     #[serde(rename = "TemporaryCredential")]
@@ -1590,7 +1590,7 @@ pub struct GrantAccessResult {
 }
 
 /// <p>Describes an instance.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Instance {
     /// <p>The agent version. This parameter is set to <code>INHERIT</code> if the instance inherits the default stack setting or to a a version number for a fixed agent version.</p>
     #[serde(rename = "AgentVersion")]
@@ -1758,7 +1758,7 @@ pub struct Instance {
 }
 
 /// <p>Contains a description of an Amazon EC2 instance from the Amazon EC2 metadata service. For more information, see <a href="http://docs.aws.amazon.com/sdkfornet/latest/apidocs/Index.html">Instance Metadata and User Data</a>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct InstanceIdentity {
     /// <p>A JSON document that contains the metadata.</p>
     #[serde(rename = "Document")]
@@ -1771,7 +1771,7 @@ pub struct InstanceIdentity {
 }
 
 /// <p>Describes how many instances a stack has for each status.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct InstancesCount {
     /// <p>The number of instances in the Assigning state.</p>
     #[serde(rename = "Assigning")]
@@ -1855,7 +1855,7 @@ pub struct InstancesCount {
 }
 
 /// <p>Describes a layer.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Layer {
     #[serde(rename = "Arn")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1950,7 +1950,7 @@ pub struct Layer {
 }
 
 /// <p>Specifies the lifecycle event configuration</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct LifecycleEventConfiguration {
     /// <p>A <code>ShutdownEventConfiguration</code> object that specifies the Shutdown event configuration.</p>
     #[serde(rename = "Shutdown")]
@@ -1958,7 +1958,7 @@ pub struct LifecycleEventConfiguration {
     pub shutdown: Option<ShutdownEventConfiguration>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListTagsRequest {
     /// <p>Do not use. A validation exception occurs if you add a <code>MaxResults</code> parameter to a <code>ListTagsRequest</code> call. </p>
     #[serde(rename = "MaxResults")]
@@ -1974,7 +1974,7 @@ pub struct ListTagsRequest {
 }
 
 /// <p>Contains the response to a <code>ListTags</code> request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListTagsResult {
     /// <p>If a paginated request does not return all of the remaining results, this parameter is set to a token that you can assign to the request object's <code>NextToken</code> parameter to get the next set of results. If the previous paginated request returned all of the remaining results, this parameter is set to <code>null</code>. </p>
     #[serde(rename = "NextToken")]
@@ -1987,7 +1987,7 @@ pub struct ListTagsResult {
 }
 
 /// <p>Describes a layer's load-based auto scaling configuration.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct LoadBasedAutoScalingConfiguration {
     /// <p>An <code>AutoScalingThresholds</code> object that describes the downscaling configuration, which defines how and when AWS OpsWorks Stacks reduces the number of instances.</p>
     #[serde(rename = "DownScaling")]
@@ -2008,7 +2008,7 @@ pub struct LoadBasedAutoScalingConfiguration {
 }
 
 /// <p>Describes supported operating systems in AWS OpsWorks Stacks.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct OperatingSystem {
     /// <p>Supported configuration manager name and versions for an AWS OpsWorks Stacks operating system.</p>
     #[serde(rename = "ConfigurationManagers")]
@@ -2041,7 +2041,7 @@ pub struct OperatingSystem {
 }
 
 /// <p>A block that contains information about the configuration manager (Chef) and the versions of the configuration manager that are supported for an operating system.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct OperatingSystemConfigurationManager {
     /// <p>The name of the configuration manager, which is Chef.</p>
     #[serde(rename = "Name")]
@@ -2054,7 +2054,7 @@ pub struct OperatingSystemConfigurationManager {
 }
 
 /// <p>Describes stack or user permissions.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Permission {
     /// <p>Whether the user can use SSH.</p>
     #[serde(rename = "AllowSsh")]
@@ -2079,7 +2079,7 @@ pub struct Permission {
 }
 
 /// <p>Describes an instance's RAID array.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RaidArray {
     /// <p>The array's Availability Zone. For more information, see <a href="http://docs.aws.amazon.com/general/latest/gr/rande.html">Regions and Endpoints</a>.</p>
     #[serde(rename = "AvailabilityZone")]
@@ -2136,7 +2136,7 @@ pub struct RaidArray {
 }
 
 /// <p>Describes an Amazon RDS instance.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RdsDbInstance {
     /// <p>The instance's address.</p>
     #[serde(rename = "Address")]
@@ -2176,7 +2176,7 @@ pub struct RdsDbInstance {
     pub stack_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RebootInstanceRequest {
     /// <p>The instance ID.</p>
     #[serde(rename = "InstanceId")]
@@ -2184,7 +2184,7 @@ pub struct RebootInstanceRequest {
 }
 
 /// <p>AWS OpsWorks Stacks supports five lifecycle events: <b>setup</b>, <b>configuration</b>, <b>deploy</b>, <b>undeploy</b>, and <b>shutdown</b>. For each layer, AWS OpsWorks Stacks runs a set of standard recipes for each event. In addition, you can provide custom recipes for any or all layers and events. AWS OpsWorks Stacks runs custom event recipes after the standard recipes. <code>LayerCustomRecipes</code> specifies the custom recipes for a particular layer to be run in response to each of the five events. </p> <p>To specify a recipe, use the cookbook's directory name in the repository followed by two colons and the recipe name, which is the recipe's file name without the .rb extension. For example: phpapp2::dbsetup specifies the dbsetup.rb recipe in the repository's phpapp2 folder.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Recipes {
     /// <p>An array of custom recipe names to be run following a <code>configure</code> event.</p>
     #[serde(rename = "Configure")]
@@ -2208,7 +2208,7 @@ pub struct Recipes {
     pub undeploy: Option<Vec<String>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RegisterEcsClusterRequest {
     /// <p>The cluster's ARN.</p>
     #[serde(rename = "EcsClusterArn")]
@@ -2219,7 +2219,7 @@ pub struct RegisterEcsClusterRequest {
 }
 
 /// <p>Contains the response to a <code>RegisterEcsCluster</code> request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RegisterEcsClusterResult {
     /// <p>The cluster's ARN.</p>
     #[serde(rename = "EcsClusterArn")]
@@ -2227,7 +2227,7 @@ pub struct RegisterEcsClusterResult {
     pub ecs_cluster_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RegisterElasticIpRequest {
     /// <p>The Elastic IP address.</p>
     #[serde(rename = "ElasticIp")]
@@ -2238,7 +2238,7 @@ pub struct RegisterElasticIpRequest {
 }
 
 /// <p>Contains the response to a <code>RegisterElasticIp</code> request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RegisterElasticIpResult {
     /// <p>The Elastic IP address.</p>
     #[serde(rename = "ElasticIp")]
@@ -2246,7 +2246,7 @@ pub struct RegisterElasticIpResult {
     pub elastic_ip: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RegisterInstanceRequest {
     /// <p>The instance's hostname.</p>
     #[serde(rename = "Hostname")]
@@ -2278,7 +2278,7 @@ pub struct RegisterInstanceRequest {
 }
 
 /// <p>Contains the response to a <code>RegisterInstanceResult</code> request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RegisterInstanceResult {
     /// <p>The registered instance's AWS OpsWorks Stacks ID.</p>
     #[serde(rename = "InstanceId")]
@@ -2286,7 +2286,7 @@ pub struct RegisterInstanceResult {
     pub instance_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RegisterRdsDbInstanceRequest {
     /// <p>The database password.</p>
     #[serde(rename = "DbPassword")]
@@ -2302,7 +2302,7 @@ pub struct RegisterRdsDbInstanceRequest {
     pub stack_id: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RegisterVolumeRequest {
     /// <p>The Amazon EBS volume ID.</p>
     #[serde(rename = "Ec2VolumeId")]
@@ -2314,7 +2314,7 @@ pub struct RegisterVolumeRequest {
 }
 
 /// <p>Contains the response to a <code>RegisterVolume</code> request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RegisterVolumeResult {
     /// <p>The volume ID.</p>
     #[serde(rename = "VolumeId")]
@@ -2323,7 +2323,7 @@ pub struct RegisterVolumeResult {
 }
 
 /// <p>A registered instance's reported operating system.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ReportedOs {
     /// <p>The operating system family.</p>
     #[serde(rename = "Family")]
@@ -2340,7 +2340,7 @@ pub struct ReportedOs {
 }
 
 /// <p>Describes a user's SSH information.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SelfUserProfile {
     /// <p>The user's IAM ARN.</p>
     #[serde(rename = "IamUserArn")]
@@ -2361,7 +2361,7 @@ pub struct SelfUserProfile {
 }
 
 /// <p>Describes an AWS OpsWorks Stacks service error.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ServiceError {
     /// <p>When the error occurred.</p>
     #[serde(rename = "CreatedAt")]
@@ -2389,7 +2389,7 @@ pub struct ServiceError {
     pub type_: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SetLoadBasedAutoScalingRequest {
     /// <p>An <code>AutoScalingThresholds</code> object with the downscaling threshold configuration. If the load falls below these thresholds for a specified amount of time, AWS OpsWorks Stacks stops a specified number of instances.</p>
     #[serde(rename = "DownScaling")]
@@ -2408,7 +2408,7 @@ pub struct SetLoadBasedAutoScalingRequest {
     pub up_scaling: Option<AutoScalingThresholds>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SetPermissionRequest {
     /// <p>The user is allowed to use SSH to communicate with the instance.</p>
     #[serde(rename = "AllowSsh")]
@@ -2430,7 +2430,7 @@ pub struct SetPermissionRequest {
     pub stack_id: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SetTimeBasedAutoScalingRequest {
     /// <p>An <code>AutoScalingSchedule</code> with the instance schedule.</p>
     #[serde(rename = "AutoScalingSchedule")]
@@ -2442,7 +2442,7 @@ pub struct SetTimeBasedAutoScalingRequest {
 }
 
 /// <p>The Shutdown event configuration.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ShutdownEventConfiguration {
     /// <p>Whether to enable Elastic Load Balancing connection draining. For more information, see <a href="http://docs.aws.amazon.com/ElasticLoadBalancing/latest/DeveloperGuide/TerminologyandKeyConcepts.html#conn-drain">Connection Draining</a> </p>
     #[serde(rename = "DelayUntilElbConnectionsDrained")]
@@ -2455,7 +2455,7 @@ pub struct ShutdownEventConfiguration {
 }
 
 /// <p>Contains the information required to retrieve an app or cookbook from a repository. For more information, see <a href="http://docs.aws.amazon.com/opsworks/latest/userguide/workingapps-creating.html">Creating Apps</a> or <a href="http://docs.aws.amazon.com/opsworks/latest/userguide/workingcookbook.html">Custom Recipes and Cookbooks</a>.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Source {
     /// <p>When included in a request, the parameter depends on the repository type.</p> <ul> <li> <p>For Amazon S3 bundles, set <code>Password</code> to the appropriate IAM secret access key.</p> </li> <li> <p>For HTTP bundles and Subversion repositories, set <code>Password</code> to the password.</p> </li> </ul> <p>For more information on how to safely handle IAM credentials, see <a href="http://docs.aws.amazon.com/general/latest/gr/aws-access-keys-best-practices.html">http://docs.aws.amazon.com/general/latest/gr/aws-access-keys-best-practices.html</a>.</p> <p>In responses, AWS OpsWorks Stacks returns <code>*****FILTERED*****</code> instead of the actual value.</p>
     #[serde(rename = "Password")]
@@ -2484,7 +2484,7 @@ pub struct Source {
 }
 
 /// <p>Describes an app's SSL configuration.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SslConfiguration {
     /// <p>The contents of the certificate's domain.crt file.</p>
     #[serde(rename = "Certificate")]
@@ -2499,7 +2499,7 @@ pub struct SslConfiguration {
 }
 
 /// <p>Describes a stack.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Stack {
     /// <p>The agent version. This parameter is set to <code>LATEST</code> for auto-update. or a version number for a fixed agent version.</p>
     #[serde(rename = "AgentVersion")]
@@ -2591,7 +2591,7 @@ pub struct Stack {
 }
 
 /// <p>Describes the configuration manager.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct StackConfigurationManager {
     /// <p>The name. This parameter must be set to "Chef".</p>
     #[serde(rename = "Name")]
@@ -2604,7 +2604,7 @@ pub struct StackConfigurationManager {
 }
 
 /// <p>Summarizes the number of layers, instances, and apps in a stack.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StackSummary {
     /// <p>The number of apps.</p>
     #[serde(rename = "AppsCount")]
@@ -2632,21 +2632,21 @@ pub struct StackSummary {
     pub stack_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StartInstanceRequest {
     /// <p>The instance ID.</p>
     #[serde(rename = "InstanceId")]
     pub instance_id: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StartStackRequest {
     /// <p>The stack ID.</p>
     #[serde(rename = "StackId")]
     pub stack_id: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StopInstanceRequest {
     #[serde(rename = "Force")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2656,14 +2656,14 @@ pub struct StopInstanceRequest {
     pub instance_id: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StopStackRequest {
     /// <p>The stack ID.</p>
     #[serde(rename = "StackId")]
     pub stack_id: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct TagResourceRequest {
     /// <p>The stack or layer's Amazon Resource Number (ARN).</p>
     #[serde(rename = "ResourceArn")]
@@ -2674,7 +2674,7 @@ pub struct TagResourceRequest {
 }
 
 /// <p>Contains the data needed by RDP clients such as the Microsoft Remote Desktop Connection to log in to the instance.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct TemporaryCredential {
     /// <p>The instance's AWS OpsWorks Stacks ID.</p>
     #[serde(rename = "InstanceId")]
@@ -2695,7 +2695,7 @@ pub struct TemporaryCredential {
 }
 
 /// <p>Describes an instance's time-based auto scaling configuration.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct TimeBasedAutoScalingConfiguration {
     /// <p>A <code>WeeklyAutoScalingSchedule</code> object with the instance schedule.</p>
     #[serde(rename = "AutoScalingSchedule")]
@@ -2707,21 +2707,21 @@ pub struct TimeBasedAutoScalingConfiguration {
     pub instance_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UnassignInstanceRequest {
     /// <p>The instance ID.</p>
     #[serde(rename = "InstanceId")]
     pub instance_id: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UnassignVolumeRequest {
     /// <p>The volume ID.</p>
     #[serde(rename = "VolumeId")]
     pub volume_id: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UntagResourceRequest {
     /// <p>The stack or layer's Amazon Resource Number (ARN).</p>
     #[serde(rename = "ResourceArn")]
@@ -2731,7 +2731,7 @@ pub struct UntagResourceRequest {
     pub tag_keys: Vec<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateAppRequest {
     /// <p>The app ID.</p>
     #[serde(rename = "AppId")]
@@ -2778,7 +2778,7 @@ pub struct UpdateAppRequest {
     pub type_: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateElasticIpRequest {
     /// <p>The address.</p>
     #[serde(rename = "ElasticIp")]
@@ -2789,7 +2789,7 @@ pub struct UpdateElasticIpRequest {
     pub name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateInstanceRequest {
     /// <p>The default AWS OpsWorks Stacks agent version. You have the following options:</p> <ul> <li> <p> <code>INHERIT</code> - Use the stack's default agent version setting.</p> </li> <li> <p> <i>version_number</i> - Use the specified agent version. This value overrides the stack's default setting. To update the agent version, you must edit the instance configuration and specify a new version. AWS OpsWorks Stacks then automatically installs that version on the instance.</p> </li> </ul> <p>The default setting is <code>INHERIT</code>. To specify an agent version, you must use the complete version number, not the abbreviated number shown on the console. For a list of available agent version numbers, call <a>DescribeAgentVersions</a>.</p> <p>AgentVersion cannot be set to Chef 12.2.</p>
     #[serde(rename = "AgentVersion")]
@@ -2840,7 +2840,7 @@ pub struct UpdateInstanceRequest {
     pub ssh_key_name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateLayerRequest {
     /// <p>One or more user-defined key/value pairs to be added to the stack attributes.</p>
     #[serde(rename = "Attributes")]
@@ -2911,7 +2911,7 @@ pub struct UpdateLayerRequest {
     pub volume_configurations: Option<Vec<VolumeConfiguration>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateMyUserProfileRequest {
     /// <p>The user's SSH public key.</p>
     #[serde(rename = "SshPublicKey")]
@@ -2919,7 +2919,7 @@ pub struct UpdateMyUserProfileRequest {
     pub ssh_public_key: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateRdsDbInstanceRequest {
     /// <p>The database password.</p>
     #[serde(rename = "DbPassword")]
@@ -2934,7 +2934,7 @@ pub struct UpdateRdsDbInstanceRequest {
     pub rds_db_instance_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateStackRequest {
     /// <p><p>The default AWS OpsWorks Stacks agent version. You have the following options:</p> <ul> <li> <p>Auto-update - Set this parameter to <code>LATEST</code>. AWS OpsWorks Stacks automatically installs new agent versions on the stack&#39;s instances as soon as they are available.</p> </li> <li> <p>Fixed version - Set this parameter to your preferred agent version. To update the agent version, you must edit the stack configuration and specify a new version. AWS OpsWorks Stacks then automatically installs that version on the stack&#39;s instances.</p> </li> </ul> <p>The default setting is <code>LATEST</code>. To specify an agent version, you must use the complete version number, not the abbreviated number shown on the console. For a list of available agent version numbers, call <a>DescribeAgentVersions</a>. AgentVersion cannot be set to Chef 12.2.</p> <note> <p>You can also specify an agent version when you create or update an instance, which overrides the stack&#39;s default setting.</p> </note></p>
     #[serde(rename = "AgentVersion")]
@@ -3008,7 +3008,7 @@ pub struct UpdateStackRequest {
     pub use_opsworks_security_groups: Option<bool>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateUserProfileRequest {
     /// <p>Whether users can specify their own SSH public key through the My Settings page. For more information, see <a href="http://docs.aws.amazon.com/opsworks/latest/userguide/security-settingsshkey.html">Managing User Permissions</a>.</p>
     #[serde(rename = "AllowSelfManagement")]
@@ -3027,7 +3027,7 @@ pub struct UpdateUserProfileRequest {
     pub ssh_username: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateVolumeRequest {
     /// <p>The new mount point.</p>
     #[serde(rename = "MountPoint")]
@@ -3043,7 +3043,7 @@ pub struct UpdateVolumeRequest {
 }
 
 /// <p>Describes a user's SSH information.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UserProfile {
     /// <p>Whether users can specify their own SSH public key through the My Settings page. For more information, see <a href="http://docs.aws.amazon.com/opsworks/latest/userguide/security-settingsshkey.html">Managing User Permissions</a>.</p>
     #[serde(rename = "AllowSelfManagement")]
@@ -3068,7 +3068,7 @@ pub struct UserProfile {
 }
 
 /// <p>Describes an instance's Amazon EBS volume.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Volume {
     /// <p>The volume Availability Zone. For more information, see <a href="http://docs.aws.amazon.com/general/latest/gr/rande.html">Regions and Endpoints</a>.</p>
     #[serde(rename = "AvailabilityZone")]
@@ -3128,7 +3128,7 @@ pub struct Volume {
 }
 
 /// <p>Describes an Amazon EBS volume configuration.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct VolumeConfiguration {
     /// <p>Specifies whether an Amazon EBS volume is encrypted. For more information, see <a href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html">Amazon EBS Encryption</a>.</p>
     #[serde(rename = "Encrypted")]
@@ -3158,7 +3158,7 @@ pub struct VolumeConfiguration {
 }
 
 /// <p>Describes a time-based instance's auto scaling schedule. The schedule consists of a set of key-value pairs.</p> <ul> <li> <p>The key is the time period (a UTC hour) and must be an integer from 0 - 23.</p> </li> <li> <p>The value indicates whether the instance should be online or offline for the specified period, and must be set to "on" or "off"</p> </li> </ul> <p>The default setting for all time periods is off, so you use the following parameters primarily to specify the online periods. You don't have to explicitly specify offline periods unless you want to change an online period to an offline period.</p> <p>The following example specifies that the instance should be online for four hours, from UTC 1200 - 1600. It will be off for the remainder of the day.</p> <p> <code> { "12":"on", "13":"on", "14":"on", "15":"on" } </code> </p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct WeeklyAutoScalingSchedule {
     /// <p>The schedule for Friday.</p>
     #[serde(rename = "Friday")]

--- a/rusoto/services/opsworkscm/src/generated.rs
+++ b/rusoto/services/opsworkscm/src/generated.rs
@@ -661,7 +661,8 @@ impl AssociateNodeError {
     pub fn from_body(body: &str) -> AssociateNodeError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -747,7 +748,8 @@ impl CreateBackupError {
     pub fn from_body(body: &str) -> CreateBackupError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -837,7 +839,8 @@ impl CreateServerError {
     pub fn from_body(body: &str) -> CreateServerError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -925,7 +928,8 @@ impl DeleteBackupError {
     pub fn from_body(body: &str) -> DeleteBackupError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1009,7 +1013,8 @@ impl DeleteServerError {
     pub fn from_body(body: &str) -> DeleteServerError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1089,7 +1094,8 @@ impl DescribeAccountAttributesError {
     pub fn from_body(body: &str) -> DescribeAccountAttributesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1167,7 +1173,8 @@ impl DescribeBackupsError {
     pub fn from_body(body: &str) -> DescribeBackupsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1251,7 +1258,8 @@ impl DescribeEventsError {
     pub fn from_body(body: &str) -> DescribeEventsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1333,7 +1341,8 @@ impl DescribeNodeAssociationStatusError {
     pub fn from_body(body: &str) -> DescribeNodeAssociationStatusError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1417,7 +1426,8 @@ impl DescribeServersError {
     pub fn from_body(body: &str) -> DescribeServersError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1501,7 +1511,8 @@ impl DisassociateNodeError {
     pub fn from_body(body: &str) -> DisassociateNodeError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1585,7 +1596,8 @@ impl RestoreServerError {
     pub fn from_body(body: &str) -> RestoreServerError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1669,7 +1681,8 @@ impl StartMaintenanceError {
     pub fn from_body(body: &str) -> StartMaintenanceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1753,7 +1766,8 @@ impl UpdateServerError {
     pub fn from_body(body: &str) -> UpdateServerError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1837,7 +1851,8 @@ impl UpdateServerEngineAttributesError {
     pub fn from_body(body: &str) -> UpdateServerEngineAttributesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/opsworkscm/src/generated.rs
+++ b/rusoto/services/opsworkscm/src/generated.rs
@@ -31,7 +31,7 @@ use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 /// <p>Stores account attributes. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AccountAttribute {
     /// <p> The maximum allowed value. </p>
     #[serde(rename = "Maximum")]
@@ -47,7 +47,7 @@ pub struct AccountAttribute {
     pub used: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AssociateNodeRequest {
     /// <p><p>Engine attributes used for associating the node. </p> <p class="title"> <b>Attributes accepted in a AssociateNode request for Chef</b> </p> <ul> <li> <p> <code>CHEF<em>ORGANIZATION</code>: The Chef organization with which the node is associated. By default only one organization named <code>default</code> can exist. </p> </li> <li> <p> <code>CHEF</em>NODE<em>PUBLIC</em>KEY</code>: A PEM-formatted public key. This key is required for the <code>chef-client</code> agent to access the Chef API. </p> </li> </ul> <p class="title"> <b>Attributes accepted in a AssociateNode request for Puppet</b> </p> <ul> <li> <p> <code>PUPPET<em>NODE</em>CSR</code>: A PEM-formatted certificate-signing request (CSR) that is created by the node. </p> </li> </ul></p>
     #[serde(rename = "EngineAttributes")]
@@ -60,7 +60,7 @@ pub struct AssociateNodeRequest {
     pub server_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AssociateNodeResponse {
     /// <p>Contains a token which can be passed to the <code>DescribeNodeAssociationStatus</code> API call to get the status of the association request. </p>
     #[serde(rename = "NodeAssociationStatusToken")]
@@ -69,7 +69,7 @@ pub struct AssociateNodeResponse {
 }
 
 /// <p>Describes a single backup. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Backup {
     /// <p>The ARN of the backup. </p>
     #[serde(rename = "BackupArn")]
@@ -161,7 +161,7 @@ pub struct Backup {
     pub user_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateBackupRequest {
     /// <p> A user-defined description of the backup. </p>
     #[serde(rename = "Description")]
@@ -172,7 +172,7 @@ pub struct CreateBackupRequest {
     pub server_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateBackupResponse {
     /// <p>Backup created by request.</p>
     #[serde(rename = "Backup")]
@@ -180,7 +180,7 @@ pub struct CreateBackupResponse {
     pub backup: Option<Backup>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateServerRequest {
     /// <p> Associate a public IP address with a server that you are launching. Valid values are <code>true</code> or <code>false</code>. The default value is <code>true</code>. </p>
     #[serde(rename = "AssociatePublicIpAddress")]
@@ -248,7 +248,7 @@ pub struct CreateServerRequest {
     pub subnet_ids: Option<Vec<String>>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateServerResponse {
     /// <p>The server that is created by the request. </p>
     #[serde(rename = "Server")]
@@ -256,30 +256,30 @@ pub struct CreateServerResponse {
     pub server: Option<Server>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteBackupRequest {
     /// <p>The ID of the backup to delete. Run the DescribeBackups command to get a list of backup IDs. Backup IDs are in the format <code>ServerName-yyyyMMddHHmmssSSS</code>. </p>
     #[serde(rename = "BackupId")]
     pub backup_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteBackupResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteServerRequest {
     /// <p>The ID of the server to delete.</p>
     #[serde(rename = "ServerName")]
     pub server_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteServerResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeAccountAttributesRequest {}
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeAccountAttributesResponse {
     /// <p> The attributes that are currently set for the account. </p>
     #[serde(rename = "Attributes")]
@@ -287,7 +287,7 @@ pub struct DescribeAccountAttributesResponse {
     pub attributes: Option<Vec<AccountAttribute>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeBackupsRequest {
     /// <p>Describes a single backup. </p>
     #[serde(rename = "BackupId")]
@@ -307,7 +307,7 @@ pub struct DescribeBackupsRequest {
     pub server_name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeBackupsResponse {
     /// <p>Contains the response to a <code>DescribeBackups</code> request. </p>
     #[serde(rename = "Backups")]
@@ -319,7 +319,7 @@ pub struct DescribeBackupsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeEventsRequest {
     /// <p>To receive a paginated response, use this parameter to specify the maximum number of results to be returned with a single call. If the number of available results exceeds this maximum, the response includes a <code>NextToken</code> value that you can assign to the <code>NextToken</code> request parameter to get the next set of results. </p>
     #[serde(rename = "MaxResults")]
@@ -334,7 +334,7 @@ pub struct DescribeEventsRequest {
     pub server_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeEventsResponse {
     /// <p>NextToken is a string that is returned in some command responses. It indicates that not all entries have been returned, and that you must run at least one more request to get remaining items. To get remaining results, call <code>DescribeEvents</code> again, and assign the token from the previous results as the value of the <code>nextToken</code> parameter. If there are no more results, the response object's <code>nextToken</code> parameter value is <code>null</code>. Setting a <code>nextToken</code> value that was not returned in your previous results causes an <code>InvalidNextTokenException</code> to occur. </p>
     #[serde(rename = "NextToken")]
@@ -346,7 +346,7 @@ pub struct DescribeEventsResponse {
     pub server_events: Option<Vec<ServerEvent>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeNodeAssociationStatusRequest {
     /// <p>The token returned in either the AssociateNodeResponse or the DisassociateNodeResponse. </p>
     #[serde(rename = "NodeAssociationStatusToken")]
@@ -356,7 +356,7 @@ pub struct DescribeNodeAssociationStatusRequest {
     pub server_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeNodeAssociationStatusResponse {
     /// <p>Attributes specific to the node association. In Puppet, the attibute PUPPET_NODE_CERT contains the signed certificate (the result of the CSR). </p>
     #[serde(rename = "EngineAttributes")]
@@ -368,7 +368,7 @@ pub struct DescribeNodeAssociationStatusResponse {
     pub node_association_status: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeServersRequest {
     /// <p>To receive a paginated response, use this parameter to specify the maximum number of results to be returned with a single call. If the number of available results exceeds this maximum, the response includes a <code>NextToken</code> value that you can assign to the <code>NextToken</code> request parameter to get the next set of results. </p>
     #[serde(rename = "MaxResults")]
@@ -384,7 +384,7 @@ pub struct DescribeServersRequest {
     pub server_name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeServersResponse {
     /// <p>NextToken is a string that is returned in some command responses. It indicates that not all entries have been returned, and that you must run at least one more request to get remaining items. To get remaining results, call <code>DescribeServers</code> again, and assign the token from the previous results as the value of the <code>nextToken</code> parameter. If there are no more results, the response object's <code>nextToken</code> parameter value is <code>null</code>. Setting a <code>nextToken</code> value that was not returned in your previous results causes an <code>InvalidNextTokenException</code> to occur. </p>
     #[serde(rename = "NextToken")]
@@ -396,7 +396,7 @@ pub struct DescribeServersResponse {
     pub servers: Option<Vec<Server>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DisassociateNodeRequest {
     /// <p><p>Engine attributes that are used for disassociating the node. No attributes are required for Puppet. </p> <p class="title"> <b>Attributes required in a DisassociateNode request for Chef</b> </p> <ul> <li> <p> <code>CHEF_ORGANIZATION</code>: The Chef organization with which the node was associated. By default only one organization named <code>default</code> can exist. </p> </li> </ul></p>
     #[serde(rename = "EngineAttributes")]
@@ -410,7 +410,7 @@ pub struct DisassociateNodeRequest {
     pub server_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DisassociateNodeResponse {
     /// <p>Contains a token which can be passed to the <code>DescribeNodeAssociationStatus</code> API call to get the status of the disassociation request. </p>
     #[serde(rename = "NodeAssociationStatusToken")]
@@ -419,7 +419,7 @@ pub struct DisassociateNodeResponse {
 }
 
 /// <p>A name and value pair that is specific to the engine of the server. </p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct EngineAttribute {
     /// <p>The name of the engine attribute. </p>
     #[serde(rename = "Name")]
@@ -431,7 +431,7 @@ pub struct EngineAttribute {
     pub value: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RestoreServerRequest {
     /// <p> The ID of the backup that you want to use to restore a server. </p>
     #[serde(rename = "BackupId")]
@@ -449,11 +449,11 @@ pub struct RestoreServerRequest {
     pub server_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RestoreServerResponse {}
 
 /// <p>Describes a configuration management server. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Server {
     /// <p>Associate a public IP address with a server that you are launching. </p>
     #[serde(rename = "AssociatePublicIpAddress")]
@@ -550,7 +550,7 @@ pub struct Server {
 }
 
 /// <p>An event that is related to the server, such as the start of maintenance or backup. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ServerEvent {
     /// <p>The time when the event occurred. </p>
     #[serde(rename = "CreatedAt")]
@@ -570,7 +570,7 @@ pub struct ServerEvent {
     pub server_name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StartMaintenanceRequest {
     /// <p>Engine attributes that are specific to the server on which you want to run maintenance. </p>
     #[serde(rename = "EngineAttributes")]
@@ -581,7 +581,7 @@ pub struct StartMaintenanceRequest {
     pub server_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StartMaintenanceResponse {
     /// <p>Contains the response to a <code>StartMaintenance</code> request. </p>
     #[serde(rename = "Server")]
@@ -589,7 +589,7 @@ pub struct StartMaintenanceResponse {
     pub server: Option<Server>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateServerEngineAttributesRequest {
     /// <p>The name of the engine attribute to update. </p>
     #[serde(rename = "AttributeName")]
@@ -603,7 +603,7 @@ pub struct UpdateServerEngineAttributesRequest {
     pub server_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateServerEngineAttributesResponse {
     /// <p>Contains the response to an <code>UpdateServerEngineAttributes</code> request. </p>
     #[serde(rename = "Server")]
@@ -611,7 +611,7 @@ pub struct UpdateServerEngineAttributesResponse {
     pub server: Option<Server>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateServerRequest {
     /// <p>Sets the number of automated backups that you want to keep. </p>
     #[serde(rename = "BackupRetentionCount")]
@@ -632,7 +632,7 @@ pub struct UpdateServerRequest {
     pub server_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateServerResponse {
     /// <p>Contains the response to a <code>UpdateServer</code> request. </p>
     #[serde(rename = "Server")]

--- a/rusoto/services/organizations/src/generated.rs
+++ b/rusoto/services/organizations/src/generated.rs
@@ -1142,7 +1142,8 @@ impl AcceptHandshakeError {
     pub fn from_body(body: &str) -> AcceptHandshakeError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1284,7 +1285,8 @@ impl AttachPolicyError {
     pub fn from_body(body: &str) -> AttachPolicyError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1414,7 +1416,8 @@ impl CancelHandshakeError {
     pub fn from_body(body: &str) -> CancelHandshakeError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1536,7 +1539,8 @@ impl CreateAccountError {
     pub fn from_body(body: &str) -> CreateAccountError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1654,7 +1658,8 @@ impl CreateOrganizationError {
     pub fn from_body(body: &str) -> CreateOrganizationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1780,7 +1785,8 @@ impl CreateOrganizationalUnitError {
     pub fn from_body(body: &str) -> CreateOrganizationalUnitError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1918,7 +1924,8 @@ impl CreatePolicyError {
     pub fn from_body(body: &str) -> CreatePolicyError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2046,7 +2053,8 @@ impl DeclineHandshakeError {
     pub fn from_body(body: &str) -> DeclineHandshakeError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2166,7 +2174,8 @@ impl DeleteOrganizationError {
     pub fn from_body(body: &str) -> DeleteOrganizationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2286,7 +2295,8 @@ impl DeleteOrganizationalUnitError {
     pub fn from_body(body: &str) -> DeleteOrganizationalUnitError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2416,7 +2426,8 @@ impl DeletePolicyError {
     pub fn from_body(body: &str) -> DeletePolicyError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2530,7 +2541,8 @@ impl DescribeAccountError {
     pub fn from_body(body: &str) -> DescribeAccountError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2638,7 +2650,8 @@ impl DescribeCreateAccountStatusError {
     pub fn from_body(body: &str) -> DescribeCreateAccountStatusError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2754,7 +2767,8 @@ impl DescribeHandshakeError {
     pub fn from_body(body: &str) -> DescribeHandshakeError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2862,7 +2876,8 @@ impl DescribeOrganizationError {
     pub fn from_body(body: &str) -> DescribeOrganizationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2972,7 +2987,8 @@ impl DescribeOrganizationalUnitError {
     pub fn from_body(body: &str) -> DescribeOrganizationalUnitError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3086,7 +3102,8 @@ impl DescribePolicyError {
     pub fn from_body(body: &str) -> DescribePolicyError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3200,7 +3217,8 @@ impl DetachPolicyError {
     pub fn from_body(body: &str) -> DetachPolicyError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3324,7 +3342,8 @@ impl DisableAWSServiceAccessError {
     pub fn from_body(body: &str) -> DisableAWSServiceAccessError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3450,7 +3469,8 @@ impl DisablePolicyTypeError {
     pub fn from_body(body: &str) -> DisablePolicyTypeError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3576,7 +3596,8 @@ impl EnableAWSServiceAccessError {
     pub fn from_body(body: &str) -> EnableAWSServiceAccessError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3698,7 +3719,8 @@ impl EnableAllFeaturesError {
     pub fn from_body(body: &str) -> EnableAllFeaturesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3824,7 +3846,8 @@ impl EnablePolicyTypeError {
     pub fn from_body(body: &str) -> EnablePolicyTypeError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3956,7 +3979,8 @@ impl InviteAccountToOrganizationError {
     pub fn from_body(body: &str) -> InviteAccountToOrganizationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4096,7 +4120,8 @@ impl LeaveOrganizationError {
     pub fn from_body(body: &str) -> LeaveOrganizationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4222,7 +4247,8 @@ impl ListAWSServiceAccessForOrganizationError {
     pub fn from_body(body: &str) -> ListAWSServiceAccessForOrganizationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4340,7 +4366,8 @@ impl ListAccountsError {
     pub fn from_body(body: &str) -> ListAccountsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4442,7 +4469,8 @@ impl ListAccountsForParentError {
     pub fn from_body(body: &str) -> ListAccountsForParentError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4554,7 +4582,8 @@ impl ListChildrenError {
     pub fn from_body(body: &str) -> ListChildrenError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4658,7 +4687,8 @@ impl ListCreateAccountStatusError {
     pub fn from_body(body: &str) -> ListCreateAccountStatusError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4764,7 +4794,8 @@ impl ListHandshakesForAccountError {
     pub fn from_body(body: &str) -> ListHandshakesForAccountError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4872,7 +4903,8 @@ impl ListHandshakesForOrganizationError {
     pub fn from_body(body: &str) -> ListHandshakesForOrganizationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4988,7 +5020,8 @@ impl ListOrganizationalUnitsForParentError {
     pub fn from_body(body: &str) -> ListOrganizationalUnitsForParentError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5104,7 +5137,8 @@ impl ListParentsError {
     pub fn from_body(body: &str) -> ListParentsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5208,7 +5242,8 @@ impl ListPoliciesError {
     pub fn from_body(body: &str) -> ListPoliciesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5310,7 +5345,8 @@ impl ListPoliciesForTargetError {
     pub fn from_body(body: &str) -> ListPoliciesForTargetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5420,7 +5456,8 @@ impl ListRootsError {
     pub fn from_body(body: &str) -> ListRootsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5520,7 +5557,8 @@ impl ListTargetsForPolicyError {
     pub fn from_body(body: &str) -> ListTargetsForPolicyError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5640,7 +5678,8 @@ impl MoveAccountError {
     pub fn from_body(body: &str) -> MoveAccountError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5768,7 +5807,8 @@ impl RemoveAccountFromOrganizationError {
     pub fn from_body(body: &str) -> RemoveAccountFromOrganizationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5906,7 +5946,8 @@ impl UpdateOrganizationalUnitError {
     pub fn from_body(body: &str) -> UpdateOrganizationalUnitError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6040,7 +6081,8 @@ impl UpdatePolicyError {
     pub fn from_body(body: &str) -> UpdatePolicyError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/organizations/src/generated.rs
+++ b/rusoto/services/organizations/src/generated.rs
@@ -30,14 +30,14 @@ use rusoto_core::signature::SignedRequest;
 use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AcceptHandshakeRequest {
     /// <p>The unique identifier (ID) of the handshake that you want to accept.</p> <p>The <a href="http://wikipedia.org/wiki/regex">regex pattern</a> for handshake ID string requires "h-" followed by from 8 to 32 lower-case letters or digits.</p>
     #[serde(rename = "HandshakeId")]
     pub handshake_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AcceptHandshakeResponse {
     /// <p>A structure that contains details about the accepted handshake.</p>
     #[serde(rename = "Handshake")]
@@ -46,7 +46,7 @@ pub struct AcceptHandshakeResponse {
 }
 
 /// <p>Contains information about an AWS account that is a member of an organization.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Account {
     /// <p>The Amazon Resource Name (ARN) of the account.</p> <p>For more information about ARNs in Organizations, see <a href="http://docs.aws.amazon.com/organizations/latest/userguide/orgs_permissions.html#orgs-permissions-arns">ARN Formats Supported by Organizations</a> in the <i>AWS Organizations User Guide</i>.</p>
     #[serde(rename = "Arn")]
@@ -78,7 +78,7 @@ pub struct Account {
     pub status: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AttachPolicyRequest {
     /// <p>The unique identifier (ID) of the policy that you want to attach to the target. You can get the ID for the policy by calling the <a>ListPolicies</a> operation.</p> <p>The <a href="http://wikipedia.org/wiki/regex">regex pattern</a> for a policy ID string requires "p-" followed by from 8 to 128 lower-case letters or digits.</p>
     #[serde(rename = "PolicyId")]
@@ -88,14 +88,14 @@ pub struct AttachPolicyRequest {
     pub target_id: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CancelHandshakeRequest {
     /// <p>The unique identifier (ID) of the handshake that you want to cancel. You can get the ID from the <a>ListHandshakesForOrganization</a> operation.</p> <p>The <a href="http://wikipedia.org/wiki/regex">regex pattern</a> for handshake ID string requires "h-" followed by from 8 to 32 lower-case letters or digits.</p>
     #[serde(rename = "HandshakeId")]
     pub handshake_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CancelHandshakeResponse {
     /// <p>A structure that contains details about the handshake that you canceled.</p>
     #[serde(rename = "Handshake")]
@@ -104,7 +104,7 @@ pub struct CancelHandshakeResponse {
 }
 
 /// <p>Contains a list of child entities, either OUs or accounts.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Child {
     /// <p><p>The unique identifier (ID) of this child entity.</p> <p>The <a href="http://wikipedia.org/wiki/regex">regex pattern</a> for a child ID string requires one of the following:</p> <ul> <li> <p>Account: a string that consists of exactly 12 digits.</p> </li> <li> <p>Organizational unit (OU): a string that begins with &quot;ou-&quot; followed by from 4 to 32 lower-case letters or digits (the ID of the root that contains the OU) followed by a second &quot;-&quot; dash and from 8 to 32 additional lower-case letters or digits.</p> </li> </ul></p>
     #[serde(rename = "Id")]
@@ -116,7 +116,7 @@ pub struct Child {
     pub type_: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateAccountRequest {
     /// <p>The friendly name of the member account.</p>
     #[serde(rename = "AccountName")]
@@ -134,7 +134,7 @@ pub struct CreateAccountRequest {
     pub role_name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateAccountResponse {
     /// <p>A structure that contains details about the request to create an account. This response structure might not be fully populated when you first receive it because account creation is an asynchronous process. You can pass the returned CreateAccountStatus ID as a parameter to <code> <a>DescribeCreateAccountStatus</a> </code> to get status about the progress of the request at later times. </p>
     #[serde(rename = "CreateAccountStatus")]
@@ -143,7 +143,7 @@ pub struct CreateAccountResponse {
 }
 
 /// <p>Contains the status about a <a>CreateAccount</a> request to create an AWS account in an organization.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateAccountStatus {
     /// <p>If the account was created successfully, the unique identifier (ID) of the new account.</p> <p>The <a href="http://wikipedia.org/wiki/regex">regex pattern</a> for an account ID string requires exactly 12 digits.</p>
     #[serde(rename = "AccountId")]
@@ -175,7 +175,7 @@ pub struct CreateAccountStatus {
     pub state: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateOrganizationRequest {
     /// <p><p>Specifies the feature set supported by the new organization. Each feature set supports different levels of functionality.</p> <ul> <li> <p> <i>CONSOLIDATED<em>BILLING</i>: All member accounts have their bills consolidated to and paid by the master account. For more information, see &lt;a href=&quot;http://docs.aws.amazon.com/organizations/latest/userguide/orgs</em>getting-started<em>concepts.html#feature-set-cb-only&quot;&gt;Consolidated Billing</a> in the <i>AWS Organizations User Guide</i>.</p> </li> <li> <p> <i>ALL</i>: In addition to all the features supported by the consolidated billing feature set, the master account can also apply any type of policy to any member account in the organization. For more information, see &lt;a href=&quot;http://docs.aws.amazon.com/organizations/latest/userguide/orgs</em>getting-started_concepts.html#feature-set-all&quot;&gt;All features</a> in the <i>AWS Organizations User Guide</i>.</p> </li> </ul></p>
     #[serde(rename = "FeatureSet")]
@@ -183,7 +183,7 @@ pub struct CreateOrganizationRequest {
     pub feature_set: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateOrganizationResponse {
     /// <p>A structure that contains details about the newly created organization.</p>
     #[serde(rename = "Organization")]
@@ -191,7 +191,7 @@ pub struct CreateOrganizationResponse {
     pub organization: Option<Organization>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateOrganizationalUnitRequest {
     /// <p>The friendly name to assign to the new OU.</p>
     #[serde(rename = "Name")]
@@ -201,7 +201,7 @@ pub struct CreateOrganizationalUnitRequest {
     pub parent_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateOrganizationalUnitResponse {
     /// <p>A structure that contains details about the newly created OU.</p>
     #[serde(rename = "OrganizationalUnit")]
@@ -209,7 +209,7 @@ pub struct CreateOrganizationalUnitResponse {
     pub organizational_unit: Option<OrganizationalUnit>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreatePolicyRequest {
     /// <p>The policy content to add to the new policy. For example, if you create a <a href="http://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_scp.html">service control policy</a> (SCP), this string must be JSON text that specifies the permissions that admins in attached accounts can delegate to their users, groups, and roles. For more information about the SCP syntax, see <a href="http://docs.aws.amazon.com/organizations/latest/userguide/orgs_reference_scp-syntax.html">Service Control Policy Syntax</a> in the <i>AWS Organizations User Guide</i>.</p>
     #[serde(rename = "Content")]
@@ -225,7 +225,7 @@ pub struct CreatePolicyRequest {
     pub type_: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreatePolicyResponse {
     /// <p>A structure that contains details about the newly created policy.</p>
     #[serde(rename = "Policy")]
@@ -233,14 +233,14 @@ pub struct CreatePolicyResponse {
     pub policy: Option<Policy>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeclineHandshakeRequest {
     /// <p>The unique identifier (ID) of the handshake that you want to decline. You can get the ID from the <a>ListHandshakesForAccount</a> operation.</p> <p>The <a href="http://wikipedia.org/wiki/regex">regex pattern</a> for handshake ID string requires "h-" followed by from 8 to 32 lower-case letters or digits.</p>
     #[serde(rename = "HandshakeId")]
     pub handshake_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeclineHandshakeResponse {
     /// <p>A structure that contains details about the declined handshake. The state is updated to show the value <code>DECLINED</code>.</p>
     #[serde(rename = "Handshake")]
@@ -248,28 +248,28 @@ pub struct DeclineHandshakeResponse {
     pub handshake: Option<Handshake>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteOrganizationalUnitRequest {
     /// <p>The unique identifier (ID) of the organizational unit that you want to delete. You can get the ID from the <a>ListOrganizationalUnitsForParent</a> operation.</p> <p>The <a href="http://wikipedia.org/wiki/regex">regex pattern</a> for an organizational unit ID string requires "ou-" followed by from 4 to 32 lower-case letters or digits (the ID of the root that contains the OU) followed by a second "-" dash and from 8 to 32 additional lower-case letters or digits.</p>
     #[serde(rename = "OrganizationalUnitId")]
     pub organizational_unit_id: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeletePolicyRequest {
     /// <p>The unique identifier (ID) of the policy that you want to delete. You can get the ID from the <a>ListPolicies</a> or <a>ListPoliciesForTarget</a> operations.</p> <p>The <a href="http://wikipedia.org/wiki/regex">regex pattern</a> for a policy ID string requires "p-" followed by from 8 to 128 lower-case letters or digits.</p>
     #[serde(rename = "PolicyId")]
     pub policy_id: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeAccountRequest {
     /// <p>The unique identifier (ID) of the AWS account that you want information about. You can get the ID from the <a>ListAccounts</a> or <a>ListAccountsForParent</a> operations.</p> <p>The <a href="http://wikipedia.org/wiki/regex">regex pattern</a> for an account ID string requires exactly 12 digits.</p>
     #[serde(rename = "AccountId")]
     pub account_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeAccountResponse {
     /// <p>A structure that contains information about the requested account.</p>
     #[serde(rename = "Account")]
@@ -277,14 +277,14 @@ pub struct DescribeAccountResponse {
     pub account: Option<Account>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeCreateAccountStatusRequest {
     /// <p>Specifies the <code>operationId</code> that uniquely identifies the request. You can get the ID from the response to an earlier <a>CreateAccount</a> request, or from the <a>ListCreateAccountStatus</a> operation.</p> <p>The <a href="http://wikipedia.org/wiki/regex">regex pattern</a> for an create account request ID string requires "car-" followed by from 8 to 32 lower-case letters or digits.</p>
     #[serde(rename = "CreateAccountRequestId")]
     pub create_account_request_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeCreateAccountStatusResponse {
     /// <p>A structure that contains the current status of an account creation request.</p>
     #[serde(rename = "CreateAccountStatus")]
@@ -292,14 +292,14 @@ pub struct DescribeCreateAccountStatusResponse {
     pub create_account_status: Option<CreateAccountStatus>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeHandshakeRequest {
     /// <p>The unique identifier (ID) of the handshake that you want information about. You can get the ID from the original call to <a>InviteAccountToOrganization</a>, or from a call to <a>ListHandshakesForAccount</a> or <a>ListHandshakesForOrganization</a>.</p> <p>The <a href="http://wikipedia.org/wiki/regex">regex pattern</a> for handshake ID string requires "h-" followed by from 8 to 32 lower-case letters or digits.</p>
     #[serde(rename = "HandshakeId")]
     pub handshake_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeHandshakeResponse {
     /// <p>A structure that contains information about the specified handshake.</p>
     #[serde(rename = "Handshake")]
@@ -307,7 +307,7 @@ pub struct DescribeHandshakeResponse {
     pub handshake: Option<Handshake>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeOrganizationResponse {
     /// <p>A structure that contains information about the organization.</p>
     #[serde(rename = "Organization")]
@@ -315,14 +315,14 @@ pub struct DescribeOrganizationResponse {
     pub organization: Option<Organization>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeOrganizationalUnitRequest {
     /// <p>The unique identifier (ID) of the organizational unit that you want details about. You can get the ID from the <a>ListOrganizationalUnitsForParent</a> operation.</p> <p>The <a href="http://wikipedia.org/wiki/regex">regex pattern</a> for an organizational unit ID string requires "ou-" followed by from 4 to 32 lower-case letters or digits (the ID of the root that contains the OU) followed by a second "-" dash and from 8 to 32 additional lower-case letters or digits.</p>
     #[serde(rename = "OrganizationalUnitId")]
     pub organizational_unit_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeOrganizationalUnitResponse {
     /// <p>A structure that contains details about the specified OU.</p>
     #[serde(rename = "OrganizationalUnit")]
@@ -330,14 +330,14 @@ pub struct DescribeOrganizationalUnitResponse {
     pub organizational_unit: Option<OrganizationalUnit>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribePolicyRequest {
     /// <p>The unique identifier (ID) of the policy that you want details about. You can get the ID from the <a>ListPolicies</a> or <a>ListPoliciesForTarget</a> operations.</p> <p>The <a href="http://wikipedia.org/wiki/regex">regex pattern</a> for a policy ID string requires "p-" followed by from 8 to 128 lower-case letters or digits.</p>
     #[serde(rename = "PolicyId")]
     pub policy_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribePolicyResponse {
     /// <p>A structure that contains details about the specified policy.</p>
     #[serde(rename = "Policy")]
@@ -345,7 +345,7 @@ pub struct DescribePolicyResponse {
     pub policy: Option<Policy>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DetachPolicyRequest {
     /// <p>The unique identifier (ID) of the policy you want to detach. You can get the ID from the <a>ListPolicies</a> or <a>ListPoliciesForTarget</a> operations.</p> <p>The <a href="http://wikipedia.org/wiki/regex">regex pattern</a> for a policy ID string requires "p-" followed by from 8 to 128 lower-case letters or digits.</p>
     #[serde(rename = "PolicyId")]
@@ -355,14 +355,14 @@ pub struct DetachPolicyRequest {
     pub target_id: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DisableAWSServiceAccessRequest {
     /// <p>The service principal name of the AWS service for which you want to disable integration with your organization. This is typically in the form of a URL, such as <code> <i>service-abbreviation</i>.amazonaws.com</code>.</p>
     #[serde(rename = "ServicePrincipal")]
     pub service_principal: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DisablePolicyTypeRequest {
     /// <p>The policy type that you want to disable in this root.</p>
     #[serde(rename = "PolicyType")]
@@ -372,7 +372,7 @@ pub struct DisablePolicyTypeRequest {
     pub root_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DisablePolicyTypeResponse {
     /// <p>A structure that shows the root with the updated list of enabled policy types.</p>
     #[serde(rename = "Root")]
@@ -380,17 +380,17 @@ pub struct DisablePolicyTypeResponse {
     pub root: Option<Root>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct EnableAWSServiceAccessRequest {
     /// <p>The service principal name of the AWS service for which you want to enable integration with your organization. This is typically in the form of a URL, such as <code> <i>service-abbreviation</i>.amazonaws.com</code>.</p>
     #[serde(rename = "ServicePrincipal")]
     pub service_principal: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct EnableAllFeaturesRequest {}
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct EnableAllFeaturesResponse {
     /// <p>A structure that contains details about the handshake created to support this request to enable all features in the organization.</p>
     #[serde(rename = "Handshake")]
@@ -398,7 +398,7 @@ pub struct EnableAllFeaturesResponse {
     pub handshake: Option<Handshake>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct EnablePolicyTypeRequest {
     /// <p>The policy type that you want to enable.</p>
     #[serde(rename = "PolicyType")]
@@ -408,7 +408,7 @@ pub struct EnablePolicyTypeRequest {
     pub root_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct EnablePolicyTypeResponse {
     /// <p>A structure that shows the root with the updated list of enabled policy types.</p>
     #[serde(rename = "Root")]
@@ -417,7 +417,7 @@ pub struct EnablePolicyTypeResponse {
 }
 
 /// <p>A structure that contains details of a service principal that is enabled to integrate with AWS Organizations.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct EnabledServicePrincipal {
     /// <p>The date that the service principal was enabled for integration with AWS Organizations.</p>
     #[serde(rename = "DateEnabled")]
@@ -430,7 +430,7 @@ pub struct EnabledServicePrincipal {
 }
 
 /// <p>Contains information that must be exchanged to securely establish a relationship between two accounts (an <i>originator</i> and a <i>recipient</i>). For example, when a master account (the originator) invites another account (the recipient) to join its organization, the two accounts exchange information as a series of handshake requests and responses.</p> <p> <b>Note:</b> Handshakes that are CANCELED, ACCEPTED, or DECLINED show up in lists for only 30 days after entering that state After that they are deleted.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Handshake {
     /// <p><p>The type of handshake, indicating what action occurs when the recipient accepts the handshake. The following handshake types are supported:</p> <ul> <li> <p> <b>INVITE</b>: This type of handshake represents a request to join an organization. It is always sent from the master account to only non-member accounts.</p> </li> <li> <p> <b>ENABLE<em>ALL</em>FEATURES</b>: This type of handshake represents a request to enable all features in an organization. It is always sent from the master account to only <i>invited</i> member accounts. Created accounts do not receive this because those accounts were created by the organization&#39;s master account and approval is inferred.</p> </li> <li> <p> <b>APPROVE<em>ALL</em>FEATURES</b>: This type of handshake is sent from the Organizations service when all member accounts have approved the <code>ENABLE<em>ALL</em>FEATURES</code> invitation. It is sent only to the master account and signals the master that it can finalize the process to enable all features.</p> </li> </ul></p>
     #[serde(rename = "Action")]
@@ -467,7 +467,7 @@ pub struct Handshake {
 }
 
 /// <p>Specifies the criteria that are used to select the handshakes for the operation.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct HandshakeFilter {
     /// <p>Specifies the type of handshake action.</p> <p>If you specify <code>ActionType</code>, you cannot also specify <code>ParentHandshakeId</code>.</p>
     #[serde(rename = "ActionType")]
@@ -480,7 +480,7 @@ pub struct HandshakeFilter {
 }
 
 /// <p>Identifies a participant in a handshake.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct HandshakeParty {
     /// <p>The unique identifier (ID) for the party.</p> <p>The <a href="http://wikipedia.org/wiki/regex">regex pattern</a> for handshake ID string requires "h-" followed by from 8 to 32 lower-case letters or digits.</p>
     #[serde(rename = "Id")]
@@ -491,7 +491,7 @@ pub struct HandshakeParty {
 }
 
 /// <p>Contains additional data that is needed to process a handshake.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct HandshakeResource {
     /// <p>When needed, contains an additional array of <code>HandshakeResource</code> objects.</p>
     #[serde(rename = "Resources")]
@@ -507,7 +507,7 @@ pub struct HandshakeResource {
     pub value: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct InviteAccountToOrganizationRequest {
     /// <p>Additional information that you want to include in the generated email to the recipient account owner.</p>
     #[serde(rename = "Notes")]
@@ -518,7 +518,7 @@ pub struct InviteAccountToOrganizationRequest {
     pub target: HandshakeParty,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct InviteAccountToOrganizationResponse {
     /// <p>A structure that contains details about the handshake that is created to support this invitation request.</p>
     #[serde(rename = "Handshake")]
@@ -526,7 +526,7 @@ pub struct InviteAccountToOrganizationResponse {
     pub handshake: Option<Handshake>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListAWSServiceAccessForOrganizationRequest {
     /// <p>(Optional) Use this to limit the number of results you want included in the response. If you do not include this parameter, it defaults to a value that is specific to the operation. If additional items exist beyond the maximum you specify, the <code>NextToken</code> response element is present and has a value (is not null). Include that value as the <code>NextToken</code> request parameter in the next call to the operation to get the next part of the results. Note that Organizations might return fewer results than the maximum even when there are more results available. You should check <code>NextToken</code> after every operation to ensure that you receive all of the results.</p>
     #[serde(rename = "MaxResults")]
@@ -538,7 +538,7 @@ pub struct ListAWSServiceAccessForOrganizationRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListAWSServiceAccessForOrganizationResponse {
     /// <p>A list of the service principals for the services that are enabled to integrate with your organization. Each principal is a structure that includes the name and the date that it was enabled for integration with AWS Organizations.</p>
     #[serde(rename = "EnabledServicePrincipals")]
@@ -550,7 +550,7 @@ pub struct ListAWSServiceAccessForOrganizationResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListAccountsForParentRequest {
     /// <p>(Optional) Use this to limit the number of results you want included in the response. If you do not include this parameter, it defaults to a value that is specific to the operation. If additional items exist beyond the maximum you specify, the <code>NextToken</code> response element is present and has a value (is not null). Include that value as the <code>NextToken</code> request parameter in the next call to the operation to get the next part of the results. Note that Organizations might return fewer results than the maximum even when there are more results available. You should check <code>NextToken</code> after every operation to ensure that you receive all of the results.</p>
     #[serde(rename = "MaxResults")]
@@ -565,7 +565,7 @@ pub struct ListAccountsForParentRequest {
     pub parent_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListAccountsForParentResponse {
     /// <p>A list of the accounts in the specified root or OU.</p>
     #[serde(rename = "Accounts")]
@@ -577,7 +577,7 @@ pub struct ListAccountsForParentResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListAccountsRequest {
     /// <p>(Optional) Use this to limit the number of results you want included in the response. If you do not include this parameter, it defaults to a value that is specific to the operation. If additional items exist beyond the maximum you specify, the <code>NextToken</code> response element is present and has a value (is not null). Include that value as the <code>NextToken</code> request parameter in the next call to the operation to get the next part of the results. Note that Organizations might return fewer results than the maximum even when there are more results available. You should check <code>NextToken</code> after every operation to ensure that you receive all of the results.</p>
     #[serde(rename = "MaxResults")]
@@ -589,7 +589,7 @@ pub struct ListAccountsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListAccountsResponse {
     /// <p>A list of objects in the organization.</p>
     #[serde(rename = "Accounts")]
@@ -601,7 +601,7 @@ pub struct ListAccountsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListChildrenRequest {
     /// <p>Filters the output to include only the specified child type.</p>
     #[serde(rename = "ChildType")]
@@ -619,7 +619,7 @@ pub struct ListChildrenRequest {
     pub parent_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListChildrenResponse {
     /// <p>The list of children of the specified parent container.</p>
     #[serde(rename = "Children")]
@@ -631,7 +631,7 @@ pub struct ListChildrenResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListCreateAccountStatusRequest {
     /// <p>(Optional) Use this to limit the number of results you want included in the response. If you do not include this parameter, it defaults to a value that is specific to the operation. If additional items exist beyond the maximum you specify, the <code>NextToken</code> response element is present and has a value (is not null). Include that value as the <code>NextToken</code> request parameter in the next call to the operation to get the next part of the results. Note that Organizations might return fewer results than the maximum even when there are more results available. You should check <code>NextToken</code> after every operation to ensure that you receive all of the results.</p>
     #[serde(rename = "MaxResults")]
@@ -647,7 +647,7 @@ pub struct ListCreateAccountStatusRequest {
     pub states: Option<Vec<String>>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListCreateAccountStatusResponse {
     /// <p>A list of objects with details about the requests. Certain elements, such as the accountId number, are present in the output only after the account has been successfully created.</p>
     #[serde(rename = "CreateAccountStatuses")]
@@ -659,7 +659,7 @@ pub struct ListCreateAccountStatusResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListHandshakesForAccountRequest {
     /// <p>Filters the handshakes that you want included in the response. The default is all types. Use the <code>ActionType</code> element to limit the output to only a specified type, such as <code>INVITE</code>, <code>ENABLE-FULL-CONTROL</code>, or <code>APPROVE-FULL-CONTROL</code>. Alternatively, for the <code>ENABLE-FULL-CONTROL</code> handshake that generates a separate child handshake for each member account, you can specify <code>ParentHandshakeId</code> to see only the handshakes that were generated by that parent request.</p>
     #[serde(rename = "Filter")]
@@ -675,7 +675,7 @@ pub struct ListHandshakesForAccountRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListHandshakesForAccountResponse {
     /// <p>A list of <a>Handshake</a> objects with details about each of the handshakes that is associated with the specified account.</p>
     #[serde(rename = "Handshakes")]
@@ -687,7 +687,7 @@ pub struct ListHandshakesForAccountResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListHandshakesForOrganizationRequest {
     /// <p>A filter of the handshakes that you want included in the response. The default is all types. Use the <code>ActionType</code> element to limit the output to only a specified type, such as <code>INVITE</code>, <code>ENABLE-ALL-FEATURES</code>, or <code>APPROVE-ALL-FEATURES</code>. Alternatively, for the <code>ENABLE-ALL-FEATURES</code> handshake that generates a separate child handshake for each member account, you can specify the <code>ParentHandshakeId</code> to see only the handshakes that were generated by that parent request.</p>
     #[serde(rename = "Filter")]
@@ -703,7 +703,7 @@ pub struct ListHandshakesForOrganizationRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListHandshakesForOrganizationResponse {
     /// <p>A list of <a>Handshake</a> objects with details about each of the handshakes that are associated with an organization.</p>
     #[serde(rename = "Handshakes")]
@@ -715,7 +715,7 @@ pub struct ListHandshakesForOrganizationResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListOrganizationalUnitsForParentRequest {
     /// <p>(Optional) Use this to limit the number of results you want included in the response. If you do not include this parameter, it defaults to a value that is specific to the operation. If additional items exist beyond the maximum you specify, the <code>NextToken</code> response element is present and has a value (is not null). Include that value as the <code>NextToken</code> request parameter in the next call to the operation to get the next part of the results. Note that Organizations might return fewer results than the maximum even when there are more results available. You should check <code>NextToken</code> after every operation to ensure that you receive all of the results.</p>
     #[serde(rename = "MaxResults")]
@@ -730,7 +730,7 @@ pub struct ListOrganizationalUnitsForParentRequest {
     pub parent_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListOrganizationalUnitsForParentResponse {
     /// <p>If present, this value indicates that there is more output available than is included in the current response. Use this value in the <code>NextToken</code> request parameter in a subsequent call to the operation to get the next part of the output. You should repeat this until the <code>NextToken</code> response element comes back as <code>null</code>.</p>
     #[serde(rename = "NextToken")]
@@ -742,7 +742,7 @@ pub struct ListOrganizationalUnitsForParentResponse {
     pub organizational_units: Option<Vec<OrganizationalUnit>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListParentsRequest {
     /// <p><p>The unique identifier (ID) of the OU or account whose parent containers you want to list. Do not specify a root.</p> <p>The <a href="http://wikipedia.org/wiki/regex">regex pattern</a> for a child ID string requires one of the following:</p> <ul> <li> <p>Account: a string that consists of exactly 12 digits.</p> </li> <li> <p>Organizational unit (OU): a string that begins with &quot;ou-&quot; followed by from 4 to 32 lower-case letters or digits (the ID of the root that contains the OU) followed by a second &quot;-&quot; dash and from 8 to 32 additional lower-case letters or digits.</p> </li> </ul></p>
     #[serde(rename = "ChildId")]
@@ -757,7 +757,7 @@ pub struct ListParentsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListParentsResponse {
     /// <p>If present, this value indicates that there is more output available than is included in the current response. Use this value in the <code>NextToken</code> request parameter in a subsequent call to the operation to get the next part of the output. You should repeat this until the <code>NextToken</code> response element comes back as <code>null</code>.</p>
     #[serde(rename = "NextToken")]
@@ -769,7 +769,7 @@ pub struct ListParentsResponse {
     pub parents: Option<Vec<Parent>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListPoliciesForTargetRequest {
     /// <p>The type of policy that you want to include in the returned list.</p>
     #[serde(rename = "Filter")]
@@ -787,7 +787,7 @@ pub struct ListPoliciesForTargetRequest {
     pub target_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListPoliciesForTargetResponse {
     /// <p>If present, this value indicates that there is more output available than is included in the current response. Use this value in the <code>NextToken</code> request parameter in a subsequent call to the operation to get the next part of the output. You should repeat this until the <code>NextToken</code> response element comes back as <code>null</code>.</p>
     #[serde(rename = "NextToken")]
@@ -799,7 +799,7 @@ pub struct ListPoliciesForTargetResponse {
     pub policies: Option<Vec<PolicySummary>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListPoliciesRequest {
     /// <p>Specifies the type of policy that you want to include in the response.</p>
     #[serde(rename = "Filter")]
@@ -814,7 +814,7 @@ pub struct ListPoliciesRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListPoliciesResponse {
     /// <p>If present, this value indicates that there is more output available than is included in the current response. Use this value in the <code>NextToken</code> request parameter in a subsequent call to the operation to get the next part of the output. You should repeat this until the <code>NextToken</code> response element comes back as <code>null</code>.</p>
     #[serde(rename = "NextToken")]
@@ -826,7 +826,7 @@ pub struct ListPoliciesResponse {
     pub policies: Option<Vec<PolicySummary>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListRootsRequest {
     /// <p>(Optional) Use this to limit the number of results you want included in the response. If you do not include this parameter, it defaults to a value that is specific to the operation. If additional items exist beyond the maximum you specify, the <code>NextToken</code> response element is present and has a value (is not null). Include that value as the <code>NextToken</code> request parameter in the next call to the operation to get the next part of the results. Note that Organizations might return fewer results than the maximum even when there are more results available. You should check <code>NextToken</code> after every operation to ensure that you receive all of the results.</p>
     #[serde(rename = "MaxResults")]
@@ -838,7 +838,7 @@ pub struct ListRootsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListRootsResponse {
     /// <p>If present, this value indicates that there is more output available than is included in the current response. Use this value in the <code>NextToken</code> request parameter in a subsequent call to the operation to get the next part of the output. You should repeat this until the <code>NextToken</code> response element comes back as <code>null</code>.</p>
     #[serde(rename = "NextToken")]
@@ -850,7 +850,7 @@ pub struct ListRootsResponse {
     pub roots: Option<Vec<Root>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListTargetsForPolicyRequest {
     /// <p>(Optional) Use this to limit the number of results you want included in the response. If you do not include this parameter, it defaults to a value that is specific to the operation. If additional items exist beyond the maximum you specify, the <code>NextToken</code> response element is present and has a value (is not null). Include that value as the <code>NextToken</code> request parameter in the next call to the operation to get the next part of the results. Note that Organizations might return fewer results than the maximum even when there are more results available. You should check <code>NextToken</code> after every operation to ensure that you receive all of the results.</p>
     #[serde(rename = "MaxResults")]
@@ -865,7 +865,7 @@ pub struct ListTargetsForPolicyRequest {
     pub policy_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListTargetsForPolicyResponse {
     /// <p>If present, this value indicates that there is more output available than is included in the current response. Use this value in the <code>NextToken</code> request parameter in a subsequent call to the operation to get the next part of the output. You should repeat this until the <code>NextToken</code> response element comes back as <code>null</code>.</p>
     #[serde(rename = "NextToken")]
@@ -877,7 +877,7 @@ pub struct ListTargetsForPolicyResponse {
     pub targets: Option<Vec<PolicyTargetSummary>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct MoveAccountRequest {
     /// <p>The unique identifier (ID) of the account that you want to move.</p> <p>The <a href="http://wikipedia.org/wiki/regex">regex pattern</a> for an account ID string requires exactly 12 digits.</p>
     #[serde(rename = "AccountId")]
@@ -891,7 +891,7 @@ pub struct MoveAccountRequest {
 }
 
 /// <p>Contains details about an organization. An organization is a collection of accounts that are centrally managed together using consolidated billing, organized hierarchically with organizational units (OUs), and controlled with policies .</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Organization {
     /// <p>The Amazon Resource Name (ARN) of an organization.</p> <p>For more information about ARNs in Organizations, see <a href="http://docs.aws.amazon.com/organizations/latest/userguide/orgs_permissions.html#orgs-permissions-arns">ARN Formats Supported by Organizations</a> in the <i>AWS Organizations User Guide</i>.</p>
     #[serde(rename = "Arn")]
@@ -924,7 +924,7 @@ pub struct Organization {
 }
 
 /// <p>Contains details about an organizational unit (OU). An OU is a container of AWS accounts within a root of an organization. Policies that are attached to an OU apply to all accounts contained in that OU and in any child OUs.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct OrganizationalUnit {
     /// <p>The Amazon Resource Name (ARN) of this OU.</p> <p>For more information about ARNs in Organizations, see <a href="http://docs.aws.amazon.com/organizations/latest/userguide/orgs_permissions.html#orgs-permissions-arns">ARN Formats Supported by Organizations</a> in the <i>AWS Organizations User Guide</i>.</p>
     #[serde(rename = "Arn")]
@@ -941,7 +941,7 @@ pub struct OrganizationalUnit {
 }
 
 /// <p>Contains information about either a root or an organizational unit (OU) that can contain OUs or accounts in an organization.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Parent {
     /// <p><p>The unique identifier (ID) of the parent entity.</p> <p>The <a href="http://wikipedia.org/wiki/regex">regex pattern</a> for a parent ID string requires one of the following:</p> <ul> <li> <p>Root: a string that begins with &quot;r-&quot; followed by from 4 to 32 lower-case letters or digits.</p> </li> <li> <p>Organizational unit (OU): a string that begins with &quot;ou-&quot; followed by from 4 to 32 lower-case letters or digits (the ID of the root that the OU is in) followed by a second &quot;-&quot; dash and from 8 to 32 additional lower-case letters or digits.</p> </li> </ul></p>
     #[serde(rename = "Id")]
@@ -954,7 +954,7 @@ pub struct Parent {
 }
 
 /// <p>Contains rules to be applied to the affected accounts. Policies can be attached directly to accounts, or to roots and OUs to affect all accounts in those hierarchies.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Policy {
     /// <p>The text content of the policy.</p>
     #[serde(rename = "Content")]
@@ -967,7 +967,7 @@ pub struct Policy {
 }
 
 /// <p>Contains information about a policy, but does not include the content. To see the content of a policy, see <a>DescribePolicy</a>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PolicySummary {
     /// <p>The Amazon Resource Name (ARN) of the policy.</p> <p>For more information about ARNs in Organizations, see <a href="http://docs.aws.amazon.com/organizations/latest/userguide/orgs_permissions.html#orgs-permissions-arns">ARN Formats Supported by Organizations</a> in the <i>AWS Organizations User Guide</i>.</p>
     #[serde(rename = "Arn")]
@@ -996,7 +996,7 @@ pub struct PolicySummary {
 }
 
 /// <p>Contains information about a root, OU, or account that a policy is attached to.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PolicyTargetSummary {
     /// <p>The Amazon Resource Name (ARN) of the policy target.</p> <p>For more information about ARNs in Organizations, see <a href="http://docs.aws.amazon.com/organizations/latest/userguide/orgs_permissions.html#orgs-permissions-arns">ARN Formats Supported by Organizations</a> in the <i>AWS Organizations User Guide</i>.</p>
     #[serde(rename = "Arn")]
@@ -1017,7 +1017,7 @@ pub struct PolicyTargetSummary {
 }
 
 /// <p>Contains information about a policy type and its status in the associated root.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PolicyTypeSummary {
     /// <p>The status of the policy type as it relates to the associated root. To attach a policy of the specified type to a root or to an OU or account in that root, it must be available in the organization and enabled for that root.</p>
     #[serde(rename = "Status")]
@@ -1029,7 +1029,7 @@ pub struct PolicyTypeSummary {
     pub type_: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RemoveAccountFromOrganizationRequest {
     /// <p>The unique identifier (ID) of the member account that you want to remove from the organization.</p> <p>The <a href="http://wikipedia.org/wiki/regex">regex pattern</a> for an account ID string requires exactly 12 digits.</p>
     #[serde(rename = "AccountId")]
@@ -1037,7 +1037,7 @@ pub struct RemoveAccountFromOrganizationRequest {
 }
 
 /// <p>Contains details about a root. A root is a top-level parent node in the hierarchy of an organization that can contain organizational units (OUs) and accounts. Every root contains every AWS account in the organization. Each root enables the accounts to be organized in a different way and to have different policy types enabled for use in that root.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Root {
     /// <p>The Amazon Resource Name (ARN) of the root.</p> <p>For more information about ARNs in Organizations, see <a href="http://docs.aws.amazon.com/organizations/latest/userguide/orgs_permissions.html#orgs-permissions-arns">ARN Formats Supported by Organizations</a> in the <i>AWS Organizations User Guide</i>.</p>
     #[serde(rename = "Arn")]
@@ -1057,7 +1057,7 @@ pub struct Root {
     pub policy_types: Option<Vec<PolicyTypeSummary>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateOrganizationalUnitRequest {
     /// <p>The new name that you want to assign to the OU.</p> <p>The <a href="http://wikipedia.org/wiki/regex">regex pattern</a> that is used to validate this parameter is a string of any of the characters in the ASCII character range.</p>
     #[serde(rename = "Name")]
@@ -1068,7 +1068,7 @@ pub struct UpdateOrganizationalUnitRequest {
     pub organizational_unit_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateOrganizationalUnitResponse {
     /// <p>A structure that contains the details about the specified OU, including its new name.</p>
     #[serde(rename = "OrganizationalUnit")]
@@ -1076,7 +1076,7 @@ pub struct UpdateOrganizationalUnitResponse {
     pub organizational_unit: Option<OrganizationalUnit>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdatePolicyRequest {
     /// <p>If provided, the new content for the policy. The text must be correctly formatted JSON that complies with the syntax for the policy's type. For more information, see <a href="http://docs.aws.amazon.com/organizations/latest/userguide/orgs_reference_scp-syntax.html">Service Control Policy Syntax</a> in the <i>AWS Organizations User Guide</i>.</p>
     #[serde(rename = "Content")]
@@ -1095,7 +1095,7 @@ pub struct UpdatePolicyRequest {
     pub policy_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdatePolicyResponse {
     /// <p>A structure that contains details about the updated policy, showing the requested changes.</p>
     #[serde(rename = "Policy")]

--- a/rusoto/services/polly/src/generated.rs
+++ b/rusoto/services/polly/src/generated.rs
@@ -30,17 +30,17 @@ use rusoto_core::signature::SignedRequest;
 use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteLexiconInput {
     /// <p>The name of the lexicon to delete. Must be an existing lexicon in the region.</p>
     #[serde(rename = "Name")]
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteLexiconOutput {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeVoicesInput {
     /// <p> The language identification tag (ISO 639 code for the language name-ISO 3166 country code) for filtering the list of voices returned. If you don't specify this optional parameter, all available voices are returned. </p>
     #[serde(rename = "LanguageCode")]
@@ -52,7 +52,7 @@ pub struct DescribeVoicesInput {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeVoicesOutput {
     /// <p>The pagination token to use in the next request to continue the listing of voices. <code>NextToken</code> is returned only if the response is truncated.</p>
     #[serde(rename = "NextToken")]
@@ -64,14 +64,14 @@ pub struct DescribeVoicesOutput {
     pub voices: Option<Vec<Voice>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetLexiconInput {
     /// <p>Name of the lexicon.</p>
     #[serde(rename = "Name")]
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetLexiconOutput {
     /// <p>Lexicon object that provides name and the string content of the lexicon. </p>
     #[serde(rename = "Lexicon")]
@@ -84,7 +84,7 @@ pub struct GetLexiconOutput {
 }
 
 /// <p>Provides lexicon name and lexicon content in string format. For more information, see <a href="https://www.w3.org/TR/pronunciation-lexicon/">Pronunciation Lexicon Specification (PLS) Version 1.0</a>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Lexicon {
     /// <p>Lexicon content in string format. The content of a lexicon must be in PLS format.</p>
     #[serde(rename = "Content")]
@@ -97,7 +97,7 @@ pub struct Lexicon {
 }
 
 /// <p>Contains metadata describing the lexicon such as the number of lexemes, language code, and so on. For more information, see <a href="http://docs.aws.amazon.com/polly/latest/dg/managing-lexicons.html">Managing Lexicons</a>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct LexiconAttributes {
     /// <p>Phonetic alphabet used in the lexicon. Valid values are <code>ipa</code> and <code>x-sampa</code>.</p>
     #[serde(rename = "Alphabet")]
@@ -126,7 +126,7 @@ pub struct LexiconAttributes {
 }
 
 /// <p>Describes the content of the lexicon.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct LexiconDescription {
     /// <p>Provides lexicon metadata.</p>
     #[serde(rename = "Attributes")]
@@ -138,7 +138,7 @@ pub struct LexiconDescription {
     pub name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListLexiconsInput {
     /// <p>An opaque pagination token returned from previous <code>ListLexicons</code> operation. If present, indicates where to continue the list of lexicons.</p>
     #[serde(rename = "NextToken")]
@@ -146,7 +146,7 @@ pub struct ListLexiconsInput {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListLexiconsOutput {
     /// <p>A list of lexicon names and attributes.</p>
     #[serde(rename = "Lexicons")]
@@ -158,7 +158,7 @@ pub struct ListLexiconsOutput {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PutLexiconInput {
     /// <p>Content of the PLS lexicon as string data.</p>
     #[serde(rename = "Content")]
@@ -168,10 +168,10 @@ pub struct PutLexiconInput {
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PutLexiconOutput {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SynthesizeSpeechInput {
     /// <p>List of one or more pronunciation lexicon names you want the service to apply during synthesis. Lexicons are applied only if the language of the lexicon is the same as the language of the voice. For information about storing lexicons, see <a href="http://docs.aws.amazon.com/polly/latest/dg/API_PutLexicon.html">PutLexicon</a>.</p>
     #[serde(rename = "LexiconNames")]
@@ -200,7 +200,7 @@ pub struct SynthesizeSpeechInput {
     pub voice_id: String,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SynthesizeSpeechOutput {
     /// <p> Stream containing the synthesized speech. </p>
     pub audio_stream: Option<Vec<u8>>,
@@ -211,7 +211,7 @@ pub struct SynthesizeSpeechOutput {
 }
 
 /// <p>Description of the voice.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Voice {
     /// <p>Gender of the voice.</p>
     #[serde(rename = "Gender")]

--- a/rusoto/services/polly/src/generated.rs
+++ b/rusoto/services/polly/src/generated.rs
@@ -256,7 +256,8 @@ impl DeleteLexiconError {
     pub fn from_body(body: &str) -> DeleteLexiconError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -340,7 +341,8 @@ impl DescribeVoicesError {
     pub fn from_body(body: &str) -> DescribeVoicesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -424,7 +426,8 @@ impl GetLexiconError {
     pub fn from_body(body: &str) -> GetLexiconError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -506,7 +509,8 @@ impl ListLexiconsError {
     pub fn from_body(body: &str) -> ListLexiconsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -600,7 +604,8 @@ impl PutLexiconError {
     pub fn from_body(body: &str) -> PutLexiconError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -712,7 +717,8 @@ impl SynthesizeSpeechError {
     pub fn from_body(body: &str) -> SynthesizeSpeechError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/rds/src/generated.rs
+++ b/rusoto/services/rds/src/generated.rs
@@ -44,7 +44,7 @@ enum DeserializerNext {
     Element(String),
 }
 /// <p>Data returned by the <b>DescribeAccountAttributes</b> action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AccountAttributesMessage {
     /// <p>A list of <a>AccountQuota</a> objects. Within this list, each quota has a name, a count of usage toward the quota maximum, and a maximum value for the quota.</p>
     pub account_quotas: Option<Vec<AccountQuota>>,
@@ -93,7 +93,7 @@ impl AccountAttributesMessageDeserializer {
     }
 }
 /// <p>Describes a quota for an AWS account, for example, the number of DB instances allowed.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AccountQuota {
     /// <p>The name of the Amazon RDS quota for this AWS account.</p>
     pub account_quota_name: Option<String>,
@@ -194,7 +194,7 @@ impl AccountQuotaListDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AddRoleToDBClusterMessage {
     /// <p>The name of the DB cluster to associate the IAM role with.</p>
     pub db_cluster_identifier: String,
@@ -223,7 +223,7 @@ impl AddRoleToDBClusterMessageSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AddSourceIdentifierToSubscriptionMessage {
     /// <p><p>The identifier of the event source to be added.</p> <p>Constraints:</p> <ul> <li> <p>If the source type is a DB instance, then a <code>DBInstanceIdentifier</code> must be supplied.</p> </li> <li> <p>If the source type is a DB security group, a <code>DBSecurityGroupName</code> must be supplied.</p> </li> <li> <p>If the source type is a DB parameter group, a <code>DBParameterGroupName</code> must be supplied.</p> </li> <li> <p>If the source type is a DB snapshot, a <code>DBSnapshotIdentifier</code> must be supplied.</p> </li> </ul></p>
     pub source_identifier: String,
@@ -251,7 +251,7 @@ impl AddSourceIdentifierToSubscriptionMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AddSourceIdentifierToSubscriptionResult {
     pub event_subscription: Option<EventSubscription>,
 }
@@ -298,7 +298,7 @@ impl AddSourceIdentifierToSubscriptionResultDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AddTagsToResourceMessage {
     /// <p>The Amazon RDS resource that the tags are added to. This value is an Amazon Resource Name (ARN). For information about creating an ARN, see <a href="http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Tagging.ARN.html#USER_Tagging.ARN.Constructing"> Constructing an RDS Amazon Resource Name (ARN)</a>.</p>
     pub resource_name: String,
@@ -338,7 +338,7 @@ impl ApplyMethodDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ApplyPendingMaintenanceActionMessage {
     /// <p>The pending maintenance action to apply to this resource.</p> <p>Valid values: <code>system-update</code>, <code>db-upgrade</code> </p>
     pub apply_action: String,
@@ -372,7 +372,7 @@ impl ApplyPendingMaintenanceActionMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ApplyPendingMaintenanceActionResult {
     pub resource_pending_maintenance_actions: Option<ResourcePendingMaintenanceActions>,
 }
@@ -477,7 +477,7 @@ impl AttributeValueListSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AuthorizeDBSecurityGroupIngressMessage {
     /// <p>The IP range to authorize.</p>
     pub cidrip: Option<String>,
@@ -531,7 +531,7 @@ impl AuthorizeDBSecurityGroupIngressMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AuthorizeDBSecurityGroupIngressResult {
     pub db_security_group: Option<DBSecurityGroup>,
 }
@@ -578,7 +578,7 @@ impl AuthorizeDBSecurityGroupIngressResultDeserializer {
     }
 }
 /// <p><p>Contains Availability Zone information.</p> <p> This data type is used as an element in the following data type:</p> <ul> <li> <p> <a>OrderableDBInstanceOption</a> </p> </li> </ul></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AvailabilityZone {
     /// <p>The name of the availability zone.</p>
     pub name: Option<String>,
@@ -750,7 +750,7 @@ impl BooleanOptionalDeserializer {
     }
 }
 /// <p>A CA certificate for an AWS account.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Certificate {
     /// <p>The Amazon Resource Name (ARN) for the certificate.</p>
     pub certificate_arn: Option<String>,
@@ -876,7 +876,7 @@ impl CertificateListDeserializer {
     }
 }
 /// <p>Data returned by the <b>DescribeCertificates</b> action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CertificateMessage {
     /// <p>The list of <a>Certificate</a> objects for the AWS account.</p>
     pub certificates: Option<Vec<Certificate>>,
@@ -930,7 +930,7 @@ impl CertificateMessageDeserializer {
     }
 }
 /// <p> This data type is used as a response element in the action <a>DescribeDBEngineVersions</a>. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CharacterSet {
     /// <p>The description of the character set.</p>
     pub character_set_description: Option<String>,
@@ -986,7 +986,7 @@ impl CharacterSetDeserializer {
     }
 }
 /// <p>The configuration setting for the log types to be enabled for export to CloudWatch Logs for a specific DB instance or DB cluster.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CloudwatchLogsExportConfiguration {
     /// <p>The list of log types to disable.</p>
     pub disable_log_types: Option<Vec<String>>,
@@ -1020,7 +1020,7 @@ impl CloudwatchLogsExportConfigurationSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CopyDBClusterParameterGroupMessage {
     /// <p><p>The identifier or Amazon Resource Name (ARN) for the source DB cluster parameter group. For information about creating an ARN, see <a href="http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Tagging.ARN.html#USER_Tagging.ARN.Constructing"> Constructing an RDS Amazon Resource Name (ARN)</a>. </p> <p>Constraints:</p> <ul> <li> <p>Must specify a valid DB cluster parameter group.</p> </li> <li> <p>If the source DB cluster parameter group is in the same AWS Region as the copy, specify a valid DB parameter group identifier, for example <code>my-db-cluster-param-group</code>, or a valid ARN.</p> </li> <li> <p>If the source DB parameter group is in a different AWS Region than the copy, specify a valid DB cluster parameter group ARN, for example <code>arn:aws:rds:us-east-1:123456789012:cluster-pg:custom-cluster-group1</code>.</p> </li> </ul></p>
     pub source_db_cluster_parameter_group_identifier: String,
@@ -1061,7 +1061,7 @@ impl CopyDBClusterParameterGroupMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CopyDBClusterParameterGroupResult {
     pub db_cluster_parameter_group: Option<DBClusterParameterGroup>,
 }
@@ -1110,7 +1110,7 @@ impl CopyDBClusterParameterGroupResultDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CopyDBClusterSnapshotMessage {
     /// <p>True to copy all tags from the source DB cluster snapshot to the target DB cluster snapshot, and otherwise false. The default is false.</p>
     pub copy_tags: Option<bool>,
@@ -1168,7 +1168,7 @@ impl CopyDBClusterSnapshotMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CopyDBClusterSnapshotResult {
     pub db_cluster_snapshot: Option<DBClusterSnapshot>,
 }
@@ -1215,7 +1215,7 @@ impl CopyDBClusterSnapshotResultDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CopyDBParameterGroupMessage {
     /// <p><p> The identifier or ARN for the source DB parameter group. For information about creating an ARN, see <a href="http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Tagging.ARN.html#USER_Tagging.ARN.Constructing"> Constructing an RDS Amazon Resource Name (ARN)</a>. </p> <p>Constraints:</p> <ul> <li> <p>Must specify a valid DB parameter group.</p> </li> <li> <p>Must specify a valid DB parameter group identifier, for example <code>my-db-param-group</code>, or a valid ARN.</p> </li> </ul></p>
     pub source_db_parameter_group_identifier: String,
@@ -1254,7 +1254,7 @@ impl CopyDBParameterGroupMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CopyDBParameterGroupResult {
     pub db_parameter_group: Option<DBParameterGroup>,
 }
@@ -1301,7 +1301,7 @@ impl CopyDBParameterGroupResultDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CopyDBSnapshotMessage {
     /// <p>True to copy all tags from the source DB snapshot to the target DB snapshot, and otherwise false. The default is false.</p>
     pub copy_tags: Option<bool>,
@@ -1365,7 +1365,7 @@ impl CopyDBSnapshotMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CopyDBSnapshotResult {
     pub db_snapshot: Option<DBSnapshot>,
 }
@@ -1413,7 +1413,7 @@ impl CopyDBSnapshotResultDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CopyOptionGroupMessage {
     /// <p><p>The identifier or ARN for the source option group. For information about creating an ARN, see <a href="http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Tagging.ARN.html#USER_Tagging.ARN.Constructing"> Constructing an RDS Amazon Resource Name (ARN)</a>. </p> <p>Constraints:</p> <ul> <li> <p>Must specify a valid option group.</p> </li> <li> <p>If the source option group is in the same AWS Region as the copy, specify a valid option group identifier, for example <code>my-option-group</code>, or a valid ARN.</p> </li> <li> <p>If the source option group is in a different AWS Region than the copy, specify a valid option group ARN, for example <code>arn:aws:rds:us-west-2:123456789012:og:special-options</code>.</p> </li> </ul></p>
     pub source_option_group_identifier: String,
@@ -1451,7 +1451,7 @@ impl CopyOptionGroupMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CopyOptionGroupResult {
     pub option_group: Option<OptionGroup>,
 }
@@ -1499,7 +1499,7 @@ impl CopyOptionGroupResultDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateDBClusterMessage {
     /// <p>A list of EC2 Availability Zones that instances in the DB cluster can be created in. For information on AWS Regions and Availability Zones, see <a href="http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html">Regions and Availability Zones</a>. </p>
     pub availability_zones: Option<Vec<String>>,
@@ -1686,7 +1686,7 @@ impl CreateDBClusterMessageSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateDBClusterParameterGroupMessage {
     /// <p><p>The name of the DB cluster parameter group.</p> <p>Constraints:</p> <ul> <li> <p>Must match the name of an existing DBClusterParameterGroup.</p> </li> </ul> <note> <p>This value is stored as a lowercase string.</p> </note></p>
     pub db_cluster_parameter_group_name: String,
@@ -1724,7 +1724,7 @@ impl CreateDBClusterParameterGroupMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateDBClusterParameterGroupResult {
     pub db_cluster_parameter_group: Option<DBClusterParameterGroup>,
 }
@@ -1772,7 +1772,7 @@ impl CreateDBClusterParameterGroupResultDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateDBClusterResult {
     pub db_cluster: Option<DBCluster>,
 }
@@ -1818,7 +1818,7 @@ impl CreateDBClusterResultDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateDBClusterSnapshotMessage {
     /// <p>The identifier of the DB cluster to create a snapshot for. This parameter is not case-sensitive.</p> <p>Constraints:</p> <ul> <li> <p>Must match the identifier of an existing DBCluster.</p> </li> </ul> <p>Example: <code>my-cluster1</code> </p>
     pub db_cluster_identifier: String,
@@ -1851,7 +1851,7 @@ impl CreateDBClusterSnapshotMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateDBClusterSnapshotResult {
     pub db_cluster_snapshot: Option<DBClusterSnapshot>,
 }
@@ -1898,7 +1898,7 @@ impl CreateDBClusterSnapshotResultDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateDBInstanceMessage {
     /// <p><p>The amount of storage (in gibibytes) to allocate for the DB instance.</p> <p>Type: Integer</p> <p> <b>Amazon Aurora</b> </p> <p>Not applicable. Aurora cluster volumes automatically grow as the amount of data in your database increases, though you are only charged for the space that you use in an Aurora cluster volume.</p> <p> <b>MySQL</b> </p> <p>Constraints to the amount of storage for each storage type are the following: </p> <ul> <li> <p>General Purpose (SSD) storage (gp2): Must be an integer from 20 to 16384.</p> </li> <li> <p>Provisioned IOPS storage (io1): Must be an integer from 100 to 16384.</p> </li> <li> <p>Magnetic storage (standard): Must be an integer from 5 to 3072.</p> </li> </ul> <p> <b>MariaDB</b> </p> <p>Constraints to the amount of storage for each storage type are the following: </p> <ul> <li> <p>General Purpose (SSD) storage (gp2): Must be an integer from 20 to 16384.</p> </li> <li> <p>Provisioned IOPS storage (io1): Must be an integer from 100 to 16384.</p> </li> <li> <p>Magnetic storage (standard): Must be an integer from 5 to 3072.</p> </li> </ul> <p> <b>PostgreSQL</b> </p> <p>Constraints to the amount of storage for each storage type are the following: </p> <ul> <li> <p>General Purpose (SSD) storage (gp2): Must be an integer from 20 to 16384.</p> </li> <li> <p>Provisioned IOPS storage (io1): Must be an integer from 100 to 16384.</p> </li> <li> <p>Magnetic storage (standard): Must be an integer from 5 to 3072.</p> </li> </ul> <p> <b>Oracle</b> </p> <p>Constraints to the amount of storage for each storage type are the following: </p> <ul> <li> <p>General Purpose (SSD) storage (gp2): Must be an integer from 20 to 16384.</p> </li> <li> <p>Provisioned IOPS storage (io1): Must be an integer from 100 to 16384.</p> </li> <li> <p>Magnetic storage (standard): Must be an integer from 10 to 3072.</p> </li> </ul> <p> <b>SQL Server</b> </p> <p>Constraints to the amount of storage for each storage type are the following: </p> <ul> <li> <p>General Purpose (SSD) storage (gp2):</p> <ul> <li> <p>Enterprise and Standard editions: Must be an integer from 200 to 16384.</p> </li> <li> <p>Web and Express editions: Must be an integer from 20 to 16384.</p> </li> </ul> </li> <li> <p>Provisioned IOPS storage (io1):</p> <ul> <li> <p>Enterprise and Standard editions: Must be an integer from 200 to 16384.</p> </li> <li> <p>Web and Express editions: Must be an integer from 100 to 16384.</p> </li> </ul> </li> <li> <p>Magnetic storage (standard):</p> <ul> <li> <p>Enterprise and Standard editions: Must be an integer from 200 to 1024.</p> </li> <li> <p>Web and Express editions: Must be an integer from 20 to 1024.</p> </li> </ul> </li> </ul></p>
     pub allocated_storage: Option<i64>,
@@ -2243,7 +2243,7 @@ impl CreateDBInstanceMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateDBInstanceReadReplicaMessage {
     /// <p>Indicates that minor engine upgrades are applied automatically to the Read Replica during the maintenance window.</p> <p>Default: Inherits from the source DB instance</p>
     pub auto_minor_version_upgrade: Option<bool>,
@@ -2428,7 +2428,7 @@ impl CreateDBInstanceReadReplicaMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateDBInstanceReadReplicaResult {
     pub db_instance: Option<DBInstance>,
 }
@@ -2475,7 +2475,7 @@ impl CreateDBInstanceReadReplicaResultDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateDBInstanceResult {
     pub db_instance: Option<DBInstance>,
 }
@@ -2523,7 +2523,7 @@ impl CreateDBInstanceResultDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateDBParameterGroupMessage {
     /// <p>The DB parameter group family name. A DB parameter group can be associated with one and only one DB parameter group family, and can be applied only to a DB instance running a database engine and engine version compatible with that DB parameter group family.</p>
     pub db_parameter_group_family: String,
@@ -2561,7 +2561,7 @@ impl CreateDBParameterGroupMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateDBParameterGroupResult {
     pub db_parameter_group: Option<DBParameterGroup>,
 }
@@ -2608,7 +2608,7 @@ impl CreateDBParameterGroupResultDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateDBSecurityGroupMessage {
     /// <p>The description for the DB security group.</p>
     pub db_security_group_description: String,
@@ -2640,7 +2640,7 @@ impl CreateDBSecurityGroupMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateDBSecurityGroupResult {
     pub db_security_group: Option<DBSecurityGroup>,
 }
@@ -2687,7 +2687,7 @@ impl CreateDBSecurityGroupResultDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateDBSnapshotMessage {
     /// <p><p>The identifier of the DB instance that you want to create the snapshot of.</p> <p>Constraints:</p> <ul> <li> <p>Must match the identifier of an existing DBInstance.</p> </li> </ul></p>
     pub db_instance_identifier: String,
@@ -2719,7 +2719,7 @@ impl CreateDBSnapshotMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateDBSnapshotResult {
     pub db_snapshot: Option<DBSnapshot>,
 }
@@ -2767,7 +2767,7 @@ impl CreateDBSnapshotResultDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateDBSubnetGroupMessage {
     /// <p>The description for the DB subnet group.</p>
     pub db_subnet_group_description: String,
@@ -2806,7 +2806,7 @@ impl CreateDBSubnetGroupMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateDBSubnetGroupResult {
     pub db_subnet_group: Option<DBSubnetGroup>,
 }
@@ -2854,7 +2854,7 @@ impl CreateDBSubnetGroupResultDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateEventSubscriptionMessage {
     /// <p> A Boolean value; set to <b>true</b> to activate the subscription, set to <b>false</b> to create the subscription but not active it. </p>
     pub enabled: Option<bool>,
@@ -2920,7 +2920,7 @@ impl CreateEventSubscriptionMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateEventSubscriptionResult {
     pub event_subscription: Option<EventSubscription>,
 }
@@ -2967,7 +2967,7 @@ impl CreateEventSubscriptionResultDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateOptionGroupMessage {
     /// <p>Specifies the name of the engine that this option group should be associated with.</p>
     pub engine_name: String,
@@ -3011,7 +3011,7 @@ impl CreateOptionGroupMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateOptionGroupResult {
     pub option_group: Option<OptionGroup>,
 }
@@ -3059,7 +3059,7 @@ impl CreateOptionGroupResultDeserializer {
     }
 }
 /// <p>Contains the details of an Amazon RDS DB cluster. </p> <p>This data type is used as a response element in the <a>DescribeDBClusters</a> action. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DBCluster {
     /// <p>For all database engines except Amazon Aurora, <code>AllocatedStorage</code> specifies the allocated storage size in gibibytes (GiB). For Aurora, <code>AllocatedStorage</code> always returns 1, because Aurora DB cluster storage size is not fixed, but instead automatically adjusts as needed.</p>
     pub allocated_storage: Option<i64>,
@@ -3400,7 +3400,7 @@ impl DBClusterListDeserializer {
     }
 }
 /// <p>Contains information about an instance that is part of a DB cluster.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DBClusterMember {
     /// <p>Specifies the status of the DB cluster parameter group for this member of the DB cluster.</p>
     pub db_cluster_parameter_group_status: Option<String>,
@@ -3515,7 +3515,7 @@ impl DBClusterMemberListDeserializer {
     }
 }
 /// <p>Contains the result of a successful invocation of the <a>DescribeDBClusters</a> action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DBClusterMessage {
     /// <p>Contains a list of DB clusters for the user.</p>
     pub db_clusters: Option<Vec<DBCluster>>,
@@ -3612,7 +3612,7 @@ impl DBClusterOptionGroupMembershipsDeserializer {
     }
 }
 /// <p>Contains status information for a DB cluster option group.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DBClusterOptionGroupStatus {
     /// <p>Specifies the name of the DB cluster option group.</p>
     pub db_cluster_option_group_name: Option<String>,
@@ -3665,7 +3665,7 @@ impl DBClusterOptionGroupStatusDeserializer {
     }
 }
 /// <p>Contains the details of an Amazon RDS DB cluster parameter group. </p> <p>This data type is used as a response element in the <a>DescribeDBClusterParameterGroups</a> action. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DBClusterParameterGroup {
     /// <p>The Amazon Resource Name (ARN) for the DB cluster parameter group.</p>
     pub db_cluster_parameter_group_arn: Option<String>,
@@ -3733,7 +3733,7 @@ impl DBClusterParameterGroupDeserializer {
     }
 }
 /// <p>Provides details about a DB cluster parameter group including the parameters in the DB cluster parameter group.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DBClusterParameterGroupDetails {
     /// <p> An optional pagination token provided by a previous DescribeDBClusterParameters request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code> . </p>
     pub marker: Option<String>,
@@ -3830,7 +3830,7 @@ impl DBClusterParameterGroupListDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DBClusterParameterGroupNameMessage {
     /// <p><p>The name of the DB cluster parameter group.</p> <p>Constraints:</p> <ul> <li> <p>Must be 1 to 255 letters or numbers.</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul> <note> <p>This value is stored as a lowercase string.</p> </note></p>
     pub db_cluster_parameter_group_name: Option<String>,
@@ -3878,7 +3878,7 @@ impl DBClusterParameterGroupNameMessageDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DBClusterParameterGroupsMessage {
     /// <p>A list of DB cluster parameter groups.</p>
     pub db_cluster_parameter_groups: Option<Vec<DBClusterParameterGroup>>,
@@ -3933,7 +3933,7 @@ impl DBClusterParameterGroupsMessageDeserializer {
     }
 }
 /// <p>Describes an AWS Identity and Access Management (IAM) role that is associated with a DB cluster.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DBClusterRole {
     /// <p>The Amazon Resource Name (ARN) of the IAM role that is associated with the DB cluster.</p>
     pub role_arn: Option<String>,
@@ -4028,7 +4028,7 @@ impl DBClusterRolesDeserializer {
     }
 }
 /// <p>Contains the details for an Amazon RDS DB cluster snapshot </p> <p>This data type is used as a response element in the <a>DescribeDBClusterSnapshots</a> action. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DBClusterSnapshot {
     /// <p>Specifies the allocated storage size in gibibytes (GiB).</p>
     pub allocated_storage: Option<i64>,
@@ -4209,7 +4209,7 @@ impl DBClusterSnapshotDeserializer {
     }
 }
 /// <p>Contains the name and values of a manual DB cluster snapshot attribute.</p> <p>Manual DB cluster snapshot attributes are used to authorize other AWS accounts to restore a manual DB cluster snapshot. For more information, see the <a>ModifyDBClusterSnapshotAttribute</a> API action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DBClusterSnapshotAttribute {
     /// <p>The name of the manual DB cluster snapshot attribute.</p> <p>The attribute named <code>restore</code> refers to the list of AWS accounts that have permission to copy or restore the manual DB cluster snapshot. For more information, see the <a>ModifyDBClusterSnapshotAttribute</a> API action.</p>
     pub attribute_name: Option<String>,
@@ -4308,7 +4308,7 @@ impl DBClusterSnapshotAttributeListDeserializer {
     }
 }
 /// <p>Contains the results of a successful call to the <a>DescribeDBClusterSnapshotAttributes</a> API action.</p> <p>Manual DB cluster snapshot attributes are used to authorize other AWS accounts to copy or restore a manual DB cluster snapshot. For more information, see the <a>ModifyDBClusterSnapshotAttribute</a> API action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DBClusterSnapshotAttributesResult {
     /// <p>The list of attributes and values for the manual DB cluster snapshot.</p>
     pub db_cluster_snapshot_attributes: Option<Vec<DBClusterSnapshotAttribute>>,
@@ -4409,7 +4409,7 @@ impl DBClusterSnapshotListDeserializer {
     }
 }
 /// <p> Provides a list of DB cluster snapshots for the user as the result of a call to the <a>DescribeDBClusterSnapshots</a> action. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DBClusterSnapshotMessage {
     /// <p>Provides a list of DB cluster snapshots for the user.</p>
     pub db_cluster_snapshots: Option<Vec<DBClusterSnapshot>>,
@@ -4464,7 +4464,7 @@ impl DBClusterSnapshotMessageDeserializer {
     }
 }
 /// <p> This data type is used as a response element in the action <a>DescribeDBEngineVersions</a>. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DBEngineVersion {
     /// <p>The description of the database engine.</p>
     pub db_engine_description: Option<String>,
@@ -4641,7 +4641,7 @@ impl DBEngineVersionListDeserializer {
     }
 }
 /// <p> Contains the result of a successful invocation of the <a>DescribeDBEngineVersions</a> action. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DBEngineVersionMessage {
     /// <p> A list of <code>DBEngineVersion</code> elements. </p>
     pub db_engine_versions: Option<Vec<DBEngineVersion>>,
@@ -4694,7 +4694,7 @@ impl DBEngineVersionMessageDeserializer {
     }
 }
 /// <p>Contains the details of an Amazon RDS DB instance. </p> <p>This data type is used as a response element in the <a>DescribeDBInstances</a> action. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DBInstance {
     /// <p>Specifies the allocated storage size specified in gibibytes.</p>
     pub allocated_storage: Option<i64>,
@@ -5183,7 +5183,7 @@ impl DBInstanceListDeserializer {
     }
 }
 /// <p> Contains the result of a successful invocation of the <a>DescribeDBInstances</a> action. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DBInstanceMessage {
     /// <p> A list of <a>DBInstance</a> instances. </p>
     pub db_instances: Option<Vec<DBInstance>>,
@@ -5237,7 +5237,7 @@ impl DBInstanceMessageDeserializer {
     }
 }
 /// <p>Provides a list of status information for a DB instance.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DBInstanceStatusInfo {
     /// <p>Details of the error if there is an error for the instance. If the instance is not in an error state, this value is blank.</p>
     pub message: Option<String>,
@@ -5342,7 +5342,7 @@ impl DBInstanceStatusInfoListDeserializer {
     }
 }
 /// <p>Contains the details of an Amazon RDS DB parameter group. </p> <p>This data type is used as a response element in the <a>DescribeDBParameterGroups</a> action. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DBParameterGroup {
     /// <p>The Amazon Resource Name (ARN) for the DB parameter group.</p>
     pub db_parameter_group_arn: Option<String>,
@@ -5412,7 +5412,7 @@ impl DBParameterGroupDeserializer {
     }
 }
 /// <p> Contains the result of a successful invocation of the <a>DescribeDBParameters</a> action. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DBParameterGroupDetails {
     /// <p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>
     pub marker: Option<String>,
@@ -5509,7 +5509,7 @@ impl DBParameterGroupListDeserializer {
     }
 }
 /// <p> Contains the result of a successful invocation of the <a>ModifyDBParameterGroup</a> or <a>ResetDBParameterGroup</a> action. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DBParameterGroupNameMessage {
     /// <p>Provides the name of the DB parameter group.</p>
     pub db_parameter_group_name: Option<String>,
@@ -5558,7 +5558,7 @@ impl DBParameterGroupNameMessageDeserializer {
     }
 }
 /// <p><p>The status of the DB parameter group.</p> <p>This data type is used as a response element in the following actions:</p> <ul> <li> <p> <a>CreateDBInstance</a> </p> </li> <li> <p> <a>CreateDBInstanceReadReplica</a> </p> </li> <li> <p> <a>DeleteDBInstance</a> </p> </li> <li> <p> <a>ModifyDBInstance</a> </p> </li> <li> <p> <a>RebootDBInstance</a> </p> </li> <li> <p> <a>RestoreDBInstanceFromDBSnapshot</a> </p> </li> </ul></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DBParameterGroupStatus {
     /// <p>The name of the DP parameter group.</p>
     pub db_parameter_group_name: Option<String>,
@@ -5658,7 +5658,7 @@ impl DBParameterGroupStatusListDeserializer {
     }
 }
 /// <p> Contains the result of a successful invocation of the <a>DescribeDBParameterGroups</a> action. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DBParameterGroupsMessage {
     /// <p> A list of <a>DBParameterGroup</a> instances. </p>
     pub db_parameter_groups: Option<Vec<DBParameterGroup>>,
@@ -5713,7 +5713,7 @@ impl DBParameterGroupsMessageDeserializer {
     }
 }
 /// <p>Contains the details for an Amazon RDS DB security group. </p> <p>This data type is used as a response element in the <a>DescribeDBSecurityGroups</a> action. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DBSecurityGroup {
     /// <p>The Amazon Resource Name (ARN) for the DB security group.</p>
     pub db_security_group_arn: Option<String>,
@@ -5804,7 +5804,7 @@ impl DBSecurityGroupDeserializer {
     }
 }
 /// <p><p>This data type is used as a response element in the following actions:</p> <ul> <li> <p> <a>ModifyDBInstance</a> </p> </li> <li> <p> <a>RebootDBInstance</a> </p> </li> <li> <p> <a>RestoreDBInstanceFromDBSnapshot</a> </p> </li> <li> <p> <a>RestoreDBInstanceToPointInTime</a> </p> </li> </ul></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DBSecurityGroupMembership {
     /// <p>The name of the DB security group.</p>
     pub db_security_group_name: Option<String>,
@@ -5901,7 +5901,7 @@ impl DBSecurityGroupMembershipListDeserializer {
     }
 }
 /// <p> Contains the result of a successful invocation of the <a>DescribeDBSecurityGroups</a> action. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DBSecurityGroupMessage {
     /// <p> A list of <a>DBSecurityGroup</a> instances. </p>
     pub db_security_groups: Option<Vec<DBSecurityGroup>>,
@@ -6009,7 +6009,7 @@ impl DBSecurityGroupsDeserializer {
     }
 }
 /// <p>Contains the details of an Amazon RDS DB snapshot. </p> <p>This data type is used as a response element in the <a>DescribeDBSnapshots</a> action. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DBSnapshot {
     /// <p>Specifies the allocated storage size in gibibytes (GiB).</p>
     pub allocated_storage: Option<i64>,
@@ -6231,7 +6231,7 @@ impl DBSnapshotDeserializer {
     }
 }
 /// <p>Contains the name and values of a manual DB snapshot attribute</p> <p>Manual DB snapshot attributes are used to authorize other AWS accounts to restore a manual DB snapshot. For more information, see the <a>ModifyDBSnapshotAttribute</a> API.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DBSnapshotAttribute {
     /// <p>The name of the manual DB snapshot attribute.</p> <p>The attribute named <code>restore</code> refers to the list of AWS accounts that have permission to copy or restore the manual DB cluster snapshot. For more information, see the <a>ModifyDBSnapshotAttribute</a> API action.</p>
     pub attribute_name: Option<String>,
@@ -6330,7 +6330,7 @@ impl DBSnapshotAttributeListDeserializer {
     }
 }
 /// <p>Contains the results of a successful call to the <a>DescribeDBSnapshotAttributes</a> API action.</p> <p>Manual DB snapshot attributes are used to authorize other AWS accounts to copy or restore a manual DB snapshot. For more information, see the <a>ModifyDBSnapshotAttribute</a> API action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DBSnapshotAttributesResult {
     /// <p>The list of attributes and values for the manual DB snapshot.</p>
     pub db_snapshot_attributes: Option<Vec<DBSnapshotAttribute>>,
@@ -6431,7 +6431,7 @@ impl DBSnapshotListDeserializer {
     }
 }
 /// <p> Contains the result of a successful invocation of the <a>DescribeDBSnapshots</a> action. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DBSnapshotMessage {
     /// <p> A list of <a>DBSnapshot</a> instances. </p>
     pub db_snapshots: Option<Vec<DBSnapshot>>,
@@ -6485,7 +6485,7 @@ impl DBSnapshotMessageDeserializer {
     }
 }
 /// <p>Contains the details of an Amazon RDS DB subnet group. </p> <p>This data type is used as a response element in the <a>DescribeDBSubnetGroups</a> action. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DBSubnetGroup {
     /// <p>The Amazon Resource Name (ARN) for the DB subnet group.</p>
     pub db_subnet_group_arn: Option<String>,
@@ -6568,7 +6568,7 @@ impl DBSubnetGroupDeserializer {
     }
 }
 /// <p> Contains the result of a successful invocation of the <a>DescribeDBSubnetGroups</a> action. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DBSubnetGroupMessage {
     /// <p> A list of <a>DBSubnetGroup</a> instances. </p>
     pub db_subnet_groups: Option<Vec<DBSubnetGroup>>,
@@ -6665,7 +6665,7 @@ impl DBSubnetGroupsDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteDBClusterMessage {
     /// <p><p>The DB cluster identifier for the DB cluster to be deleted. This parameter isn&#39;t case-sensitive.</p> <p>Constraints:</p> <ul> <li> <p>Must match an existing DBClusterIdentifier.</p> </li> </ul></p>
     pub db_cluster_identifier: String,
@@ -6704,7 +6704,7 @@ impl DeleteDBClusterMessageSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteDBClusterParameterGroupMessage {
     /// <p><p>The name of the DB cluster parameter group.</p> <p>Constraints:</p> <ul> <li> <p>Must be the name of an existing DB cluster parameter group.</p> </li> <li> <p>You can&#39;t delete a default DB cluster parameter group.</p> </li> <li> <p>Cannot be associated with any DB clusters.</p> </li> </ul></p>
     pub db_cluster_parameter_group_name: String,
@@ -6726,7 +6726,7 @@ impl DeleteDBClusterParameterGroupMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteDBClusterResult {
     pub db_cluster: Option<DBCluster>,
 }
@@ -6772,7 +6772,7 @@ impl DeleteDBClusterResultDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteDBClusterSnapshotMessage {
     /// <p>The identifier of the DB cluster snapshot to delete.</p> <p>Constraints: Must be the name of an existing DB cluster snapshot in the <code>available</code> state.</p>
     pub db_cluster_snapshot_identifier: String,
@@ -6794,7 +6794,7 @@ impl DeleteDBClusterSnapshotMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteDBClusterSnapshotResult {
     pub db_cluster_snapshot: Option<DBClusterSnapshot>,
 }
@@ -6841,7 +6841,7 @@ impl DeleteDBClusterSnapshotResultDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteDBInstanceMessage {
     /// <p><p>The DB instance identifier for the DB instance to be deleted. This parameter isn&#39;t case-sensitive.</p> <p>Constraints:</p> <ul> <li> <p>Must match the name of an existing DB instance.</p> </li> </ul></p>
     pub db_instance_identifier: String,
@@ -6879,7 +6879,7 @@ impl DeleteDBInstanceMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteDBInstanceResult {
     pub db_instance: Option<DBInstance>,
 }
@@ -6927,7 +6927,7 @@ impl DeleteDBInstanceResultDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteDBParameterGroupMessage {
     /// <p><p>The name of the DB parameter group.</p> <p>Constraints:</p> <ul> <li> <p>Must be the name of an existing DB parameter group</p> </li> <li> <p>You can&#39;t delete a default DB parameter group</p> </li> <li> <p>Cannot be associated with any DB instances</p> </li> </ul></p>
     pub db_parameter_group_name: String,
@@ -6950,7 +6950,7 @@ impl DeleteDBParameterGroupMessageSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteDBSecurityGroupMessage {
     /// <p><p>The name of the DB security group to delete.</p> <note> <p>You can&#39;t delete the default DB security group.</p> </note> <p>Constraints:</p> <ul> <li> <p>Must be 1 to 255 letters, numbers, or hyphens.</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> <li> <p>Must not be &quot;Default&quot;</p> </li> </ul></p>
     pub db_security_group_name: String,
@@ -6973,7 +6973,7 @@ impl DeleteDBSecurityGroupMessageSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteDBSnapshotMessage {
     /// <p>The DBSnapshot identifier.</p> <p>Constraints: Must be the name of an existing DB snapshot in the <code>available</code> state.</p>
     pub db_snapshot_identifier: String,
@@ -6995,7 +6995,7 @@ impl DeleteDBSnapshotMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteDBSnapshotResult {
     pub db_snapshot: Option<DBSnapshot>,
 }
@@ -7043,7 +7043,7 @@ impl DeleteDBSnapshotResultDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteDBSubnetGroupMessage {
     /// <p>The name of the database subnet group to delete.</p> <note> <p>You can't delete the default subnet group.</p> </note> <p>Constraints:</p> <p>Constraints: Must match the name of an existing DBSubnetGroup. Must not be default.</p> <p>Example: <code>mySubnetgroup</code> </p>
     pub db_subnet_group_name: String,
@@ -7066,7 +7066,7 @@ impl DeleteDBSubnetGroupMessageSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteEventSubscriptionMessage {
     /// <p>The name of the RDS event notification subscription you want to delete.</p>
     pub subscription_name: String,
@@ -7088,7 +7088,7 @@ impl DeleteEventSubscriptionMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteEventSubscriptionResult {
     pub event_subscription: Option<EventSubscription>,
 }
@@ -7135,7 +7135,7 @@ impl DeleteEventSubscriptionResultDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteOptionGroupMessage {
     /// <p><p>The name of the option group to be deleted.</p> <note> <p>You can&#39;t delete default option groups.</p> </note></p>
     pub option_group_name: String,
@@ -7158,7 +7158,7 @@ impl DeleteOptionGroupMessageSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeAccountAttributesMessage {}
 
 /// Serialize `DescribeAccountAttributesMessage` contents to a `SignedRequest`.
@@ -7173,7 +7173,7 @@ impl DescribeAccountAttributesMessageSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeCertificatesMessage {
     /// <p><p>The user-supplied certificate identifier. If this parameter is specified, information for only the identified certificate is returned. This parameter isn&#39;t case-sensitive.</p> <p>Constraints:</p> <ul> <li> <p>Must match an existing CertificateIdentifier.</p> </li> </ul></p>
     pub certificate_identifier: Option<String>,
@@ -7223,7 +7223,7 @@ impl DescribeCertificatesMessageSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeDBClusterParameterGroupsMessage {
     /// <p><p>The name of a specific DB cluster parameter group to return details for.</p> <p>Constraints:</p> <ul> <li> <p>If supplied, must match the name of an existing DBClusterParameterGroup.</p> </li> </ul></p>
     pub db_cluster_parameter_group_name: Option<String>,
@@ -7273,7 +7273,7 @@ impl DescribeDBClusterParameterGroupsMessageSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeDBClusterParametersMessage {
     /// <p><p>The name of a specific DB cluster parameter group to return parameter details for.</p> <p>Constraints:</p> <ul> <li> <p>If supplied, must match the name of an existing DBClusterParameterGroup.</p> </li> </ul></p>
     pub db_cluster_parameter_group_name: String,
@@ -7329,7 +7329,7 @@ impl DescribeDBClusterParametersMessageSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeDBClusterSnapshotAttributesMessage {
     /// <p>The identifier for the DB cluster snapshot to describe the attributes for.</p>
     pub db_cluster_snapshot_identifier: String,
@@ -7355,7 +7355,7 @@ impl DescribeDBClusterSnapshotAttributesMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeDBClusterSnapshotAttributesResult {
     pub db_cluster_snapshot_attributes_result: Option<DBClusterSnapshotAttributesResult>,
 }
@@ -7405,7 +7405,7 @@ impl DescribeDBClusterSnapshotAttributesResultDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeDBClusterSnapshotsMessage {
     /// <p><p>The ID of the DB cluster to retrieve the list of DB cluster snapshots for. This parameter can&#39;t be used in conjunction with the <code>DBClusterSnapshotIdentifier</code> parameter. This parameter is not case-sensitive. </p> <p>Constraints:</p> <ul> <li> <p>If supplied, must match the identifier of an existing DBCluster.</p> </li> </ul></p>
     pub db_cluster_identifier: Option<String>,
@@ -7487,7 +7487,7 @@ impl DescribeDBClusterSnapshotsMessageSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeDBClustersMessage {
     /// <p><p>The user-supplied DB cluster identifier. If this parameter is specified, information from only the specific DB cluster is returned. This parameter isn&#39;t case-sensitive.</p> <p>Constraints:</p> <ul> <li> <p>If supplied, must match an existing DBClusterIdentifier.</p> </li> </ul></p>
     pub db_cluster_identifier: Option<String>,
@@ -7536,7 +7536,7 @@ impl DescribeDBClustersMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeDBEngineVersionsMessage {
     /// <p><p>The name of a specific DB parameter group family to return details for.</p> <p>Constraints:</p> <ul> <li> <p>If supplied, must match an existing DBParameterGroupFamily.</p> </li> </ul></p>
     pub db_parameter_group_family: Option<String>,
@@ -7626,7 +7626,7 @@ impl DescribeDBEngineVersionsMessageSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeDBInstancesMessage {
     /// <p><p>The user-supplied instance identifier. If this parameter is specified, information from only the specific DB instance is returned. This parameter isn&#39;t case-sensitive.</p> <p>Constraints:</p> <ul> <li> <p>If supplied, must match the identifier of an existing DBInstance.</p> </li> </ul></p>
     pub db_instance_identifier: Option<String>,
@@ -7676,7 +7676,7 @@ impl DescribeDBInstancesMessageSerializer {
 }
 
 /// <p>This data type is used as a response element to <a>DescribeDBLogFiles</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeDBLogFilesDetails {
     /// <p>A POSIX timestamp when the last log entry was written.</p>
     pub last_written: Option<i64>,
@@ -7777,7 +7777,7 @@ impl DescribeDBLogFilesListDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeDBLogFilesMessage {
     /// <p><p>The customer-assigned name of the DB instance that contains the log files you want to list.</p> <p>Constraints:</p> <ul> <li> <p>Must match the identifier of an existing DBInstance.</p> </li> </ul></p>
     pub db_instance_identifier: String,
@@ -7849,7 +7849,7 @@ impl DescribeDBLogFilesMessageSerializer {
 }
 
 /// <p> The response from a call to <a>DescribeDBLogFiles</a>. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeDBLogFilesResponse {
     /// <p>The DB log files returned.</p>
     pub describe_db_log_files: Option<Vec<DescribeDBLogFilesDetails>>,
@@ -7904,7 +7904,7 @@ impl DescribeDBLogFilesResponseDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeDBParameterGroupsMessage {
     /// <p><p>The name of a specific DB parameter group to return details for.</p> <p>Constraints:</p> <ul> <li> <p>If supplied, must match the name of an existing DBClusterParameterGroup.</p> </li> </ul></p>
     pub db_parameter_group_name: Option<String>,
@@ -7953,7 +7953,7 @@ impl DescribeDBParameterGroupsMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeDBParametersMessage {
     /// <p><p>The name of a specific DB parameter group to return details for.</p> <p>Constraints:</p> <ul> <li> <p>If supplied, must match the name of an existing DBParameterGroup.</p> </li> </ul></p>
     pub db_parameter_group_name: String,
@@ -8009,7 +8009,7 @@ impl DescribeDBParametersMessageSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeDBSecurityGroupsMessage {
     /// <p>The name of the DB security group to return details for.</p>
     pub db_security_group_name: Option<String>,
@@ -8059,7 +8059,7 @@ impl DescribeDBSecurityGroupsMessageSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeDBSnapshotAttributesMessage {
     /// <p>The identifier for the DB snapshot to describe the attributes for.</p>
     pub db_snapshot_identifier: String,
@@ -8081,7 +8081,7 @@ impl DescribeDBSnapshotAttributesMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeDBSnapshotAttributesResult {
     pub db_snapshot_attributes_result: Option<DBSnapshotAttributesResult>,
 }
@@ -8130,7 +8130,7 @@ impl DescribeDBSnapshotAttributesResultDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeDBSnapshotsMessage {
     /// <p><p>The ID of the DB instance to retrieve the list of DB snapshots for. This parameter can&#39;t be used in conjunction with <code>DBSnapshotIdentifier</code>. This parameter is not case-sensitive. </p> <p>Constraints:</p> <ul> <li> <p>If supplied, must match the identifier of an existing DBInstance.</p> </li> </ul></p>
     pub db_instance_identifier: Option<String>,
@@ -8212,7 +8212,7 @@ impl DescribeDBSnapshotsMessageSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeDBSubnetGroupsMessage {
     /// <p>The name of the DB subnet group to return details for.</p>
     pub db_subnet_group_name: Option<String>,
@@ -8262,7 +8262,7 @@ impl DescribeDBSubnetGroupsMessageSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeEngineDefaultClusterParametersMessage {
     /// <p>The name of the DB cluster parameter group family to return engine parameter information for.</p>
     pub db_parameter_group_family: String,
@@ -8313,7 +8313,7 @@ impl DescribeEngineDefaultClusterParametersMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeEngineDefaultClusterParametersResult {
     pub engine_defaults: Option<EngineDefaults>,
 }
@@ -8361,7 +8361,7 @@ impl DescribeEngineDefaultClusterParametersResultDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeEngineDefaultParametersMessage {
     /// <p>The name of the DB parameter group family.</p>
     pub db_parameter_group_family: String,
@@ -8408,7 +8408,7 @@ impl DescribeEngineDefaultParametersMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeEngineDefaultParametersResult {
     pub engine_defaults: Option<EngineDefaults>,
 }
@@ -8456,7 +8456,7 @@ impl DescribeEngineDefaultParametersResultDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeEventCategoriesMessage {
     /// <p>This parameter is not currently supported.</p>
     pub filters: Option<Vec<Filter>>,
@@ -8490,7 +8490,7 @@ impl DescribeEventCategoriesMessageSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeEventSubscriptionsMessage {
     /// <p>This parameter is not currently supported.</p>
     pub filters: Option<Vec<Filter>>,
@@ -8540,7 +8540,7 @@ impl DescribeEventSubscriptionsMessageSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeEventsMessage {
     /// <p>The number of minutes to retrieve events for.</p> <p>Default: 60</p>
     pub duration: Option<i64>,
@@ -8631,7 +8631,7 @@ impl DescribeEventsMessageSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeOptionGroupOptionsMessage {
     /// <p>A required parameter. Options available for the given engine name are described.</p>
     pub engine_name: String,
@@ -8687,7 +8687,7 @@ impl DescribeOptionGroupOptionsMessageSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeOptionGroupsMessage {
     /// <p>Filters the list of option groups to only include groups associated with a specific database engine.</p>
     pub engine_name: Option<String>,
@@ -8753,7 +8753,7 @@ impl DescribeOptionGroupsMessageSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeOrderableDBInstanceOptionsMessage {
     /// <p>The DB instance class filter value. Specify this parameter to show only the available offerings matching the specified DB instance class.</p>
     pub db_instance_class: Option<String>,
@@ -8833,7 +8833,7 @@ impl DescribeOrderableDBInstanceOptionsMessageSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribePendingMaintenanceActionsMessage {
     /// <p><p>A filter that specifies one or more resources to return pending maintenance actions for.</p> <p>Supported filters:</p> <ul> <li> <p> <code>db-cluster-id</code> - Accepts DB cluster identifiers and DB cluster Amazon Resource Names (ARNs). The results list will only include pending maintenance actions for the DB clusters identified by these ARNs.</p> </li> <li> <p> <code>db-instance-id</code> - Accepts DB instance identifiers and DB instance ARNs. The results list will only include pending maintenance actions for the DB instances identified by these ARNs.</p> </li> </ul></p>
     pub filters: Option<Vec<Filter>>,
@@ -8883,7 +8883,7 @@ impl DescribePendingMaintenanceActionsMessageSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeReservedDBInstancesMessage {
     /// <p>The DB instance class filter value. Specify this parameter to show only those reservations matching the specified DB instances class.</p>
     pub db_instance_class: Option<String>,
@@ -8981,7 +8981,7 @@ impl DescribeReservedDBInstancesMessageSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeReservedDBInstancesOfferingsMessage {
     /// <p>The DB instance class filter value. Specify this parameter to show only the available offerings matching the specified DB instance class.</p>
     pub db_instance_class: Option<String>,
@@ -9075,7 +9075,7 @@ impl DescribeReservedDBInstancesOfferingsMessageSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeSourceRegionsMessage {
     /// <p>This parameter is not currently supported.</p>
     pub filters: Option<Vec<Filter>>,
@@ -9125,7 +9125,7 @@ impl DescribeSourceRegionsMessageSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeValidDBInstanceModificationsMessage {
     /// <p>The customer identifier or the ARN of your DB instance. </p>
     pub db_instance_identifier: String,
@@ -9151,7 +9151,7 @@ impl DescribeValidDBInstanceModificationsMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeValidDBInstanceModificationsResult {
     pub valid_db_instance_modifications_message: Option<ValidDBInstanceModificationsMessage>,
 }
@@ -9201,7 +9201,7 @@ impl DescribeValidDBInstanceModificationsResultDeserializer {
     }
 }
 /// <p>An Active Directory Domain membership record associated with the DB instance.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DomainMembership {
     /// <p>The identifier of the Active Directory Domain.</p>
     pub domain: Option<String>,
@@ -9334,7 +9334,7 @@ impl DoubleOptionalDeserializer {
     }
 }
 /// <p>A range of double values.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DoubleRange {
     /// <p>The minimum value in the range.</p>
     pub from: Option<f64>,
@@ -9428,7 +9428,7 @@ impl DoubleRangeListDeserializer {
     }
 }
 /// <p>This data type is used as a response element to <a>DownloadDBLogFilePortion</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DownloadDBLogFilePortionDetails {
     /// <p>Boolean value that if true, indicates there is more data to be downloaded.</p>
     pub additional_data_pending: Option<bool>,
@@ -9488,7 +9488,7 @@ impl DownloadDBLogFilePortionDetailsDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DownloadDBLogFilePortionMessage {
     /// <p><p>The customer-assigned name of the DB instance that contains the log files you want to list.</p> <p>Constraints:</p> <ul> <li> <p>Must match the identifier of an existing DBInstance.</p> </li> </ul></p>
     pub db_instance_identifier: String,
@@ -9533,7 +9533,7 @@ impl DownloadDBLogFilePortionMessageSerializer {
 }
 
 /// <p><p>This data type is used as a response element in the following actions:</p> <ul> <li> <p> <a>AuthorizeDBSecurityGroupIngress</a> </p> </li> <li> <p> <a>DescribeDBSecurityGroups</a> </p> </li> <li> <p> <a>RevokeDBSecurityGroupIngress</a> </p> </li> </ul></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct EC2SecurityGroup {
     /// <p>Specifies the id of the EC2 security group.</p>
     pub ec2_security_group_id: Option<String>,
@@ -9645,7 +9645,7 @@ impl EC2SecurityGroupListDeserializer {
     }
 }
 /// <p><p>This data type is used as a response element in the following actions:</p> <ul> <li> <p> <a>CreateDBInstance</a> </p> </li> <li> <p> <a>DescribeDBInstances</a> </p> </li> <li> <p> <a>DeleteDBInstance</a> </p> </li> </ul></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Endpoint {
     /// <p>Specifies the DNS address of the DB instance.</p>
     pub address: Option<String>,
@@ -9702,7 +9702,7 @@ impl EndpointDeserializer {
     }
 }
 /// <p> Contains the result of a successful invocation of the <a>DescribeEngineDefaultParameters</a> action. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct EngineDefaults {
     /// <p>Specifies the name of the DB parameter group family that the engine default parameters apply to.</p>
     pub db_parameter_group_family: Option<String>,
@@ -9763,7 +9763,7 @@ impl EngineDefaultsDeserializer {
     }
 }
 /// <p> This data type is used as a response element in the <a>DescribeEvents</a> action. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Event {
     /// <p>Specifies the date and time of the event.</p>
     pub date: Option<String>,
@@ -9898,7 +9898,7 @@ impl EventCategoriesListSerializer {
 }
 
 /// <p>Contains the results of a successful invocation of the <a>DescribeEventCategories</a> action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct EventCategoriesMap {
     /// <p>The event categories for the specified source type</p>
     pub event_categories: Option<Vec<String>>,
@@ -9995,7 +9995,7 @@ impl EventCategoriesMapListDeserializer {
     }
 }
 /// <p>Data returned from the <b>DescribeEventCategories</b> action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct EventCategoriesMessage {
     /// <p>A list of EventCategoriesMap data types.</p>
     pub event_categories_map_list: Option<Vec<EventCategoriesMap>>,
@@ -10085,7 +10085,7 @@ impl EventListDeserializer {
     }
 }
 /// <p>Contains the results of a successful invocation of the <a>DescribeEventSubscriptions</a> action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct EventSubscription {
     /// <p>The RDS event notification subscription Id.</p>
     pub cust_subscription_id: Option<String>,
@@ -10240,7 +10240,7 @@ impl EventSubscriptionsListDeserializer {
     }
 }
 /// <p>Data returned by the <b>DescribeEventSubscriptions</b> action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct EventSubscriptionsMessage {
     /// <p>A list of EventSubscriptions data types.</p>
     pub event_subscriptions_list: Option<Vec<EventSubscription>>,
@@ -10295,7 +10295,7 @@ impl EventSubscriptionsMessageDeserializer {
     }
 }
 /// <p> Contains the result of a successful invocation of the <a>DescribeEvents</a> action. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct EventsMessage {
     /// <p> A list of <a>Event</a> instances. </p>
     pub events: Option<Vec<Event>>,
@@ -10347,7 +10347,7 @@ impl EventsMessageDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct FailoverDBClusterMessage {
     /// <p><p>A DB cluster identifier to force a failover for. This parameter is not case-sensitive.</p> <p>Constraints:</p> <ul> <li> <p>Must match the identifier of an existing DBCluster.</p> </li> </ul></p>
     pub db_cluster_identifier: Option<String>,
@@ -10379,7 +10379,7 @@ impl FailoverDBClusterMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct FailoverDBClusterResult {
     pub db_cluster: Option<DBCluster>,
 }
@@ -10425,7 +10425,7 @@ impl FailoverDBClusterResultDeserializer {
     }
 }
 /// <p>This type is not currently supported.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Filter {
     /// <p>This parameter is not currently supported.</p>
     pub name: String,
@@ -10477,7 +10477,7 @@ impl FilterValueListSerializer {
 }
 
 /// <p> This data type is used as a response element in the <a>DescribeDBSecurityGroups</a> action. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct IPRange {
     /// <p>Specifies the IP range.</p>
     pub cidrip: Option<String>,
@@ -10608,7 +10608,7 @@ impl KeyListSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListTagsForResourceMessage {
     /// <p>This parameter is not currently supported.</p>
     pub filters: Option<Vec<Filter>>,
@@ -10706,7 +10706,7 @@ impl LongDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyDBClusterMessage {
     /// <p>A value that specifies whether the modifications in this request and any pending modifications are asynchronously applied as soon as possible, regardless of the <code>PreferredMaintenanceWindow</code> setting for the DB cluster. If this parameter is set to <code>false</code>, changes to the DB cluster are applied during the next maintenance window.</p> <p>The <code>ApplyImmediately</code> parameter only affects the <code>NewDBClusterIdentifier</code> and <code>MasterUserPassword</code> values. If you set the <code>ApplyImmediately</code> parameter value to false, then changes to the <code>NewDBClusterIdentifier</code> and <code>MasterUserPassword</code> values are applied during the next maintenance window. All other changes are applied immediately, regardless of the value of the <code>ApplyImmediately</code> parameter.</p> <p>Default: <code>false</code> </p>
     pub apply_immediately: Option<bool>,
@@ -10818,7 +10818,7 @@ impl ModifyDBClusterMessageSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyDBClusterParameterGroupMessage {
     /// <p>The name of the DB cluster parameter group to modify.</p>
     pub db_cluster_parameter_group_name: String,
@@ -10847,7 +10847,7 @@ impl ModifyDBClusterParameterGroupMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyDBClusterResult {
     pub db_cluster: Option<DBCluster>,
 }
@@ -10893,7 +10893,7 @@ impl ModifyDBClusterResultDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyDBClusterSnapshotAttributeMessage {
     /// <p>The name of the DB cluster snapshot attribute to modify.</p> <p>To manage authorization for other AWS accounts to copy or restore a manual DB cluster snapshot, set this value to <code>restore</code>.</p>
     pub attribute_name: String,
@@ -10939,7 +10939,7 @@ impl ModifyDBClusterSnapshotAttributeMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyDBClusterSnapshotAttributeResult {
     pub db_cluster_snapshot_attributes_result: Option<DBClusterSnapshotAttributesResult>,
 }
@@ -10989,7 +10989,7 @@ impl ModifyDBClusterSnapshotAttributeResultDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyDBInstanceMessage {
     /// <p>The new amount of storage (in gibibytes) to allocate for the DB instance. </p> <p>For MariaDB, MySQL, Oracle, and PostgreSQL, the value supplied must be at least 10% greater than the current value. Values that are not at least 10% greater than the existing value are rounded up so that they are 10% greater than the current value. </p> <p>For the valid values for allocated storage for each engine, see <a>CreateDBInstance</a>. </p>
     pub allocated_storage: Option<i64>,
@@ -11294,7 +11294,7 @@ impl ModifyDBInstanceMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyDBInstanceResult {
     pub db_instance: Option<DBInstance>,
 }
@@ -11342,7 +11342,7 @@ impl ModifyDBInstanceResultDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyDBParameterGroupMessage {
     /// <p><p>The name of the DB parameter group.</p> <p>Constraints:</p> <ul> <li> <p>If supplied, must match the name of an existing DBParameterGroup.</p> </li> </ul></p>
     pub db_parameter_group_name: String,
@@ -11372,7 +11372,7 @@ impl ModifyDBParameterGroupMessageSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyDBSnapshotAttributeMessage {
     /// <p>The name of the DB snapshot attribute to modify.</p> <p>To manage authorization for other AWS accounts to copy or restore a manual DB snapshot, set this value to <code>restore</code>.</p>
     pub attribute_name: String,
@@ -11418,7 +11418,7 @@ impl ModifyDBSnapshotAttributeMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyDBSnapshotAttributeResult {
     pub db_snapshot_attributes_result: Option<DBSnapshotAttributesResult>,
 }
@@ -11466,7 +11466,7 @@ impl ModifyDBSnapshotAttributeResultDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyDBSnapshotMessage {
     /// <p>The identifier of the DB snapshot to modify.</p>
     pub db_snapshot_identifier: String,
@@ -11504,7 +11504,7 @@ impl ModifyDBSnapshotMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyDBSnapshotResult {
     pub db_snapshot: Option<DBSnapshot>,
 }
@@ -11552,7 +11552,7 @@ impl ModifyDBSnapshotResultDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyDBSubnetGroupMessage {
     /// <p>The description for the DB subnet group.</p>
     pub db_subnet_group_description: Option<String>,
@@ -11589,7 +11589,7 @@ impl ModifyDBSubnetGroupMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyDBSubnetGroupResult {
     pub db_subnet_group: Option<DBSubnetGroup>,
 }
@@ -11637,7 +11637,7 @@ impl ModifyDBSubnetGroupResultDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyEventSubscriptionMessage {
     /// <p> A Boolean value; set to <b>true</b> to activate the subscription. </p>
     pub enabled: Option<bool>,
@@ -11692,7 +11692,7 @@ impl ModifyEventSubscriptionMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyEventSubscriptionResult {
     pub event_subscription: Option<EventSubscription>,
 }
@@ -11739,7 +11739,7 @@ impl ModifyEventSubscriptionResultDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyOptionGroupMessage {
     /// <p>Indicates whether the changes should be applied immediately, or during the next maintenance window for each instance associated with the option group.</p>
     pub apply_immediately: Option<bool>,
@@ -11787,7 +11787,7 @@ impl ModifyOptionGroupMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyOptionGroupResult {
     pub option_group: Option<OptionGroup>,
 }
@@ -11835,7 +11835,7 @@ impl ModifyOptionGroupResultDeserializer {
     }
 }
 /// <p>Option details.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RDSOption {
     /// <p>If the option requires access to a port, then this DB security group allows access to the port.</p>
     pub db_security_group_memberships: Option<Vec<DBSecurityGroupMembership>>,
@@ -11947,7 +11947,7 @@ impl RDSOptionDeserializer {
     }
 }
 /// <p>A list of all available options</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct OptionConfiguration {
     /// <p>A list of DBSecurityGroupMemebrship name strings used for this option.</p>
     pub db_security_group_memberships: Option<Vec<String>>,
@@ -12024,7 +12024,7 @@ impl OptionConfigurationListSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct OptionGroup {
     /// <p>Indicates whether this option group can be applied to both VPC and non-VPC instances. The value <code>true</code> indicates the option group can be applied to both VPC and non-VPC instances. </p>
     pub allows_vpc_and_non_vpc_instance_memberships: Option<bool>,
@@ -12123,7 +12123,7 @@ impl OptionGroupDeserializer {
     }
 }
 /// <p>Provides information on the option groups the DB instance is a member of.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct OptionGroupMembership {
     /// <p>The name of the option group that the instance belongs to.</p>
     pub option_group_name: Option<String>,
@@ -12220,7 +12220,7 @@ impl OptionGroupMembershipListDeserializer {
     }
 }
 /// <p>Available option.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct OptionGroupOption {
     /// <p>If the option requires a port, specifies the default port for the option.</p>
     pub default_port: Option<i64>,
@@ -12383,7 +12383,7 @@ impl OptionGroupOptionDeserializer {
     }
 }
 /// <p>Option group option settings are used to display settings available for each option with their default values and other information. These values are used with the DescribeOptionGroupOptions action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct OptionGroupOptionSetting {
     /// <p>Indicates the acceptable values for the option group option.</p>
     pub allowed_values: Option<String>,
@@ -12595,7 +12595,7 @@ impl OptionGroupOptionsListDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct OptionGroupOptionsMessage {
     /// <p>An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>.</p>
     pub marker: Option<String>,
@@ -12649,7 +12649,7 @@ impl OptionGroupOptionsMessageDeserializer {
     }
 }
 /// <p>List of option groups.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct OptionGroups {
     /// <p>An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>
     pub marker: Option<String>,
@@ -12757,7 +12757,7 @@ impl OptionNamesListSerializer {
 }
 
 /// <p>Option settings are the actual settings being applied or configured for that option. It is used when you modify an option group or describe option groups. For example, the NATIVE_NETWORK_ENCRYPTION option has a setting called SQLNET.ENCRYPTION_SERVER that can have several different values.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct OptionSetting {
     /// <p>The allowed values of the option setting.</p>
     pub allowed_values: Option<String>,
@@ -12978,7 +12978,7 @@ impl OptionSettingsListSerializer {
 }
 
 /// <p>The version for an option. Option group option versions are returned by the <a>DescribeOptionGroupOptions</a> action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct OptionVersion {
     /// <p>True if the version is the default version of the option, and otherwise false.</p>
     pub is_default: Option<bool>,
@@ -13153,7 +13153,7 @@ impl OptionsListDeserializer {
     }
 }
 /// <p>Contains a list of available options for a DB instance.</p> <p> This data type is used as a response element in the <a>DescribeOrderableDBInstanceOptions</a> action. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct OrderableDBInstanceOption {
     /// <p>A list of Availability Zones for a DB instance.</p>
     pub availability_zones: Option<Vec<AvailabilityZone>>,
@@ -13382,7 +13382,7 @@ impl OrderableDBInstanceOptionsListDeserializer {
     }
 }
 /// <p> Contains the result of a successful invocation of the <a>DescribeOrderableDBInstanceOptions</a> action. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct OrderableDBInstanceOptionsMessage {
     /// <p> An optional pagination token provided by a previous OrderableDBInstanceOptions request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code> . </p>
     pub marker: Option<String>,
@@ -13438,7 +13438,7 @@ impl OrderableDBInstanceOptionsMessageDeserializer {
     }
 }
 /// <p> This data type is used as a request parameter in the <a>ModifyDBParameterGroup</a> and <a>ResetDBParameterGroup</a> actions. </p> <p>This data type is used as a response element in the <a>DescribeEngineDefaultParameters</a> and <a>DescribeDBParameters</a> actions.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Parameter {
     /// <p>Specifies the valid range of values for the parameter.</p>
     pub allowed_values: Option<String>,
@@ -13675,7 +13675,7 @@ impl ParametersListSerializer {
 }
 
 /// <p>A list of the log types whose configuration is still pending. In other words, these log types are in the process of being activated or deactivated.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PendingCloudwatchLogsExports {
     /// <p>Log types that are in the process of being enabled. After they are enabled, these log types are exported to CloudWatch Logs.</p>
     pub log_types_to_disable: Option<Vec<String>>,
@@ -13731,7 +13731,7 @@ impl PendingCloudwatchLogsExportsDeserializer {
     }
 }
 /// <p>Provides information about a pending maintenance action for a resource.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PendingMaintenanceAction {
     /// <p>The type of pending maintenance action that is available for the resource.</p>
     pub action: Option<String>,
@@ -13901,7 +13901,7 @@ impl PendingMaintenanceActionsDeserializer {
     }
 }
 /// <p>Data returned from the <b>DescribePendingMaintenanceActions</b> action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PendingMaintenanceActionsMessage {
     /// <p> An optional pagination token provided by a previous <code>DescribePendingMaintenanceActions</code> request. If this parameter is specified, the response includes only records beyond the marker, up to a number of records specified by <code>MaxRecords</code>. </p>
     pub marker: Option<String>,
@@ -13956,7 +13956,7 @@ impl PendingMaintenanceActionsMessageDeserializer {
     }
 }
 /// <p> This data type is used as a response element in the <a>ModifyDBInstance</a> action. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PendingModifiedValues {
     /// <p> Contains the new <code>AllocatedStorage</code> size for the DB instance that will be applied or is currently being applied. </p>
     pub allocated_storage: Option<i64>,
@@ -14101,7 +14101,7 @@ impl PendingModifiedValuesDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PromoteReadReplicaDBClusterMessage {
     /// <p>The identifier of the DB cluster Read Replica to promote. This parameter is not case-sensitive. </p> <p>Constraints:</p> <ul> <li> <p>Must match the identifier of an existing DBCluster Read Replica.</p> </li> </ul> <p>Example: <code>my-cluster-replica1</code> </p>
     pub db_cluster_identifier: String,
@@ -14123,7 +14123,7 @@ impl PromoteReadReplicaDBClusterMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PromoteReadReplicaDBClusterResult {
     pub db_cluster: Option<DBCluster>,
 }
@@ -14169,7 +14169,7 @@ impl PromoteReadReplicaDBClusterResultDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PromoteReadReplicaMessage {
     /// <p><p>The number of days to retain automated backups. Setting this parameter to a positive number enables backups. Setting this parameter to 0 disables automated backups.</p> <p>Default: 1</p> <p>Constraints:</p> <ul> <li> <p>Must be a value from 0 to 8</p> </li> </ul></p>
     pub backup_retention_period: Option<i64>,
@@ -14207,7 +14207,7 @@ impl PromoteReadReplicaMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PromoteReadReplicaResult {
     pub db_instance: Option<DBInstance>,
 }
@@ -14255,7 +14255,7 @@ impl PromoteReadReplicaResultDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PurchaseReservedDBInstancesOfferingMessage {
     /// <p>The number of instances to reserve.</p> <p>Default: <code>1</code> </p>
     pub db_instance_count: Option<i64>,
@@ -14301,7 +14301,7 @@ impl PurchaseReservedDBInstancesOfferingMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PurchaseReservedDBInstancesOfferingResult {
     pub reserved_db_instance: Option<ReservedDBInstance>,
 }
@@ -14350,7 +14350,7 @@ impl PurchaseReservedDBInstancesOfferingResultDeserializer {
     }
 }
 /// <p>A range of integer values.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Range {
     /// <p>The minimum value in the range.</p>
     pub from: Option<i64>,
@@ -14577,7 +14577,7 @@ impl ReadReplicaIdentifierListDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RebootDBInstanceMessage {
     /// <p><p>The DB instance identifier. This parameter is stored as a lowercase string.</p> <p>Constraints:</p> <ul> <li> <p>Must match the identifier of an existing DBInstance.</p> </li> </ul></p>
     pub db_instance_identifier: String,
@@ -14607,7 +14607,7 @@ impl RebootDBInstanceMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RebootDBInstanceResult {
     pub db_instance: Option<DBInstance>,
 }
@@ -14655,7 +14655,7 @@ impl RebootDBInstanceResultDeserializer {
     }
 }
 /// <p> This data type is used as a response element in the <a>DescribeReservedDBInstances</a> and <a>DescribeReservedDBInstancesOfferings</a> actions. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RecurringCharge {
     /// <p>The amount of the recurring charge.</p>
     pub recurring_charge_amount: Option<f64>,
@@ -14753,7 +14753,7 @@ impl RecurringChargeListDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RemoveRoleFromDBClusterMessage {
     /// <p>The name of the DB cluster to disassociate the IAM role from.</p>
     pub db_cluster_identifier: String,
@@ -14782,7 +14782,7 @@ impl RemoveRoleFromDBClusterMessageSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RemoveSourceIdentifierFromSubscriptionMessage {
     /// <p> The source identifier to be removed from the subscription, such as the <b>DB instance identifier</b> for a DB instance or the name of a security group. </p>
     pub source_identifier: String,
@@ -14814,7 +14814,7 @@ impl RemoveSourceIdentifierFromSubscriptionMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RemoveSourceIdentifierFromSubscriptionResult {
     pub event_subscription: Option<EventSubscription>,
 }
@@ -14861,7 +14861,7 @@ impl RemoveSourceIdentifierFromSubscriptionResultDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RemoveTagsFromResourceMessage {
     /// <p>The Amazon RDS resource that the tags are removed from. This value is an Amazon Resource Name (ARN). For information about creating an ARN, see <a href="http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Tagging.ARN.html#USER_Tagging.ARN.Constructing"> Constructing an RDS Amazon Resource Name (ARN)</a>.</p>
     pub resource_name: String,
@@ -14887,7 +14887,7 @@ impl RemoveTagsFromResourceMessageSerializer {
 }
 
 /// <p> This data type is used as a response element in the <a>DescribeReservedDBInstances</a> and <a>PurchaseReservedDBInstancesOffering</a> actions. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ReservedDBInstance {
     /// <p>The currency code for the reserved DB instance.</p>
     pub currency_code: Option<String>,
@@ -15072,7 +15072,7 @@ impl ReservedDBInstanceListDeserializer {
     }
 }
 /// <p> Contains the result of a successful invocation of the <a>DescribeReservedDBInstances</a> action. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ReservedDBInstanceMessage {
     /// <p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>
     pub marker: Option<String>,
@@ -15127,7 +15127,7 @@ impl ReservedDBInstanceMessageDeserializer {
     }
 }
 /// <p> This data type is used as a response element in the <a>DescribeReservedDBInstancesOfferings</a> action. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ReservedDBInstancesOffering {
     /// <p>The currency code for the reserved DB instance offering.</p>
     pub currency_code: Option<String>,
@@ -15277,7 +15277,7 @@ impl ReservedDBInstancesOfferingListDeserializer {
     }
 }
 /// <p> Contains the result of a successful invocation of the <a>DescribeReservedDBInstancesOfferings</a> action. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ReservedDBInstancesOfferingMessage {
     /// <p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>
     pub marker: Option<String>,
@@ -15333,7 +15333,7 @@ impl ReservedDBInstancesOfferingMessageDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ResetDBClusterParameterGroupMessage {
     /// <p>The name of the DB cluster parameter group to reset.</p>
     pub db_cluster_parameter_group_name: String,
@@ -15373,7 +15373,7 @@ impl ResetDBClusterParameterGroupMessageSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ResetDBParameterGroupMessage {
     /// <p><p>The name of the DB parameter group.</p> <p>Constraints:</p> <ul> <li> <p>Must match the name of an existing DBParameterGroup.</p> </li> </ul></p>
     pub db_parameter_group_name: String,
@@ -15413,7 +15413,7 @@ impl ResetDBParameterGroupMessageSerializer {
 }
 
 /// <p>Describes the pending maintenance actions for a resource.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ResourcePendingMaintenanceActions {
     /// <p>A list that provides details about the pending maintenance actions for the resource.</p>
     pub pending_maintenance_action_details: Option<Vec<PendingMaintenanceAction>>,
@@ -15471,7 +15471,7 @@ impl ResourcePendingMaintenanceActionsDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RestoreDBClusterFromS3Message {
     /// <p>A list of EC2 Availability Zones that instances in the restored DB cluster can be created in.</p>
     pub availability_zones: Option<Vec<String>>,
@@ -15669,7 +15669,7 @@ impl RestoreDBClusterFromS3MessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RestoreDBClusterFromS3Result {
     pub db_cluster: Option<DBCluster>,
 }
@@ -15715,7 +15715,7 @@ impl RestoreDBClusterFromS3ResultDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RestoreDBClusterFromSnapshotMessage {
     /// <p>Provides the list of EC2 Availability Zones that instances in the restored DB cluster can be created in.</p>
     pub availability_zones: Option<Vec<String>>,
@@ -15828,7 +15828,7 @@ impl RestoreDBClusterFromSnapshotMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RestoreDBClusterFromSnapshotResult {
     pub db_cluster: Option<DBCluster>,
 }
@@ -15874,7 +15874,7 @@ impl RestoreDBClusterFromSnapshotResultDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RestoreDBClusterToPointInTimeMessage {
     /// <p><p>The name of the new DB cluster to be created.</p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 63 letters, numbers, or hyphens</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul></p>
     pub db_cluster_identifier: String,
@@ -15979,7 +15979,7 @@ impl RestoreDBClusterToPointInTimeMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RestoreDBClusterToPointInTimeResult {
     pub db_cluster: Option<DBCluster>,
 }
@@ -16025,7 +16025,7 @@ impl RestoreDBClusterToPointInTimeResultDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RestoreDBInstanceFromDBSnapshotMessage {
     /// <p>Indicates that minor version upgrades are applied automatically to the DB instance during the maintenance window.</p>
     pub auto_minor_version_upgrade: Option<bool>,
@@ -16218,7 +16218,7 @@ impl RestoreDBInstanceFromDBSnapshotMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RestoreDBInstanceFromDBSnapshotResult {
     pub db_instance: Option<DBInstance>,
 }
@@ -16265,7 +16265,7 @@ impl RestoreDBInstanceFromDBSnapshotResultDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RestoreDBInstanceFromS3Message {
     /// <p><p>The amount of storage (in gigabytes) to allocate initially for the DB instance. Follow the allocation rules specified in <a>CreateDBInstance</a>. </p> <note> <p>Be sure to allocate enough memory for your new DB instance so that the restore operation can succeed. You can also allocate additional memory for future growth. </p> </note></p>
     pub allocated_storage: Option<i64>,
@@ -16579,7 +16579,7 @@ impl RestoreDBInstanceFromS3MessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RestoreDBInstanceFromS3Result {
     pub db_instance: Option<DBInstance>,
 }
@@ -16627,7 +16627,7 @@ impl RestoreDBInstanceFromS3ResultDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RestoreDBInstanceToPointInTimeMessage {
     /// <p>Indicates that minor version upgrades are applied automatically to the DB instance during the maintenance window.</p>
     pub auto_minor_version_upgrade: Option<bool>,
@@ -16836,7 +16836,7 @@ impl RestoreDBInstanceToPointInTimeMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RestoreDBInstanceToPointInTimeResult {
     pub db_instance: Option<DBInstance>,
 }
@@ -16884,7 +16884,7 @@ impl RestoreDBInstanceToPointInTimeResultDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RevokeDBSecurityGroupIngressMessage {
     /// <p> The IP range to revoke access from. Must be a valid CIDR range. If <code>CIDRIP</code> is specified, <code>EC2SecurityGroupName</code>, <code>EC2SecurityGroupId</code> and <code>EC2SecurityGroupOwnerId</code> can't be provided. </p>
     pub cidrip: Option<String>,
@@ -16938,7 +16938,7 @@ impl RevokeDBSecurityGroupIngressMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RevokeDBSecurityGroupIngressResult {
     pub db_security_group: Option<DBSecurityGroup>,
 }
@@ -17037,7 +17037,7 @@ impl SourceIdsListSerializer {
 }
 
 /// <p>Contains an AWS Region name as the result of a successful call to the <a>DescribeSourceRegions</a> action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SourceRegion {
     /// <p>The endpoint for the source AWS Region endpoint.</p>
     pub endpoint: Option<String>,
@@ -17138,7 +17138,7 @@ impl SourceRegionListDeserializer {
     }
 }
 /// <p>Contains the result of a successful invocation of the <a>DescribeSourceRegions</a> action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SourceRegionMessage {
     /// <p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>
     pub marker: Option<String>,
@@ -17205,7 +17205,7 @@ impl SourceTypeDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct StartDBInstanceMessage {
     /// <p> The user-supplied instance identifier. </p>
     pub db_instance_identifier: String,
@@ -17227,7 +17227,7 @@ impl StartDBInstanceMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct StartDBInstanceResult {
     pub db_instance: Option<DBInstance>,
 }
@@ -17274,7 +17274,7 @@ impl StartDBInstanceResultDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct StopDBInstanceMessage {
     /// <p> The user-supplied instance identifier. </p>
     pub db_instance_identifier: String,
@@ -17304,7 +17304,7 @@ impl StopDBInstanceMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct StopDBInstanceResult {
     pub db_instance: Option<DBInstance>,
 }
@@ -17366,7 +17366,7 @@ impl StringDeserializer {
     }
 }
 /// <p> This data type is used as a response element in the <a>DescribeDBSubnetGroups</a> action. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Subnet {
     pub subnet_availability_zone: Option<AvailabilityZone>,
     /// <p>Specifies the identifier of the subnet.</p>
@@ -17578,7 +17578,7 @@ impl TStampDeserializer {
     }
 }
 /// <p>Metadata assigned to an Amazon RDS resource consisting of a key-value pair.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Tag {
     /// <p>A key is the required name of the tag. The string value can be from 1 to 128 Unicode characters in length and can't be prefixed with "aws:" or "rds:". The string can only contain only the set of Unicode letters, digits, white-space, '_', '.', '/', '=', '+', '-' (Java regex: "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-]*)$").</p>
     pub key: Option<String>,
@@ -17706,7 +17706,7 @@ impl TagListSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct TagListMessage {
     /// <p>List of tags returned by the ListTagsForResource operation.</p>
     pub tag_list: Option<Vec<Tag>>,
@@ -17753,7 +17753,7 @@ impl TagListMessageDeserializer {
     }
 }
 /// <p>A time zone associated with a <a>DBInstance</a> or a <a>DBSnapshot</a>. This data type is an element in the response to the <a>DescribeDBInstances</a>, the <a>DescribeDBSnapshots</a>, and the <a>DescribeDBEngineVersions</a> actions. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Timezone {
     /// <p>The name of the time zone.</p>
     pub timezone_name: Option<String>,
@@ -17800,7 +17800,7 @@ impl TimezoneDeserializer {
     }
 }
 /// <p>The version of the database engine that a DB instance can be upgraded to.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpgradeTarget {
     /// <p>A value that indicates whether the target version is applied to any source DB instances that have AutoMinorVersionUpgrade set to true.</p>
     pub auto_upgrade: Option<bool>,
@@ -17873,7 +17873,7 @@ impl UpgradeTargetDeserializer {
     }
 }
 /// <p>Information about valid modifications that you can make to your DB instance. Contains the result of a successful call to the <a>DescribeValidDBInstanceModifications</a> action. You can use this information when you call <a>ModifyDBInstance</a>. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ValidDBInstanceModificationsMessage {
     /// <p>Valid storage options for your DB instance. </p>
     pub storage: Option<Vec<ValidStorageOptions>>,
@@ -17921,7 +17921,7 @@ impl ValidDBInstanceModificationsMessageDeserializer {
     }
 }
 /// <p>Information about valid modifications that you can make to your DB instance. Contains the result of a successful call to the <a>DescribeValidDBInstanceModifications</a> action. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ValidStorageOptions {
     /// <p>The valid range of Provisioned IOPS to gibibytes of storage multiplier. For example, 3-10, which means that provisioned IOPS can be between 3 and 10 times storage. </p>
     pub iops_to_storage_ratio: Option<Vec<DoubleRange>>,
@@ -18089,7 +18089,7 @@ impl VpcSecurityGroupIdListSerializer {
 }
 
 /// <p>This data type is used as a response element for queries on VPC security group membership.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct VpcSecurityGroupMembership {
     /// <p>The status of the VPC security group.</p>
     pub status: Option<String>,

--- a/rusoto/services/rds/src/generated.rs
+++ b/rusoto/services/rds/src/generated.rs
@@ -29,8 +29,9 @@ use hyper::StatusCode;
 use rusoto_core::param::{Params, ServiceParams};
 use rusoto_core::signature::SignedRequest;
 use rusoto_core::xmlerror::*;
-use rusoto_core::xmlutil::{characters, end_element, find_start_element, peek_at_name, skip_tree,
-                           start_element};
+use rusoto_core::xmlutil::{
+    characters, end_element, find_start_element, peek_at_name, skip_tree, start_element,
+};
 use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
 use std::str::FromStr;
 use xml::reader::ParserConfig;

--- a/rusoto/services/redshift/src/generated.rs
+++ b/rusoto/services/redshift/src/generated.rs
@@ -44,7 +44,7 @@ enum DeserializerNext {
     Element(String),
 }
 /// <p>Describes an AWS customer account authorized to restore a snapshot.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AccountWithRestoreAccess {
     /// <p>The identifier of an AWS support account authorized to restore a snapshot. For AWS support, the identifier is <code>amazon-redshift-support</code>. </p>
     pub account_alias: Option<String>,
@@ -140,7 +140,7 @@ impl AccountsWithRestoreAccessListDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AuthorizeClusterSecurityGroupIngressMessage {
     /// <p>The IP range to be added the Amazon Redshift security group.</p>
     pub cidrip: Option<String>,
@@ -190,7 +190,7 @@ impl AuthorizeClusterSecurityGroupIngressMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AuthorizeClusterSecurityGroupIngressResult {
     pub cluster_security_group: Option<ClusterSecurityGroup>,
 }
@@ -239,7 +239,7 @@ impl AuthorizeClusterSecurityGroupIngressResultDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AuthorizeSnapshotAccessMessage {
     /// <p>The identifier of the AWS customer account authorized to restore the specified snapshot.</p> <p>To share a snapshot with AWS support, specify amazon-redshift-support.</p>
     pub account_with_restore_access: String,
@@ -275,7 +275,7 @@ impl AuthorizeSnapshotAccessMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AuthorizeSnapshotAccessResult {
     pub snapshot: Option<Snapshot>,
 }
@@ -321,7 +321,7 @@ impl AuthorizeSnapshotAccessResultDeserializer {
     }
 }
 /// <p>Describes an availability zone.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AvailabilityZone {
     /// <p>The name of the availability zone.</p>
     pub name: Option<String>,
@@ -446,7 +446,7 @@ impl BooleanOptionalDeserializer {
     }
 }
 /// <p>Describes a cluster.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Cluster {
     /// <p>A Boolean value that, if <code>true</code>, indicates that major version upgrades will be applied automatically to the cluster during the maintenance window. </p>
     pub allow_version_upgrade: Option<bool>,
@@ -735,7 +735,7 @@ impl ClusterDeserializer {
     }
 }
 /// <p>Temporary credentials with authorization to log on to an Amazon Redshift database. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ClusterCredentials {
     /// <p>A temporary password that authorizes the user name returned by <code>DbUser</code> to log on to the database <code>DbName</code>. </p>
     pub db_password: Option<String>,
@@ -795,7 +795,7 @@ impl ClusterCredentialsDeserializer {
     }
 }
 /// <p>An AWS Identity and Access Management (IAM) role that can be used by the associated Amazon Redshift cluster to access other AWS services.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ClusterIamRole {
     /// <p><p>A value that describes the status of the IAM role&#39;s association with an Amazon Redshift cluster.</p> <p>The following are possible statuses and descriptions.</p> <ul> <li> <p> <code>in-sync</code>: The role is available for use by the cluster.</p> </li> <li> <p> <code>adding</code>: The role is in the process of being associated with the cluster.</p> </li> <li> <p> <code>removing</code>: The role is in the process of being disassociated with the cluster.</p> </li> </ul></p>
     pub apply_status: Option<String>,
@@ -931,7 +931,7 @@ impl ClusterListDeserializer {
     }
 }
 /// <p>The identifier of a node in a cluster.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ClusterNode {
     /// <p>Whether the node is a leader node or a compute node.</p>
     pub node_role: Option<String>,
@@ -1034,7 +1034,7 @@ impl ClusterNodesListDeserializer {
     }
 }
 /// <p>Describes a parameter group.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ClusterParameterGroup {
     /// <p>The description of the parameter group.</p>
     pub description: Option<String>,
@@ -1102,7 +1102,7 @@ impl ClusterParameterGroupDeserializer {
     }
 }
 /// <p>Contains the output from the <a>DescribeClusterParameters</a> action. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ClusterParameterGroupDetails {
     /// <p>A value that indicates the starting point for the next set of response records in a subsequent request. If a value is returned in a response, you can retrieve the next set of records by providing this returned marker value in the <code>Marker</code> parameter and retrying the command. If the <code>Marker</code> field is empty, all response records have been retrieved for the request. </p>
     pub marker: Option<String>,
@@ -1156,7 +1156,7 @@ impl ClusterParameterGroupDetailsDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ClusterParameterGroupNameMessage {
     /// <p>The name of the cluster parameter group.</p>
     pub parameter_group_name: Option<String>,
@@ -1213,7 +1213,7 @@ impl ClusterParameterGroupNameMessageDeserializer {
     }
 }
 /// <p>Describes the status of a parameter group.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ClusterParameterGroupStatus {
     /// <p>The list of parameter statuses.</p> <p> For more information about parameters and parameter groups, go to <a href="http://docs.aws.amazon.com/redshift/latest/mgmt/working-with-parameter-groups.html">Amazon Redshift Parameter Groups</a> in the <i>Amazon Redshift Cluster Management Guide</i>.</p>
     pub cluster_parameter_status_list: Option<Vec<ClusterParameterStatus>>,
@@ -1322,7 +1322,7 @@ impl ClusterParameterGroupStatusListDeserializer {
     }
 }
 /// <p>Contains the output from the <a>DescribeClusterParameterGroups</a> action. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ClusterParameterGroupsMessage {
     /// <p>A value that indicates the starting point for the next set of response records in a subsequent request. If a value is returned in a response, you can retrieve the next set of records by providing this returned marker value in the <code>Marker</code> parameter and retrying the command. If the <code>Marker</code> field is empty, all response records have been retrieved for the request. </p>
     pub marker: Option<String>,
@@ -1375,7 +1375,7 @@ impl ClusterParameterGroupsMessageDeserializer {
     }
 }
 /// <p>Describes the status of a parameter group.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ClusterParameterStatus {
     /// <p>The error that prevented the parameter from being applied to the database.</p>
     pub parameter_apply_error_description: Option<String>,
@@ -1483,7 +1483,7 @@ impl ClusterParameterStatusListDeserializer {
     }
 }
 /// <p>Describes a security group.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ClusterSecurityGroup {
     /// <p>The name of the cluster security group to which the operation was applied.</p>
     pub cluster_security_group_name: Option<String>,
@@ -1558,7 +1558,7 @@ impl ClusterSecurityGroupDeserializer {
     }
 }
 /// <p>Describes a cluster security group.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ClusterSecurityGroupMembership {
     /// <p>The name of the cluster security group.</p>
     pub cluster_security_group_name: Option<String>,
@@ -1656,7 +1656,7 @@ impl ClusterSecurityGroupMembershipListDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ClusterSecurityGroupMessage {
     /// <p>A list of <a>ClusterSecurityGroup</a> instances. </p>
     pub cluster_security_groups: Option<Vec<ClusterSecurityGroup>>,
@@ -1766,7 +1766,7 @@ impl ClusterSecurityGroupsDeserializer {
     }
 }
 /// <p>Returns the destination region and retention period that are configured for cross-region snapshot copy.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ClusterSnapshotCopyStatus {
     /// <p>The destination region that snapshots are automatically copied to when cross-region snapshot copy is enabled.</p>
     pub destination_region: Option<String>,
@@ -1831,7 +1831,7 @@ impl ClusterSnapshotCopyStatusDeserializer {
     }
 }
 /// <p>Describes a subnet group.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ClusterSubnetGroup {
     /// <p>The name of the cluster subnet group.</p>
     pub cluster_subnet_group_name: Option<String>,
@@ -1909,7 +1909,7 @@ impl ClusterSubnetGroupDeserializer {
     }
 }
 /// <p>Contains the output from the <a>DescribeClusterSubnetGroups</a> action. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ClusterSubnetGroupMessage {
     /// <p>A list of <a>ClusterSubnetGroup</a> instances. </p>
     pub cluster_subnet_groups: Option<Vec<ClusterSubnetGroup>>,
@@ -2007,7 +2007,7 @@ impl ClusterSubnetGroupsDeserializer {
     }
 }
 /// <p>Describes a cluster version, including the parameter group family and description of the version.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ClusterVersion {
     /// <p>The name of the cluster parameter group family for the cluster.</p>
     pub cluster_parameter_group_family: Option<String>,
@@ -2112,7 +2112,7 @@ impl ClusterVersionListDeserializer {
     }
 }
 /// <p>Contains the output from the <a>DescribeClusterVersions</a> action. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ClusterVersionsMessage {
     /// <p>A list of <code>Version</code> elements. </p>
     pub cluster_versions: Option<Vec<ClusterVersion>>,
@@ -2165,7 +2165,7 @@ impl ClusterVersionsMessageDeserializer {
     }
 }
 /// <p>Contains the output from the <a>DescribeClusters</a> action. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ClustersMessage {
     /// <p>A list of <code>Cluster</code> objects, where each object describes one cluster. </p>
     pub clusters: Option<Vec<Cluster>>,
@@ -2218,7 +2218,7 @@ impl ClustersMessageDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CopyClusterSnapshotMessage {
     /// <p><p>The identifier of the cluster the source snapshot was created from. This parameter is required if your IAM user has a policy containing a snapshot resource element that specifies anything other than * for the cluster name.</p> <p>Constraints:</p> <ul> <li> <p>Must be the identifier for a valid cluster.</p> </li> </ul></p>
     pub source_snapshot_cluster_identifier: Option<String>,
@@ -2254,7 +2254,7 @@ impl CopyClusterSnapshotMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CopyClusterSnapshotResult {
     pub snapshot: Option<Snapshot>,
 }
@@ -2300,7 +2300,7 @@ impl CopyClusterSnapshotResultDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateClusterMessage {
     /// <p>Reserved.</p>
     pub additional_info: Option<String>,
@@ -2525,7 +2525,7 @@ impl CreateClusterMessageSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateClusterParameterGroupMessage {
     /// <p>A description of the parameter group.</p>
     pub description: String,
@@ -2564,7 +2564,7 @@ impl CreateClusterParameterGroupMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateClusterParameterGroupResult {
     pub cluster_parameter_group: Option<ClusterParameterGroup>,
 }
@@ -2612,7 +2612,7 @@ impl CreateClusterParameterGroupResultDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateClusterResult {
     pub cluster: Option<Cluster>,
 }
@@ -2658,7 +2658,7 @@ impl CreateClusterResultDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateClusterSecurityGroupMessage {
     /// <p>The name for the security group. Amazon Redshift stores the value as a lowercase string.</p> <p>Constraints:</p> <ul> <li> <p>Must contain no more than 255 alphanumeric characters or hyphens.</p> </li> <li> <p>Must not be "Default".</p> </li> <li> <p>Must be unique for all security groups that are created by your AWS account.</p> </li> </ul> <p>Example: <code>examplesecuritygroup</code> </p>
     pub cluster_security_group_name: String,
@@ -2691,7 +2691,7 @@ impl CreateClusterSecurityGroupMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateClusterSecurityGroupResult {
     pub cluster_security_group: Option<ClusterSecurityGroup>,
 }
@@ -2740,7 +2740,7 @@ impl CreateClusterSecurityGroupResultDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateClusterSnapshotMessage {
     /// <p>The cluster identifier for which you want a snapshot.</p>
     pub cluster_identifier: String,
@@ -2773,7 +2773,7 @@ impl CreateClusterSnapshotMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateClusterSnapshotResult {
     pub snapshot: Option<Snapshot>,
 }
@@ -2819,7 +2819,7 @@ impl CreateClusterSnapshotResultDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateClusterSubnetGroupMessage {
     /// <p>The name for the subnet group. Amazon Redshift stores the value as a lowercase string.</p> <p>Constraints:</p> <ul> <li> <p>Must contain no more than 255 alphanumeric characters or hyphens.</p> </li> <li> <p>Must not be "Default".</p> </li> <li> <p>Must be unique for all subnet groups that are created by your AWS account.</p> </li> </ul> <p>Example: <code>examplesubnetgroup</code> </p>
     pub cluster_subnet_group_name: String,
@@ -2859,7 +2859,7 @@ impl CreateClusterSubnetGroupMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateClusterSubnetGroupResult {
     pub cluster_subnet_group: Option<ClusterSubnetGroup>,
 }
@@ -2908,7 +2908,7 @@ impl CreateClusterSubnetGroupResultDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateEventSubscriptionMessage {
     /// <p>A Boolean value; set to <code>true</code> to activate the subscription, set to <code>false</code> to create the subscription but not active it. </p>
     pub enabled: Option<bool>,
@@ -2983,7 +2983,7 @@ impl CreateEventSubscriptionMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateEventSubscriptionResult {
     pub event_subscription: Option<EventSubscription>,
 }
@@ -3030,7 +3030,7 @@ impl CreateEventSubscriptionResultDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateHsmClientCertificateMessage {
     /// <p>The identifier to be assigned to the new HSM client certificate that the cluster will use to connect to the HSM to use the database encryption keys.</p>
     pub hsm_client_certificate_identifier: String,
@@ -3057,7 +3057,7 @@ impl CreateHsmClientCertificateMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateHsmClientCertificateResult {
     pub hsm_client_certificate: Option<HsmClientCertificate>,
 }
@@ -3106,7 +3106,7 @@ impl CreateHsmClientCertificateResultDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateHsmConfigurationMessage {
     /// <p>A text description of the HSM configuration to be created.</p>
     pub description: String,
@@ -3163,7 +3163,7 @@ impl CreateHsmConfigurationMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateHsmConfigurationResult {
     pub hsm_configuration: Option<HsmConfiguration>,
 }
@@ -3210,7 +3210,7 @@ impl CreateHsmConfigurationResultDeserializer {
     }
 }
 /// <p>The result of the <code>CreateSnapshotCopyGrant</code> action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateSnapshotCopyGrantMessage {
     /// <p>The unique identifier of the customer master key (CMK) to which to grant Amazon Redshift permission. If no key is specified, the default key is used.</p>
     pub kms_key_id: Option<String>,
@@ -3245,7 +3245,7 @@ impl CreateSnapshotCopyGrantMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateSnapshotCopyGrantResult {
     pub snapshot_copy_grant: Option<SnapshotCopyGrant>,
 }
@@ -3292,7 +3292,7 @@ impl CreateSnapshotCopyGrantResultDeserializer {
     }
 }
 /// <p>Contains the output from the <code>CreateTags</code> action. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateTagsMessage {
     /// <p>The Amazon Resource Name (ARN) to which you want to add the tag or tags. For example, <code>arn:aws:redshift:us-east-1:123456789:cluster:t1</code>. </p>
     pub resource_name: String,
@@ -3329,7 +3329,7 @@ impl DbGroupListSerializer {
 }
 
 /// <p>Describes the default cluster parameters for a parameter group family.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DefaultClusterParameters {
     /// <p>A value that indicates the starting point for the next set of response records in a subsequent request. If a value is returned in a response, you can retrieve the next set of records by providing this returned marker value in the <code>Marker</code> parameter and retrying the command. If the <code>Marker</code> field is empty, all response records have been retrieved for the request. </p>
     pub marker: Option<String>,
@@ -3391,7 +3391,7 @@ impl DefaultClusterParametersDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteClusterMessage {
     /// <p><p>The identifier of the cluster to be deleted.</p> <p>Constraints:</p> <ul> <li> <p>Must contain lowercase characters.</p> </li> <li> <p>Must contain from 1 to 63 alphanumeric characters or hyphens.</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens.</p> </li> </ul></p>
     pub cluster_identifier: String,
@@ -3430,7 +3430,7 @@ impl DeleteClusterMessageSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteClusterParameterGroupMessage {
     /// <p><p>The name of the parameter group to be deleted.</p> <p>Constraints:</p> <ul> <li> <p>Must be the name of an existing cluster parameter group.</p> </li> <li> <p>Cannot delete a default cluster parameter group.</p> </li> </ul></p>
     pub parameter_group_name: String,
@@ -3452,7 +3452,7 @@ impl DeleteClusterParameterGroupMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteClusterResult {
     pub cluster: Option<Cluster>,
 }
@@ -3498,7 +3498,7 @@ impl DeleteClusterResultDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteClusterSecurityGroupMessage {
     /// <p>The name of the cluster security group to be deleted.</p>
     pub cluster_security_group_name: String,
@@ -3521,7 +3521,7 @@ impl DeleteClusterSecurityGroupMessageSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteClusterSnapshotMessage {
     /// <p>The unique identifier of the cluster the snapshot was created from. This parameter is required if your IAM user has a policy containing a snapshot resource element that specifies anything other than * for the cluster name.</p> <p>Constraints: Must be the name of valid cluster.</p>
     pub snapshot_cluster_identifier: Option<String>,
@@ -3551,7 +3551,7 @@ impl DeleteClusterSnapshotMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteClusterSnapshotResult {
     pub snapshot: Option<Snapshot>,
 }
@@ -3597,7 +3597,7 @@ impl DeleteClusterSnapshotResultDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteClusterSubnetGroupMessage {
     /// <p>The name of the cluster subnet group name to be deleted.</p>
     pub cluster_subnet_group_name: String,
@@ -3620,7 +3620,7 @@ impl DeleteClusterSubnetGroupMessageSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteEventSubscriptionMessage {
     /// <p>The name of the Amazon Redshift event notification subscription to be deleted.</p>
     pub subscription_name: String,
@@ -3643,7 +3643,7 @@ impl DeleteEventSubscriptionMessageSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteHsmClientCertificateMessage {
     /// <p>The identifier of the HSM client certificate to be deleted.</p>
     pub hsm_client_certificate_identifier: String,
@@ -3666,7 +3666,7 @@ impl DeleteHsmClientCertificateMessageSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteHsmConfigurationMessage {
     /// <p>The identifier of the Amazon Redshift HSM configuration to be deleted.</p>
     pub hsm_configuration_identifier: String,
@@ -3689,7 +3689,7 @@ impl DeleteHsmConfigurationMessageSerializer {
 }
 
 /// <p>The result of the <code>DeleteSnapshotCopyGrant</code> action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteSnapshotCopyGrantMessage {
     /// <p>The name of the snapshot copy grant to delete.</p>
     pub snapshot_copy_grant_name: String,
@@ -3712,7 +3712,7 @@ impl DeleteSnapshotCopyGrantMessageSerializer {
 }
 
 /// <p>Contains the output from the <code>DeleteTags</code> action. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteTagsMessage {
     /// <p>The Amazon Resource Name (ARN) from which you want to remove the tag or tags. For example, <code>arn:aws:redshift:us-east-1:123456789:cluster:t1</code>. </p>
     pub resource_name: String,
@@ -3738,7 +3738,7 @@ impl DeleteTagsMessageSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeClusterParameterGroupsMessage {
     /// <p>An optional parameter that specifies the starting point to return a set of response records. When the results of a <a>DescribeClusterParameterGroups</a> request exceed the value specified in <code>MaxRecords</code>, AWS returns a value in the <code>Marker</code> field of the response. You can retrieve the next set of response records by providing the returned marker value in the <code>Marker</code> parameter and retrying the request. </p>
     pub marker: Option<String>,
@@ -3797,7 +3797,7 @@ impl DescribeClusterParameterGroupsMessageSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeClusterParametersMessage {
     /// <p>An optional parameter that specifies the starting point to return a set of response records. When the results of a <a>DescribeClusterParameters</a> request exceed the value specified in <code>MaxRecords</code>, AWS returns a value in the <code>Marker</code> field of the response. You can retrieve the next set of response records by providing the returned marker value in the <code>Marker</code> parameter and retrying the request. </p>
     pub marker: Option<String>,
@@ -3844,7 +3844,7 @@ impl DescribeClusterParametersMessageSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeClusterSecurityGroupsMessage {
     /// <p>The name of a cluster security group for which you are requesting details. You can specify either the <b>Marker</b> parameter or a <b>ClusterSecurityGroupName</b> parameter, but not both. </p> <p> Example: <code>securitygroup1</code> </p>
     pub cluster_security_group_name: Option<String>,
@@ -3903,7 +3903,7 @@ impl DescribeClusterSecurityGroupsMessageSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeClusterSnapshotsMessage {
     /// <p>A value that indicates whether to return snapshots only for an existing cluster. Table-level restore can be performed only using a snapshot of an existing cluster, that is, a cluster that has not been deleted. If <code>ClusterExists</code> is set to <code>true</code>, <code>ClusterIdentifier</code> is required.</p>
     pub cluster_exists: Option<bool>,
@@ -4010,7 +4010,7 @@ impl DescribeClusterSnapshotsMessageSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeClusterSubnetGroupsMessage {
     /// <p>The name of the cluster subnet group for which information is requested.</p>
     pub cluster_subnet_group_name: Option<String>,
@@ -4069,7 +4069,7 @@ impl DescribeClusterSubnetGroupsMessageSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeClusterVersionsMessage {
     /// <p><p>The name of a specific cluster parameter group family to return details for.</p> <p>Constraints:</p> <ul> <li> <p>Must be 1 to 255 alphanumeric characters</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul></p>
     pub cluster_parameter_group_family: Option<String>,
@@ -4118,7 +4118,7 @@ impl DescribeClusterVersionsMessageSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeClustersMessage {
     /// <p>The unique identifier of a cluster whose properties you are requesting. This parameter is case sensitive.</p> <p>The default is that all clusters defined for an account are returned.</p>
     pub cluster_identifier: Option<String>,
@@ -4177,7 +4177,7 @@ impl DescribeClustersMessageSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeDefaultClusterParametersMessage {
     /// <p>An optional parameter that specifies the starting point to return a set of response records. When the results of a <a>DescribeDefaultClusterParameters</a> request exceed the value specified in <code>MaxRecords</code>, AWS returns a value in the <code>Marker</code> field of the response. You can retrieve the next set of response records by providing the returned marker value in the <code>Marker</code> parameter and retrying the request. </p>
     pub marker: Option<String>,
@@ -4215,7 +4215,7 @@ impl DescribeDefaultClusterParametersMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeDefaultClusterParametersResult {
     pub default_cluster_parameters: Option<DefaultClusterParameters>,
 }
@@ -4264,7 +4264,7 @@ impl DescribeDefaultClusterParametersResultDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeEventCategoriesMessage {
     /// <p>The source type, such as cluster or parameter group, to which the described event categories apply.</p> <p>Valid values: cluster, cluster-snapshot, cluster-parameter-group, and cluster-security-group.</p>
     pub source_type: Option<String>,
@@ -4289,7 +4289,7 @@ impl DescribeEventCategoriesMessageSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeEventSubscriptionsMessage {
     /// <p>An optional parameter that specifies the starting point to return a set of response records. When the results of a DescribeEventSubscriptions request exceed the value specified in <code>MaxRecords</code>, AWS returns a value in the <code>Marker</code> field of the response. You can retrieve the next set of response records by providing the returned marker value in the <code>Marker</code> parameter and retrying the request. </p>
     pub marker: Option<String>,
@@ -4348,7 +4348,7 @@ impl DescribeEventSubscriptionsMessageSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeEventsMessage {
     /// <p>The number of minutes prior to the time of the request for which to retrieve events. For example, if the request is sent at 18:00 and you specify a duration of 60, then only events which have occurred after 17:00 will be returned.</p> <p>Default: <code>60</code> </p>
     pub duration: Option<i64>,
@@ -4421,7 +4421,7 @@ impl DescribeEventsMessageSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeHsmClientCertificatesMessage {
     /// <p>The identifier of a specific HSM client certificate for which you want information. If no identifier is specified, information is returned for all HSM client certificates owned by your AWS customer account.</p>
     pub hsm_client_certificate_identifier: Option<String>,
@@ -4480,7 +4480,7 @@ impl DescribeHsmClientCertificatesMessageSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeHsmConfigurationsMessage {
     /// <p>The identifier of a specific Amazon Redshift HSM configuration to be described. If no identifier is specified, information is returned for all HSM configurations owned by your AWS customer account.</p>
     pub hsm_configuration_identifier: Option<String>,
@@ -4539,7 +4539,7 @@ impl DescribeHsmConfigurationsMessageSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeLoggingStatusMessage {
     /// <p>The identifier of the cluster from which to get the logging status.</p> <p>Example: <code>examplecluster</code> </p>
     pub cluster_identifier: String,
@@ -4562,7 +4562,7 @@ impl DescribeLoggingStatusMessageSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeOrderableClusterOptionsMessage {
     /// <p>The version filter value. Specify this parameter to show only the available offerings matching the specified version.</p> <p>Default: All versions.</p> <p>Constraints: Must be one of the version returned from <a>DescribeClusterVersions</a>.</p>
     pub cluster_version: Option<String>,
@@ -4611,7 +4611,7 @@ impl DescribeOrderableClusterOptionsMessageSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeReservedNodeOfferingsMessage {
     /// <p>An optional parameter that specifies the starting point to return a set of response records. When the results of a <a>DescribeReservedNodeOfferings</a> request exceed the value specified in <code>MaxRecords</code>, AWS returns a value in the <code>Marker</code> field of the response. You can retrieve the next set of response records by providing the returned marker value in the <code>Marker</code> parameter and retrying the request. </p>
     pub marker: Option<String>,
@@ -4652,7 +4652,7 @@ impl DescribeReservedNodeOfferingsMessageSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeReservedNodesMessage {
     /// <p>An optional parameter that specifies the starting point to return a set of response records. When the results of a <a>DescribeReservedNodes</a> request exceed the value specified in <code>MaxRecords</code>, AWS returns a value in the <code>Marker</code> field of the response. You can retrieve the next set of response records by providing the returned marker value in the <code>Marker</code> parameter and retrying the request. </p>
     pub marker: Option<String>,
@@ -4693,7 +4693,7 @@ impl DescribeReservedNodesMessageSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeResizeMessage {
     /// <p>The unique identifier of a cluster whose resize progress you are requesting. This parameter is case-sensitive.</p> <p>By default, resize operations for all clusters defined for an AWS account are returned.</p>
     pub cluster_identifier: String,
@@ -4716,7 +4716,7 @@ impl DescribeResizeMessageSerializer {
 }
 
 /// <p>The result of the <code>DescribeSnapshotCopyGrants</code> action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeSnapshotCopyGrantsMessage {
     /// <p>An optional parameter that specifies the starting point to return a set of response records. When the results of a <code>DescribeSnapshotCopyGrant</code> request exceed the value specified in <code>MaxRecords</code>, AWS returns a value in the <code>Marker</code> field of the response. You can retrieve the next set of response records by providing the returned marker value in the <code>Marker</code> parameter and retrying the request. </p> <p>Constraints: You can specify either the <b>SnapshotCopyGrantName</b> parameter or the <b>Marker</b> parameter, but not both. </p>
     pub marker: Option<String>,
@@ -4775,7 +4775,7 @@ impl DescribeSnapshotCopyGrantsMessageSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeTableRestoreStatusMessage {
     /// <p>The Amazon Redshift cluster that the table is being restored to.</p>
     pub cluster_identifier: Option<String>,
@@ -4824,7 +4824,7 @@ impl DescribeTableRestoreStatusMessageSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeTagsMessage {
     /// <p>A value that indicates the starting point for the next set of response records in a subsequent request. If a value is returned in a response, you can retrieve the next set of records by providing this returned marker value in the <code>marker</code> parameter and retrying the command. If the <code>marker</code> field is empty, all response records have been retrieved for the request. </p>
     pub marker: Option<String>,
@@ -4891,7 +4891,7 @@ impl DescribeTagsMessageSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DisableLoggingMessage {
     /// <p>The identifier of the cluster on which logging is to be stopped.</p> <p>Example: <code>examplecluster</code> </p>
     pub cluster_identifier: String,
@@ -4914,7 +4914,7 @@ impl DisableLoggingMessageSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DisableSnapshotCopyMessage {
     /// <p>The unique identifier of the source cluster that you want to disable copying of snapshots to a destination region.</p> <p>Constraints: Must be the valid name of an existing cluster that has cross-region snapshot copy enabled.</p>
     pub cluster_identifier: String,
@@ -4936,7 +4936,7 @@ impl DisableSnapshotCopyMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DisableSnapshotCopyResult {
     pub cluster: Option<Cluster>,
 }
@@ -5010,7 +5010,7 @@ impl DoubleOptionalDeserializer {
     }
 }
 /// <p>Describes an Amazon EC2 security group.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct EC2SecurityGroup {
     /// <p>The name of the EC2 Security Group.</p>
     pub ec2_security_group_name: Option<String>,
@@ -5119,7 +5119,7 @@ impl EC2SecurityGroupListDeserializer {
     }
 }
 /// <p>Describes the status of the elastic IP (EIP) address.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ElasticIpStatus {
     /// <p>The elastic IP (EIP) address for the cluster.</p>
     pub elastic_ip: Option<String>,
@@ -5171,7 +5171,7 @@ impl ElasticIpStatusDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct EnableLoggingMessage {
     /// <p><p>The name of an existing S3 bucket where the log files are to be stored.</p> <p>Constraints:</p> <ul> <li> <p>Must be in the same region as the cluster</p> </li> <li> <p>The cluster must have read bucket and put object permissions</p> </li> </ul></p>
     pub bucket_name: String,
@@ -5208,7 +5208,7 @@ impl EnableLoggingMessageSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct EnableSnapshotCopyMessage {
     /// <p>The unique identifier of the source cluster to copy snapshots from.</p> <p>Constraints: Must be the valid name of an existing cluster that does not already have cross-region snapshot copy enabled.</p>
     pub cluster_identifier: String,
@@ -5252,7 +5252,7 @@ impl EnableSnapshotCopyMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct EnableSnapshotCopyResult {
     pub cluster: Option<Cluster>,
 }
@@ -5298,7 +5298,7 @@ impl EnableSnapshotCopyResultDeserializer {
     }
 }
 /// <p>Describes a connection endpoint.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Endpoint {
     /// <p>The DNS address of the Cluster.</p>
     pub address: Option<String>,
@@ -5349,7 +5349,7 @@ impl EndpointDeserializer {
     }
 }
 /// <p>Describes an event.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Event {
     /// <p>The date and time of the event.</p>
     pub date: Option<String>,
@@ -5490,7 +5490,7 @@ impl EventCategoriesListSerializer {
 }
 
 /// <p>Describes event categories.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct EventCategoriesMap {
     /// <p>The events in the event category.</p>
     pub events: Option<Vec<EventInfoMap>>,
@@ -5587,7 +5587,7 @@ impl EventCategoriesMapListDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct EventCategoriesMessage {
     /// <p>A list of event categories descriptions.</p>
     pub event_categories_map_list: Option<Vec<EventCategoriesMap>>,
@@ -5637,7 +5637,7 @@ impl EventCategoriesMessageDeserializer {
     }
 }
 /// <p>Describes event information.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct EventInfoMap {
     /// <p>The category of an Amazon Redshift event.</p>
     pub event_categories: Option<Vec<String>>,
@@ -5788,7 +5788,7 @@ impl EventListDeserializer {
     }
 }
 /// <p>Describes event subscriptions.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct EventSubscription {
     /// <p>The name of the Amazon Redshift event notification subscription.</p>
     pub cust_subscription_id: Option<String>,
@@ -5946,7 +5946,7 @@ impl EventSubscriptionsListDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct EventSubscriptionsMessage {
     /// <p>A list of event subscriptions.</p>
     pub event_subscriptions_list: Option<Vec<EventSubscription>>,
@@ -6001,7 +6001,7 @@ impl EventSubscriptionsMessageDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct EventsMessage {
     /// <p>A list of <code>Event</code> instances. </p>
     pub events: Option<Vec<Event>>,
@@ -6053,7 +6053,7 @@ impl EventsMessageDeserializer {
     }
 }
 /// <p>The request parameters to get cluster credentials.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetClusterCredentialsMessage {
     /// <p>Create a database user with the name specified for the user named in <code>DbUser</code> if one does not exist.</p>
     pub auto_create: Option<bool>,
@@ -6115,7 +6115,7 @@ impl GetClusterCredentialsMessageSerializer {
 }
 
 /// <p>Returns information about an HSM client certificate. The certificate is stored in a secure Hardware Storage Module (HSM), and used by the Amazon Redshift cluster to encrypt data files.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct HsmClientCertificate {
     /// <p>The identifier of the HSM client certificate.</p>
     pub hsm_client_certificate_identifier: Option<String>,
@@ -6220,7 +6220,7 @@ impl HsmClientCertificateListDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct HsmClientCertificateMessage {
     /// <p>A list of the identifiers for one or more HSM client certificates used by Amazon Redshift clusters to store and retrieve database encryption keys in an HSM.</p>
     pub hsm_client_certificates: Option<Vec<HsmClientCertificate>>,
@@ -6275,7 +6275,7 @@ impl HsmClientCertificateMessageDeserializer {
     }
 }
 /// <p>Returns information about an HSM configuration, which is an object that describes to Amazon Redshift clusters the information they require to connect to an HSM where they can store database encryption keys.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct HsmConfiguration {
     /// <p>A text description of the HSM configuration.</p>
     pub description: Option<String>,
@@ -6391,7 +6391,7 @@ impl HsmConfigurationListDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct HsmConfigurationMessage {
     /// <p>A list of <code>HsmConfiguration</code> objects.</p>
     pub hsm_configurations: Option<Vec<HsmConfiguration>>,
@@ -6446,7 +6446,7 @@ impl HsmConfigurationMessageDeserializer {
     }
 }
 /// <p>Describes the status of changes to HSM settings.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct HsmStatus {
     /// <p>Specifies the name of the HSM client certificate the Amazon Redshift cluster uses to retrieve the data encryption keys stored in an HSM.</p>
     pub hsm_client_certificate_identifier: Option<String>,
@@ -6508,7 +6508,7 @@ impl HsmStatusDeserializer {
     }
 }
 /// <p>Describes an IP range used in a security group.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct IPRange {
     /// <p>The IP range in Classless Inter-Domain Routing (CIDR) notation.</p>
     pub cidrip: Option<String>,
@@ -6764,7 +6764,7 @@ impl IntegerOptionalDeserializer {
     }
 }
 /// <p>Describes the status of logging for a cluster.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct LoggingStatus {
     /// <p>The name of the S3 bucket where the log files are stored.</p>
     pub bucket_name: Option<String>,
@@ -6876,7 +6876,7 @@ impl LongOptionalDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyClusterIamRolesMessage {
     /// <p>Zero or more IAM roles to associate with the cluster. The roles must be in their Amazon Resource Name (ARN) format. You can associate up to 10 IAM roles with a single cluster in a single request.</p>
     pub add_iam_roles: Option<Vec<String>>,
@@ -6916,7 +6916,7 @@ impl ModifyClusterIamRolesMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyClusterIamRolesResult {
     pub cluster: Option<Cluster>,
 }
@@ -6962,7 +6962,7 @@ impl ModifyClusterIamRolesResultDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyClusterMessage {
     /// <p>If <code>true</code>, major version upgrades will be applied automatically to the cluster during the maintenance window. </p> <p>Default: <code>false</code> </p>
     pub allow_version_upgrade: Option<bool>,
@@ -7123,7 +7123,7 @@ impl ModifyClusterMessageSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyClusterParameterGroupMessage {
     /// <p>The name of the parameter group to be modified.</p>
     pub parameter_group_name: String,
@@ -7152,7 +7152,7 @@ impl ModifyClusterParameterGroupMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyClusterResult {
     pub cluster: Option<Cluster>,
 }
@@ -7198,7 +7198,7 @@ impl ModifyClusterResultDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyClusterSubnetGroupMessage {
     /// <p>The name of the subnet group to be modified.</p>
     pub cluster_subnet_group_name: String,
@@ -7235,7 +7235,7 @@ impl ModifyClusterSubnetGroupMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyClusterSubnetGroupResult {
     pub cluster_subnet_group: Option<ClusterSubnetGroup>,
 }
@@ -7284,7 +7284,7 @@ impl ModifyClusterSubnetGroupResultDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyEventSubscriptionMessage {
     /// <p>A Boolean value indicating if the subscription is enabled. <code>true</code> indicates the subscription is enabled </p>
     pub enabled: Option<bool>,
@@ -7356,7 +7356,7 @@ impl ModifyEventSubscriptionMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifyEventSubscriptionResult {
     pub event_subscription: Option<EventSubscription>,
 }
@@ -7403,7 +7403,7 @@ impl ModifyEventSubscriptionResultDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifySnapshotCopyRetentionPeriodMessage {
     /// <p>The unique identifier of the cluster for which you want to change the retention period for automated snapshots that are copied to a destination region.</p> <p>Constraints: Must be the valid name of an existing cluster that has cross-region snapshot copy enabled.</p>
     pub cluster_identifier: String,
@@ -7431,7 +7431,7 @@ impl ModifySnapshotCopyRetentionPeriodMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ModifySnapshotCopyRetentionPeriodResult {
     pub cluster: Option<Cluster>,
 }
@@ -7477,7 +7477,7 @@ impl ModifySnapshotCopyRetentionPeriodResultDeserializer {
     }
 }
 /// <p>Describes an orderable cluster option.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct OrderableClusterOption {
     /// <p>A list of availability zones for the orderable cluster.</p>
     pub availability_zones: Option<Vec<AvailabilityZone>>,
@@ -7590,7 +7590,7 @@ impl OrderableClusterOptionsListDeserializer {
     }
 }
 /// <p>Contains the output from the <a>DescribeOrderableClusterOptions</a> action. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct OrderableClusterOptionsMessage {
     /// <p>A value that indicates the starting point for the next set of response records in a subsequent request. If a value is returned in a response, you can retrieve the next set of records by providing this returned marker value in the <code>Marker</code> parameter and retrying the command. If the <code>Marker</code> field is empty, all response records have been retrieved for the request. </p>
     pub marker: Option<String>,
@@ -7645,7 +7645,7 @@ impl OrderableClusterOptionsMessageDeserializer {
     }
 }
 /// <p>Describes a parameter in a cluster parameter group.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Parameter {
     /// <p>The valid range of values for the parameter.</p>
     pub allowed_values: Option<String>,
@@ -7927,7 +7927,7 @@ impl ParametersListSerializer {
 }
 
 /// <p>Describes cluster attributes that are in a pending state. A change to one or more the attributes was requested and is in progress or will be applied.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PendingModifiedValues {
     /// <p>The pending or in-progress change of the automated snapshot retention period.</p>
     pub automated_snapshot_retention_period: Option<i64>,
@@ -8035,7 +8035,7 @@ impl PendingModifiedValuesDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PurchaseReservedNodeOfferingMessage {
     /// <p>The number of reserved nodes that you want to purchase.</p> <p>Default: <code>1</code> </p>
     pub node_count: Option<i64>,
@@ -8065,7 +8065,7 @@ impl PurchaseReservedNodeOfferingMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PurchaseReservedNodeOfferingResult {
     pub reserved_node: Option<ReservedNode>,
 }
@@ -8113,7 +8113,7 @@ impl PurchaseReservedNodeOfferingResultDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RebootClusterMessage {
     /// <p>The cluster identifier.</p>
     pub cluster_identifier: String,
@@ -8135,7 +8135,7 @@ impl RebootClusterMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RebootClusterResult {
     pub cluster: Option<Cluster>,
 }
@@ -8181,7 +8181,7 @@ impl RebootClusterResultDeserializer {
     }
 }
 /// <p>Describes a recurring charge.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RecurringCharge {
     /// <p>The amount charged per the period of time specified by the recurring charge frequency.</p>
     pub recurring_charge_amount: Option<f64>,
@@ -8280,7 +8280,7 @@ impl RecurringChargeListDeserializer {
     }
 }
 /// <p>Describes a reserved node. You can call the <a>DescribeReservedNodeOfferings</a> API to obtain the available reserved node offerings. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ReservedNode {
     /// <p>The currency code for the reserved cluster.</p>
     pub currency_code: Option<String>,
@@ -8447,7 +8447,7 @@ impl ReservedNodeListDeserializer {
     }
 }
 /// <p>Describes a reserved node offering.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ReservedNodeOffering {
     /// <p>The currency code for the compute nodes offering.</p>
     pub currency_code: Option<String>,
@@ -8603,7 +8603,7 @@ impl ReservedNodeOfferingTypeDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ReservedNodeOfferingsMessage {
     /// <p>A value that indicates the starting point for the next set of response records in a subsequent request. If a value is returned in a response, you can retrieve the next set of records by providing this returned marker value in the <code>Marker</code> parameter and retrying the command. If the <code>Marker</code> field is empty, all response records have been retrieved for the request. </p>
     pub marker: Option<String>,
@@ -8658,7 +8658,7 @@ impl ReservedNodeOfferingsMessageDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ReservedNodesMessage {
     /// <p>A value that indicates the starting point for the next set of response records in a subsequent request. If a value is returned in a response, you can retrieve the next set of records by providing this returned marker value in the <code>Marker</code> parameter and retrying the command. If the <code>Marker</code> field is empty, all response records have been retrieved for the request. </p>
     pub marker: Option<String>,
@@ -8712,7 +8712,7 @@ impl ReservedNodesMessageDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ResetClusterParameterGroupMessage {
     /// <p>The name of the cluster parameter group to be reset.</p>
     pub parameter_group_name: String,
@@ -8752,7 +8752,7 @@ impl ResetClusterParameterGroupMessageSerializer {
 }
 
 /// <p>Describes the result of a cluster resize operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ResizeProgressMessage {
     /// <p>The average rate of the resize operation over the last few minutes, measured in megabytes per second. After the resize operation completes, this value shows the average rate of the entire resize operation.</p>
     pub avg_resize_rate_in_mega_bytes_per_second: Option<f64>,
@@ -8929,7 +8929,7 @@ impl RestorableNodeTypeListDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RestoreFromClusterSnapshotMessage {
     /// <p>Reserved.</p>
     pub additional_info: Option<String>,
@@ -9120,7 +9120,7 @@ impl RestoreFromClusterSnapshotMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RestoreFromClusterSnapshotResult {
     pub cluster: Option<Cluster>,
 }
@@ -9166,7 +9166,7 @@ impl RestoreFromClusterSnapshotResultDeserializer {
     }
 }
 /// <p>Describes the status of a cluster restore action. Returns null if the cluster was not created by restoring a snapshot.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RestoreStatus {
     /// <p>The number of megabytes per second being transferred from the backup storage. Returns the average rate for a completed backup.</p>
     pub current_restore_rate_in_mega_bytes_per_second: Option<f64>,
@@ -9253,7 +9253,7 @@ impl RestoreStatusDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RestoreTableFromClusterSnapshotMessage {
     /// <p>The identifier of the Amazon Redshift cluster to restore the table to.</p>
     pub cluster_identifier: String,
@@ -9323,7 +9323,7 @@ impl RestoreTableFromClusterSnapshotMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RestoreTableFromClusterSnapshotResult {
     pub table_restore_status: Option<TableRestoreStatus>,
 }
@@ -9372,7 +9372,7 @@ impl RestoreTableFromClusterSnapshotResultDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RevokeClusterSecurityGroupIngressMessage {
     /// <p>The IP range for which to revoke access. This range must be a valid Classless Inter-Domain Routing (CIDR) block of IP addresses. If <code>CIDRIP</code> is specified, <code>EC2SecurityGroupName</code> and <code>EC2SecurityGroupOwnerId</code> cannot be provided. </p>
     pub cidrip: Option<String>,
@@ -9418,7 +9418,7 @@ impl RevokeClusterSecurityGroupIngressMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RevokeClusterSecurityGroupIngressResult {
     pub cluster_security_group: Option<ClusterSecurityGroup>,
 }
@@ -9467,7 +9467,7 @@ impl RevokeClusterSecurityGroupIngressResultDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RevokeSnapshotAccessMessage {
     /// <p>The identifier of the AWS customer account that can no longer restore the specified snapshot.</p>
     pub account_with_restore_access: String,
@@ -9503,7 +9503,7 @@ impl RevokeSnapshotAccessMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RevokeSnapshotAccessResult {
     pub snapshot: Option<Snapshot>,
 }
@@ -9549,7 +9549,7 @@ impl RevokeSnapshotAccessResultDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RotateEncryptionKeyMessage {
     /// <p>The unique identifier of the cluster that you want to rotate the encryption keys for.</p> <p>Constraints: Must be the name of valid cluster that has encryption enabled.</p>
     pub cluster_identifier: String,
@@ -9571,7 +9571,7 @@ impl RotateEncryptionKeyMessageSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RotateEncryptionKeyResult {
     pub cluster: Option<Cluster>,
 }
@@ -9631,7 +9631,7 @@ impl SensitiveStringDeserializer {
     }
 }
 /// <p>Describes a snapshot.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Snapshot {
     /// <p>A list of the AWS customer accounts authorized to restore the snapshot. Returns <code>null</code> if no accounts are authorized. Visible only to the snapshot owner. </p>
     pub accounts_with_restore_access: Option<Vec<AccountWithRestoreAccess>>,
@@ -9879,7 +9879,7 @@ impl SnapshotDeserializer {
     }
 }
 /// <p>The snapshot copy grant that grants Amazon Redshift permission to encrypt copied snapshots with the specified customer master key (CMK) from AWS KMS in the destination region.</p> <p> For more information about managing snapshot copy grants, go to <a href="http://docs.aws.amazon.com/redshift/latest/mgmt/working-with-db-encryption.html">Amazon Redshift Database Encryption</a> in the <i>Amazon Redshift Cluster Management Guide</i>. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SnapshotCopyGrant {
     /// <p>The unique identifier of the customer master key (CMK) in AWS KMS to which Amazon Redshift is granted permission.</p>
     pub kms_key_id: Option<String>,
@@ -9982,7 +9982,7 @@ impl SnapshotCopyGrantListDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SnapshotCopyGrantMessage {
     /// <p>An optional parameter that specifies the starting point to return a set of response records. When the results of a <code>DescribeSnapshotCopyGrant</code> request exceed the value specified in <code>MaxRecords</code>, AWS returns a value in the <code>Marker</code> field of the response. You can retrieve the next set of response records by providing the returned marker value in the <code>Marker</code> parameter and retrying the request. </p> <p>Constraints: You can specify either the <b>SnapshotCopyGrantName</b> parameter or the <b>Marker</b> parameter, but not both. </p>
     pub marker: Option<String>,
@@ -10077,7 +10077,7 @@ impl SnapshotListDeserializer {
     }
 }
 /// <p>Contains the output from the <a>DescribeClusterSnapshots</a> action. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SnapshotMessage {
     /// <p>A value that indicates the starting point for the next set of response records in a subsequent request. If a value is returned in a response, you can retrieve the next set of records by providing this returned marker value in the <code>Marker</code> parameter and retrying the command. If the <code>Marker</code> field is empty, all response records have been retrieved for the request. </p>
     pub marker: Option<String>,
@@ -10211,7 +10211,7 @@ impl StringDeserializer {
     }
 }
 /// <p>Describes a subnet.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Subnet {
     pub subnet_availability_zone: Option<AvailabilityZone>,
     /// <p>The identifier of the subnet.</p>
@@ -10326,7 +10326,7 @@ impl SubnetListDeserializer {
     }
 }
 /// <p>A list of supported platforms for orderable clusters.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SupportedPlatform {
     pub name: Option<String>,
 }
@@ -10428,7 +10428,7 @@ impl TStampDeserializer {
     }
 }
 /// <p>Describes the status of a <a>RestoreTableFromClusterSnapshot</a> operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct TableRestoreStatus {
     /// <p>The identifier of the Amazon Redshift cluster that the table is being restored to.</p>
     pub cluster_identifier: Option<String>,
@@ -10614,7 +10614,7 @@ impl TableRestoreStatusListDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct TableRestoreStatusMessage {
     /// <p>A pagination token that can be used in a subsequent <a>DescribeTableRestoreStatus</a> request.</p>
     pub marker: Option<String>,
@@ -10683,7 +10683,7 @@ impl TableRestoreStatusTypeDeserializer {
     }
 }
 /// <p>A tag consisting of a name/value pair for a resource.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Tag {
     /// <p>The key, or name, for the resource tag.</p>
     pub key: Option<String>,
@@ -10833,7 +10833,7 @@ impl TagValueListSerializer {
 }
 
 /// <p>A tag and its associated resource.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct TaggedResource {
     /// <p>The Amazon Resource Name (ARN) with which the tag is associated. For example, <code>arn:aws:redshift:us-east-1:123456789:cluster:t1</code>.</p>
     pub resource_name: Option<String>,
@@ -10934,7 +10934,7 @@ impl TaggedResourceListDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct TaggedResourceListMessage {
     /// <p>A value that indicates the starting point for the next set of response records in a subsequent request. If a value is returned in a response, you can retrieve the next set of records by providing this returned marker value in the <code>Marker</code> parameter and retrying the command. If the <code>Marker</code> field is empty, all response records have been retrieved for the request. </p>
     pub marker: Option<String>,
@@ -10999,7 +10999,7 @@ impl VpcSecurityGroupIdListSerializer {
 }
 
 /// <p>Describes the members of a VPC security group.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct VpcSecurityGroupMembership {
     /// <p>The status of the VPC security group.</p>
     pub status: Option<String>,

--- a/rusoto/services/redshift/src/generated.rs
+++ b/rusoto/services/redshift/src/generated.rs
@@ -29,8 +29,9 @@ use hyper::StatusCode;
 use rusoto_core::param::{Params, ServiceParams};
 use rusoto_core::signature::SignedRequest;
 use rusoto_core::xmlerror::*;
-use rusoto_core::xmlutil::{characters, end_element, find_start_element, peek_at_name, skip_tree,
-                           start_element};
+use rusoto_core::xmlutil::{
+    characters, end_element, find_start_element, peek_at_name, skip_tree, start_element,
+};
 use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
 use std::str::FromStr;
 use xml::reader::ParserConfig;

--- a/rusoto/services/rekognition/src/generated.rs
+++ b/rusoto/services/rekognition/src/generated.rs
@@ -31,7 +31,7 @@ use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 /// <p>Structure containing the estimated age range, in years, for a face.</p> <p>Rekognition estimates an age-range for faces detected in the input image. Estimated age ranges can overlap; a face of a 5 year old may have an estimated range of 4-6 whilst the face of a 6 year old may have an estimated range of 4-8.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AgeRange {
     /// <p>The highest estimated age.</p>
     #[serde(rename = "High")]
@@ -44,7 +44,7 @@ pub struct AgeRange {
 }
 
 /// <p>Indicates whether or not the face has a beard, and the confidence level in the determination.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Beard {
     /// <p>Level of confidence in the determination.</p>
     #[serde(rename = "Confidence")]
@@ -57,7 +57,7 @@ pub struct Beard {
 }
 
 /// <p><p>Identifies the bounding box around the object, face or text. The <code>left</code> (x-coordinate) and <code>top</code> (y-coordinate) are coordinates representing the top and left sides of the bounding box. Note that the upper-left corner of the image is the origin (0,0). </p> <p>The <code>top</code> and <code>left</code> values returned are ratios of the overall image size. For example, if the input image is 700x200 pixels, and the top-left coordinate of the bounding box is 350x50 pixels, the API returns a <code>left</code> value of 0.5 (350/700) and a <code>top</code> value of 0.25 (50/200).</p> <p>The <code>width</code> and <code>height</code> values represent the dimensions of the bounding box as a ratio of the overall image dimension. For example, if the input image is 700x200 pixels, and the bounding box width is 70 pixels, the width returned is 0.1. </p> <note> <p> The bounding box coordinates can have negative values. For example, if Amazon Rekognition is able to detect a face that is at the image edge and is only partially visible, the service can return coordinates that are outside the image bounds and, depending on the image edge, you might get negative values or values greater than 1 for the <code>left</code> or <code>top</code> values. </p> </note></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BoundingBox {
     /// <p>Height of the bounding box as a ratio of the overall image height.</p>
     #[serde(rename = "Height")]
@@ -78,7 +78,7 @@ pub struct BoundingBox {
 }
 
 /// <p>Provides information about a celebrity recognized by the operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Celebrity {
     /// <p>Provides information about the celebrity's face, such as its location on the image.</p>
     #[serde(rename = "Face")]
@@ -103,7 +103,7 @@ pub struct Celebrity {
 }
 
 /// <p>Information about a recognized celebrity.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CelebrityDetail {
     /// <p>Bounding box around the body of a celebrity.</p>
     #[serde(rename = "BoundingBox")]
@@ -132,7 +132,7 @@ pub struct CelebrityDetail {
 }
 
 /// <p>Information about a detected celebrity and the time the celebrity was detected in a stored video. For more information, see .</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CelebrityRecognition {
     /// <p>Information about a recognized celebrity.</p>
     #[serde(rename = "Celebrity")]
@@ -145,7 +145,7 @@ pub struct CelebrityRecognition {
 }
 
 /// <p>Provides information about a face in a target image that matches the source image face analysed by <code>CompareFaces</code>. The <code>Face</code> property contains the bounding box of the face in the target image. The <code>Similarity</code> property is the confidence that the source image face matches the face in the bounding box.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CompareFacesMatch {
     /// <p>Provides face metadata (bounding box and confidence that the bounding box actually contains a face).</p>
     #[serde(rename = "Face")]
@@ -157,7 +157,7 @@ pub struct CompareFacesMatch {
     pub similarity: Option<f32>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CompareFacesRequest {
     /// <p>The minimum level of confidence in the face matches that a match must meet to be included in the <code>FaceMatches</code> array.</p>
     #[serde(rename = "SimilarityThreshold")]
@@ -171,7 +171,7 @@ pub struct CompareFacesRequest {
     pub target_image: Image,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CompareFacesResponse {
     /// <p>An array of faces in the target image that match the source image face. Each <code>CompareFacesMatch</code> object provides the bounding box, the confidence level that the bounding box contains a face, and the similarity score for the face in the bounding box and the face in the source image.</p>
     #[serde(rename = "FaceMatches")]
@@ -196,7 +196,7 @@ pub struct CompareFacesResponse {
 }
 
 /// <p>Provides face metadata for target image faces that are analysed by <code>CompareFaces</code> and <code>RecognizeCelebrities</code>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ComparedFace {
     /// <p>Bounding box of the face.</p>
     #[serde(rename = "BoundingBox")]
@@ -221,7 +221,7 @@ pub struct ComparedFace {
 }
 
 /// <p>Type that describes the face Amazon Rekognition chose to compare with the faces in the target. This contains a bounding box for the selected face and confidence level that the bounding box contains a face. Note that Amazon Rekognition selects the largest face in the source image for this comparison. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ComparedSourceImageFace {
     /// <p>Bounding box of the face.</p>
     #[serde(rename = "BoundingBox")]
@@ -234,7 +234,7 @@ pub struct ComparedSourceImageFace {
 }
 
 /// <p>Information about a moderation label detection in a stored video.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ContentModerationDetection {
     /// <p>The moderation label detected by in the stored video.</p>
     #[serde(rename = "ModerationLabel")]
@@ -246,14 +246,14 @@ pub struct ContentModerationDetection {
     pub timestamp: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateCollectionRequest {
     /// <p>ID for the collection that you are creating.</p>
     #[serde(rename = "CollectionId")]
     pub collection_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateCollectionResponse {
     /// <p>Amazon Resource Name (ARN) of the collection. You can use this to manage permissions on your resources. </p>
     #[serde(rename = "CollectionArn")]
@@ -269,7 +269,7 @@ pub struct CreateCollectionResponse {
     pub status_code: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateStreamProcessorRequest {
     /// <p>Kinesis video stream stream that provides the source streaming video. If you are using the AWS CLI, the parameter name is <code>StreamProcessorInput</code>.</p>
     #[serde(rename = "Input")]
@@ -288,7 +288,7 @@ pub struct CreateStreamProcessorRequest {
     pub settings: StreamProcessorSettings,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateStreamProcessorResponse {
     /// <p>ARN for the newly create stream processor.</p>
     #[serde(rename = "StreamProcessorArn")]
@@ -296,14 +296,14 @@ pub struct CreateStreamProcessorResponse {
     pub stream_processor_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteCollectionRequest {
     /// <p>ID of the collection to delete.</p>
     #[serde(rename = "CollectionId")]
     pub collection_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteCollectionResponse {
     /// <p>HTTP status code that indicates the result of the operation.</p>
     #[serde(rename = "StatusCode")]
@@ -311,7 +311,7 @@ pub struct DeleteCollectionResponse {
     pub status_code: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteFacesRequest {
     /// <p>Collection from which to remove the specific faces.</p>
     #[serde(rename = "CollectionId")]
@@ -321,7 +321,7 @@ pub struct DeleteFacesRequest {
     pub face_ids: Vec<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteFacesResponse {
     /// <p>An array of strings (face IDs) of the faces that were deleted.</p>
     #[serde(rename = "DeletedFaces")]
@@ -329,24 +329,24 @@ pub struct DeleteFacesResponse {
     pub deleted_faces: Option<Vec<String>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteStreamProcessorRequest {
     /// <p>The name of the stream processor you want to delete.</p>
     #[serde(rename = "Name")]
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteStreamProcessorResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeStreamProcessorRequest {
     /// <p>Name of the stream processor for which you want information.</p>
     #[serde(rename = "Name")]
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeStreamProcessorResponse {
     /// <p>Date and time the stream processor was created</p>
     #[serde(rename = "CreationTimestamp")]
@@ -390,7 +390,7 @@ pub struct DescribeStreamProcessorResponse {
     pub stream_processor_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DetectFacesRequest {
     /// <p>An array of facial attributes you want to be returned. This can be the default list of attributes or all attributes. If you don't specify a value for <code>Attributes</code> or if you specify <code>["DEFAULT"]</code>, the API returns the following subset of facial attributes: <code>BoundingBox</code>, <code>Confidence</code>, <code>Pose</code>, <code>Quality</code> and <code>Landmarks</code>. If you provide <code>["ALL"]</code>, all facial attributes are returned but the operation will take longer to complete.</p> <p>If you provide both, <code>["ALL", "DEFAULT"]</code>, the service uses a logical AND operator to determine which attributes to return (in this case, all attributes). </p>
     #[serde(rename = "Attributes")]
@@ -401,7 +401,7 @@ pub struct DetectFacesRequest {
     pub image: Image,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DetectFacesResponse {
     /// <p>Details of each face found in the image. </p>
     #[serde(rename = "FaceDetails")]
@@ -413,7 +413,7 @@ pub struct DetectFacesResponse {
     pub orientation_correction: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DetectLabelsRequest {
     /// <p>The input image as base64-encoded bytes or an S3 object. If you use the AWS CLI to call Amazon Rekognition operations, passing base64-encoded image bytes is not supported. </p>
     #[serde(rename = "Image")]
@@ -428,7 +428,7 @@ pub struct DetectLabelsRequest {
     pub min_confidence: Option<f32>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DetectLabelsResponse {
     /// <p>An array of labels for the real-world objects detected. </p>
     #[serde(rename = "Labels")]
@@ -440,7 +440,7 @@ pub struct DetectLabelsResponse {
     pub orientation_correction: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DetectModerationLabelsRequest {
     /// <p>The input image as base64-encoded bytes or an S3 object. If you use the AWS CLI to call Amazon Rekognition operations, passing base64-encoded image bytes is not supported. </p>
     #[serde(rename = "Image")]
@@ -451,7 +451,7 @@ pub struct DetectModerationLabelsRequest {
     pub min_confidence: Option<f32>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DetectModerationLabelsResponse {
     /// <p>Array of detected Moderation labels and the time, in millseconds from the start of the video, they were detected.</p>
     #[serde(rename = "ModerationLabels")]
@@ -459,14 +459,14 @@ pub struct DetectModerationLabelsResponse {
     pub moderation_labels: Option<Vec<ModerationLabel>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DetectTextRequest {
     /// <p>The input image as base64-encoded bytes or an Amazon S3 object. If you use the AWS CLI to call Amazon Rekognition operations, you can't pass image bytes. </p>
     #[serde(rename = "Image")]
     pub image: Image,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DetectTextResponse {
     /// <p>An array of text that was detected in the input image.</p>
     #[serde(rename = "TextDetections")]
@@ -475,7 +475,7 @@ pub struct DetectTextResponse {
 }
 
 /// <p>The emotions detected on the face, and the confidence level in the determination. For example, HAPPY, SAD, and ANGRY.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Emotion {
     /// <p>Level of confidence in the determination.</p>
     #[serde(rename = "Confidence")]
@@ -488,7 +488,7 @@ pub struct Emotion {
 }
 
 /// <p>Indicates whether or not the eyes on the face are open, and the confidence level in the determination.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct EyeOpen {
     /// <p>Level of confidence in the determination.</p>
     #[serde(rename = "Confidence")]
@@ -501,7 +501,7 @@ pub struct EyeOpen {
 }
 
 /// <p>Indicates whether or not the face is wearing eye glasses, and the confidence level in the determination.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Eyeglasses {
     /// <p>Level of confidence in the determination.</p>
     #[serde(rename = "Confidence")]
@@ -514,7 +514,7 @@ pub struct Eyeglasses {
 }
 
 /// <p>Describes the face properties such as the bounding box, face ID, image ID of the input image, and external image ID that you assigned. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Face {
     /// <p>Bounding box of the face.</p>
     #[serde(rename = "BoundingBox")]
@@ -539,7 +539,7 @@ pub struct Face {
 }
 
 /// <p>Structure containing attributes of the face that the algorithm detected.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct FaceDetail {
     /// <p>The estimated age range, in years, for the face. Low represents the lowest estimated age and High represents the highest estimated age.</p>
     #[serde(rename = "AgeRange")]
@@ -604,7 +604,7 @@ pub struct FaceDetail {
 }
 
 /// <p>Information about a face detected in a video analysis request and the time the face was detected in the video. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct FaceDetection {
     /// <p>The face properties for the detected face.</p>
     #[serde(rename = "Face")]
@@ -617,7 +617,7 @@ pub struct FaceDetection {
 }
 
 /// <p>Provides face metadata. In addition, it also provides the confidence in the match of this face with the input face.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct FaceMatch {
     /// <p>Describes the face properties such as the bounding box, face ID, image ID of the source image, and external image ID that you assigned.</p>
     #[serde(rename = "Face")]
@@ -630,7 +630,7 @@ pub struct FaceMatch {
 }
 
 /// <p>Object containing both the face metadata (stored in the back-end database) and facial attributes that are detected but aren't stored in the database.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct FaceRecord {
     /// <p>Describes the face properties such as the bounding box, face ID, image ID of the input image, and external image ID that you assigned. </p>
     #[serde(rename = "Face")]
@@ -643,7 +643,7 @@ pub struct FaceRecord {
 }
 
 /// <p>Input face recognition parameters for an Amazon Rekognition stream processor. <code>FaceRecognitionSettings</code> is a request parameter for .</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct FaceSearchSettings {
     /// <p>The ID of a collection that contains faces that you want to search for.</p>
     #[serde(rename = "CollectionId")]
@@ -656,7 +656,7 @@ pub struct FaceSearchSettings {
 }
 
 /// <p>Gender of the face and the confidence level in the determination.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Gender {
     /// <p>Level of confidence in the determination.</p>
     #[serde(rename = "Confidence")]
@@ -669,7 +669,7 @@ pub struct Gender {
 }
 
 /// <p>Information about where text detected by is located on an image.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Geometry {
     /// <p>An axis-aligned coarse representation of the detected text's location on the image.</p>
     #[serde(rename = "BoundingBox")]
@@ -681,14 +681,14 @@ pub struct Geometry {
     pub polygon: Option<Vec<Point>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetCelebrityInfoRequest {
     /// <p>The ID for the celebrity. You get the celebrity ID from a call to the operation, which recognizes celebrities in an image. </p>
     #[serde(rename = "Id")]
     pub id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetCelebrityInfoResponse {
     /// <p>The name of the celebrity.</p>
     #[serde(rename = "Name")]
@@ -700,7 +700,7 @@ pub struct GetCelebrityInfoResponse {
     pub urls: Option<Vec<String>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetCelebrityRecognitionRequest {
     /// <p>Job identifier for the required celebrity recognition analysis. You can get the job identifer from a call to <code>StartCelebrityRecognition</code>.</p>
     #[serde(rename = "JobId")]
@@ -719,7 +719,7 @@ pub struct GetCelebrityRecognitionRequest {
     pub sort_by: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetCelebrityRecognitionResponse {
     /// <p>Array of celebrities recognized in the video.</p>
     #[serde(rename = "Celebrities")]
@@ -743,7 +743,7 @@ pub struct GetCelebrityRecognitionResponse {
     pub video_metadata: Option<VideoMetadata>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetContentModerationRequest {
     /// <p>The identifier for the content moderation job. Use <code>JobId</code> to identify the job in a subsequent call to <code>GetContentModeration</code>.</p>
     #[serde(rename = "JobId")]
@@ -762,7 +762,7 @@ pub struct GetContentModerationRequest {
     pub sort_by: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetContentModerationResponse {
     /// <p>The current status of the content moderation job.</p>
     #[serde(rename = "JobStatus")]
@@ -786,7 +786,7 @@ pub struct GetContentModerationResponse {
     pub video_metadata: Option<VideoMetadata>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetFaceDetectionRequest {
     /// <p>Unique identifier for the face detection job. The <code>JobId</code> is returned from <code>StartFaceDetection</code>.</p>
     #[serde(rename = "JobId")]
@@ -801,7 +801,7 @@ pub struct GetFaceDetectionRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetFaceDetectionResponse {
     /// <p>An array of faces detected in the video. Each element contains a detected face's details and the time, in milliseconds from the start of the video, the face was detected. </p>
     #[serde(rename = "Faces")]
@@ -825,7 +825,7 @@ pub struct GetFaceDetectionResponse {
     pub video_metadata: Option<VideoMetadata>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetFaceSearchRequest {
     /// <p>The job identifer for the search request. You get the job identifier from an initial call to <code>StartFaceSearch</code>.</p>
     #[serde(rename = "JobId")]
@@ -844,7 +844,7 @@ pub struct GetFaceSearchRequest {
     pub sort_by: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetFaceSearchResponse {
     /// <p>The current status of the face search job.</p>
     #[serde(rename = "JobStatus")]
@@ -868,7 +868,7 @@ pub struct GetFaceSearchResponse {
     pub video_metadata: Option<VideoMetadata>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetLabelDetectionRequest {
     /// <p>Job identifier for the label detection operation for which you want results returned. You get the job identifer from an initial call to <code>StartlabelDetection</code>.</p>
     #[serde(rename = "JobId")]
@@ -887,7 +887,7 @@ pub struct GetLabelDetectionRequest {
     pub sort_by: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetLabelDetectionResponse {
     /// <p>The current status of the label detection job.</p>
     #[serde(rename = "JobStatus")]
@@ -911,7 +911,7 @@ pub struct GetLabelDetectionResponse {
     pub video_metadata: Option<VideoMetadata>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetPersonTrackingRequest {
     /// <p>The identifier for a job that tracks persons in a video. You get the <code>JobId</code> from a call to <code>StartPersonTracking</code>. </p>
     #[serde(rename = "JobId")]
@@ -930,7 +930,7 @@ pub struct GetPersonTrackingRequest {
     pub sort_by: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetPersonTrackingResponse {
     /// <p>The current status of the person tracking job.</p>
     #[serde(rename = "JobStatus")]
@@ -955,7 +955,7 @@ pub struct GetPersonTrackingResponse {
 }
 
 /// <p>Provides the input image either as bytes or an S3 object.</p> <p>You pass image bytes to a Rekognition API operation by using the <code>Bytes</code> property. For example, you would use the <code>Bytes</code> property to pass an image loaded from a local file system. Image bytes passed by using the <code>Bytes</code> property must be base64-encoded. Your code may not need to encode image bytes if you are using an AWS SDK to call Rekognition API operations. For more information, see <a>images-bytes</a>.</p> <p> You pass images stored in an S3 bucket to a Rekognition API operation by using the <code>S3Object</code> property. Images stored in an S3 bucket do not need to be base64-encoded.</p> <p>The region for the S3 bucket containing the S3 object must match the region you use for Amazon Rekognition operations.</p> <p>If you use the Amazon CLI to call Amazon Rekognition operations, passing image bytes using the Bytes property is not supported. You must first upload the image to an Amazon S3 bucket and then call the operation using the S3Object property.</p> <p>For Amazon Rekognition to process an S3 object, the user must have permission to access the S3 object. For more information, see <a>manage-access-resource-policies</a>. </p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct Image {
     /// <p>Blob of image bytes up to 5 MBs.</p>
     #[serde(rename = "Bytes")]
@@ -972,7 +972,7 @@ pub struct Image {
 }
 
 /// <p>Identifies face image brightness and sharpness. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ImageQuality {
     /// <p>Value representing brightness of the face. The service returns a value between 0 and 100 (inclusive). A higher value indicates a brighter face image.</p>
     #[serde(rename = "Brightness")]
@@ -984,7 +984,7 @@ pub struct ImageQuality {
     pub sharpness: Option<f32>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct IndexFacesRequest {
     /// <p>The ID of an existing collection to which you want to add the faces that are detected in the input images.</p>
     #[serde(rename = "CollectionId")]
@@ -1002,7 +1002,7 @@ pub struct IndexFacesRequest {
     pub image: Image,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct IndexFacesResponse {
     /// <p>Version number of the face detection model associated with the input collection (<code>CollectionId</code>).</p>
     #[serde(rename = "FaceModelVersion")]
@@ -1019,7 +1019,7 @@ pub struct IndexFacesResponse {
 }
 
 /// <p>The Kinesis data stream Amazon Rekognition to which the analysis results of a Amazon Rekognition stream processor are streamed. For more information, see .</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct KinesisDataStream {
     /// <p>ARN of the output Amazon Kinesis Data Streams stream.</p>
     #[serde(rename = "Arn")]
@@ -1028,7 +1028,7 @@ pub struct KinesisDataStream {
 }
 
 /// <p>Kinesis video stream stream that provides the source streaming video for a Rekognition Video stream processor. For more information, see .</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct KinesisVideoStream {
     /// <p>ARN of the Kinesis video stream stream that streams the source video.</p>
     #[serde(rename = "Arn")]
@@ -1037,7 +1037,7 @@ pub struct KinesisVideoStream {
 }
 
 /// <p>Structure containing details about the detected label, including name, and level of confidence.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Label {
     /// <p>Level of confidence.</p>
     #[serde(rename = "Confidence")]
@@ -1050,7 +1050,7 @@ pub struct Label {
 }
 
 /// <p>Information about a label detected in a video analysis request and the time the label was detected in the video. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct LabelDetection {
     /// <p>Details about the detected label.</p>
     #[serde(rename = "Label")]
@@ -1063,7 +1063,7 @@ pub struct LabelDetection {
 }
 
 /// <p>Indicates the location of the landmark on the face.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Landmark {
     /// <p>Type of the landmark.</p>
     #[serde(rename = "Type")]
@@ -1079,7 +1079,7 @@ pub struct Landmark {
     pub y: Option<f32>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListCollectionsRequest {
     /// <p>Maximum number of collection IDs to return. </p>
     #[serde(rename = "MaxResults")]
@@ -1091,7 +1091,7 @@ pub struct ListCollectionsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListCollectionsResponse {
     /// <p>An array of collection IDs.</p>
     #[serde(rename = "CollectionIds")]
@@ -1107,7 +1107,7 @@ pub struct ListCollectionsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListFacesRequest {
     /// <p>ID of the collection from which to list the faces.</p>
     #[serde(rename = "CollectionId")]
@@ -1122,7 +1122,7 @@ pub struct ListFacesRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListFacesResponse {
     /// <p>Version number of the face detection model associated with the input collection (<code>CollectionId</code>).</p>
     #[serde(rename = "FaceModelVersion")]
@@ -1138,7 +1138,7 @@ pub struct ListFacesResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListStreamProcessorsRequest {
     /// <p>Maximum number of stream processors you want Rekognition Video to return in the response. The default is 1000. </p>
     #[serde(rename = "MaxResults")]
@@ -1150,7 +1150,7 @@ pub struct ListStreamProcessorsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListStreamProcessorsResponse {
     /// <p>If the response is truncated, Rekognition Video returns this token that you can use in the subsequent request to retrieve the next set of stream processors. </p>
     #[serde(rename = "NextToken")]
@@ -1163,7 +1163,7 @@ pub struct ListStreamProcessorsResponse {
 }
 
 /// <p>Provides information about a single type of moderated content found in an image or video. Each type of moderated content has a label within a hierarchical taxonomy. For more information, see <a>moderation</a>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ModerationLabel {
     /// <p>Specifies the confidence that Amazon Rekognition has that the label has been correctly identified.</p> <p>If you don't specify the <code>MinConfidence</code> parameter in the call to <code>DetectModerationLabels</code>, the operation returns labels with a confidence value greater than or equal to 50 percent.</p>
     #[serde(rename = "Confidence")]
@@ -1180,7 +1180,7 @@ pub struct ModerationLabel {
 }
 
 /// <p>Indicates whether or not the mouth on the face is open, and the confidence level in the determination.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct MouthOpen {
     /// <p>Level of confidence in the determination.</p>
     #[serde(rename = "Confidence")]
@@ -1193,7 +1193,7 @@ pub struct MouthOpen {
 }
 
 /// <p>Indicates whether or not the face has a mustache, and the confidence level in the determination.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Mustache {
     /// <p>Level of confidence in the determination.</p>
     #[serde(rename = "Confidence")]
@@ -1206,7 +1206,7 @@ pub struct Mustache {
 }
 
 /// <p>The Amazon Simple Notification Service topic to which Amazon Rekognition publishes the completion status of a video analysis operation. For more information, see <a>api-video</a>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct NotificationChannel {
     /// <p>The ARN of an IAM role that gives Amazon Rekognition publishing permissions to the Amazon SNS topic. </p>
     #[serde(rename = "RoleArn")]
@@ -1217,7 +1217,7 @@ pub struct NotificationChannel {
 }
 
 /// <p>Details about a person detected in a video analysis request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PersonDetail {
     /// <p>Bounding box around the detected person.</p>
     #[serde(rename = "BoundingBox")]
@@ -1234,7 +1234,7 @@ pub struct PersonDetail {
 }
 
 /// <p>Details and tracking information for a single time a person is tracked in a video. Amazon Rekognition operations that track persons return an array of <code>PersonDetection</code> objects with elements for each time a person is tracked in a video. For more information, see . </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PersonDetection {
     /// <p>Details about a person tracked in a video.</p>
     #[serde(rename = "Person")]
@@ -1247,7 +1247,7 @@ pub struct PersonDetection {
 }
 
 /// <p>Information about a person whose face matches a face(s) in a Amazon Rekognition collection. Includes information about the faces in the Amazon Rekognition collection (,information about the person (<a>PersonDetail</a>) and the timestamp for when the person was detected in a video. An array of <code>PersonMatch</code> objects is returned by . </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PersonMatch {
     /// <p>Information about the faces in the input collection that match the face of a person in the video.</p>
     #[serde(rename = "FaceMatches")]
@@ -1264,7 +1264,7 @@ pub struct PersonMatch {
 }
 
 /// <p>The X and Y coordinates of a point on an image. The X and Y values returned are ratios of the overall image size. For example, if the input image is 700x200 and the operation returns X=0.5 and Y=0.25, then the point is at the (350,50) pixel coordinate on the image.</p> <p>An array of <code>Point</code> objects, <code>Polygon</code>, is returned by . <code>Polygon</code> represents a fine-grained polygon around detected text. For more information, see . </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Point {
     /// <p>The value of the X coordinate for a point on a <code>Polygon</code>.</p>
     #[serde(rename = "X")]
@@ -1277,7 +1277,7 @@ pub struct Point {
 }
 
 /// <p>Indicates the pose of the face as determined by its pitch, roll, and yaw.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Pose {
     /// <p>Value representing the face rotation on the pitch axis.</p>
     #[serde(rename = "Pitch")]
@@ -1293,14 +1293,14 @@ pub struct Pose {
     pub yaw: Option<f32>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RecognizeCelebritiesRequest {
     /// <p>The input image as base64-encoded bytes or an S3 object. If you use the AWS CLI to call Amazon Rekognition operations, passing base64-encoded image bytes is not supported. </p>
     #[serde(rename = "Image")]
     pub image: Image,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RecognizeCelebritiesResponse {
     /// <p>Details about each celebrity found in the image. Amazon Rekognition can detect a maximum of 15 celebrities in an image.</p>
     #[serde(rename = "CelebrityFaces")]
@@ -1317,7 +1317,7 @@ pub struct RecognizeCelebritiesResponse {
 }
 
 /// <p>Provides the S3 bucket name and object name.</p> <p>The region for the S3 bucket containing the S3 object must match the region you use for Amazon Rekognition operations.</p> <p>For Amazon Rekognition to process an S3 object, the user must have permission to access the S3 object. For more information, see <a>manage-access-resource-policies</a>. </p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct S3Object {
     /// <p>Name of the S3 bucket.</p>
     #[serde(rename = "Bucket")]
@@ -1333,7 +1333,7 @@ pub struct S3Object {
     pub version: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SearchFacesByImageRequest {
     /// <p>ID of the collection to search.</p>
     #[serde(rename = "CollectionId")]
@@ -1351,7 +1351,7 @@ pub struct SearchFacesByImageRequest {
     pub max_faces: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SearchFacesByImageResponse {
     /// <p>An array of faces that match the input face, along with the confidence in the match.</p>
     #[serde(rename = "FaceMatches")]
@@ -1371,7 +1371,7 @@ pub struct SearchFacesByImageResponse {
     pub searched_face_confidence: Option<f32>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SearchFacesRequest {
     /// <p>ID of the collection the face belongs to.</p>
     #[serde(rename = "CollectionId")]
@@ -1389,7 +1389,7 @@ pub struct SearchFacesRequest {
     pub max_faces: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SearchFacesResponse {
     /// <p>An array of faces that matched the input face, along with the confidence in the match.</p>
     #[serde(rename = "FaceMatches")]
@@ -1406,7 +1406,7 @@ pub struct SearchFacesResponse {
 }
 
 /// <p>Indicates whether or not the face is smiling, and the confidence level in the determination.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Smile {
     /// <p>Level of confidence in the determination.</p>
     #[serde(rename = "Confidence")]
@@ -1418,7 +1418,7 @@ pub struct Smile {
     pub value: Option<bool>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StartCelebrityRecognitionRequest {
     /// <p>Idempotent token used to identify the start request. If you use the same token with multiple <code>StartCelebrityRecognition</code> requests, the same <code>JobId</code> is returned. Use <code>ClientRequestToken</code> to prevent the same job from being accidently started more than once. </p>
     #[serde(rename = "ClientRequestToken")]
@@ -1437,7 +1437,7 @@ pub struct StartCelebrityRecognitionRequest {
     pub video: Video,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StartCelebrityRecognitionResponse {
     /// <p>The identifier for the celebrity recognition analysis job. Use <code>JobId</code> to identify the job in a subsequent call to <code>GetCelebrityRecognition</code>.</p>
     #[serde(rename = "JobId")]
@@ -1445,7 +1445,7 @@ pub struct StartCelebrityRecognitionResponse {
     pub job_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StartContentModerationRequest {
     /// <p>Idempotent token used to identify the start request. If you use the same token with multiple <code>StartContentModeration</code> requests, the same <code>JobId</code> is returned. Use <code>ClientRequestToken</code> to prevent the same job from being accidently started more than once. </p>
     #[serde(rename = "ClientRequestToken")]
@@ -1468,7 +1468,7 @@ pub struct StartContentModerationRequest {
     pub video: Video,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StartContentModerationResponse {
     /// <p>The identifier for the content moderation analysis job. Use <code>JobId</code> to identify the job in a subsequent call to <code>GetContentModeration</code>.</p>
     #[serde(rename = "JobId")]
@@ -1476,7 +1476,7 @@ pub struct StartContentModerationResponse {
     pub job_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StartFaceDetectionRequest {
     /// <p>Idempotent token used to identify the start request. If you use the same token with multiple <code>StartFaceDetection</code> requests, the same <code>JobId</code> is returned. Use <code>ClientRequestToken</code> to prevent the same job from being accidently started more than once. </p>
     #[serde(rename = "ClientRequestToken")]
@@ -1499,7 +1499,7 @@ pub struct StartFaceDetectionRequest {
     pub video: Video,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StartFaceDetectionResponse {
     /// <p>The identifier for the face detection job. Use <code>JobId</code> to identify the job in a subsequent call to <code>GetFaceDetection</code>.</p>
     #[serde(rename = "JobId")]
@@ -1507,7 +1507,7 @@ pub struct StartFaceDetectionResponse {
     pub job_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StartFaceSearchRequest {
     /// <p>Idempotent token used to identify the start request. If you use the same token with multiple <code>StartFaceSearch</code> requests, the same <code>JobId</code> is returned. Use <code>ClientRequestToken</code> to prevent the same job from being accidently started more than once. </p>
     #[serde(rename = "ClientRequestToken")]
@@ -1533,7 +1533,7 @@ pub struct StartFaceSearchRequest {
     pub video: Video,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StartFaceSearchResponse {
     /// <p>The identifier for the search job. Use <code>JobId</code> to identify the job in a subsequent call to <code>GetFaceSearch</code>. </p>
     #[serde(rename = "JobId")]
@@ -1541,7 +1541,7 @@ pub struct StartFaceSearchResponse {
     pub job_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StartLabelDetectionRequest {
     /// <p>Idempotent token used to identify the start request. If you use the same token with multiple <code>StartLabelDetection</code> requests, the same <code>JobId</code> is returned. Use <code>ClientRequestToken</code> to prevent the same job from being accidently started more than once. </p>
     #[serde(rename = "ClientRequestToken")]
@@ -1564,7 +1564,7 @@ pub struct StartLabelDetectionRequest {
     pub video: Video,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StartLabelDetectionResponse {
     /// <p>The identifier for the label detection job. Use <code>JobId</code> to identify the job in a subsequent call to <code>GetLabelDetection</code>. </p>
     #[serde(rename = "JobId")]
@@ -1572,7 +1572,7 @@ pub struct StartLabelDetectionResponse {
     pub job_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StartPersonTrackingRequest {
     /// <p>Idempotent token used to identify the start request. If you use the same token with multiple <code>StartPersonTracking</code> requests, the same <code>JobId</code> is returned. Use <code>ClientRequestToken</code> to prevent the same job from being accidently started more than once. </p>
     #[serde(rename = "ClientRequestToken")]
@@ -1591,7 +1591,7 @@ pub struct StartPersonTrackingRequest {
     pub video: Video,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StartPersonTrackingResponse {
     /// <p>The identifier for the person detection job. Use <code>JobId</code> to identify the job in a subsequent call to <code>GetPersonTracking</code>.</p>
     #[serde(rename = "JobId")]
@@ -1599,28 +1599,28 @@ pub struct StartPersonTrackingResponse {
     pub job_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StartStreamProcessorRequest {
     /// <p>The name of the stream processor to start processing.</p>
     #[serde(rename = "Name")]
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StartStreamProcessorResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StopStreamProcessorRequest {
     /// <p>The name of a stream processor created by .</p>
     #[serde(rename = "Name")]
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StopStreamProcessorResponse {}
 
 /// <p>An object that recognizes faces in a streaming video. An Amazon Rekognition stream processor is created by a call to . The request parameters for <code>CreateStreamProcessor</code> describe the Kinesis video stream source for the streaming video, face recognition parameters, and where to stream the analysis resullts. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StreamProcessor {
     /// <p>Name of the Amazon Rekognition stream processor. </p>
     #[serde(rename = "Name")]
@@ -1633,7 +1633,7 @@ pub struct StreamProcessor {
 }
 
 /// <p>Information about the source streaming video. </p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct StreamProcessorInput {
     /// <p>The Kinesis video stream input stream for the source streaming video.</p>
     #[serde(rename = "KinesisVideoStream")]
@@ -1642,7 +1642,7 @@ pub struct StreamProcessorInput {
 }
 
 /// <p>Information about the Amazon Kinesis Data Streams stream to which a Rekognition Video stream processor streams the results of a video analysis. For more information, see .</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct StreamProcessorOutput {
     /// <p>The Amazon Kinesis Data Streams stream to which the Amazon Rekognition stream processor streams the analysis results.</p>
     #[serde(rename = "KinesisDataStream")]
@@ -1651,7 +1651,7 @@ pub struct StreamProcessorOutput {
 }
 
 /// <p>Input parameters used to recognize faces in a streaming video analyzed by a Amazon Rekognition stream processor.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct StreamProcessorSettings {
     /// <p>Face search settings to use on a streaming video. </p>
     #[serde(rename = "FaceSearch")]
@@ -1660,7 +1660,7 @@ pub struct StreamProcessorSettings {
 }
 
 /// <p>Indicates whether or not the face is wearing sunglasses, and the confidence level in the determination.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Sunglasses {
     /// <p>Level of confidence in the determination.</p>
     #[serde(rename = "Confidence")]
@@ -1673,7 +1673,7 @@ pub struct Sunglasses {
 }
 
 /// <p>Information about a word or line of text detected by .</p> <p>The <code>DetectedText</code> field contains the text that Amazon Rekognition detected in the image. </p> <p>Every word and line has an identifier (<code>Id</code>). Each word belongs to a line and has a parent identifier (<code>ParentId</code>) that identifies the line of text in which the word appears. The word <code>Id</code> is also an index for the word within a line of words. </p> <p>For more information, see <a>text-detection</a>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct TextDetection {
     /// <p>The confidence that Amazon Rekognition has in the accuracy of the detected text and the accuracy of the geometry points around the detected text.</p>
     #[serde(rename = "Confidence")]
@@ -1702,7 +1702,7 @@ pub struct TextDetection {
 }
 
 /// <p>Video file stored in an Amazon S3 bucket. Amazon Rekognition video start operations such as use <code>Video</code> to specify a video for analysis. The supported file formats are .mp4, .mov and .avi.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct Video {
     /// <p>The Amazon S3 bucket name and file name for the video.</p>
     #[serde(rename = "S3Object")]
@@ -1711,7 +1711,7 @@ pub struct Video {
 }
 
 /// <p>Information about a video that Amazon Rekognition analyzed. <code>Videometadata</code> is returned in every page of paginated responses from a Amazon Rekognition video operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct VideoMetadata {
     /// <p>Type of compression used in the analyzed video. </p>
     #[serde(rename = "Codec")]

--- a/rusoto/services/rekognition/src/generated.rs
+++ b/rusoto/services/rekognition/src/generated.rs
@@ -1772,7 +1772,8 @@ impl CompareFacesError {
     pub fn from_body(body: &str) -> CompareFacesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1890,7 +1891,8 @@ impl CreateCollectionError {
     pub fn from_body(body: &str) -> CreateCollectionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2002,7 +2004,8 @@ impl CreateStreamProcessorError {
     pub fn from_body(body: &str) -> CreateStreamProcessorError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2118,7 +2121,8 @@ impl DeleteCollectionError {
     pub fn from_body(body: &str) -> DeleteCollectionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2228,7 +2232,8 @@ impl DeleteFacesError {
     pub fn from_body(body: &str) -> DeleteFacesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2338,7 +2343,8 @@ impl DeleteStreamProcessorError {
     pub fn from_body(body: &str) -> DeleteStreamProcessorError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2454,7 +2460,8 @@ impl DescribeStreamProcessorError {
     pub fn from_body(body: &str) -> DescribeStreamProcessorError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2570,7 +2577,8 @@ impl DetectFacesError {
     pub fn from_body(body: &str) -> DetectFacesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2690,7 +2698,8 @@ impl DetectLabelsError {
     pub fn from_body(body: &str) -> DetectLabelsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2812,7 +2821,8 @@ impl DetectModerationLabelsError {
     pub fn from_body(body: &str) -> DetectModerationLabelsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2936,7 +2946,8 @@ impl DetectTextError {
     pub fn from_body(body: &str) -> DetectTextError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3050,7 +3061,8 @@ impl GetCelebrityInfoError {
     pub fn from_body(body: &str) -> GetCelebrityInfoError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3162,7 +3174,8 @@ impl GetCelebrityRecognitionError {
     pub fn from_body(body: &str) -> GetCelebrityRecognitionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3282,7 +3295,8 @@ impl GetContentModerationError {
     pub fn from_body(body: &str) -> GetContentModerationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3402,7 +3416,8 @@ impl GetFaceDetectionError {
     pub fn from_body(body: &str) -> GetFaceDetectionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3518,7 +3533,8 @@ impl GetFaceSearchError {
     pub fn from_body(body: &str) -> GetFaceSearchError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3634,7 +3650,8 @@ impl GetLabelDetectionError {
     pub fn from_body(body: &str) -> GetLabelDetectionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3752,7 +3769,8 @@ impl GetPersonTrackingError {
     pub fn from_body(body: &str) -> GetPersonTrackingError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3874,7 +3892,8 @@ impl IndexFacesError {
     pub fn from_body(body: &str) -> IndexFacesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3994,7 +4013,8 @@ impl ListCollectionsError {
     pub fn from_body(body: &str) -> ListCollectionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4110,7 +4130,8 @@ impl ListFacesError {
     pub fn from_body(body: &str) -> ListFacesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4220,7 +4241,8 @@ impl ListStreamProcessorsError {
     pub fn from_body(body: &str) -> ListStreamProcessorsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4338,7 +4360,8 @@ impl RecognizeCelebritiesError {
     pub fn from_body(body: &str) -> RecognizeCelebritiesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4458,7 +4481,8 @@ impl SearchFacesError {
     pub fn from_body(body: &str) -> SearchFacesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4572,7 +4596,8 @@ impl SearchFacesByImageError {
     pub fn from_body(body: &str) -> SearchFacesByImageError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4702,7 +4727,8 @@ impl StartCelebrityRecognitionError {
     pub fn from_body(body: &str) -> StartCelebrityRecognitionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4836,7 +4862,8 @@ impl StartContentModerationError {
     pub fn from_body(body: &str) -> StartContentModerationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4968,7 +4995,8 @@ impl StartFaceDetectionError {
     pub fn from_body(body: &str) -> StartFaceDetectionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5102,7 +5130,8 @@ impl StartFaceSearchError {
     pub fn from_body(body: &str) -> StartFaceSearchError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5236,7 +5265,8 @@ impl StartLabelDetectionError {
     pub fn from_body(body: &str) -> StartLabelDetectionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5368,7 +5398,8 @@ impl StartPersonTrackingError {
     pub fn from_body(body: &str) -> StartPersonTrackingError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5496,7 +5527,8 @@ impl StartStreamProcessorError {
     pub fn from_body(body: &str) -> StartStreamProcessorError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5614,7 +5646,8 @@ impl StopStreamProcessorError {
     pub fn from_body(body: &str) -> StopStreamProcessorError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/resourcegroupstaggingapi/src/generated.rs
+++ b/rusoto/services/resourcegroupstaggingapi/src/generated.rs
@@ -31,7 +31,7 @@ use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 /// <p>Details of the common errors that all actions return.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct FailureInfo {
     /// <p>The code of the common error. Valid values include <code>InternalServiceException</code>, <code>InvalidParameterException</code>, and any valid error code returned by the AWS service that hosts the resource that you want to tag.</p>
     #[serde(rename = "ErrorCode")]
@@ -47,7 +47,7 @@ pub struct FailureInfo {
     pub status_code: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetResourcesInput {
     /// <p>A string that indicates that additional data is available. Leave this value empty for your initial request. If the response includes a <code>PaginationToken</code>, use that string for this value to request an additional page of data.</p>
     #[serde(rename = "PaginationToken")]
@@ -71,7 +71,7 @@ pub struct GetResourcesInput {
     pub tags_per_page: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetResourcesOutput {
     /// <p>A string that indicates that the response contains more data than can be returned in a single response. To receive additional data, specify this string for the <code>PaginationToken</code> value in a subsequent request.</p>
     #[serde(rename = "PaginationToken")]
@@ -83,7 +83,7 @@ pub struct GetResourcesOutput {
     pub resource_tag_mapping_list: Option<Vec<ResourceTagMapping>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetTagKeysInput {
     /// <p>A string that indicates that additional data is available. Leave this value empty for your initial request. If the response includes a PaginationToken, use that string for this value to request an additional page of data.</p>
     #[serde(rename = "PaginationToken")]
@@ -91,7 +91,7 @@ pub struct GetTagKeysInput {
     pub pagination_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetTagKeysOutput {
     /// <p>A string that indicates that the response contains more data than can be returned in a single response. To receive additional data, specify this string for the <code>PaginationToken</code> value in a subsequent request.</p>
     #[serde(rename = "PaginationToken")]
@@ -103,7 +103,7 @@ pub struct GetTagKeysOutput {
     pub tag_keys: Option<Vec<String>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetTagValuesInput {
     /// <p>The key for which you want to list all existing values in the specified region for the AWS account.</p>
     #[serde(rename = "Key")]
@@ -114,7 +114,7 @@ pub struct GetTagValuesInput {
     pub pagination_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetTagValuesOutput {
     /// <p>A string that indicates that the response contains more data than can be returned in a single response. To receive additional data, specify this string for the <code>PaginationToken</code> value in a subsequent request.</p>
     #[serde(rename = "PaginationToken")]
@@ -127,7 +127,7 @@ pub struct GetTagValuesOutput {
 }
 
 /// <p>A list of resource ARNs and the tags (keys and values) that are associated with each.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ResourceTagMapping {
     /// <p>An array of resource ARN(s).</p>
     #[serde(rename = "ResourceARN")]
@@ -140,7 +140,7 @@ pub struct ResourceTagMapping {
 }
 
 /// <p>The metadata that you apply to AWS resources to help you categorize and organize them. Each tag consists of a key and an optional value, both of which you define. For more information, see <a href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#tag-basics">Tag Basics</a> in the <i>Amazon EC2 User Guide for Linux Instances</i>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Tag {
     /// <p>One part of a key-value pair that make up a tag. A key is a general label that acts like a category for more specific tag values.</p>
     #[serde(rename = "Key")]
@@ -151,7 +151,7 @@ pub struct Tag {
 }
 
 /// <p>A list of tags (keys and values) that are used to specify the associated resources.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct TagFilter {
     /// <p>One part of a key-value pair that make up a tag. A key is a general label that acts like a category for more specific tag values.</p>
     #[serde(rename = "Key")]
@@ -163,7 +163,7 @@ pub struct TagFilter {
     pub values: Option<Vec<String>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct TagResourcesInput {
     /// <p>A list of ARNs. An ARN (Amazon Resource Name) uniquely identifies a resource. You can specify a minimum of 1 and a maximum of 20 ARNs (resources) to tag. An ARN can be set to a maximum of 1600 characters. For more information, see <a href="http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html">Amazon Resource Names (ARNs) and AWS Service Namespaces</a> in the <i>AWS General Reference</i>.</p>
     #[serde(rename = "ResourceARNList")]
@@ -173,7 +173,7 @@ pub struct TagResourcesInput {
     pub tags: ::std::collections::HashMap<String, String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct TagResourcesOutput {
     /// <p>Details of resources that could not be tagged. An error code, status code, and error message are returned for each failed item.</p>
     #[serde(rename = "FailedResourcesMap")]
@@ -181,7 +181,7 @@ pub struct TagResourcesOutput {
     pub failed_resources_map: Option<::std::collections::HashMap<String, FailureInfo>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UntagResourcesInput {
     /// <p>A list of ARNs. An ARN (Amazon Resource Name) uniquely identifies a resource. You can specify a minimum of 1 and a maximum of 20 ARNs (resources) to untag. An ARN can be set to a maximum of 1600 characters. For more information, see <a href="http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html">Amazon Resource Names (ARNs) and AWS Service Namespaces</a> in the <i>AWS General Reference</i>.</p>
     #[serde(rename = "ResourceARNList")]
@@ -191,7 +191,7 @@ pub struct UntagResourcesInput {
     pub tag_keys: Vec<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UntagResourcesOutput {
     /// <p>Details of resources that could not be untagged. An error code, status code, and error message are returned for each failed item.</p>
     #[serde(rename = "FailedResourcesMap")]

--- a/rusoto/services/resourcegroupstaggingapi/src/generated.rs
+++ b/rusoto/services/resourcegroupstaggingapi/src/generated.rs
@@ -224,7 +224,8 @@ impl GetResourcesError {
     pub fn from_body(body: &str) -> GetResourcesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -320,7 +321,8 @@ impl GetTagKeysError {
     pub fn from_body(body: &str) -> GetTagKeysError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -412,7 +414,8 @@ impl GetTagValuesError {
     pub fn from_body(body: &str) -> GetTagValuesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -506,7 +509,8 @@ impl TagResourcesError {
     pub fn from_body(body: &str) -> TagResourcesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -596,7 +600,8 @@ impl UntagResourcesError {
     pub fn from_body(body: &str) -> UntagResourcesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/route53/src/generated.rs
+++ b/rusoto/services/route53/src/generated.rs
@@ -46,7 +46,7 @@ enum DeserializerNext {
     Element(String),
 }
 /// <p>A complex type that contains the type of limit that you specified in the request and the current value for that limit.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AccountLimit {
     /// <p><p>The limit that you requested. Valid values include the following:</p> <ul> <li> <p> <b>MAX<em>HEALTH</em>CHECKS<em>BY</em>OWNER</b>: The maximum number of health checks that you can create using the current account.</p> </li> <li> <p> <b>MAX<em>HOSTED</em>ZONES<em>BY</em>OWNER</b>: The maximum number of hosted zones that you can create using the current account.</p> </li> <li> <p> <b>MAX<em>REUSABLE</em>DELEGATION<em>SETS</em>BY<em>OWNER</b>: The maximum number of reusable delegation sets that you can create using the current account.</p> </li> <li> <p> <b>MAX</em>TRAFFIC<em>POLICIES</em>BY<em>OWNER</b>: The maximum number of traffic policies that you can create using the current account.</p> </li> <li> <p> <b>MAX</em>TRAFFIC<em>POLICY</em>INSTANCES<em>BY</em>OWNER</b>: The maximum number of traffic policy instances that you can create using the current account. (Traffic policy instances are referred to as traffic flow policy records in the Amazon Route 53 console.)</p> </li> </ul></p>
     pub type_: String,
@@ -132,7 +132,7 @@ impl AccountLimitTypeSerializer {
 }
 
 /// <p>A complex type that identifies the CloudWatch alarm that you want Amazon Route 53 health checkers to use to determine whether this health check is healthy.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AlarmIdentifier {
     /// <p>The name of the CloudWatch alarm that you want Amazon Route 53 health checkers to use to determine whether this health check is healthy.</p>
     pub name: String,
@@ -283,7 +283,7 @@ impl AliasHealthEnabledSerializer {
 }
 
 /// <p><p> <i>Alias resource record sets only:</i> Information about the CloudFront distribution, Elastic Beanstalk environment, ELB load balancer, Amazon S3 bucket, or Amazon Route 53 resource record set that you&#39;re redirecting queries to. An Elastic Beanstalk environment must have a regionalized subdomain.</p> <p>When creating resource record sets for a private hosted zone, note the following:</p> <ul> <li> <p>Resource record sets can&#39;t be created for CloudFront distributions in a private hosted zone.</p> </li> <li> <p>Creating geolocation alias resource record sets or latency alias resource record sets in a private hosted zone is unsupported.</p> </li> <li> <p>For information about creating failover resource record sets in a private hosted zone, see <a href="http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover-private-hosted-zones.html">Configuring Failover in a Private Hosted Zone</a>.</p> </li> </ul></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AliasTarget {
     /// <p><p> <i>Alias resource record sets only:</i> The value that you specify depends on where you want to route queries:</p> <dl> <dt>CloudFront distribution</dt> <dd> <p>Specify the domain name that CloudFront assigned when you created your distribution.</p> <p>Your CloudFront distribution must include an alternate domain name that matches the name of the resource record set. For example, if the name of the resource record set is <i>acme.example.com</i>, your CloudFront distribution must include <i>acme.example.com</i> as one of the alternate domain names. For more information, see <a href="http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/CNAMEs.html">Using Alternate Domain Names (CNAMEs)</a> in the <i>Amazon CloudFront Developer Guide</i>.</p> </dd> <dt>Elastic Beanstalk environment</dt> <dd> <p>Specify the <code>CNAME</code> attribute for the environment. (The environment must have a regionalized domain name.) You can use the following methods to get the value of the CNAME attribute:</p> <ul> <li> <p> <i>AWS Management Console</i>: For information about how to get the value by using the console, see <a href="http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/customdomains.html">Using Custom Domains with AWS Elastic Beanstalk</a> in the <i>AWS Elastic Beanstalk Developer Guide</i>.</p> </li> <li> <p> <i>Elastic Beanstalk API</i>: Use the <code>DescribeEnvironments</code> action to get the value of the <code>CNAME</code> attribute. For more information, see <a href="http://docs.aws.amazon.com/elasticbeanstalk/latest/api/API_DescribeEnvironments.html">DescribeEnvironments</a> in the <i>AWS Elastic Beanstalk API Reference</i>.</p> </li> <li> <p> <i>AWS CLI</i>: Use the <code>describe-environments</code> command to get the value of the <code>CNAME</code> attribute. For more information, see <a href="http://docs.aws.amazon.com/cli/latest/reference/elasticbeanstalk/describe-environments.html">describe-environments</a> in the <i>AWS Command Line Interface Reference</i>.</p> </li> </ul> </dd> <dt>ELB load balancer</dt> <dd> <p>Specify the DNS name that is associated with the load balancer. Get the DNS name by using the AWS Management Console, the ELB API, or the AWS CLI. </p> <ul> <li> <p> <b>AWS Management Console</b>: Go to the EC2 page, choose <b>Load Balancers</b> in the navigation pane, choose the load balancer, choose the <b>Description</b> tab, and get the value of the <b>DNS name</b> field. (If you&#39;re routing traffic to a Classic Load Balancer, get the value that begins with <b>dualstack</b>.) </p> </li> <li> <p> <b>Elastic Load Balancing API</b>: Use <code>DescribeLoadBalancers</code> to get the value of <code>DNSName</code>. For more information, see the applicable guide:</p> <ul> <li> <p>Classic Load Balancers: <a href="http://docs.aws.amazon.com/elasticloadbalancing/2012-06-01/APIReference/API_DescribeLoadBalancers.html">DescribeLoadBalancers</a> </p> </li> <li> <p>Application and Network Load Balancers: <a href="http://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_DescribeLoadBalancers.html">DescribeLoadBalancers</a> </p> </li> </ul> </li> <li> <p> <b>AWS CLI</b>: Use <code>describe-load-balancers</code> to get the value of <code>DNSName</code>. For more information, see the applicable guide:</p> <ul> <li> <p>Classic Load Balancers: <a href="http://docs.aws.amazon.com/cli/latest/reference/elb/describe-load-balancers.html">describe-load-balancers</a> </p> </li> <li> <p>Application and Network Load Balancers: <a href="http://docs.aws.amazon.com/cli/latest/reference/elbv2/describe-load-balancers.html">describe-load-balancers</a> </p> </li> </ul> </li> </ul> </dd> <dt>Amazon S3 bucket that is configured as a static website</dt> <dd> <p>Specify the domain name of the Amazon S3 website endpoint in which you created the bucket, for example, <code>s3-website-us-east-2.amazonaws.com</code>. For more information about valid values, see the table <a href="http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region">Amazon Simple Storage Service (S3) Website Endpoints</a> in the <i>Amazon Web Services General Reference</i>. For more information about using S3 buckets for websites, see <a href="http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/getting-started.html">Getting Started with Amazon Route 53</a> in the <i>Amazon Route 53 Developer Guide.</i> </p> </dd> <dt>Another Amazon Route 53 resource record set</dt> <dd> <p>Specify the value of the <code>Name</code> element for a resource record set in the current hosted zone.</p> </dd> </dl></p>
     pub dns_name: String,
@@ -399,7 +399,7 @@ impl AssociateVPCCommentSerializer {
 }
 
 /// <p>A complex type that contains information about the request to associate a VPC with a private hosted zone.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AssociateVPCWithHostedZoneRequest {
     /// <p> <i>Optional:</i> A comment about the association request.</p>
     pub comment: Option<String>,
@@ -430,7 +430,7 @@ impl AssociateVPCWithHostedZoneRequestSerializer {
     }
 }
 /// <p>A complex type that contains the response information for the <code>AssociateVPCWithHostedZone</code> request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AssociateVPCWithHostedZoneResponse {
     /// <p>A complex type that describes the changes made to your hosted zone.</p>
     pub change_info: ChangeInfo,
@@ -477,7 +477,7 @@ impl AssociateVPCWithHostedZoneResponseDeserializer {
     }
 }
 /// <p>The information for each resource record set that you want to change.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Change {
     /// <p><p>The action to perform:</p> <ul> <li> <p> <code>CREATE</code>: Creates a resource record set that has the specified values.</p> </li> <li> <p> <code>DELETE</code>: Deletes a existing resource record set.</p> <important> <p>To delete the resource record set that is associated with a traffic policy instance, use <code> <a>DeleteTrafficPolicyInstance</a> </code>. Amazon Route 53 will delete the resource record set automatically. If you delete the resource record set by using <code>ChangeResourceRecordSets</code>, Amazon Route 53 doesn&#39;t automatically delete the traffic policy instance, and you&#39;ll continue to be charged for it even though it&#39;s no longer in use. </p> </important> </li> <li> <p> <code>UPSERT</code>: If a resource record set doesn&#39;t already exist, Amazon Route 53 creates it. If a resource record set does exist, Amazon Route 53 updates it with the values in the request.</p> </li> </ul></p>
     pub action: String,
@@ -533,7 +533,7 @@ impl ChangeActionSerializer {
 }
 
 /// <p>The information for a change request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ChangeBatch {
     /// <p>Information about the changes to make to the record sets.</p>
     pub changes: Vec<Change>,
@@ -567,7 +567,7 @@ impl ChangeBatchSerializer {
 }
 
 /// <p>A complex type that describes change information about changes made to your hosted zone.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ChangeInfo {
     /// <p>A complex type that describes change information about changes made to your hosted zone.</p> <p>This element contains an ID that you use when performing a <a>GetChange</a> action to get detailed information about the change.</p>
     pub comment: Option<String>,
@@ -631,7 +631,7 @@ impl ChangeInfoDeserializer {
     }
 }
 /// <p>A complex type that contains change information for the resource record set.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ChangeResourceRecordSetsRequest {
     /// <p>A complex type that contains an optional comment and the <code>Changes</code> element.</p>
     pub change_batch: ChangeBatch,
@@ -657,7 +657,7 @@ impl ChangeResourceRecordSetsRequestSerializer {
     }
 }
 /// <p>A complex type containing the response for the request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ChangeResourceRecordSetsResponse {
     /// <p>A complex type that contains information about changes made to your hosted zone.</p> <p>This element contains an ID that you use when performing a <a>GetChange</a> action to get detailed information about the change.</p>
     pub change_info: ChangeInfo,
@@ -718,7 +718,7 @@ impl ChangeStatusDeserializer {
     }
 }
 /// <p>A complex type that contains information about the tags that you want to add, edit, or delete.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ChangeTagsForResourceRequest {
     /// <p>A complex type that contains a list of the tags that you want to add to the specified health check or hosted zone and/or the tags that you want to edit <code>Value</code> for.</p> <p>You can add a maximum of 10 tags to a health check or a hosted zone.</p>
     pub add_tags: Option<Vec<Tag>>,
@@ -753,7 +753,7 @@ impl ChangeTagsForResourceRequestSerializer {
     }
 }
 /// <p>Empty response for the request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ChangeTagsForResourceResponse {}
 
 struct ChangeTagsForResourceResponseDeserializer;
@@ -900,7 +900,7 @@ impl ChildHealthCheckListSerializer {
 }
 
 /// <p>A complex type that contains information about the CloudWatch alarm that Amazon Route 53 is monitoring for this health check.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CloudWatchAlarmConfiguration {
     /// <p>For the metric that the CloudWatch alarm is associated with, the arithmetic operation that is used for the comparison.</p>
     pub comparison_operator: String,
@@ -1079,7 +1079,7 @@ impl ComparisonOperatorDeserializer {
     }
 }
 /// <p>A complex type that contains the health check request information.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateHealthCheckRequest {
     /// <p><p>A unique string that identifies the request and that allows you to retry a failed <code>CreateHealthCheck</code> request without the risk of creating two identical health checks:</p> <ul> <li> <p>If you send a <code>CreateHealthCheck</code> request with the same <code>CallerReference</code> and settings as a previous request, and if the health check doesn&#39;t exist, Amazon Route 53 creates the health check. If the health check does exist, Amazon Route 53 returns the settings for the existing health check.</p> </li> <li> <p>If you send a <code>CreateHealthCheck</code> request with the same <code>CallerReference</code> as a deleted health check, regardless of the settings, Amazon Route 53 returns a <code>HealthCheckAlreadyExists</code> error.</p> </li> <li> <p>If you send a <code>CreateHealthCheck</code> request with the same <code>CallerReference</code> as an existing health check but with different settings, Amazon Route 53 returns a <code>HealthCheckAlreadyExists</code> error.</p> </li> <li> <p>If you send a <code>CreateHealthCheck</code> request with a unique <code>CallerReference</code> but settings identical to an existing health check, Amazon Route 53 creates the health check.</p> </li> </ul></p>
     pub caller_reference: String,
@@ -1114,7 +1114,7 @@ impl CreateHealthCheckRequestSerializer {
     }
 }
 /// <p>A complex type containing the response information for the new health check.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateHealthCheckResponse {
     /// <p>A complex type that contains identifying information about the health check.</p>
     pub health_check: HealthCheck,
@@ -1163,7 +1163,7 @@ impl CreateHealthCheckResponseDeserializer {
     }
 }
 /// <p>A complex type that contains information about the request to create a hosted zone.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateHostedZoneRequest {
     /// <p>A unique string that identifies the request and that allows failed <code>CreateHostedZone</code> requests to be retried without the risk of executing the operation twice. You must use a unique <code>CallerReference</code> string every time you submit a <code>CreateHostedZone</code> request. <code>CallerReference</code> can be any unique string, for example, a date/time stamp.</p>
     pub caller_reference: String,
@@ -1205,7 +1205,7 @@ impl CreateHostedZoneRequestSerializer {
     }
 }
 /// <p>A complex type containing the response information for the hosted zone.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateHostedZoneResponse {
     /// <p>A complex type that contains information about the <code>CreateHostedZone</code> request.</p>
     pub change_info: ChangeInfo,
@@ -1272,7 +1272,7 @@ impl CreateHostedZoneResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateQueryLoggingConfigRequest {
     /// <p>The Amazon Resource Name (ARN) for the log group that you want to Amazon Route 53 to send query logs to. This is the format of the ARN:</p> <p>arn:aws:logs:<i>region</i>:<i>account-id</i>:log-group:<i>log_group_name</i> </p> <p>To get the ARN for a log group, you can use the CloudWatch console, the <a href="http://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_DescribeLogGroups.html">DescribeLogGroups</a> API action, the <a href="http://docs.aws.amazon.com/cli/latest/reference/logs/describe-log-groups.html">describe-log-groups</a> command, or the applicable command in one of the AWS SDKs.</p>
     pub cloud_watch_logs_log_group_arn: String,
@@ -1302,7 +1302,7 @@ impl CreateQueryLoggingConfigRequestSerializer {
         writer.write(xml::writer::XmlEvent::end_element())
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateQueryLoggingConfigResponse {
     /// <p>The unique URL representing the new query logging configuration.</p>
     pub location: String,
@@ -1353,7 +1353,7 @@ impl CreateQueryLoggingConfigResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateReusableDelegationSetRequest {
     /// <p>A unique string that identifies the request, and that allows you to retry failed <code>CreateReusableDelegationSet</code> requests without the risk of executing the operation twice. You must use a unique <code>CallerReference</code> string every time you submit a <code>CreateReusableDelegationSet</code> request. <code>CallerReference</code> can be any unique string, for example a date/time stamp.</p>
     pub caller_reference: String,
@@ -1381,7 +1381,7 @@ impl CreateReusableDelegationSetRequestSerializer {
         writer.write(xml::writer::XmlEvent::end_element())
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateReusableDelegationSetResponse {
     /// <p>A complex type that contains name server information.</p>
     pub delegation_set: DelegationSet,
@@ -1432,7 +1432,7 @@ impl CreateReusableDelegationSetResponseDeserializer {
     }
 }
 /// <p>A complex type that contains information about the resource record sets that you want to create based on a specified traffic policy.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateTrafficPolicyInstanceRequest {
     /// <p>The ID of the hosted zone in which you want Amazon Route 53 to create resource record sets by using the configuration in a traffic policy.</p>
     pub hosted_zone_id: String,
@@ -1476,7 +1476,7 @@ impl CreateTrafficPolicyInstanceRequestSerializer {
     }
 }
 /// <p>A complex type that contains the response information for the <code>CreateTrafficPolicyInstance</code> request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateTrafficPolicyInstanceResponse {
     /// <p>A unique URL that represents a new traffic policy instance.</p>
     pub location: String,
@@ -1528,7 +1528,7 @@ impl CreateTrafficPolicyInstanceResponseDeserializer {
     }
 }
 /// <p>A complex type that contains information about the traffic policy that you want to create.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateTrafficPolicyRequest {
     /// <p>(Optional) Any comments that you want to include about the traffic policy.</p>
     pub comment: Option<String>,
@@ -1560,7 +1560,7 @@ impl CreateTrafficPolicyRequestSerializer {
     }
 }
 /// <p>A complex type that contains the response information for the <code>CreateTrafficPolicy</code> request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateTrafficPolicyResponse {
     /// <p>A unique URL that represents a new traffic policy.</p>
     pub location: String,
@@ -1611,7 +1611,7 @@ impl CreateTrafficPolicyResponseDeserializer {
     }
 }
 /// <p>A complex type that contains information about the traffic policy that you want to create a new version for.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateTrafficPolicyVersionRequest {
     /// <p>The comment that you specified in the <code>CreateTrafficPolicyVersion</code> request, if any.</p>
     pub comment: Option<String>,
@@ -1642,7 +1642,7 @@ impl CreateTrafficPolicyVersionRequestSerializer {
     }
 }
 /// <p>A complex type that contains the response information for the <code>CreateTrafficPolicyVersion</code> request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateTrafficPolicyVersionResponse {
     /// <p>A unique URL that represents a new traffic policy version.</p>
     pub location: String,
@@ -1693,7 +1693,7 @@ impl CreateTrafficPolicyVersionResponseDeserializer {
     }
 }
 /// <p>A complex type that contains information about the request to authorize associating a VPC with your private hosted zone. Authorization is only required when a private hosted zone and a VPC were created by using different accounts.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateVPCAssociationAuthorizationRequest {
     /// <p>The ID of the private hosted zone that you want to authorize associating a VPC with.</p>
     pub hosted_zone_id: String,
@@ -1719,7 +1719,7 @@ impl CreateVPCAssociationAuthorizationRequestSerializer {
     }
 }
 /// <p>A complex type that contains the response information from a <code>CreateVPCAssociationAuthorization</code> request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateVPCAssociationAuthorizationResponse {
     /// <p>The ID of the hosted zone that you authorized associating a VPC with.</p>
     pub hosted_zone_id: String,
@@ -1820,7 +1820,7 @@ impl DNSRCodeDeserializer {
     }
 }
 /// <p>A complex type that lists the name servers in a delegation set, as well as the <code>CallerReference</code> and the <code>ID</code> for the delegation set.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DelegationSet {
     /// <p>The value that you specified for <code>CallerReference</code> when you created the reusable delegation set.</p>
     pub caller_reference: Option<String>,
@@ -1965,14 +1965,14 @@ impl DelegationSetsDeserializer {
     }
 }
 /// <p>This action deletes a health check.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteHealthCheckRequest {
     /// <p>The ID of the health check that you want to delete.</p>
     pub health_check_id: String,
 }
 
 /// <p>An empty element.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteHealthCheckResponse {}
 
 struct DeleteHealthCheckResponseDeserializer;
@@ -1992,14 +1992,14 @@ impl DeleteHealthCheckResponseDeserializer {
     }
 }
 /// <p>A request to delete a hosted zone.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteHostedZoneRequest {
     /// <p>The ID of the hosted zone you want to delete.</p>
     pub id: String,
 }
 
 /// <p>A complex type that contains the response to a <code>DeleteHostedZone</code> request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteHostedZoneResponse {
     /// <p>A complex type that contains the ID, the status, and the date and time of a request to delete a hosted zone.</p>
     pub change_info: ChangeInfo,
@@ -2045,13 +2045,13 @@ impl DeleteHostedZoneResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteQueryLoggingConfigRequest {
     /// <p>The ID of the configuration that you want to delete. </p>
     pub id: String,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteQueryLoggingConfigResponse {}
 
 struct DeleteQueryLoggingConfigResponseDeserializer;
@@ -2071,14 +2071,14 @@ impl DeleteQueryLoggingConfigResponseDeserializer {
     }
 }
 /// <p>A request to delete a reusable delegation set.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteReusableDelegationSetRequest {
     /// <p>The ID of the reusable delegation set that you want to delete.</p>
     pub id: String,
 }
 
 /// <p>An empty element.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteReusableDelegationSetResponse {}
 
 struct DeleteReusableDelegationSetResponseDeserializer;
@@ -2098,14 +2098,14 @@ impl DeleteReusableDelegationSetResponseDeserializer {
     }
 }
 /// <p>A request to delete a specified traffic policy instance.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteTrafficPolicyInstanceRequest {
     /// <p><p>The ID of the traffic policy instance that you want to delete. </p> <important> <p>When you delete a traffic policy instance, Amazon Route 53 also deletes all of the resource record sets that were created when you created the traffic policy instance.</p> </important></p>
     pub id: String,
 }
 
 /// <p>An empty element.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteTrafficPolicyInstanceResponse {}
 
 struct DeleteTrafficPolicyInstanceResponseDeserializer;
@@ -2125,7 +2125,7 @@ impl DeleteTrafficPolicyInstanceResponseDeserializer {
     }
 }
 /// <p>A request to delete a specified traffic policy version.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteTrafficPolicyRequest {
     /// <p>The ID of the traffic policy that you want to delete.</p>
     pub id: String,
@@ -2134,7 +2134,7 @@ pub struct DeleteTrafficPolicyRequest {
 }
 
 /// <p>An empty element.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteTrafficPolicyResponse {}
 
 struct DeleteTrafficPolicyResponseDeserializer;
@@ -2154,7 +2154,7 @@ impl DeleteTrafficPolicyResponseDeserializer {
     }
 }
 /// <p>A complex type that contains information about the request to remove authorization to associate a VPC that was created by one AWS account with a hosted zone that was created with a different AWS account. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteVPCAssociationAuthorizationRequest {
     /// <p>When removing authorization to associate a VPC that was created by one AWS account with a hosted zone that was created with a different AWS account, the ID of the hosted zone.</p>
     pub hosted_zone_id: String,
@@ -2180,7 +2180,7 @@ impl DeleteVPCAssociationAuthorizationRequestSerializer {
     }
 }
 /// <p>Empty response for the request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteVPCAssociationAuthorizationResponse {}
 
 struct DeleteVPCAssociationAuthorizationResponseDeserializer;
@@ -2200,7 +2200,7 @@ impl DeleteVPCAssociationAuthorizationResponseDeserializer {
     }
 }
 /// <p>For the metric that the CloudWatch alarm is associated with, a complex type that contains information about one dimension.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Dimension {
     /// <p>For the metric that the CloudWatch alarm is associated with, the name of one dimension.</p>
     pub name: String,
@@ -2326,7 +2326,7 @@ impl DisassociateVPCCommentSerializer {
 }
 
 /// <p>A complex type that contains information about the VPC that you want to disassociate from a specified private hosted zone.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DisassociateVPCFromHostedZoneRequest {
     /// <p> <i>Optional:</i> A comment about the disassociation request.</p>
     pub comment: Option<String>,
@@ -2357,7 +2357,7 @@ impl DisassociateVPCFromHostedZoneRequestSerializer {
     }
 }
 /// <p>A complex type that contains the response information for the disassociate request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DisassociateVPCFromHostedZoneResponse {
     /// <p>A complex type that describes the changes made to the specified private hosted zone.</p>
     pub change_info: ChangeInfo,
@@ -2523,7 +2523,7 @@ impl FullyQualifiedDomainNameSerializer {
 }
 
 /// <p>A complex type that contains information about a geo location.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GeoLocation {
     /// <p>The two-letter code for the continent.</p> <p>Valid values: <code>AF</code> | <code>AN</code> | <code>AS</code> | <code>EU</code> | <code>OC</code> | <code>NA</code> | <code>SA</code> </p> <p>Constraint: Specifying <code>ContinentCode</code> with either <code>CountryCode</code> or <code>SubdivisionCode</code> returns an <code>InvalidInput</code> error.</p>
     pub continent_code: Option<String>,
@@ -2728,7 +2728,7 @@ impl GeoLocationCountryNameDeserializer {
     }
 }
 /// <p>A complex type that contains the codes and full continent, country, and subdivision names for the specified <code>geolocation</code> code.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GeoLocationDetails {
     /// <p>The two-letter code for the continent.</p>
     pub continent_code: Option<String>,
@@ -2911,14 +2911,14 @@ impl GeoLocationSubdivisionNameDeserializer {
     }
 }
 /// <p>A complex type that contains information about the request to create a hosted zone.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetAccountLimitRequest {
     /// <p><p>The limit that you want to get. Valid values include the following:</p> <ul> <li> <p> <b>MAX<em>HEALTH</em>CHECKS<em>BY</em>OWNER</b>: The maximum number of health checks that you can create using the current account.</p> </li> <li> <p> <b>MAX<em>HOSTED</em>ZONES<em>BY</em>OWNER</b>: The maximum number of hosted zones that you can create using the current account.</p> </li> <li> <p> <b>MAX<em>REUSABLE</em>DELEGATION<em>SETS</em>BY<em>OWNER</b>: The maximum number of reusable delegation sets that you can create using the current account.</p> </li> <li> <p> <b>MAX</em>TRAFFIC<em>POLICIES</em>BY<em>OWNER</b>: The maximum number of traffic policies that you can create using the current account.</p> </li> <li> <p> <b>MAX</em>TRAFFIC<em>POLICY</em>INSTANCES<em>BY</em>OWNER</b>: The maximum number of traffic policy instances that you can create using the current account. (Traffic policy instances are referred to as traffic flow policy records in the Amazon Route 53 console.)</p> </li> </ul></p>
     pub type_: String,
 }
 
 /// <p>A complex type that contains the requested limit. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetAccountLimitResponse {
     /// <p>The current number of entities that you have created of the specified type. For example, if you specified <code>MAX_HEALTH_CHECKS_BY_OWNER</code> for the value of <code>Type</code> in the request, the value of <code>Count</code> is the current number of health checks that you have created using the current account.</p>
     pub count: i64,
@@ -2969,14 +2969,14 @@ impl GetAccountLimitResponseDeserializer {
     }
 }
 /// <p>The input for a GetChange request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetChangeRequest {
     /// <p>The ID of the change batch request. The value that you specify here is the value that <code>ChangeResourceRecordSets</code> returned in the <code>Id</code> element when you submitted the request.</p>
     pub id: String,
 }
 
 /// <p>A complex type that contains the <code>ChangeInfo</code> element.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetChangeResponse {
     /// <p>A complex type that contains information about the specified change batch.</p>
     pub change_info: ChangeInfo,
@@ -3022,10 +3022,10 @@ impl GetChangeResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetCheckerIpRangesRequest {}
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetCheckerIpRangesResponse {
     pub checker_ip_ranges: Vec<String>,
 }
@@ -3073,7 +3073,7 @@ impl GetCheckerIpRangesResponseDeserializer {
     }
 }
 /// <p>A request for information about whether a specified geographic location is supported for Amazon Route 53 geolocation resource record sets.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetGeoLocationRequest {
     /// <p><p>Amazon Route 53 supports the following continent codes:</p> <ul> <li> <p> <b>AF</b>: Africa</p> </li> <li> <p> <b>AN</b>: Antarctica</p> </li> <li> <p> <b>AS</b>: Asia</p> </li> <li> <p> <b>EU</b>: Europe</p> </li> <li> <p> <b>OC</b>: Oceania</p> </li> <li> <p> <b>NA</b>: North America</p> </li> <li> <p> <b>SA</b>: South America</p> </li> </ul></p>
     pub continent_code: Option<String>,
@@ -3084,7 +3084,7 @@ pub struct GetGeoLocationRequest {
 }
 
 /// <p>A complex type that contains the response information for the specified geolocation code.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetGeoLocationResponse {
     /// <p>A complex type that contains the codes and full continent, country, and subdivision names for the specified geolocation code.</p>
     pub geo_location_details: GeoLocationDetails,
@@ -3134,11 +3134,11 @@ impl GetGeoLocationResponseDeserializer {
     }
 }
 /// <p>A request for the number of health checks that are associated with the current AWS account.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetHealthCheckCountRequest {}
 
 /// <p>A complex type that contains the response to a <code>GetHealthCheckCount</code> request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetHealthCheckCountResponse {
     /// <p>The number of health checks associated with the current AWS account.</p>
     pub health_check_count: i64,
@@ -3187,14 +3187,14 @@ impl GetHealthCheckCountResponseDeserializer {
     }
 }
 /// <p>A request for the reason that a health check failed most recently.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetHealthCheckLastFailureReasonRequest {
     /// <p><p>The ID for the health check for which you want the last failure reason. When you created the health check, <code>CreateHealthCheck</code> returned the ID in the response, in the <code>HealthCheckId</code> element.</p> <note> <p>If you want to get the last failure reason for a calculated health check, you must use the Amazon Route 53 console or the CloudWatch console. You can&#39;t use <code>GetHealthCheckLastFailureReason</code> for a calculated health check.</p> </note></p>
     pub health_check_id: String,
 }
 
 /// <p>A complex type that contains the response to a <code>GetHealthCheckLastFailureReason</code> request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetHealthCheckLastFailureReasonResponse {
     /// <p>A list that contains one <code>Observation</code> element for each Amazon Route 53 health checker that is reporting a last failure reason. </p>
     pub health_check_observations: Vec<HealthCheckObservation>,
@@ -3244,14 +3244,14 @@ impl GetHealthCheckLastFailureReasonResponseDeserializer {
     }
 }
 /// <p>A request to get information about a specified health check. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetHealthCheckRequest {
     /// <p>The identifier that Amazon Route 53 assigned to the health check when you created it. When you add or update a resource record set, you use this value to specify which health check to use. The value can be up to 64 characters long.</p>
     pub health_check_id: String,
 }
 
 /// <p>A complex type that contains the response to a <code>GetHealthCheck</code> request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetHealthCheckResponse {
     /// <p>A complex type that contains information about one health check that is associated with the current AWS account.</p>
     pub health_check: HealthCheck,
@@ -3298,14 +3298,14 @@ impl GetHealthCheckResponseDeserializer {
     }
 }
 /// <p>A request to get the status for a health check.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetHealthCheckStatusRequest {
     /// <p><p>The ID for the health check that you want the current status for. When you created the health check, <code>CreateHealthCheck</code> returned the ID in the response, in the <code>HealthCheckId</code> element.</p> <note> <p>If you want to check the status of a calculated health check, you must use the Amazon Route 53 console or the CloudWatch console. You can&#39;t use <code>GetHealthCheckStatus</code> to get the status of a calculated health check.</p> </note></p>
     pub health_check_id: String,
 }
 
 /// <p>A complex type that contains the response to a <code>GetHealthCheck</code> request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetHealthCheckStatusResponse {
     /// <p>A list that contains one <code>HealthCheckObservation</code> element for each Amazon Route 53 health checker that is reporting a status about the health check endpoint.</p>
     pub health_check_observations: Vec<HealthCheckObservation>,
@@ -3355,11 +3355,11 @@ impl GetHealthCheckStatusResponseDeserializer {
     }
 }
 /// <p>A request to retrieve a count of all the hosted zones that are associated with the current AWS account.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetHostedZoneCountRequest {}
 
 /// <p>A complex type that contains the response to a <code>GetHostedZoneCount</code> request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetHostedZoneCountResponse {
     /// <p>The total number of public and private hosted zones that are associated with the current AWS account.</p>
     pub hosted_zone_count: i64,
@@ -3408,7 +3408,7 @@ impl GetHostedZoneCountResponseDeserializer {
     }
 }
 /// <p>A complex type that contains information about the request to create a hosted zone.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetHostedZoneLimitRequest {
     /// <p>The ID of the hosted zone that you want to get a limit for.</p>
     pub hosted_zone_id: String,
@@ -3417,7 +3417,7 @@ pub struct GetHostedZoneLimitRequest {
 }
 
 /// <p>A complex type that contains the requested limit. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetHostedZoneLimitResponse {
     /// <p>The current number of entities that you have created of the specified type. For example, if you specified <code>MAX_RRSETS_BY_ZONE</code> for the value of <code>Type</code> in the request, the value of <code>Count</code> is the current number of records that you have created in the specified hosted zone.</p>
     pub count: i64,
@@ -3468,14 +3468,14 @@ impl GetHostedZoneLimitResponseDeserializer {
     }
 }
 /// <p>A request to get information about a specified hosted zone. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetHostedZoneRequest {
     /// <p>The ID of the hosted zone that you want to get information about.</p>
     pub id: String,
 }
 
 /// <p>A complex type that contain the response to a <code>GetHostedZone</code> request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetHostedZoneResponse {
     /// <p>A complex type that lists the Amazon Route 53 name servers for the specified hosted zone.</p>
     pub delegation_set: Option<DelegationSet>,
@@ -3534,13 +3534,13 @@ impl GetHostedZoneResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetQueryLoggingConfigRequest {
     /// <p>The ID of the configuration for DNS query logging that you want to get information about.</p>
     pub id: String,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetQueryLoggingConfigResponse {
     /// <p>A complex type that contains information about the query logging configuration that you specified in a <a>GetQueryLoggingConfig</a> request.</p>
     pub query_logging_config: QueryLoggingConfig,
@@ -3590,7 +3590,7 @@ impl GetQueryLoggingConfigResponseDeserializer {
     }
 }
 /// <p>A complex type that contains information about the request to create a hosted zone.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetReusableDelegationSetLimitRequest {
     /// <p>The ID of the delegation set that you want to get the limit for.</p>
     pub delegation_set_id: String,
@@ -3599,7 +3599,7 @@ pub struct GetReusableDelegationSetLimitRequest {
 }
 
 /// <p>A complex type that contains the requested limit. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetReusableDelegationSetLimitResponse {
     /// <p>The current number of hosted zones that you can associate with the specified reusable delegation set.</p>
     pub count: i64,
@@ -3652,14 +3652,14 @@ impl GetReusableDelegationSetLimitResponseDeserializer {
     }
 }
 /// <p>A request to get information about a specified reusable delegation set.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetReusableDelegationSetRequest {
     /// <p>The ID of the reusable delegation set that you want to get a list of name servers for.</p>
     pub id: String,
 }
 
 /// <p>A complex type that contains the response to the <code>GetReusableDelegationSet</code> request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetReusableDelegationSetResponse {
     /// <p>A complex type that contains information about the reusable delegation set.</p>
     pub delegation_set: DelegationSet,
@@ -3708,11 +3708,11 @@ impl GetReusableDelegationSetResponseDeserializer {
     }
 }
 /// <p>Request to get the number of traffic policy instances that are associated with the current AWS account.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetTrafficPolicyInstanceCountRequest {}
 
 /// <p>A complex type that contains information about the resource record sets that Amazon Route 53 created based on a specified traffic policy.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetTrafficPolicyInstanceCountResponse {
     /// <p>The number of traffic policy instances that are associated with the current AWS account.</p>
     pub traffic_policy_instance_count: i64,
@@ -3762,14 +3762,14 @@ impl GetTrafficPolicyInstanceCountResponseDeserializer {
     }
 }
 /// <p>Gets information about a specified traffic policy instance.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetTrafficPolicyInstanceRequest {
     /// <p>The ID of the traffic policy instance that you want to get information about.</p>
     pub id: String,
 }
 
 /// <p>A complex type that contains information about the resource record sets that Amazon Route 53 created based on a specified traffic policy.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetTrafficPolicyInstanceResponse {
     /// <p>A complex type that contains settings for the traffic policy instance.</p>
     pub traffic_policy_instance: TrafficPolicyInstance,
@@ -3819,7 +3819,7 @@ impl GetTrafficPolicyInstanceResponseDeserializer {
     }
 }
 /// <p>Gets information about a specific traffic policy version.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetTrafficPolicyRequest {
     /// <p>The ID of the traffic policy that you want to get information about.</p>
     pub id: String,
@@ -3828,7 +3828,7 @@ pub struct GetTrafficPolicyRequest {
 }
 
 /// <p>A complex type that contains the response information for the request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetTrafficPolicyResponse {
     /// <p>A complex type that contains settings for the specified traffic policy.</p>
     pub traffic_policy: TrafficPolicy,
@@ -3877,7 +3877,7 @@ impl GetTrafficPolicyResponseDeserializer {
     }
 }
 /// <p>A complex type that contains information about one health check that is associated with the current AWS account.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct HealthCheck {
     /// <p>A unique string that you specified when you created the health check.</p>
     pub caller_reference: String,
@@ -3965,7 +3965,7 @@ impl HealthCheckDeserializer {
     }
 }
 /// <p>A complex type that contains information about the health check.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct HealthCheckConfig {
     /// <p>A complex type that identifies the CloudWatch alarm that you want Amazon Route 53 health checkers to use to determine whether this health check is healthy.</p>
     pub alarm_identifier: Option<AlarmIdentifier>,
@@ -4336,7 +4336,7 @@ impl HealthCheckNonceSerializer {
 }
 
 /// <p>A complex type that contains the last failure reason as reported by one Amazon Route 53 health checker.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct HealthCheckObservation {
     /// <p>The IP address of the Amazon Route 53 health checker that provided the failure reason in <code>StatusReport</code>.</p>
     pub ip_address: Option<String>,
@@ -4687,7 +4687,7 @@ impl HealthThresholdSerializer {
 }
 
 /// <p>A complex type that contains general information about the hosted zone.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct HostedZone {
     /// <p>The value that you specified for <code>CallerReference</code> when you created the hosted zone.</p>
     pub caller_reference: String,
@@ -4768,7 +4768,7 @@ impl HostedZoneDeserializer {
     }
 }
 /// <p>A complex type that contains an optional comment about your hosted zone. If you don't want to specify a comment, omit both the <code>HostedZoneConfig</code> and <code>Comment</code> elements.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct HostedZoneConfig {
     /// <p>Any comments that you want to include about the hosted zone.</p>
     pub comment: Option<String>,
@@ -4871,7 +4871,7 @@ impl HostedZoneCountDeserializer {
     }
 }
 /// <p>A complex type that contains the type of limit that you specified in the request and the current value for that limit.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct HostedZoneLimit {
     /// <p><p>The limit that you requested. Valid values include the following:</p> <ul> <li> <p> <b>MAX<em>RRSETS</em>BY<em>ZONE</b>: The maximum number of records that you can create in the specified hosted zone.</p> </li> <li> <p> <b>MAX</em>VPCS<em>ASSOCIATED</em>BY_ZONE</b>: The maximum number of Amazon VPCs that you can associate with the specified private hosted zone.</p> </li> </ul></p>
     pub type_: String,
@@ -5183,7 +5183,7 @@ impl LimitValueDeserializer {
     }
 }
 /// <p>If a health check or hosted zone was created by another service, <code>LinkedService</code> is a complex type that describes the service that created the resource. When a resource is created by another service, you can't edit or delete it using Amazon Route 53. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct LinkedService {
     /// <p>If the health check or hosted zone was created by another service, an optional description that can be provided by the other service. When a resource is created by another service, you can't edit or delete it using Amazon Route 53. </p>
     pub description: Option<String>,
@@ -5239,7 +5239,7 @@ impl LinkedServiceDeserializer {
     }
 }
 /// <p>A request to get a list of geographic locations that Amazon Route 53 supports for geolocation resource record sets. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListGeoLocationsRequest {
     /// <p>(Optional) The maximum number of geolocations to be included in the response body for this request. If more than <code>MaxItems</code> geolocations remain to be listed, then the value of the <code>IsTruncated</code> element in the response is <code>true</code>.</p>
     pub max_items: Option<String>,
@@ -5252,7 +5252,7 @@ pub struct ListGeoLocationsRequest {
 }
 
 /// <p>A complex type containing the response information for the request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListGeoLocationsResponse {
     /// <p>A complex type that contains one <code>GeoLocationDetails</code> element for each location that Amazon Route 53 supports for geolocation.</p>
     pub geo_location_details_list: Vec<GeoLocationDetails>,
@@ -5341,7 +5341,7 @@ impl ListGeoLocationsResponseDeserializer {
     }
 }
 /// <p>A request to retrieve a list of the health checks that are associated with the current AWS account.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListHealthChecksRequest {
     /// <p>If the value of <code>IsTruncated</code> in the previous response was <code>true</code>, you have more health checks. To get another group, submit another <code>ListHealthChecks</code> request. </p> <p>For the value of <code>marker</code>, specify the value of <code>NextMarker</code> from the previous response, which is the ID of the first health check that Amazon Route 53 will return if you submit another request.</p> <p>If the value of <code>IsTruncated</code> in the previous response was <code>false</code>, there are no more health checks to get.</p>
     pub marker: Option<String>,
@@ -5350,7 +5350,7 @@ pub struct ListHealthChecksRequest {
 }
 
 /// <p>A complex type that contains the response to a <code>ListHealthChecks</code> request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListHealthChecksResponse {
     /// <p>A complex type that contains one <code>HealthCheck</code> element for each health check that is associated with the current AWS account.</p>
     pub health_checks: Vec<HealthCheck>,
@@ -5422,7 +5422,7 @@ impl ListHealthChecksResponseDeserializer {
     }
 }
 /// <p>Retrieves a list of the public and private hosted zones that are associated with the current AWS account in ASCII order by domain name. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListHostedZonesByNameRequest {
     /// <p>(Optional) For your first request to <code>ListHostedZonesByName</code>, include the <code>dnsname</code> parameter only if you want to specify the name of the first hosted zone in the response. If you don't include the <code>dnsname</code> parameter, Amazon Route 53 returns all of the hosted zones that were created by the current AWS account, in ASCII order. For subsequent requests, include both <code>dnsname</code> and <code>hostedzoneid</code> parameters. For <code>dnsname</code>, specify the value of <code>NextDNSName</code> from the previous response.</p>
     pub dns_name: Option<String>,
@@ -5433,7 +5433,7 @@ pub struct ListHostedZonesByNameRequest {
 }
 
 /// <p>A complex type that contains the response information for the request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListHostedZonesByNameResponse {
     /// <p>For the second and subsequent calls to <code>ListHostedZonesByName</code>, <code>DNSName</code> is the value that you specified for the <code>dnsname</code> parameter in the request that produced the current response.</p>
     pub dns_name: Option<String>,
@@ -5520,7 +5520,7 @@ impl ListHostedZonesByNameResponseDeserializer {
     }
 }
 /// <p>A request to retrieve a list of the public and private hosted zones that are associated with the current AWS account.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListHostedZonesRequest {
     /// <p>If you're using reusable delegation sets and you want to list all of the hosted zones that are associated with a reusable delegation set, specify the ID of that reusable delegation set. </p>
     pub delegation_set_id: Option<String>,
@@ -5530,7 +5530,7 @@ pub struct ListHostedZonesRequest {
     pub max_items: Option<String>,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListHostedZonesResponse {
     /// <p>A complex type that contains general information about the hosted zone.</p>
     pub hosted_zones: Vec<HostedZone>,
@@ -5601,7 +5601,7 @@ impl ListHostedZonesResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListQueryLoggingConfigsRequest {
     /// <p>(Optional) If you want to list the query logging configuration that is associated with a hosted zone, specify the ID in <code>HostedZoneId</code>. </p> <p>If you don't specify a hosted zone ID, <code>ListQueryLoggingConfigs</code> returns all of the configurations that are associated with the current AWS account.</p>
     pub hosted_zone_id: Option<String>,
@@ -5611,7 +5611,7 @@ pub struct ListQueryLoggingConfigsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListQueryLoggingConfigsResponse {
     /// <p>If a response includes the last of the query logging configurations that are associated with the current AWS account, <code>NextToken</code> doesn't appear in the response.</p> <p>If a response doesn't include the last of the configurations, you can get more configurations by submitting another <a>ListQueryLoggingConfigs</a> request. Get the value of <code>NextToken</code> that Amazon Route 53 returned in the previous response and include it in <code>NextToken</code> in the next request.</p>
     pub next_token: Option<String>,
@@ -5669,7 +5669,7 @@ impl ListQueryLoggingConfigsResponseDeserializer {
     }
 }
 /// <p>A request for the resource record sets that are associated with a specified hosted zone.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListResourceRecordSetsRequest {
     /// <p>The ID of the hosted zone that contains the resource record sets that you want to list.</p>
     pub hosted_zone_id: String,
@@ -5684,7 +5684,7 @@ pub struct ListResourceRecordSetsRequest {
 }
 
 /// <p>A complex type that contains list information for the resource record set.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListResourceRecordSetsResponse {
     /// <p>A flag that indicates whether more resource record sets remain to be listed. If your results were truncated, you can make a follow-up pagination request by using the <code>NextRecordName</code> element.</p>
     pub is_truncated: bool,
@@ -5771,7 +5771,7 @@ impl ListResourceRecordSetsResponseDeserializer {
     }
 }
 /// <p>A request to get a list of the reusable delegation sets that are associated with the current AWS account.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListReusableDelegationSetsRequest {
     /// <p>If the value of <code>IsTruncated</code> in the previous response was <code>true</code>, you have more reusable delegation sets. To get another group, submit another <code>ListReusableDelegationSets</code> request. </p> <p>For the value of <code>marker</code>, specify the value of <code>NextMarker</code> from the previous response, which is the ID of the first reusable delegation set that Amazon Route 53 will return if you submit another request.</p> <p>If the value of <code>IsTruncated</code> in the previous response was <code>false</code>, there are no more reusable delegation sets to get.</p>
     pub marker: Option<String>,
@@ -5780,7 +5780,7 @@ pub struct ListReusableDelegationSetsRequest {
 }
 
 /// <p>A complex type that contains information about the reusable delegation sets that are associated with the current AWS account.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListReusableDelegationSetsResponse {
     /// <p>A complex type that contains one <code>DelegationSet</code> element for each reusable delegation set that was created by the current AWS account.</p>
     pub delegation_sets: Vec<DelegationSet>,
@@ -5854,7 +5854,7 @@ impl ListReusableDelegationSetsResponseDeserializer {
     }
 }
 /// <p>A complex type containing information about a request for a list of the tags that are associated with an individual resource.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListTagsForResourceRequest {
     /// <p>The ID of the resource for which you want to retrieve tags.</p>
     pub resource_id: String,
@@ -5863,7 +5863,7 @@ pub struct ListTagsForResourceRequest {
 }
 
 /// <p>A complex type that contains information about the health checks or hosted zones for which you want to list tags.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListTagsForResourceResponse {
     /// <p>A <code>ResourceTagSet</code> containing tags associated with the specified resource.</p>
     pub resource_tag_set: ResourceTagSet,
@@ -5912,7 +5912,7 @@ impl ListTagsForResourceResponseDeserializer {
     }
 }
 /// <p>A complex type that contains information about the health checks or hosted zones for which you want to list tags.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListTagsForResourcesRequest {
     /// <p>A complex type that contains the ResourceId element for each resource for which you want to get a list of tags.</p>
     pub resource_ids: Vec<String>,
@@ -5938,7 +5938,7 @@ impl ListTagsForResourcesRequestSerializer {
     }
 }
 /// <p>A complex type containing tags for the specified resources.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListTagsForResourcesResponse {
     /// <p>A list of <code>ResourceTagSet</code>s containing tags associated with the specified resources.</p>
     pub resource_tag_sets: Vec<ResourceTagSet>,
@@ -5987,7 +5987,7 @@ impl ListTagsForResourcesResponseDeserializer {
     }
 }
 /// <p>A complex type that contains the information about the request to list the traffic policies that are associated with the current AWS account.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListTrafficPoliciesRequest {
     /// <p>(Optional) The maximum number of traffic policies that you want Amazon Route 53 to return in response to this request. If you have more than <code>MaxItems</code> traffic policies, the value of <code>IsTruncated</code> in the response is <code>true</code>, and the value of <code>TrafficPolicyIdMarker</code> is the ID of the first traffic policy that Amazon Route 53 will return if you submit another request.</p>
     pub max_items: Option<String>,
@@ -5996,7 +5996,7 @@ pub struct ListTrafficPoliciesRequest {
 }
 
 /// <p>A complex type that contains the response information for the request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListTrafficPoliciesResponse {
     /// <p>A flag that indicates whether there are more traffic policies to be listed. If the response was truncated, you can get the next group of traffic policies by submitting another <code>ListTrafficPolicies</code> request and specifying the value of <code>TrafficPolicyIdMarker</code> in the <code>TrafficPolicyIdMarker</code> request parameter.</p>
     pub is_truncated: bool,
@@ -6067,7 +6067,7 @@ impl ListTrafficPoliciesResponseDeserializer {
     }
 }
 /// <p>A request for the traffic policy instances that you created in a specified hosted zone.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListTrafficPolicyInstancesByHostedZoneRequest {
     /// <p>The ID of the hosted zone that you want to list traffic policy instances for.</p>
     pub hosted_zone_id: String,
@@ -6080,7 +6080,7 @@ pub struct ListTrafficPolicyInstancesByHostedZoneRequest {
 }
 
 /// <p>A complex type that contains the response information for the request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListTrafficPolicyInstancesByHostedZoneResponse {
     /// <p>A flag that indicates whether there are more traffic policy instances to be listed. If the response was truncated, you can get the next group of traffic policy instances by submitting another <code>ListTrafficPolicyInstancesByHostedZone</code> request and specifying the values of <code>HostedZoneIdMarker</code>, <code>TrafficPolicyInstanceNameMarker</code>, and <code>TrafficPolicyInstanceTypeMarker</code> in the corresponding request parameters.</p>
     pub is_truncated: bool,
@@ -6160,7 +6160,7 @@ impl ListTrafficPolicyInstancesByHostedZoneResponseDeserializer {
     }
 }
 /// <p>A complex type that contains the information about the request to list your traffic policy instances.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListTrafficPolicyInstancesByPolicyRequest {
     /// <p>If the value of <code>IsTruncated</code> in the previous response was <code>true</code>, you have more traffic policy instances. To get more traffic policy instances, submit another <code>ListTrafficPolicyInstancesByPolicy</code> request. </p> <p>For the value of <code>hostedzoneid</code>, specify the value of <code>HostedZoneIdMarker</code> from the previous response, which is the hosted zone ID of the first traffic policy instance that Amazon Route 53 will return if you submit another request.</p> <p>If the value of <code>IsTruncated</code> in the previous response was <code>false</code>, there are no more traffic policy instances to get.</p>
     pub hosted_zone_id_marker: Option<String>,
@@ -6177,7 +6177,7 @@ pub struct ListTrafficPolicyInstancesByPolicyRequest {
 }
 
 /// <p>A complex type that contains the response information for the request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListTrafficPolicyInstancesByPolicyResponse {
     /// <p>If <code>IsTruncated</code> is <code>true</code>, <code>HostedZoneIdMarker</code> is the ID of the hosted zone of the first traffic policy instance in the next group of traffic policy instances.</p>
     pub hosted_zone_id_marker: Option<String>,
@@ -6264,7 +6264,7 @@ impl ListTrafficPolicyInstancesByPolicyResponseDeserializer {
     }
 }
 /// <p>A request to get information about the traffic policy instances that you created by using the current AWS account.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListTrafficPolicyInstancesRequest {
     /// <p>If the value of <code>IsTruncated</code> in the previous response was <code>true</code>, you have more traffic policy instances. To get more traffic policy instances, submit another <code>ListTrafficPolicyInstances</code> request. For the value of <code>HostedZoneId</code>, specify the value of <code>HostedZoneIdMarker</code> from the previous response, which is the hosted zone ID of the first traffic policy instance in the next group of traffic policy instances.</p> <p>If the value of <code>IsTruncated</code> in the previous response was <code>false</code>, there are no more traffic policy instances to get.</p>
     pub hosted_zone_id_marker: Option<String>,
@@ -6277,7 +6277,7 @@ pub struct ListTrafficPolicyInstancesRequest {
 }
 
 /// <p>A complex type that contains the response information for the request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListTrafficPolicyInstancesResponse {
     /// <p>If <code>IsTruncated</code> is <code>true</code>, <code>HostedZoneIdMarker</code> is the ID of the hosted zone of the first traffic policy instance that Amazon Route 53 will return if you submit another <code>ListTrafficPolicyInstances</code> request. </p>
     pub hosted_zone_id_marker: Option<String>,
@@ -6364,7 +6364,7 @@ impl ListTrafficPolicyInstancesResponseDeserializer {
     }
 }
 /// <p>A complex type that contains the information about the request to list your traffic policies.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListTrafficPolicyVersionsRequest {
     /// <p>Specify the value of <code>Id</code> of the traffic policy for which you want to list all versions.</p>
     pub id: String,
@@ -6375,7 +6375,7 @@ pub struct ListTrafficPolicyVersionsRequest {
 }
 
 /// <p>A complex type that contains the response information for the request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListTrafficPolicyVersionsResponse {
     /// <p>A flag that indicates whether there are more traffic policies to be listed. If the response was truncated, you can get the next group of traffic policies by submitting another <code>ListTrafficPolicyVersions</code> request and specifying the value of <code>NextMarker</code> in the <code>marker</code> parameter.</p>
     pub is_truncated: bool,
@@ -6445,7 +6445,7 @@ impl ListTrafficPolicyVersionsResponseDeserializer {
     }
 }
 /// <p>A complex type that contains information about that can be associated with your hosted zone.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListVPCAssociationAuthorizationsRequest {
     /// <p>The ID of the hosted zone for which you want a list of VPCs that can be associated with the hosted zone.</p>
     pub hosted_zone_id: String,
@@ -6456,7 +6456,7 @@ pub struct ListVPCAssociationAuthorizationsRequest {
 }
 
 /// <p>A complex type that contains the response information for the request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListVPCAssociationAuthorizationsResponse {
     /// <p>The ID of the hosted zone that you can associate the listed VPCs with.</p>
     pub hosted_zone_id: String,
@@ -6831,7 +6831,7 @@ impl PortSerializer {
 }
 
 /// <p>A complex type that contains information about a configuration for DNS query logging.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct QueryLoggingConfig {
     /// <p>The Amazon Resource Name (ARN) of the CloudWatch Logs log group that Amazon Route 53 is publishing logs to.</p>
     pub cloud_watch_logs_log_group_arn: String,
@@ -7277,7 +7277,7 @@ impl ResourcePathSerializer {
 }
 
 /// <p><p>Information specific to the resource record.</p> <note> <p>If you&#39;re creating an alias resource record set, omit <code>ResourceRecord</code>.</p> </note></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ResourceRecord {
     /// <p><p>The current or new DNS record value, not to exceed 4,000 characters. In the case of a <code>DELETE</code> action, if the current value does not match the actual value, an error is returned. For descriptions about how to format <code>Value</code> for different record types, see <a href="http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/ResourceRecordTypes.html">Supported DNS Resource Record Types</a> in the <i>Amazon Route 53 Developer Guide</i>.</p> <p>You can specify more than one value for all record types except <code>CNAME</code> and <code>SOA</code>. </p> <note> <p>If you&#39;re creating an alias resource record set, omit <code>Value</code>.</p> </note></p>
     pub value: String,
@@ -7346,7 +7346,7 @@ impl ResourceRecordSerializer {
 }
 
 /// <p>Information about the resource record set to create or delete.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ResourceRecordSet {
     /// <p><p> <i>Alias resource record sets only:</i> Information about the CloudFront distribution, AWS Elastic Beanstalk environment, ELB load balancer, Amazon S3 bucket, or Amazon Route 53 resource record set to which you&#39;re redirecting queries. The AWS Elastic Beanstalk environment must have a regionalized subdomain.</p> <p>If you&#39;re creating resource records sets for a private hosted zone, note the following:</p> <ul> <li> <p>You can&#39;t create alias resource record sets for CloudFront distributions in a private hosted zone.</p> </li> <li> <p>Creating geolocation alias resource record sets or latency alias resource record sets in a private hosted zone is unsupported.</p> </li> <li> <p>For information about creating failover resource record sets in a private hosted zone, see <a href="http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover-private-hosted-zones.html">Configuring Failover in a Private Hosted Zone</a> in the <i>Amazon Route 53 Developer Guide</i>.</p> </li> </ul></p>
     pub alias_target: Option<AliasTarget>,
@@ -7868,7 +7868,7 @@ impl ResourceRecordsSerializer {
 }
 
 /// <p>A complex type containing a resource and its associated tags.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ResourceTagSet {
     /// <p>The ID for the specified resource.</p>
     pub resource_id: Option<String>,
@@ -7973,7 +7973,7 @@ impl ResourceTagSetListDeserializer {
     }
 }
 /// <p>A complex type that contains the type of limit that you specified in the request and the current value for that limit.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ReusableDelegationSetLimit {
     /// <p>The limit that you requested: <code>MAX_ZONES_BY_REUSABLE_DELEGATION_SET</code>, the maximum number of hosted zones that you can associate with the specified reusable delegation set.</p>
     pub type_: String,
@@ -8138,7 +8138,7 @@ impl StatusDeserializer {
     }
 }
 /// <p>A complex type that contains the status that one Amazon Route 53 health checker reports and the time of the health check.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct StatusReport {
     /// <p>The date and time that the health checker performed the health check in <a href="https://en.wikipedia.org/wiki/ISO_8601">ISO 8601 format</a> and Coordinated Universal Time (UTC). For example, the value <code>2017-03-27T17:48:16.751Z</code> represents March 27, 2017 at 17:48:16.751 UTC.</p>
     pub checked_time: Option<String>,
@@ -8248,7 +8248,7 @@ impl TTLSerializer {
 }
 
 /// <p>A complex type that contains information about a tag that you want to add or edit for the specified health check or hosted zone.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Tag {
     /// <p><p>The value of <code>Key</code> depends on the operation that you want to perform:</p> <ul> <li> <p> <b>Add a tag to a health check or hosted zone</b>: <code>Key</code> is the name that you want to give the new tag.</p> </li> <li> <p> <b>Edit a tag</b>: <code>Key</code> is the name of the tag that you want to change the <code>Value</code> for.</p> </li> <li> <p> <b> Delete a key</b>: <code>Key</code> is the name of the tag you want to remove.</p> </li> <li> <p> <b>Give a name to a health check</b>: Edit the default <code>Name</code> tag. In the Amazon Route 53 console, the list of your health checks includes a <b>Name</b> column that lets you see the name that you&#39;ve given to each health check.</p> </li> </ul></p>
     pub key: Option<String>,
@@ -8573,7 +8573,7 @@ impl TagValueSerializer {
 }
 
 /// <p>Gets the value that Amazon Route 53 returns in response to a DNS request for a specified record name and type. You can optionally specify the IP address of a DNS resolver, an EDNS0 client subnet IP address, and a subnet mask. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct TestDNSAnswerRequest {
     /// <p>If the resolver that you specified for resolverip supports EDNS0, specify the IPv4 or IPv6 address of a client in the applicable location, for example, <code>192.0.2.44</code> or <code>2001:db8:85a3::8a2e:370:7334</code>.</p>
     pub edns0_client_subnet_ip: Option<String>,
@@ -8590,7 +8590,7 @@ pub struct TestDNSAnswerRequest {
 }
 
 /// <p>A complex type that contains the response to a <code>TestDNSAnswer</code> request. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct TestDNSAnswerResponse {
     /// <p>The Amazon Route 53 name server used to respond to the request.</p>
     pub nameserver: String,
@@ -8739,7 +8739,7 @@ impl TrafficPoliciesDeserializer {
     }
 }
 /// <p>A complex type that contains settings for a traffic policy.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct TrafficPolicy {
     /// <p>The comment that you specify in the <code>CreateTrafficPolicy</code> request, if any.</p>
     pub comment: Option<String>,
@@ -8921,7 +8921,7 @@ impl TrafficPolicyIdSerializer {
 }
 
 /// <p>A complex type that contains settings for the new traffic policy instance.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct TrafficPolicyInstance {
     /// <p>The ID of the hosted zone that Amazon Route 53 created resource record sets in.</p>
     pub hosted_zone_id: String,
@@ -9204,7 +9204,7 @@ impl TrafficPolicySummariesDeserializer {
     }
 }
 /// <p>A complex type that contains information about the latest version of one traffic policy that is associated with the current AWS account.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct TrafficPolicySummary {
     /// <p>The ID that Amazon Route 53 assigned to the traffic policy when you created it.</p>
     pub id: String,
@@ -9361,7 +9361,7 @@ impl TransportProtocolDeserializer {
     }
 }
 /// <p>A complex type that contains information about a request to update a health check.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateHealthCheckRequest {
     pub alarm_identifier: Option<AlarmIdentifier>,
     /// <p>A complex type that contains one <code>ChildHealthCheck</code> element for each health check that you want to associate with a <code>CALCULATED</code> health check.</p>
@@ -9465,7 +9465,7 @@ impl UpdateHealthCheckRequestSerializer {
         writer.write(xml::writer::XmlEvent::end_element())
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateHealthCheckResponse {
     pub health_check: HealthCheck,
 }
@@ -9511,7 +9511,7 @@ impl UpdateHealthCheckResponseDeserializer {
     }
 }
 /// <p>A request to update the comment for a hosted zone.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateHostedZoneCommentRequest {
     /// <p>The new comment for the hosted zone. If you don't specify a value for <code>Comment</code>, Amazon Route 53 deletes the existing value of the <code>Comment</code> element, if any.</p>
     pub comment: Option<String>,
@@ -9539,7 +9539,7 @@ impl UpdateHostedZoneCommentRequestSerializer {
     }
 }
 /// <p>A complex type that contains the response to the <code>UpdateHostedZoneComment</code> request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateHostedZoneCommentResponse {
     pub hosted_zone: HostedZone,
 }
@@ -9585,7 +9585,7 @@ impl UpdateHostedZoneCommentResponseDeserializer {
     }
 }
 /// <p>A complex type that contains information about the traffic policy that you want to update the comment for.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateTrafficPolicyCommentRequest {
     /// <p>The new comment for the specified traffic policy and version.</p>
     pub comment: String,
@@ -9613,7 +9613,7 @@ impl UpdateTrafficPolicyCommentRequestSerializer {
     }
 }
 /// <p>A complex type that contains the response information for the traffic policy.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateTrafficPolicyCommentResponse {
     /// <p>A complex type that contains settings for the specified traffic policy.</p>
     pub traffic_policy: TrafficPolicy,
@@ -9662,7 +9662,7 @@ impl UpdateTrafficPolicyCommentResponseDeserializer {
     }
 }
 /// <p>A complex type that contains information about the resource record sets that you want to update based on a specified traffic policy instance.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateTrafficPolicyInstanceRequest {
     /// <p>The ID of the traffic policy instance that you want to update.</p>
     pub id: String,
@@ -9702,7 +9702,7 @@ impl UpdateTrafficPolicyInstanceRequestSerializer {
     }
 }
 /// <p>A complex type that contains information about the resource record sets that Amazon Route 53 created based on a specified traffic policy.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateTrafficPolicyInstanceResponse {
     /// <p>A complex type that contains settings for the updated traffic policy instance.</p>
     pub traffic_policy_instance: TrafficPolicyInstance,
@@ -9766,7 +9766,7 @@ impl UsageCountDeserializer {
     }
 }
 /// <p>(Private hosted zones only) A complex type that contains information about an Amazon VPC.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct VPC {
     pub vpc_id: Option<String>,
     /// <p>(Private hosted zones only) The region in which you created an Amazon VPC.</p>

--- a/rusoto/services/route53/src/generated.rs
+++ b/rusoto/services/route53/src/generated.rs
@@ -29,8 +29,9 @@ use hyper::StatusCode;
 use rusoto_core::param::{Params, ServiceParams};
 use rusoto_core::signature::SignedRequest;
 use rusoto_core::xmlerror::*;
-use rusoto_core::xmlutil::{characters, end_element, find_start_element, peek_at_name, skip_tree,
-                           start_element};
+use rusoto_core::xmlutil::{
+    characters, end_element, find_start_element, peek_at_name, skip_tree, start_element,
+};
 use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
 use std::io::Write;
 use std::str::FromStr;
@@ -15570,7 +15571,8 @@ where
         request.set_payload(Some(writer.into_inner()));
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -15629,7 +15631,8 @@ where
         request.set_payload(Some(writer.into_inner()));
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -15689,7 +15692,8 @@ where
         request.set_payload(Some(writer.into_inner()));
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -15745,7 +15749,8 @@ where
         request.set_payload(Some(writer.into_inner()));
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -15803,7 +15808,8 @@ where
         request.set_payload(Some(writer.into_inner()));
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -15861,7 +15867,8 @@ where
         request.set_payload(Some(writer.into_inner()));
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -15919,7 +15926,8 @@ where
         request.set_payload(Some(writer.into_inner()));
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -15979,7 +15987,8 @@ where
         request.set_payload(Some(writer.into_inner()));
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -16037,7 +16046,8 @@ where
         request.set_payload(Some(writer.into_inner()));
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -16097,7 +16107,8 @@ where
         request.set_payload(Some(writer.into_inner()));
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -16161,7 +16172,8 @@ where
         request.set_payload(Some(writer.into_inner()));
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -16213,7 +16225,8 @@ where
         let mut request = SignedRequest::new("DELETE", "route53", &self.region, &request_uri);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -16260,7 +16273,8 @@ where
         let mut request = SignedRequest::new("DELETE", "route53", &self.region, &request_uri);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -16307,7 +16321,8 @@ where
         let mut request = SignedRequest::new("DELETE", "route53", &self.region, &request_uri);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -16354,7 +16369,8 @@ where
         let mut request = SignedRequest::new("DELETE", "route53", &self.region, &request_uri);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -16407,7 +16423,8 @@ where
         let mut request = SignedRequest::new("DELETE", "route53", &self.region, &request_uri);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -16454,7 +16471,8 @@ where
         let mut request = SignedRequest::new("DELETE", "route53", &self.region, &request_uri);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -16518,7 +16536,8 @@ where
         request.set_payload(Some(writer.into_inner()));
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -16580,7 +16599,8 @@ where
         request.set_payload(Some(writer.into_inner()));
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -16629,7 +16649,8 @@ where
         let mut request = SignedRequest::new("GET", "route53", &self.region, &request_uri);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -16676,7 +16697,8 @@ where
         let mut request = SignedRequest::new("GET", "route53", &self.region, &request_uri);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -16723,7 +16745,8 @@ where
         let mut request = SignedRequest::new("GET", "route53", &self.region, &request_uri);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -16782,7 +16805,8 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -16832,7 +16856,8 @@ where
         let mut request = SignedRequest::new("GET", "route53", &self.region, &request_uri);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -16879,7 +16904,8 @@ where
         let mut request = SignedRequest::new("GET", "route53", &self.region, &request_uri);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -16930,7 +16956,8 @@ where
         let mut request = SignedRequest::new("GET", "route53", &self.region, &request_uri);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -16982,7 +17009,8 @@ where
         let mut request = SignedRequest::new("GET", "route53", &self.region, &request_uri);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -17029,7 +17057,8 @@ where
         let mut request = SignedRequest::new("GET", "route53", &self.region, &request_uri);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -17076,7 +17105,8 @@ where
         let mut request = SignedRequest::new("GET", "route53", &self.region, &request_uri);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -17123,7 +17153,8 @@ where
         let mut request = SignedRequest::new("GET", "route53", &self.region, &request_uri);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -17170,7 +17201,8 @@ where
         let mut request = SignedRequest::new("GET", "route53", &self.region, &request_uri);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -17217,7 +17249,8 @@ where
         let mut request = SignedRequest::new("GET", "route53", &self.region, &request_uri);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -17265,7 +17298,8 @@ where
         let mut request = SignedRequest::new("GET", "route53", &self.region, &request_uri);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -17318,7 +17352,8 @@ where
         let mut request = SignedRequest::new("GET", "route53", &self.region, &request_uri);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -17365,7 +17400,8 @@ where
         let mut request = SignedRequest::new("GET", "route53", &self.region, &request_uri);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -17413,7 +17449,8 @@ where
         let mut request = SignedRequest::new("GET", "route53", &self.region, &request_uri);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -17477,7 +17514,8 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -17533,7 +17571,8 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -17592,7 +17631,8 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -17651,7 +17691,8 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -17710,7 +17751,8 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -17775,7 +17817,8 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -17831,7 +17874,8 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -17882,7 +17926,8 @@ where
         let mut request = SignedRequest::new("GET", "route53", &self.region, &request_uri);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -17941,7 +17986,8 @@ where
         request.set_payload(Some(writer.into_inner()));
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -17997,7 +18043,8 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -18059,7 +18106,8 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -18122,7 +18170,8 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -18191,7 +18240,8 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -18249,7 +18299,8 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -18309,7 +18360,8 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -18373,7 +18425,8 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -18432,7 +18485,8 @@ where
         request.set_payload(Some(writer.into_inner()));
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -18488,7 +18542,8 @@ where
         request.set_payload(Some(writer.into_inner()));
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -18548,7 +18603,8 @@ where
         request.set_payload(Some(writer.into_inner()));
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -18604,7 +18660,8 @@ where
         request.set_payload(Some(writer.into_inner()));
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {

--- a/rusoto/services/route53domains/src/generated.rs
+++ b/rusoto/services/route53domains/src/generated.rs
@@ -862,7 +862,8 @@ impl CheckDomainAvailabilityError {
     pub fn from_body(body: &str) -> CheckDomainAvailabilityError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -948,7 +949,8 @@ impl CheckDomainTransferabilityError {
     pub fn from_body(body: &str) -> CheckDomainTransferabilityError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1036,7 +1038,8 @@ impl DeleteTagsForDomainError {
     pub fn from_body(body: &str) -> DeleteTagsForDomainError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1126,7 +1129,8 @@ impl DisableDomainAutoRenewError {
     pub fn from_body(body: &str) -> DisableDomainAutoRenewError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1218,7 +1222,8 @@ impl DisableDomainTransferLockError {
     pub fn from_body(body: &str) -> DisableDomainTransferLockError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1320,7 +1325,8 @@ impl EnableDomainAutoRenewError {
     pub fn from_body(body: &str) -> EnableDomainAutoRenewError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1416,7 +1422,8 @@ impl EnableDomainTransferLockError {
     pub fn from_body(body: &str) -> EnableDomainTransferLockError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1518,7 +1525,8 @@ impl GetContactReachabilityStatusError {
     pub fn from_body(body: &str) -> GetContactReachabilityStatusError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1610,7 +1618,8 @@ impl GetDomainDetailError {
     pub fn from_body(body: &str) -> GetDomainDetailError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1694,7 +1703,8 @@ impl GetDomainSuggestionsError {
     pub fn from_body(body: &str) -> GetDomainSuggestionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1778,7 +1788,8 @@ impl GetOperationDetailError {
     pub fn from_body(body: &str) -> GetOperationDetailError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1858,7 +1869,8 @@ impl ListDomainsError {
     pub fn from_body(body: &str) -> ListDomainsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1934,7 +1946,8 @@ impl ListOperationsError {
     pub fn from_body(body: &str) -> ListOperationsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2016,7 +2029,8 @@ impl ListTagsForDomainError {
     pub fn from_body(body: &str) -> ListTagsForDomainError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2114,7 +2128,8 @@ impl RegisterDomainError {
     pub fn from_body(body: &str) -> RegisterDomainError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2220,7 +2235,8 @@ impl RenewDomainError {
     pub fn from_body(body: &str) -> RenewDomainError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2316,7 +2332,8 @@ impl ResendContactReachabilityEmailError {
     pub fn from_body(body: &str) -> ResendContactReachabilityEmailError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2408,7 +2425,8 @@ impl RetrieveDomainAuthCodeError {
     pub fn from_body(body: &str) -> RetrieveDomainAuthCodeError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2502,7 +2520,8 @@ impl TransferDomainError {
     pub fn from_body(body: &str) -> TransferDomainError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2608,7 +2627,8 @@ impl UpdateDomainContactError {
     pub fn from_body(body: &str) -> UpdateDomainContactError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2712,7 +2732,8 @@ impl UpdateDomainContactPrivacyError {
     pub fn from_body(body: &str) -> UpdateDomainContactPrivacyError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2818,7 +2839,8 @@ impl UpdateDomainNameserversError {
     pub fn from_body(body: &str) -> UpdateDomainNameserversError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2920,7 +2942,8 @@ impl UpdateTagsForDomainError {
     pub fn from_body(body: &str) -> UpdateTagsForDomainError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3008,7 +3031,8 @@ impl ViewBillingError {
     pub fn from_body(body: &str) -> ViewBillingError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/route53domains/src/generated.rs
+++ b/rusoto/services/route53domains/src/generated.rs
@@ -31,7 +31,7 @@ use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 /// <p>Information for one billing record.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BillingRecord {
     /// <p>The date that the operation was billed, in Unix format.</p>
     #[serde(rename = "BillDate")]
@@ -56,7 +56,7 @@ pub struct BillingRecord {
 }
 
 /// <p>The CheckDomainAvailability request contains the following elements.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CheckDomainAvailabilityRequest {
     /// <p>The name of the domain that you want to get availability for.</p> <p>Constraints: The domain name can contain only the letters a through z, the numbers 0 through 9, and hyphen (-). Internationalized Domain Names are not supported.</p>
     #[serde(rename = "DomainName")]
@@ -68,7 +68,7 @@ pub struct CheckDomainAvailabilityRequest {
 }
 
 /// <p>The CheckDomainAvailability response includes the following elements.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CheckDomainAvailabilityResponse {
     /// <p><p>Whether the domain name is available for registering.</p> <note> <p>You can register only domains designated as <code>AVAILABLE</code>.</p> </note> <p>Valid values:</p> <dl> <dt>AVAILABLE</dt> <dd> <p>The domain name is available.</p> </dd> <dt>AVAILABLE<em>RESERVED</dt> <dd> <p>The domain name is reserved under specific conditions.</p> </dd> <dt>AVAILABLE</em>PREORDER</dt> <dd> <p>The domain name is available and can be preordered.</p> </dd> <dt>DONT<em>KNOW</dt> <dd> <p>The TLD registry didn&#39;t reply with a definitive answer about whether the domain name is available. Amazon Route 53 can return this response for a variety of reasons, for example, the registry is performing maintenance. Try again later.</p> </dd> <dt>PENDING</dt> <dd> <p>The TLD registry didn&#39;t return a response in the expected amount of time. When the response is delayed, it usually takes just a few extra seconds. You can resubmit the request immediately.</p> </dd> <dt>RESERVED</dt> <dd> <p>The domain name has been reserved for another person or organization.</p> </dd> <dt>UNAVAILABLE</dt> <dd> <p>The domain name is not available.</p> </dd> <dt>UNAVAILABLE</em>PREMIUM</dt> <dd> <p>The domain name is not available.</p> </dd> <dt>UNAVAILABLE_RESTRICTED</dt> <dd> <p>The domain name is forbidden.</p> </dd> </dl></p>
     #[serde(rename = "Availability")]
@@ -76,7 +76,7 @@ pub struct CheckDomainAvailabilityResponse {
 }
 
 /// <p>The CheckDomainTransferability request contains the following elements.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CheckDomainTransferabilityRequest {
     /// <p>If the registrar for the top-level domain (TLD) requires an authorization code to transfer the domain, the code that you got from the current registrar for the domain.</p>
     #[serde(rename = "AuthCode")]
@@ -88,7 +88,7 @@ pub struct CheckDomainTransferabilityRequest {
 }
 
 /// <p>The CheckDomainTransferability response includes the following elements.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CheckDomainTransferabilityResponse {
     /// <p>A complex type that contains information about whether the specified domain can be transferred to Amazon Route 53.</p>
     #[serde(rename = "Transferability")]
@@ -96,7 +96,7 @@ pub struct CheckDomainTransferabilityResponse {
 }
 
 /// <p>ContactDetail includes the following elements.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ContactDetail {
     /// <p>First line of the contact's address.</p>
     #[serde(rename = "AddressLine1")]
@@ -157,7 +157,7 @@ pub struct ContactDetail {
 }
 
 /// <p>The DeleteTagsForDomainRequest includes the following elements.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteTagsForDomainRequest {
     /// <p>The domain for which you want to delete one or more tags.</p>
     #[serde(rename = "DomainName")]
@@ -167,21 +167,21 @@ pub struct DeleteTagsForDomainRequest {
     pub tags_to_delete: Vec<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteTagsForDomainResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DisableDomainAutoRenewRequest {
     /// <p>The name of the domain that you want to disable automatic renewal for.</p>
     #[serde(rename = "DomainName")]
     pub domain_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DisableDomainAutoRenewResponse {}
 
 /// <p>The DisableDomainTransferLock request includes the following element.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DisableDomainTransferLockRequest {
     /// <p>The name of the domain that you want to remove the transfer lock for.</p>
     #[serde(rename = "DomainName")]
@@ -189,7 +189,7 @@ pub struct DisableDomainTransferLockRequest {
 }
 
 /// <p>The DisableDomainTransferLock response includes the following element.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DisableDomainTransferLockResponse {
     /// <p>Identifier for tracking the progress of the request. To use this ID to query the operation status, use <a>GetOperationDetail</a>.</p>
     #[serde(rename = "OperationId")]
@@ -197,7 +197,7 @@ pub struct DisableDomainTransferLockResponse {
 }
 
 /// <p>Information about one suggested domain name.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DomainSuggestion {
     /// <p><p>Whether the domain name is available for registering.</p> <note> <p>You can register only the domains that are designated as <code>AVAILABLE</code>.</p> </note> <p>Valid values:</p> <dl> <dt>AVAILABLE</dt> <dd> <p>The domain name is available.</p> </dd> <dt>AVAILABLE<em>RESERVED</dt> <dd> <p>The domain name is reserved under specific conditions.</p> </dd> <dt>AVAILABLE</em>PREORDER</dt> <dd> <p>The domain name is available and can be preordered.</p> </dd> <dt>DONT<em>KNOW</dt> <dd> <p>The TLD registry didn&#39;t reply with a definitive answer about whether the domain name is available. Amazon Route 53 can return this response for a variety of reasons, for example, the registry is performing maintenance. Try again later.</p> </dd> <dt>PENDING</dt> <dd> <p>The TLD registry didn&#39;t return a response in the expected amount of time. When the response is delayed, it usually takes just a few extra seconds. You can resubmit the request immediately.</p> </dd> <dt>RESERVED</dt> <dd> <p>The domain name has been reserved for another person or organization.</p> </dd> <dt>UNAVAILABLE</dt> <dd> <p>The domain name is not available.</p> </dd> <dt>UNAVAILABLE</em>PREMIUM</dt> <dd> <p>The domain name is not available.</p> </dd> <dt>UNAVAILABLE_RESTRICTED</dt> <dd> <p>The domain name is forbidden.</p> </dd> </dl></p>
     #[serde(rename = "Availability")]
@@ -210,7 +210,7 @@ pub struct DomainSuggestion {
 }
 
 /// <p>Summary information about one domain.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DomainSummary {
     /// <p>Indicates whether the domain is automatically renewed upon expiration.</p>
     #[serde(rename = "AutoRenew")]
@@ -229,25 +229,25 @@ pub struct DomainSummary {
     pub transfer_lock: Option<bool>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DomainTransferability {
     #[serde(rename = "Transferable")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub transferable: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct EnableDomainAutoRenewRequest {
     /// <p>The name of the domain that you want to enable automatic renewal for.</p>
     #[serde(rename = "DomainName")]
     pub domain_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct EnableDomainAutoRenewResponse {}
 
 /// <p>A request to set the transfer lock for the specified domain.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct EnableDomainTransferLockRequest {
     /// <p>The name of the domain that you want to set the transfer lock for.</p>
     #[serde(rename = "DomainName")]
@@ -255,7 +255,7 @@ pub struct EnableDomainTransferLockRequest {
 }
 
 /// <p>The EnableDomainTransferLock response includes the following elements.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct EnableDomainTransferLockResponse {
     /// <p>Identifier for tracking the progress of the request. To use this ID to query the operation status, use GetOperationDetail.</p>
     #[serde(rename = "OperationId")]
@@ -263,7 +263,7 @@ pub struct EnableDomainTransferLockResponse {
 }
 
 /// <p>ExtraParam includes the following elements.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ExtraParam {
     /// <p>Name of the additional parameter required by the top-level domain.</p>
     #[serde(rename = "Name")]
@@ -273,7 +273,7 @@ pub struct ExtraParam {
     pub value: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetContactReachabilityStatusRequest {
     /// <p>The name of the domain for which you want to know whether the registrant contact has confirmed that the email address is valid.</p>
     #[serde(rename = "domainName")]
@@ -281,7 +281,7 @@ pub struct GetContactReachabilityStatusRequest {
     pub domain_name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetContactReachabilityStatusResponse {
     /// <p>The domain name for which you requested the reachability status.</p>
     #[serde(rename = "domainName")]
@@ -294,7 +294,7 @@ pub struct GetContactReachabilityStatusResponse {
 }
 
 /// <p>The GetDomainDetail request includes the following element.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetDomainDetailRequest {
     /// <p>The name of the domain that you want to get detailed information about.</p>
     #[serde(rename = "DomainName")]
@@ -302,7 +302,7 @@ pub struct GetDomainDetailRequest {
 }
 
 /// <p>The GetDomainDetail response includes the following elements.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetDomainDetailResponse {
     /// <p>Email address to contact to report incorrect contact information for a domain, to report that the domain is being used to send spam, to report that someone is cybersquatting on a domain name, or report some other type of abuse.</p>
     #[serde(rename = "AbuseContactEmail")]
@@ -385,7 +385,7 @@ pub struct GetDomainDetailResponse {
     pub who_is_server: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetDomainSuggestionsRequest {
     /// <p>A domain name that you want to use as the basis for a list of possible domain names. The domain name must contain a top-level domain (TLD), such as .com, that Amazon Route 53 supports. For a list of TLDs, see <a href="http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/registrar-tld-list.html">Domains that You Can Register with Amazon Route 53</a> in the <i>Amazon Route 53 Developer Guide</i>.</p>
     #[serde(rename = "DomainName")]
@@ -398,7 +398,7 @@ pub struct GetDomainSuggestionsRequest {
     pub suggestion_count: i64,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetDomainSuggestionsResponse {
     /// <p>A list of possible domain names. If you specified <code>true</code> for <code>OnlyAvailable</code> in the request, the list contains only domains that are available for registration.</p>
     #[serde(rename = "SuggestionsList")]
@@ -407,7 +407,7 @@ pub struct GetDomainSuggestionsResponse {
 }
 
 /// <p>The <a>GetOperationDetail</a> request includes the following element.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetOperationDetailRequest {
     /// <p>The identifier for the operation for which you want to get the status. Amazon Route 53 returned the identifier in the response to the original request.</p>
     #[serde(rename = "OperationId")]
@@ -415,7 +415,7 @@ pub struct GetOperationDetailRequest {
 }
 
 /// <p>The GetOperationDetail response includes the following elements.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetOperationDetailResponse {
     /// <p>The name of a domain.</p>
     #[serde(rename = "DomainName")]
@@ -444,7 +444,7 @@ pub struct GetOperationDetailResponse {
 }
 
 /// <p>The ListDomains request includes the following elements.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListDomainsRequest {
     /// <p>For an initial request for a list of domains, omit this element. If the number of domains that are associated with the current AWS account is greater than the value that you specified for <code>MaxItems</code>, you can use <code>Marker</code> to return additional domains. Get the value of <code>NextPageMarker</code> from the previous response, and submit another request that includes the value of <code>NextPageMarker</code> in the <code>Marker</code> element.</p> <p>Constraints: The marker must match the value specified in the previous request.</p>
     #[serde(rename = "Marker")]
@@ -457,7 +457,7 @@ pub struct ListDomainsRequest {
 }
 
 /// <p>The ListDomains response includes the following elements.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListDomainsResponse {
     /// <p>A summary of domains.</p>
     #[serde(rename = "Domains")]
@@ -469,7 +469,7 @@ pub struct ListDomainsResponse {
 }
 
 /// <p>The ListOperations request includes the following elements.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListOperationsRequest {
     /// <p>For an initial request for a list of operations, omit this element. If the number of operations that are not yet complete is greater than the value that you specified for <code>MaxItems</code>, you can use <code>Marker</code> to return additional operations. Get the value of <code>NextPageMarker</code> from the previous response, and submit another request that includes the value of <code>NextPageMarker</code> in the <code>Marker</code> element.</p>
     #[serde(rename = "Marker")]
@@ -482,7 +482,7 @@ pub struct ListOperationsRequest {
 }
 
 /// <p>The ListOperations response includes the following elements.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListOperationsResponse {
     /// <p>If there are more operations than you specified for <code>MaxItems</code> in the request, submit another request and include the value of <code>NextPageMarker</code> in the value of <code>Marker</code>.</p>
     #[serde(rename = "NextPageMarker")]
@@ -494,7 +494,7 @@ pub struct ListOperationsResponse {
 }
 
 /// <p>The ListTagsForDomainRequest includes the following elements.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListTagsForDomainRequest {
     /// <p>The domain for which you want to get a list of tags.</p>
     #[serde(rename = "DomainName")]
@@ -502,7 +502,7 @@ pub struct ListTagsForDomainRequest {
 }
 
 /// <p>The ListTagsForDomain response includes the following elements.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListTagsForDomainResponse {
     /// <p>A list of the tags that are associated with the specified domain.</p>
     #[serde(rename = "TagList")]
@@ -510,7 +510,7 @@ pub struct ListTagsForDomainResponse {
 }
 
 /// <p>Nameserver includes the following elements.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Nameserver {
     /// <p>Glue IP address of a name server entry. Glue IP addresses are required only when the name of the name server is a subdomain of the domain. For example, if your domain is example.com and the name server for the domain is ns.example.com, you need to specify the IP address for ns.example.com.</p> <p>Constraints: The list can contain only one IPv4 and one IPv6 address.</p>
     #[serde(rename = "GlueIps")]
@@ -522,7 +522,7 @@ pub struct Nameserver {
 }
 
 /// <p>OperationSummary includes the following elements.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct OperationSummary {
     /// <p>Identifier returned to track the requested action.</p>
     #[serde(rename = "OperationId")]
@@ -539,7 +539,7 @@ pub struct OperationSummary {
 }
 
 /// <p>The RegisterDomain request includes the following elements.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RegisterDomainRequest {
     /// <p>Provides detailed contact information.</p>
     #[serde(rename = "AdminContact")]
@@ -579,7 +579,7 @@ pub struct RegisterDomainRequest {
 }
 
 /// <p>The RegisterDomain response includes the following element.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RegisterDomainResponse {
     /// <p>Identifier for tracking the progress of the request. To use this ID to query the operation status, use <a>GetOperationDetail</a>.</p>
     #[serde(rename = "OperationId")]
@@ -587,7 +587,7 @@ pub struct RegisterDomainResponse {
 }
 
 /// <p>A <code>RenewDomain</code> request includes the number of years that you want to renew for and the current expiration year.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RenewDomainRequest {
     /// <p>The year when the registration for the domain is set to expire. This value must match the current expiration date for the domain.</p>
     #[serde(rename = "CurrentExpiryYear")]
@@ -601,14 +601,14 @@ pub struct RenewDomainRequest {
     pub duration_in_years: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RenewDomainResponse {
     /// <p>The identifier for tracking the progress of the request. To use this ID to query the operation status, use <a>GetOperationDetail</a>.</p>
     #[serde(rename = "OperationId")]
     pub operation_id: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ResendContactReachabilityEmailRequest {
     /// <p>The name of the domain for which you want Amazon Route 53 to resend a confirmation email to the registrant contact.</p>
     #[serde(rename = "domainName")]
@@ -616,7 +616,7 @@ pub struct ResendContactReachabilityEmailRequest {
     pub domain_name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ResendContactReachabilityEmailResponse {
     /// <p>The domain name for which you requested a confirmation email.</p>
     #[serde(rename = "domainName")]
@@ -633,7 +633,7 @@ pub struct ResendContactReachabilityEmailResponse {
 }
 
 /// <p>A request for the authorization code for the specified domain. To transfer a domain to another registrar, you provide this value to the new registrar.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RetrieveDomainAuthCodeRequest {
     /// <p>The name of the domain that you want to get an authorization code for.</p>
     #[serde(rename = "DomainName")]
@@ -641,7 +641,7 @@ pub struct RetrieveDomainAuthCodeRequest {
 }
 
 /// <p>The RetrieveDomainAuthCode response includes the following element.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RetrieveDomainAuthCodeResponse {
     /// <p>The authorization code for the domain.</p>
     #[serde(rename = "AuthCode")]
@@ -649,7 +649,7 @@ pub struct RetrieveDomainAuthCodeResponse {
 }
 
 /// <p>Each tag includes the following elements.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Tag {
     /// <p>The key (name) of a tag.</p> <p>Valid values: A-Z, a-z, 0-9, space, ".:/=+\-@"</p> <p>Constraints: Each key can be 1-128 characters long.</p>
     #[serde(rename = "Key")]
@@ -662,7 +662,7 @@ pub struct Tag {
 }
 
 /// <p>The TransferDomain request includes the following elements.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct TransferDomainRequest {
     /// <p>Provides detailed contact information.</p>
     #[serde(rename = "AdminContact")]
@@ -710,7 +710,7 @@ pub struct TransferDomainRequest {
 }
 
 /// <p>The TranserDomain response includes the following element.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct TransferDomainResponse {
     /// <p>Identifier for tracking the progress of the request. To use this ID to query the operation status, use <a>GetOperationDetail</a>.</p>
     #[serde(rename = "OperationId")]
@@ -718,7 +718,7 @@ pub struct TransferDomainResponse {
 }
 
 /// <p>The UpdateDomainContactPrivacy request includes the following elements.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateDomainContactPrivacyRequest {
     /// <p>Whether you want to conceal contact information from WHOIS queries. If you specify <code>true</code>, WHOIS ("who is") queries will return contact information for our registrar partner, Gandi, instead of the contact information that you enter.</p>
     #[serde(rename = "AdminPrivacy")]
@@ -738,7 +738,7 @@ pub struct UpdateDomainContactPrivacyRequest {
 }
 
 /// <p>The UpdateDomainContactPrivacy response includes the following element.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateDomainContactPrivacyResponse {
     /// <p>Identifier for tracking the progress of the request. To use this ID to query the operation status, use GetOperationDetail.</p>
     #[serde(rename = "OperationId")]
@@ -746,7 +746,7 @@ pub struct UpdateDomainContactPrivacyResponse {
 }
 
 /// <p>The UpdateDomainContact request includes the following elements.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateDomainContactRequest {
     /// <p>Provides detailed contact information.</p>
     #[serde(rename = "AdminContact")]
@@ -766,7 +766,7 @@ pub struct UpdateDomainContactRequest {
 }
 
 /// <p>The UpdateDomainContact response includes the following element.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateDomainContactResponse {
     /// <p>Identifier for tracking the progress of the request. To use this ID to query the operation status, use <a>GetOperationDetail</a>.</p>
     #[serde(rename = "OperationId")]
@@ -774,7 +774,7 @@ pub struct UpdateDomainContactResponse {
 }
 
 /// <p>Replaces the current set of name servers for the domain with the specified set of name servers. If you use Amazon Route 53 as your DNS service, specify the four name servers in the delegation set for the hosted zone for the domain.</p> <p>If successful, this operation returns an operation ID that you can use to track the progress and completion of the action. If the request is not completed successfully, the domain registrant will be notified by email. </p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateDomainNameserversRequest {
     /// <p>The name of the domain that you want to change name servers for.</p>
     #[serde(rename = "DomainName")]
@@ -785,7 +785,7 @@ pub struct UpdateDomainNameserversRequest {
 }
 
 /// <p>The UpdateDomainNameservers response includes the following element.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateDomainNameserversResponse {
     /// <p>Identifier for tracking the progress of the request. To use this ID to query the operation status, use <a>GetOperationDetail</a>.</p>
     #[serde(rename = "OperationId")]
@@ -793,7 +793,7 @@ pub struct UpdateDomainNameserversResponse {
 }
 
 /// <p>The UpdateTagsForDomainRequest includes the following elements.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateTagsForDomainRequest {
     /// <p>The domain for which you want to add or update tags.</p>
     #[serde(rename = "DomainName")]
@@ -804,11 +804,11 @@ pub struct UpdateTagsForDomainRequest {
     pub tags_to_update: Option<Vec<Tag>>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateTagsForDomainResponse {}
 
 /// <p>The ViewBilling request includes the following elements.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ViewBillingRequest {
     /// <p>The end date and time for the time period for which you want a list of billing records. Specify the date in Unix time format.</p>
     #[serde(rename = "End")]
@@ -829,7 +829,7 @@ pub struct ViewBillingRequest {
 }
 
 /// <p>The ViewBilling response includes the following elements.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ViewBillingResponse {
     /// <p>A summary of billing records.</p>
     #[serde(rename = "BillingRecords")]

--- a/rusoto/services/s3/src/generated.rs
+++ b/rusoto/services/s3/src/generated.rs
@@ -46,7 +46,7 @@ enum DeserializerNext {
     Element(String),
 }
 /// <p>Specifies the days since the initiation of an Incomplete Multipart Upload that Lifecycle will wait before permanently removing all parts of the upload.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AbortIncompleteMultipartUpload {
     /// <p>Indicates the number of days that must pass since initiation for Lifecycle to abort an Incomplete Multipart Upload.</p>
     pub days_after_initiation: Option<i64>,
@@ -120,7 +120,7 @@ impl AbortIncompleteMultipartUploadSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AbortMultipartUploadOutput {
     pub request_charged: Option<String>,
 }
@@ -141,7 +141,7 @@ impl AbortMultipartUploadOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AbortMultipartUploadRequest {
     pub bucket: String,
     pub key: String,
@@ -149,7 +149,7 @@ pub struct AbortMultipartUploadRequest {
     pub upload_id: String,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AccelerateConfiguration {
     /// <p>The accelerate configuration of the bucket.</p>
     pub status: Option<String>,
@@ -179,7 +179,7 @@ impl AccelerateConfigurationSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AccessControlPolicy {
     /// <p>A list of grants.</p>
     pub grants: Option<Vec<Grant>>,
@@ -209,7 +209,7 @@ impl AccessControlPolicySerializer {
 }
 
 /// <p>Container for information regarding the access control for replicas.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AccessControlTranslation {
     /// <p>The override value for the owner of the replica object.</p>
     pub owner: String,
@@ -555,7 +555,7 @@ impl AllowedOriginsSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AnalyticsAndOperator {
     /// <p>The prefix to use when evaluating an AND predicate.</p>
     pub prefix: Option<String>,
@@ -633,7 +633,7 @@ impl AnalyticsAndOperatorSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AnalyticsConfiguration {
     /// <p>The filter used to describe a set of objects for analyses. A filter must have exactly one prefix, one tag, or one conjunction (AnalyticsAndOperator). If no filter is provided, all objects will be considered in any analysis.</p>
     pub filter: Option<AnalyticsFilter>,
@@ -752,7 +752,7 @@ impl AnalyticsConfigurationListDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AnalyticsExportDestination {
     /// <p>A destination signifying output to an S3 bucket.</p>
     pub s3_bucket_destination: AnalyticsS3BucketDestination,
@@ -823,7 +823,7 @@ impl AnalyticsExportDestinationSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AnalyticsFilter {
     /// <p>A conjunction (logical AND) of predicates, which is used in evaluating an analytics filter. The operator must have at least two predicates.</p>
     pub and: Option<AnalyticsAndOperator>,
@@ -946,7 +946,7 @@ impl AnalyticsIdSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AnalyticsS3BucketDestination {
     /// <p>The Amazon resource name (ARN) of the bucket to which data is exported.</p>
     pub bucket: String,
@@ -1166,7 +1166,7 @@ impl BodySerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Bucket {
     /// <p>Date the bucket was created.</p>
     pub creation_date: Option<String>,
@@ -1254,7 +1254,7 @@ impl BucketAccelerateStatusSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct BucketLifecycleConfiguration {
     pub rules: Vec<LifecycleRule>,
 }
@@ -1311,7 +1311,7 @@ impl BucketLocationConstraintSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct BucketLoggingStatus {
     pub logging_enabled: Option<LoggingEnabled>,
 }
@@ -1508,7 +1508,7 @@ impl BytesScannedDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CORSConfiguration {
     pub cors_rules: Vec<CORSRule>,
 }
@@ -1530,7 +1530,7 @@ impl CORSConfigurationSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CORSRule {
     /// <p>Specifies which headers are allowed in a pre-flight OPTIONS request.</p>
     pub allowed_headers: Option<Vec<String>>,
@@ -1687,7 +1687,7 @@ impl CORSRulesSerializer {
 }
 
 /// <p>Describes how a CSV-formatted input object is formatted.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CSVInput {
     /// <p>Single character used to indicate a row should be ignored when present at the start of a row.</p>
     pub comments: Option<String>,
@@ -1768,7 +1768,7 @@ impl CSVInputSerializer {
 }
 
 /// <p>Describes how CSV-formatted results are formatted.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CSVOutput {
     /// <p>Value used to separate individual fields in a record.</p>
     pub field_delimiter: Option<String>,
@@ -1873,7 +1873,7 @@ impl CloudFunctionSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CloudFunctionConfiguration {
     pub cloud_function: Option<String>,
     pub events: Option<Vec<String>>,
@@ -2050,7 +2050,7 @@ impl CommentsSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CommonPrefix {
     pub prefix: Option<String>,
 }
@@ -2119,7 +2119,7 @@ impl CommonPrefixListDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CompleteMultipartUploadOutput {
     pub bucket: Option<String>,
     /// <p>Entity tag of the object.</p>
@@ -2187,7 +2187,7 @@ impl CompleteMultipartUploadOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CompleteMultipartUploadRequest {
     pub bucket: String,
     pub key: String,
@@ -2196,7 +2196,7 @@ pub struct CompleteMultipartUploadRequest {
     pub upload_id: String,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CompletedMultipartUpload {
     pub parts: Option<Vec<CompletedPart>>,
 }
@@ -2220,7 +2220,7 @@ impl CompletedMultipartUploadSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CompletedPart {
     /// <p>Entity tag returned when the part was uploaded.</p>
     pub e_tag: Option<String>,
@@ -2298,7 +2298,7 @@ impl CompressionTypeSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Condition {
     /// <p>The HTTP error code when the redirect is applied. In the event of an error, if the error code equals this value, then the specified redirect is applied. Required when parent element Condition is specified and sibling KeyPrefixEquals is not specified. If both are specified, then both must be true for the redirect to be applied.</p>
     pub http_error_code_returned_equals: Option<String>,
@@ -2389,7 +2389,7 @@ impl ConditionSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ContinuationEvent {}
 
 struct ContinuationEventDeserializer;
@@ -2408,7 +2408,7 @@ impl ContinuationEventDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CopyObjectOutput {
     pub copy_object_result: Option<CopyObjectResult>,
     pub copy_source_version_id: Option<String>,
@@ -2468,7 +2468,7 @@ impl CopyObjectOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CopyObjectRequest {
     /// <p>The canned ACL to apply to the object.</p>
     pub acl: Option<String>,
@@ -2535,7 +2535,7 @@ pub struct CopyObjectRequest {
     pub website_redirect_location: Option<String>,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CopyObjectResult {
     pub e_tag: Option<String>,
     pub last_modified: Option<String>,
@@ -2586,7 +2586,7 @@ impl CopyObjectResultDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CopyPartResult {
     /// <p>Entity tag of the object.</p>
     pub e_tag: Option<String>,
@@ -2639,7 +2639,7 @@ impl CopyPartResultDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateBucketConfiguration {
     /// <p>Specifies the region where the bucket will be created. If you don&#39;t specify a region, the bucket will be created in US Standard.</p>
     pub location_constraint: Option<String>,
@@ -2669,7 +2669,7 @@ impl CreateBucketConfigurationSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateBucketOutput {
     pub location: Option<String>,
 }
@@ -2690,7 +2690,7 @@ impl CreateBucketOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateBucketRequest {
     /// <p>The canned ACL to apply to the bucket.</p>
     pub acl: Option<String>,
@@ -2708,7 +2708,7 @@ pub struct CreateBucketRequest {
     pub grant_write_acp: Option<String>,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateMultipartUploadOutput {
     /// <p>Date when multipart upload will become eligible for abort operation by lifecycle.</p>
     pub abort_date: Option<String>,
@@ -2779,7 +2779,7 @@ impl CreateMultipartUploadOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateMultipartUploadRequest {
     /// <p>The canned ACL to apply to the object.</p>
     pub acl: Option<String>,
@@ -2945,7 +2945,7 @@ impl DaysAfterInitiationSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Delete {
     pub objects: Vec<ObjectIdentifier>,
     /// <p>Element to enable quiet mode for the request. When you add this element, you must set its value to true.</p>
@@ -2977,7 +2977,7 @@ impl DeleteSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteBucketAnalyticsConfigurationRequest {
     /// <p>The name of the bucket from which an analytics configuration is deleted.</p>
     pub bucket: String,
@@ -2985,18 +2985,18 @@ pub struct DeleteBucketAnalyticsConfigurationRequest {
     pub id: String,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteBucketCorsRequest {
     pub bucket: String,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteBucketEncryptionRequest {
     /// <p>The name of the bucket containing the server-side encryption configuration to delete.</p>
     pub bucket: String,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteBucketInventoryConfigurationRequest {
     /// <p>The name of the bucket containing the inventory configuration to delete.</p>
     pub bucket: String,
@@ -3004,12 +3004,12 @@ pub struct DeleteBucketInventoryConfigurationRequest {
     pub id: String,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteBucketLifecycleRequest {
     pub bucket: String,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteBucketMetricsConfigurationRequest {
     /// <p>The name of the bucket containing the metrics configuration to delete.</p>
     pub bucket: String,
@@ -3017,27 +3017,27 @@ pub struct DeleteBucketMetricsConfigurationRequest {
     pub id: String,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteBucketPolicyRequest {
     pub bucket: String,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteBucketReplicationRequest {
     pub bucket: String,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteBucketRequest {
     pub bucket: String,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteBucketTaggingRequest {
     pub bucket: String,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteBucketWebsiteRequest {
     pub bucket: String,
 }
@@ -3056,7 +3056,7 @@ impl DeleteMarkerDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteMarkerEntry {
     /// <p>Specifies whether the object is (true) or is not (false) the latest version of an object.</p>
     pub is_latest: Option<bool>,
@@ -3168,7 +3168,7 @@ impl DeleteMarkersDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteObjectOutput {
     /// <p>Specifies whether the versioned object that was permanently deleted was (true) or was not (false) a delete marker.</p>
     pub delete_marker: Option<bool>,
@@ -3193,7 +3193,7 @@ impl DeleteObjectOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteObjectRequest {
     pub bucket: String,
     pub key: String,
@@ -3204,7 +3204,7 @@ pub struct DeleteObjectRequest {
     pub version_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteObjectTaggingOutput {
     /// <p>The versionId of the object the tag-set was removed from.</p>
     pub version_id: Option<String>,
@@ -3226,7 +3226,7 @@ impl DeleteObjectTaggingOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteObjectTaggingRequest {
     pub bucket: String,
     pub key: String,
@@ -3234,7 +3234,7 @@ pub struct DeleteObjectTaggingRequest {
     pub version_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteObjectsOutput {
     pub deleted: Option<Vec<DeletedObject>>,
     pub errors: Option<Vec<S3Error>>,
@@ -3285,7 +3285,7 @@ impl DeleteObjectsOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteObjectsRequest {
     pub bucket: String,
     pub delete: Delete,
@@ -3294,7 +3294,7 @@ pub struct DeleteObjectsRequest {
     pub request_payer: Option<String>,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeletedObject {
     pub delete_marker: Option<bool>,
     pub delete_marker_version_id: Option<String>,
@@ -3443,7 +3443,7 @@ impl DescriptionSerializer {
 }
 
 /// <p>Container for replication destination information.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Destination {
     /// <p>Container for information regarding the access control for replicas.</p>
     pub access_control_translation: Option<AccessControlTranslation>,
@@ -3734,7 +3734,7 @@ impl EncodingTypeSerializer {
 }
 
 /// <p>Describes the server-side encryption that will be applied to the restore results.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Encryption {
     /// <p>The server-side encryption algorithm used when storing job results in Amazon S3 (e.g., AES256, aws:kms).</p>
     pub encryption_type: String,
@@ -3783,7 +3783,7 @@ impl EncryptionSerializer {
 }
 
 /// <p>Container for information regarding encryption based configuration for replicas.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct EncryptionConfiguration {
     /// <p>The id of the KMS key used to encrypt the replica object.</p>
     pub replica_kms_key_id: Option<String>,
@@ -3855,7 +3855,7 @@ impl EncryptionConfigurationSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct EndEvent {}
 
 struct EndEventDeserializer;
@@ -3874,7 +3874,7 @@ impl EndEventDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct S3Error {
     pub code: Option<String>,
     pub key: Option<String>,
@@ -3934,7 +3934,7 @@ impl S3ErrorDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ErrorDocument {
     /// <p>The object key name to use when a 4XX class error occurs.</p>
     pub key: String,
@@ -4356,7 +4356,7 @@ impl FileHeaderInfoSerializer {
 }
 
 /// <p>Container for key value pair that defines the criteria for the filter rule.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct FilterRule {
     /// <p>Object key name prefix or suffix identifying one or more objects to which the filtering rule applies. Maximum prefix length can be up to 1,024 characters. Overlapping prefixes and suffixes are not supported. For more information, go to <a href="http://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html">Configuring Event Notifications</a> in the Amazon Simple Storage Service Developer Guide.</p>
     pub name: Option<String>,
@@ -4555,7 +4555,7 @@ impl FilterRuleValueSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetBucketAccelerateConfigurationOutput {
     /// <p>The accelerate configuration of the bucket.</p>
     pub status: Option<String>,
@@ -4602,13 +4602,13 @@ impl GetBucketAccelerateConfigurationOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetBucketAccelerateConfigurationRequest {
     /// <p>Name of the bucket for which the accelerate configuration is retrieved.</p>
     pub bucket: String,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetBucketAclOutput {
     /// <p>A list of grants.</p>
     pub grants: Option<Vec<Grant>>,
@@ -4660,12 +4660,12 @@ impl GetBucketAclOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetBucketAclRequest {
     pub bucket: String,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetBucketAnalyticsConfigurationOutput {
     /// <p>The configuration and any analyses for the analytics filter.</p>
     pub analytics_configuration: Option<AnalyticsConfiguration>,
@@ -4714,7 +4714,7 @@ impl GetBucketAnalyticsConfigurationOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetBucketAnalyticsConfigurationRequest {
     /// <p>The name of the bucket from which an analytics configuration is retrieved.</p>
     pub bucket: String,
@@ -4722,7 +4722,7 @@ pub struct GetBucketAnalyticsConfigurationRequest {
     pub id: String,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetBucketCorsOutput {
     pub cors_rules: Option<Vec<CORSRule>>,
 }
@@ -4767,12 +4767,12 @@ impl GetBucketCorsOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetBucketCorsRequest {
     pub bucket: String,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetBucketEncryptionOutput {
     pub server_side_encryption_configuration: Option<ServerSideEncryptionConfiguration>,
 }
@@ -4821,13 +4821,13 @@ impl GetBucketEncryptionOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetBucketEncryptionRequest {
     /// <p>The name of the bucket from which the server-side encryption configuration is retrieved.</p>
     pub bucket: String,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetBucketInventoryConfigurationOutput {
     /// <p>Specifies the inventory configuration.</p>
     pub inventory_configuration: Option<InventoryConfiguration>,
@@ -4876,7 +4876,7 @@ impl GetBucketInventoryConfigurationOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetBucketInventoryConfigurationRequest {
     /// <p>The name of the bucket containing the inventory configuration to retrieve.</p>
     pub bucket: String,
@@ -4884,7 +4884,7 @@ pub struct GetBucketInventoryConfigurationRequest {
     pub id: String,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetBucketLifecycleConfigurationOutput {
     pub rules: Option<Vec<LifecycleRule>>,
 }
@@ -4929,12 +4929,12 @@ impl GetBucketLifecycleConfigurationOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetBucketLifecycleConfigurationRequest {
     pub bucket: String,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetBucketLifecycleOutput {
     pub rules: Option<Vec<Rule>>,
 }
@@ -4978,12 +4978,12 @@ impl GetBucketLifecycleOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetBucketLifecycleRequest {
     pub bucket: String,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetBucketLocationOutput {
     pub location_constraint: Option<String>,
 }
@@ -5003,12 +5003,12 @@ impl GetBucketLocationOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetBucketLocationRequest {
     pub bucket: String,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetBucketLoggingOutput {
     pub logging_enabled: Option<LoggingEnabled>,
 }
@@ -5055,12 +5055,12 @@ impl GetBucketLoggingOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetBucketLoggingRequest {
     pub bucket: String,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetBucketMetricsConfigurationOutput {
     /// <p>Specifies the metrics configuration.</p>
     pub metrics_configuration: Option<MetricsConfiguration>,
@@ -5109,7 +5109,7 @@ impl GetBucketMetricsConfigurationOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetBucketMetricsConfigurationRequest {
     /// <p>The name of the bucket containing the metrics configuration to retrieve.</p>
     pub bucket: String,
@@ -5117,24 +5117,24 @@ pub struct GetBucketMetricsConfigurationRequest {
     pub id: String,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetBucketNotificationConfigurationRequest {
     /// <p>Name of the bucket to get the notification configuration for.</p>
     pub bucket: String,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetBucketPolicyOutput {
     /// <p>The bucket policy as a JSON document.</p>
     pub policy: Option<String>,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetBucketPolicyRequest {
     pub bucket: String,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetBucketReplicationOutput {
     pub replication_configuration: Option<ReplicationConfiguration>,
 }
@@ -5182,12 +5182,12 @@ impl GetBucketReplicationOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetBucketReplicationRequest {
     pub bucket: String,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetBucketRequestPaymentOutput {
     /// <p>Specifies who pays for the download and request fees.</p>
     pub payer: Option<String>,
@@ -5232,12 +5232,12 @@ impl GetBucketRequestPaymentOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetBucketRequestPaymentRequest {
     pub bucket: String,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetBucketTaggingOutput {
     pub tag_set: Vec<Tag>,
 }
@@ -5281,12 +5281,12 @@ impl GetBucketTaggingOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetBucketTaggingRequest {
     pub bucket: String,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetBucketVersioningOutput {
     /// <p>Specifies whether MFA delete is enabled in the bucket versioning configuration. This element is only returned if the bucket has been configured with MFA delete. If the bucket has never been so configured, this element is not returned.</p>
     pub mfa_delete: Option<String>,
@@ -5341,12 +5341,12 @@ impl GetBucketVersioningOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetBucketVersioningRequest {
     pub bucket: String,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetBucketWebsiteOutput {
     pub error_document: Option<ErrorDocument>,
     pub index_document: Option<IndexDocument>,
@@ -5415,12 +5415,12 @@ impl GetBucketWebsiteOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetBucketWebsiteRequest {
     pub bucket: String,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetObjectAclOutput {
     /// <p>A list of grants.</p>
     pub grants: Option<Vec<Grant>>,
@@ -5473,7 +5473,7 @@ impl GetObjectAclOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetObjectAclRequest {
     pub bucket: String,
     pub key: String,
@@ -5538,7 +5538,7 @@ pub struct GetObjectOutput {
     pub website_redirect_location: Option<String>,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetObjectRequest {
     pub bucket: String,
     /// <p>Return the object only if its entity tag (ETag) is the same as the one specified, otherwise return a 412 (precondition failed).</p>
@@ -5577,7 +5577,7 @@ pub struct GetObjectRequest {
     pub version_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetObjectTaggingOutput {
     pub tag_set: Vec<Tag>,
     pub version_id: Option<String>,
@@ -5622,7 +5622,7 @@ impl GetObjectTaggingOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetObjectTaggingRequest {
     pub bucket: String,
     pub key: String,
@@ -5635,14 +5635,14 @@ pub struct GetObjectTorrentOutput {
     pub request_charged: Option<String>,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetObjectTorrentRequest {
     pub bucket: String,
     pub key: String,
     pub request_payer: Option<String>,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GlacierJobParameters {
     /// <p>Glacier retrieval tier at which the restore will be processed.</p>
     pub tier: String,
@@ -5670,7 +5670,7 @@ impl GlacierJobParametersSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Grant {
     pub grantee: Option<Grantee>,
     /// <p>Specifies the permission given to the grantee.</p>
@@ -5751,7 +5751,7 @@ impl GrantSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Grantee {
     /// <p>Screen name of the grantee.</p>
     pub display_name: Option<String>,
@@ -5938,12 +5938,12 @@ impl GrantsSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct HeadBucketRequest {
     pub bucket: String,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct HeadObjectOutput {
     pub accept_ranges: Option<String>,
     /// <p>Specifies caching behavior along the request/reply chain.</p>
@@ -6009,7 +6009,7 @@ impl HeadObjectOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct HeadObjectRequest {
     pub bucket: String,
     /// <p>Return the object only if its entity tag (ETag) is the same as the one specified, otherwise return a 412 (precondition failed).</p>
@@ -6176,7 +6176,7 @@ impl IDSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct IndexDocument {
     /// <p>A suffix that is appended to a request that is for a directory on the website endpoint (e.g. if the suffix is index.html and you make a request to samplebucket/images/ the data that is returned will be for the object with the key name images/index.html) The suffix must not be empty and must not include a slash character.</p>
     pub suffix: String,
@@ -6258,7 +6258,7 @@ impl InitiatedDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Initiator {
     /// <p>Name of the Principal.</p>
     pub display_name: Option<String>,
@@ -6312,7 +6312,7 @@ impl InitiatorDeserializer {
     }
 }
 /// <p>Describes the serialization format of the object.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct InputSerialization {
     /// <p>Describes the serialization of a CSV-encoded object.</p>
     pub csv: Option<CSVInput>,
@@ -6352,7 +6352,7 @@ impl InputSerializationSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct InventoryConfiguration {
     /// <p>Contains information about where to publish the inventory results.</p>
     pub destination: InventoryDestination,
@@ -6515,7 +6515,7 @@ impl InventoryConfigurationListDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct InventoryDestination {
     /// <p>Contains the bucket name, file format, bucket owner (optional), and prefix (optional) where inventory results are published.</p>
     pub s3_bucket_destination: InventoryS3BucketDestination,
@@ -6587,7 +6587,7 @@ impl InventoryDestinationSerializer {
 }
 
 /// <p>Contains the type of server-side encryption used to encrypt the inventory results.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct InventoryEncryption {
     /// <p>Specifies the use of SSE-KMS to encrypt delievered Inventory reports.</p>
     pub ssekms: Option<SSEKMS>,
@@ -6660,7 +6660,7 @@ impl InventoryEncryptionSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct InventoryFilter {
     /// <p>The prefix that an object must have to be included in the inventory results.</p>
     pub prefix: String,
@@ -6966,7 +6966,7 @@ impl InventoryOptionalFieldsSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct InventoryS3BucketDestination {
     /// <p>The ID of the account that owns the destination bucket.</p>
     pub account_id: Option<String>,
@@ -7084,7 +7084,7 @@ impl InventoryS3BucketDestinationSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct InventorySchedule {
     /// <p>Specifies how frequently inventory results are produced.</p>
     pub frequency: String,
@@ -7218,7 +7218,7 @@ impl IsTruncatedDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct JSONInput {
     /// <p>The type of JSON. Valid values: Document, Lines.</p>
     pub type_: Option<String>,
@@ -7248,7 +7248,7 @@ impl JSONInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct JSONOutput {
     /// <p>The value used to separate individual records in the output.</p>
     pub record_delimiter: Option<String>,
@@ -7438,7 +7438,7 @@ impl LambdaFunctionArnSerializer {
 }
 
 /// <p>Container for specifying the AWS Lambda notification configuration.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct LambdaFunctionConfiguration {
     pub events: Vec<String>,
     pub filter: Option<NotificationConfigurationFilter>,
@@ -7597,7 +7597,7 @@ impl LastModifiedDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct LifecycleConfiguration {
     pub rules: Vec<Rule>,
 }
@@ -7619,7 +7619,7 @@ impl LifecycleConfigurationSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct LifecycleExpiration {
     /// <p>Indicates at what date the object is to be moved or deleted. Should be in GMT ISO 8601 Format.</p>
     pub date: Option<String>,
@@ -7721,7 +7721,7 @@ impl LifecycleExpirationSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct LifecycleRule {
     pub abort_incomplete_multipart_upload: Option<AbortIncompleteMultipartUpload>,
     pub expiration: Option<LifecycleExpiration>,
@@ -7880,7 +7880,7 @@ impl LifecycleRuleSerializer {
 }
 
 /// <p>This is used in a Lifecycle Rule Filter to apply a logical AND to two or more predicates. The Lifecycle Rule will apply to any object matching all of the predicates configured inside the And operator.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct LifecycleRuleAndOperator {
     pub prefix: Option<String>,
     /// <p>All of these tags must exist in the object&#39;s tag set in order for the rule to apply.</p>
@@ -7958,7 +7958,7 @@ impl LifecycleRuleAndOperatorSerializer {
 }
 
 /// <p>The Filter is used to identify objects that a Lifecycle Rule applies to. A Filter must have exactly one of Prefix, Tag, or And specified.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct LifecycleRuleFilter {
     pub and: Option<LifecycleRuleAndOperator>,
     /// <p>Prefix identifying one or more objects to which the rule applies.</p>
@@ -8091,7 +8091,7 @@ impl LifecycleRulesSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListBucketAnalyticsConfigurationsOutput {
     /// <p>The list of analytics configurations for a bucket.</p>
     pub analytics_configuration_list: Option<Vec<AnalyticsConfiguration>>,
@@ -8163,7 +8163,7 @@ impl ListBucketAnalyticsConfigurationsOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListBucketAnalyticsConfigurationsRequest {
     /// <p>The name of the bucket from which analytics configurations are retrieved.</p>
     pub bucket: String,
@@ -8171,7 +8171,7 @@ pub struct ListBucketAnalyticsConfigurationsRequest {
     pub continuation_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListBucketInventoryConfigurationsOutput {
     /// <p>If sent in the request, the marker that is used as a starting point for this inventory configuration list response.</p>
     pub continuation_token: Option<String>,
@@ -8243,7 +8243,7 @@ impl ListBucketInventoryConfigurationsOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListBucketInventoryConfigurationsRequest {
     /// <p>The name of the bucket containing the inventory configurations to retrieve.</p>
     pub bucket: String,
@@ -8251,7 +8251,7 @@ pub struct ListBucketInventoryConfigurationsRequest {
     pub continuation_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListBucketMetricsConfigurationsOutput {
     /// <p>The marker that is used as a starting point for this metrics configuration list response. This value is present if it was sent in the request.</p>
     pub continuation_token: Option<String>,
@@ -8323,7 +8323,7 @@ impl ListBucketMetricsConfigurationsOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListBucketMetricsConfigurationsRequest {
     /// <p>The name of the bucket containing the metrics configurations to retrieve.</p>
     pub bucket: String,
@@ -8331,7 +8331,7 @@ pub struct ListBucketMetricsConfigurationsRequest {
     pub continuation_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListBucketsOutput {
     pub buckets: Option<Vec<Bucket>>,
     pub owner: Option<Owner>,
@@ -8380,7 +8380,7 @@ impl ListBucketsOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListMultipartUploadsOutput {
     /// <p>Name of the bucket to which the multipart upload was initiated.</p>
     pub bucket: Option<String>,
@@ -8503,7 +8503,7 @@ impl ListMultipartUploadsOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListMultipartUploadsRequest {
     pub bucket: String,
     /// <p>Character you use to group keys.</p>
@@ -8519,7 +8519,7 @@ pub struct ListMultipartUploadsRequest {
     pub upload_id_marker: Option<String>,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListObjectVersionsOutput {
     pub common_prefixes: Option<Vec<CommonPrefix>>,
     pub delete_markers: Option<Vec<DeleteMarkerEntry>>,
@@ -8641,7 +8641,7 @@ impl ListObjectVersionsOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListObjectVersionsRequest {
     pub bucket: String,
     /// <p>A delimiter is a character you use to group keys.</p>
@@ -8657,7 +8657,7 @@ pub struct ListObjectVersionsRequest {
     pub version_id_marker: Option<String>,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListObjectsOutput {
     pub common_prefixes: Option<Vec<CommonPrefix>>,
     pub contents: Option<Vec<Object>>,
@@ -8754,7 +8754,7 @@ impl ListObjectsOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListObjectsRequest {
     pub bucket: String,
     /// <p>A delimiter is a character you use to group keys.</p>
@@ -8770,7 +8770,7 @@ pub struct ListObjectsRequest {
     pub request_payer: Option<String>,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListObjectsV2Output {
     /// <p>CommonPrefixes contains all (if there are any) keys between Prefix and the next occurrence of the string specified by delimiter</p>
     pub common_prefixes: Option<Vec<CommonPrefix>>,
@@ -8890,7 +8890,7 @@ impl ListObjectsV2OutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListObjectsV2Request {
     /// <p>Name of the bucket to list.</p>
     pub bucket: String,
@@ -8912,7 +8912,7 @@ pub struct ListObjectsV2Request {
     pub start_after: Option<String>,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListPartsOutput {
     /// <p>Date when multipart upload will become eligible for abort operation by lifecycle.</p>
     pub abort_date: Option<String>,
@@ -9027,7 +9027,7 @@ impl ListPartsOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListPartsRequest {
     pub bucket: String,
     pub key: String,
@@ -9076,7 +9076,7 @@ impl LocationPrefixSerializer {
 }
 
 /// <p>Container for logging information. Presence of this element indicates that logging is enabled. Parameters TargetBucket and TargetPrefix are required in this case.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct LoggingEnabled {
     /// <p>Specifies the bucket where you want Amazon S3 to store server access logs. You can have your logs delivered to any bucket that you own, including the same bucket that is being logged. You can also configure multiple buckets to deliver their logs to the same target bucket. In this case you should choose a different TargetPrefix for each source bucket so that the delivered log files can be distinguished by key.</p>
     pub target_bucket: String,
@@ -9391,7 +9391,7 @@ impl MessageDeserializer {
     }
 }
 /// <p>A metadata key-value pair to store with an object.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct MetadataEntry {
     pub name: Option<String>,
     pub value: Option<String>,
@@ -9469,7 +9469,7 @@ impl MetadataValueSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct MetricsAndOperator {
     /// <p>The prefix used when evaluating an AND predicate.</p>
     pub prefix: Option<String>,
@@ -9547,7 +9547,7 @@ impl MetricsAndOperatorSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct MetricsConfiguration {
     /// <p>Specifies a metrics configuration filter. The metrics configuration will only include objects that meet the filter&#39;s criteria. A filter must be a prefix, a tag, or a conjunction (MetricsAndOperator).</p>
     pub filter: Option<MetricsFilter>,
@@ -9652,7 +9652,7 @@ impl MetricsConfigurationListDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct MetricsFilter {
     /// <p>A conjunction (logical AND) of predicates, which is used in evaluating a metrics filter. The operator must have at least two predicates, and an object must match all of the predicates in order for the filter to apply.</p>
     pub and: Option<MetricsAndOperator>,
@@ -9775,7 +9775,7 @@ impl MetricsIdSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct MultipartUpload {
     /// <p>Date and time at which the multipart upload was initiated.</p>
     pub initiated: Option<String>,
@@ -9998,7 +9998,7 @@ impl NextVersionIdMarkerDeserializer {
     }
 }
 /// <p>Specifies when noncurrent object versions expire. Upon expiration, Amazon S3 permanently deletes the noncurrent object versions. You set this lifecycle configuration action on a bucket that has versioning enabled (or suspended) to request that Amazon S3 delete noncurrent object versions at a specific period in the object&#39;s lifetime.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct NoncurrentVersionExpiration {
     /// <p>Specifies the number of days an object is noncurrent before Amazon S3 can perform the associated action. For information about the noncurrent days calculations, see <a href="http://docs.aws.amazon.com/AmazonS3/latest/dev/s3-access-control.html">How Amazon S3 Calculates When an Object Became Noncurrent</a> in the Amazon Simple Storage Service Developer Guide.</p>
     pub noncurrent_days: Option<i64>,
@@ -10070,7 +10070,7 @@ impl NoncurrentVersionExpirationSerializer {
 }
 
 /// <p>Container for the transition rule that describes when noncurrent objects transition to the STANDARD<em>IA, ONEZONE</em>IA or GLACIER storage class. If your bucket is versioning-enabled (or versioning is suspended), you can set this action to request that Amazon S3 transition noncurrent object versions to the STANDARD<em>IA, ONEZONE</em>IA or GLACIER storage class at a specific period in the object&#39;s lifetime.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct NoncurrentVersionTransition {
     /// <p>Specifies the number of days an object is noncurrent before Amazon S3 can perform the associated action. For information about the noncurrent days calculations, see <a href="http://docs.aws.amazon.com/AmazonS3/latest/dev/s3-access-control.html">How Amazon S3 Calculates When an Object Became Noncurrent</a> in the Amazon Simple Storage Service Developer Guide.</p>
     pub noncurrent_days: Option<i64>,
@@ -10203,7 +10203,7 @@ impl NoncurrentVersionTransitionListSerializer {
 }
 
 /// <p>Container for specifying the notification configuration of the bucket. If this element is empty, notifications are turned off on the bucket.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct NotificationConfiguration {
     pub lambda_function_configurations: Option<Vec<LambdaFunctionConfiguration>>,
     pub queue_configurations: Option<Vec<QueueConfiguration>>,
@@ -10298,7 +10298,7 @@ impl NotificationConfigurationSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct NotificationConfigurationDeprecated {
     pub cloud_function_configuration: Option<CloudFunctionConfiguration>,
     pub queue_configuration: Option<QueueConfigurationDeprecated>,
@@ -10401,7 +10401,7 @@ impl NotificationConfigurationDeprecatedSerializer {
 }
 
 /// <p>Container for object key name filtering rules. For information about key name filtering, go to <a href="http://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html">Configuring Event Notifications</a> in the Amazon Simple Storage Service Developer Guide.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct NotificationConfigurationFilter {
     pub key: Option<S3KeyFilter>,
 }
@@ -10500,7 +10500,7 @@ impl NotificationIdSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Object {
     pub e_tag: Option<String>,
     pub key: Option<String>,
@@ -10591,7 +10591,7 @@ impl ObjectCannedACLSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ObjectIdentifier {
     /// <p>Key name of the object to delete.</p>
     pub key: String,
@@ -10721,7 +10721,7 @@ impl ObjectStorageClassDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ObjectVersion {
     pub e_tag: Option<String>,
     /// <p>Specifies whether the object is (true) or is not (false) the latest version of an object.</p>
@@ -10887,7 +10887,7 @@ impl ObjectVersionStorageClassDeserializer {
     }
 }
 /// <p>Describes the location where the restore job&#39;s output is stored.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct OutputLocation {
     /// <p>Describes an S3 location that will receive the results of the restore request.</p>
     pub s3: Option<S3Location>,
@@ -10913,7 +10913,7 @@ impl OutputLocationSerializer {
 }
 
 /// <p>Describes how results of the Select job are serialized.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct OutputSerialization {
     /// <p>Describes the serialization of CSV-encoded Select results.</p>
     pub csv: Option<CSVOutput>,
@@ -10943,7 +10943,7 @@ impl OutputSerializationSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Owner {
     pub display_name: Option<String>,
     pub id: Option<String>,
@@ -11062,7 +11062,7 @@ impl OwnerOverrideSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Part {
     /// <p>Entity tag returned when the part was uploaded.</p>
     pub e_tag: Option<String>,
@@ -11348,7 +11348,7 @@ impl PrefixSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Progress {
     /// <p>Current number of uncompressed object bytes processed.</p>
     pub bytes_processed: Option<i64>,
@@ -11404,7 +11404,7 @@ impl ProgressDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ProgressEvent {
     /// <p>The Progress event details.</p>
     pub details: Option<Progress>,
@@ -11485,7 +11485,7 @@ impl ProtocolSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PutBucketAccelerateConfigurationRequest {
     /// <p>Specifies the Accelerate Configuration you want to set for the bucket.</p>
     pub accelerate_configuration: AccelerateConfiguration,
@@ -11493,7 +11493,7 @@ pub struct PutBucketAccelerateConfigurationRequest {
     pub bucket: String,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PutBucketAclRequest {
     /// <p>The canned ACL to apply to the bucket.</p>
     pub acl: Option<String>,
@@ -11512,7 +11512,7 @@ pub struct PutBucketAclRequest {
     pub grant_write_acp: Option<String>,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PutBucketAnalyticsConfigurationRequest {
     /// <p>The configuration and any analyses for the analytics filter.</p>
     pub analytics_configuration: AnalyticsConfiguration,
@@ -11522,14 +11522,14 @@ pub struct PutBucketAnalyticsConfigurationRequest {
     pub id: String,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PutBucketCorsRequest {
     pub bucket: String,
     pub cors_configuration: CORSConfiguration,
     pub content_md5: Option<String>,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PutBucketEncryptionRequest {
     /// <p>The name of the bucket for which the server-side encryption configuration is set.</p>
     pub bucket: String,
@@ -11538,7 +11538,7 @@ pub struct PutBucketEncryptionRequest {
     pub server_side_encryption_configuration: ServerSideEncryptionConfiguration,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PutBucketInventoryConfigurationRequest {
     /// <p>The name of the bucket where the inventory configuration will be stored.</p>
     pub bucket: String,
@@ -11548,27 +11548,27 @@ pub struct PutBucketInventoryConfigurationRequest {
     pub inventory_configuration: InventoryConfiguration,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PutBucketLifecycleConfigurationRequest {
     pub bucket: String,
     pub lifecycle_configuration: Option<BucketLifecycleConfiguration>,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PutBucketLifecycleRequest {
     pub bucket: String,
     pub content_md5: Option<String>,
     pub lifecycle_configuration: Option<LifecycleConfiguration>,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PutBucketLoggingRequest {
     pub bucket: String,
     pub bucket_logging_status: BucketLoggingStatus,
     pub content_md5: Option<String>,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PutBucketMetricsConfigurationRequest {
     /// <p>The name of the bucket for which the metrics configuration is set.</p>
     pub bucket: String,
@@ -11578,20 +11578,20 @@ pub struct PutBucketMetricsConfigurationRequest {
     pub metrics_configuration: MetricsConfiguration,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PutBucketNotificationConfigurationRequest {
     pub bucket: String,
     pub notification_configuration: NotificationConfiguration,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PutBucketNotificationRequest {
     pub bucket: String,
     pub content_md5: Option<String>,
     pub notification_configuration: NotificationConfigurationDeprecated,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PutBucketPolicyRequest {
     pub bucket: String,
     /// <p>Set this parameter to true to confirm that you want to remove your permissions to change this bucket policy in the future.</p>
@@ -11601,28 +11601,28 @@ pub struct PutBucketPolicyRequest {
     pub policy: String,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PutBucketReplicationRequest {
     pub bucket: String,
     pub content_md5: Option<String>,
     pub replication_configuration: ReplicationConfiguration,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PutBucketRequestPaymentRequest {
     pub bucket: String,
     pub content_md5: Option<String>,
     pub request_payment_configuration: RequestPaymentConfiguration,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PutBucketTaggingRequest {
     pub bucket: String,
     pub content_md5: Option<String>,
     pub tagging: Tagging,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PutBucketVersioningRequest {
     pub bucket: String,
     pub content_md5: Option<String>,
@@ -11631,14 +11631,14 @@ pub struct PutBucketVersioningRequest {
     pub versioning_configuration: VersioningConfiguration,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PutBucketWebsiteRequest {
     pub bucket: String,
     pub content_md5: Option<String>,
     pub website_configuration: WebsiteConfiguration,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PutObjectAclOutput {
     pub request_charged: Option<String>,
 }
@@ -11659,7 +11659,7 @@ impl PutObjectAclOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PutObjectAclRequest {
     /// <p>The canned ACL to apply to the object.</p>
     pub acl: Option<String>,
@@ -11682,7 +11682,7 @@ pub struct PutObjectAclRequest {
     pub version_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PutObjectOutput {
     /// <p>Entity tag for the uploaded object.</p>
     pub e_tag: Option<String>,
@@ -11772,7 +11772,7 @@ pub struct PutObjectRequest {
     pub website_redirect_location: Option<String>,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PutObjectTaggingOutput {
     pub version_id: Option<String>,
 }
@@ -11793,7 +11793,7 @@ impl PutObjectTaggingOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PutObjectTaggingRequest {
     pub bucket: String,
     pub content_md5: Option<String>,
@@ -11838,7 +11838,7 @@ impl QueueArnSerializer {
 }
 
 /// <p>Container for specifying an configuration when you want Amazon S3 to publish events to an Amazon Simple Queue Service (Amazon SQS) queue.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct QueueConfiguration {
     pub events: Vec<String>,
     pub filter: Option<NotificationConfigurationFilter>,
@@ -11934,7 +11934,7 @@ impl QueueConfigurationSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct QueueConfigurationDeprecated {
     pub events: Option<Vec<String>>,
     pub id: Option<String>,
@@ -12168,7 +12168,7 @@ impl RecordDelimiterSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RecordsEvent {
     /// <p>The byte array of partial, one or more result records.</p>
     pub payload: Option<Vec<u8>>,
@@ -12213,7 +12213,7 @@ impl RecordsEventDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Redirect {
     /// <p>The host name to use in the redirect request.</p>
     pub host_name: Option<String>,
@@ -12346,7 +12346,7 @@ impl RedirectSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RedirectAllRequestsTo {
     /// <p>Name of the host where requests will be redirected.</p>
     pub host_name: String,
@@ -12534,7 +12534,7 @@ impl ReplicaKmsKeyIDSerializer {
 }
 
 /// <p>Container for replication rules. You can add as many as 1,000 rules. Total replication configuration size can be up to 2 MB.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ReplicationConfiguration {
     /// <p>Amazon Resource Name (ARN) of an IAM role for Amazon S3 to assume when replicating the objects.</p>
     pub role: String,
@@ -12609,7 +12609,7 @@ impl ReplicationConfigurationSerializer {
 }
 
 /// <p>Container for information about a particular replication rule.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ReplicationRule {
     /// <p>Container for replication destination information.</p>
     pub destination: Destination,
@@ -12807,7 +12807,7 @@ impl ReplicationRulesSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RequestPaymentConfiguration {
     /// <p>Specifies who pays for the download and request fees.</p>
     pub payer: String,
@@ -12835,7 +12835,7 @@ impl RequestPaymentConfigurationSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RequestProgress {
     /// <p>Specifies whether periodic QueryProgress frames should be sent. Valid values: TRUE, FALSE. Default value: FALSE.</p>
     pub enabled: Option<bool>,
@@ -12985,7 +12985,7 @@ impl ResponseExpiresSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RestoreObjectOutput {
     pub request_charged: Option<String>,
     /// <p>Indicates the path in the provided S3 output location where Select results will be restored to.</p>
@@ -13008,7 +13008,7 @@ impl RestoreObjectOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RestoreObjectRequest {
     pub bucket: String,
     pub key: String,
@@ -13018,7 +13018,7 @@ pub struct RestoreObjectRequest {
 }
 
 /// <p>Container for restore job parameters.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RestoreRequest {
     /// <p>Lifetime of the active copy in days. Do not use with restores that specify OutputLocation.</p>
     pub days: Option<i64>,
@@ -13148,7 +13148,7 @@ impl RoleSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RoutingRule {
     /// <p>A container for describing a condition that must be met for the specified redirect to apply. For example, 1. If request is for pages in the /docs folder, redirect to the /documents folder. 2. If request results in HTTP error 4xx, redirect request to another host where you might process the error.</p>
     pub condition: Option<Condition>,
@@ -13284,7 +13284,7 @@ impl RoutingRulesSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Rule {
     pub abort_incomplete_multipart_upload: Option<AbortIncompleteMultipartUpload>,
     pub expiration: Option<LifecycleExpiration>,
@@ -13488,7 +13488,7 @@ impl RulesSerializer {
 }
 
 /// <p>Container for object key name prefix and suffix filtering rules.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct S3KeyFilter {
     pub filter_rules: Option<Vec<FilterRule>>,
 }
@@ -13556,7 +13556,7 @@ impl S3KeyFilterSerializer {
 }
 
 /// <p>Describes an S3 location that will receive the results of the restore request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct S3Location {
     /// <p>A list of grants that control access to the staged results.</p>
     pub access_control_list: Option<Vec<Grant>>,
@@ -13632,7 +13632,7 @@ impl S3LocationSerializer {
 }
 
 /// <p>Specifies the use of SSE-KMS to encrypt delievered Inventory reports.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SSEKMS {
     /// <p>Specifies the ID of the AWS Key Management Service (KMS) master encryption key to use for encrypting Inventory reports.</p>
     pub key_id: String,
@@ -13736,7 +13736,7 @@ impl SSEKMSKeyIdSerializer {
 }
 
 /// <p>Specifies the use of SSE-S3 to encrypt delievered Inventory reports.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SSES3 {}
 
 struct SSES3Deserializer;
@@ -13772,7 +13772,7 @@ impl SSES3Serializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SelectObjectContentEventStream {
     /// <p>The Continuation Event.</p>
     pub cont: Option<ContinuationEvent>,
@@ -13843,7 +13843,7 @@ impl SelectObjectContentEventStreamDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SelectObjectContentOutput {
     pub payload: Option<SelectObjectContentEventStream>,
 }
@@ -13892,7 +13892,7 @@ impl SelectObjectContentOutputDeserializer {
     }
 }
 /// <p>Request to filter the contents of an Amazon S3 object based on a simple Structured Query Language (SQL) statement. In the request, along with the SQL expression, you must also specify a data serialization format (JSON or CSV) of the object. Amazon S3 uses this to parse object data into records, and returns only records that match the specified SQL expression. You must also specify the data serialization format for the response. For more information, go to <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectSELECTContent.html">S3Select API Documentation</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SelectObjectContentRequest {
     /// <p>The S3 Bucket.</p>
     pub bucket: String,
@@ -13948,7 +13948,7 @@ impl SelectObjectContentRequestSerializer {
     }
 }
 /// <p>Describes the parameters for Select job types.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SelectParameters {
     /// <p>The expression that is used to query the object.</p>
     pub expression: String,
@@ -14034,7 +14034,7 @@ impl ServerSideEncryptionSerializer {
 }
 
 /// <p>Describes the default server-side encryption to apply to new objects in the bucket. If Put Object request does not specify any server-side encryption, this default encryption will be applied.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ServerSideEncryptionByDefault {
     /// <p>KMS master key ID to use for the default encryption. This parameter is allowed if SSEAlgorithm is aws:kms.</p>
     pub kms_master_key_id: Option<String>,
@@ -14122,7 +14122,7 @@ impl ServerSideEncryptionByDefaultSerializer {
 }
 
 /// <p>Container for server-side encryption configuration rules. Currently S3 supports one rule only.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ServerSideEncryptionConfiguration {
     /// <p>Container for information about a particular server-side encryption configuration rule.</p>
     pub rules: Vec<ServerSideEncryptionRule>,
@@ -14188,7 +14188,7 @@ impl ServerSideEncryptionConfigurationSerializer {
 }
 
 /// <p>Container for information about a particular server-side encryption configuration rule.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ServerSideEncryptionRule {
     /// <p>Describes the default server-side encryption to apply to new objects in the bucket. If Put Object request does not specify any server-side encryption, this default encryption will be applied.</p>
     pub apply_server_side_encryption_by_default: Option<ServerSideEncryptionByDefault>,
@@ -14323,7 +14323,7 @@ impl SizeDeserializer {
     }
 }
 /// <p>Container for filters that define which source objects should be replicated.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SourceSelectionCriteria {
     /// <p>Container for filter information of selection of KMS Encrypted S3 objects.</p>
     pub sse_kms_encrypted_objects: Option<SseKmsEncryptedObjects>,
@@ -14397,7 +14397,7 @@ impl SourceSelectionCriteriaSerializer {
 }
 
 /// <p>Container for filter information of selection of KMS Encrypted S3 objects.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SseKmsEncryptedObjects {
     /// <p>The replication for KMS encrypted S3 objects is disabled if status is not Enabled.</p>
     pub status: String,
@@ -14537,7 +14537,7 @@ impl StartAfterSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Stats {
     /// <p>Total number of uncompressed object bytes processed.</p>
     pub bytes_processed: Option<i64>,
@@ -14593,7 +14593,7 @@ impl StatsDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct StatsEvent {
     /// <p>The Stats event details.</p>
     pub details: Option<Stats>,
@@ -14673,7 +14673,7 @@ impl StorageClassSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct StorageClassAnalysis {
     /// <p>A container used to describe how data related to the storage class analysis should be exported.</p>
     pub data_export: Option<StorageClassAnalysisDataExport>,
@@ -14743,7 +14743,7 @@ impl StorageClassAnalysisSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct StorageClassAnalysisDataExport {
     /// <p>The place to store the data for an analysis.</p>
     pub destination: AnalyticsExportDestination,
@@ -14899,7 +14899,7 @@ impl SuffixSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Tag {
     /// <p>Name of the tag.</p>
     pub key: String,
@@ -15039,7 +15039,7 @@ impl TagSetSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Tagging {
     pub tag_set: Vec<Tag>,
 }
@@ -15096,7 +15096,7 @@ impl TargetBucketSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct TargetGrant {
     pub grantee: Option<Grantee>,
     /// <p>Logging permissions assigned to the Grantee for the bucket.</p>
@@ -15364,7 +15364,7 @@ impl TopicArnSerializer {
 }
 
 /// <p>Container for specifying the configuration when you want Amazon S3 to publish events to an Amazon Simple Notification Service (Amazon SNS) topic.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct TopicConfiguration {
     pub events: Vec<String>,
     pub filter: Option<NotificationConfigurationFilter>,
@@ -15460,7 +15460,7 @@ impl TopicConfigurationSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct TopicConfigurationDeprecated {
     pub events: Option<Vec<String>>,
     pub id: Option<String>,
@@ -15595,7 +15595,7 @@ impl TopicConfigurationListSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Transition {
     /// <p>Indicates at what date the object is to be moved or deleted. Should be in GMT ISO 8601 Format.</p>
     pub date: Option<String>,
@@ -15877,7 +15877,7 @@ impl UploadIdMarkerSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UploadPartCopyOutput {
     pub copy_part_result: Option<CopyPartResult>,
     /// <p>The version of the source object that was copied, if you have enabled versioning on the source bucket.</p>
@@ -15935,7 +15935,7 @@ impl UploadPartCopyOutputDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UploadPartCopyRequest {
     pub bucket: String,
     /// <p>The name of the source bucket and key name of the source object, separated by a slash (/). Must be URL-encoded.</p>
@@ -15970,7 +15970,7 @@ pub struct UploadPartCopyRequest {
     pub upload_id: String,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UploadPartOutput {
     /// <p>Entity tag for the uploaded object.</p>
     pub e_tag: Option<String>,
@@ -16116,7 +16116,7 @@ impl VersionIdMarkerSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct VersioningConfiguration {
     /// <p>Specifies whether MFA delete is enabled in the bucket versioning configuration. This element is only returned if the bucket has been configured with MFA delete. If the bucket has never been so configured, this element is not returned.</p>
     pub mfa_delete: Option<String>,
@@ -16156,7 +16156,7 @@ impl VersioningConfigurationSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct WebsiteConfiguration {
     pub error_document: Option<ErrorDocument>,
     pub index_document: Option<IndexDocument>,

--- a/rusoto/services/s3/src/generated.rs
+++ b/rusoto/services/s3/src/generated.rs
@@ -29,8 +29,9 @@ use hyper::StatusCode;
 use rusoto_core::param::{Params, ServiceParams};
 use rusoto_core::signature::SignedRequest;
 use rusoto_core::xmlerror::*;
-use rusoto_core::xmlutil::{characters, end_element, find_start_element, peek_at_name, skip_tree,
-                           start_element};
+use rusoto_core::xmlutil::{
+    characters, end_element, find_start_element, peek_at_name, skip_tree, start_element,
+};
 use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
 use std::io::Write;
 use std::str::FromStr;
@@ -22314,7 +22315,8 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -22383,7 +22385,8 @@ where
         }
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -22620,7 +22623,8 @@ where
         }
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -22748,7 +22752,8 @@ where
         }
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -22907,7 +22912,8 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -22990,7 +22996,8 @@ where
         let mut request = SignedRequest::new("DELETE", "s3", &self.region, &request_uri);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -23022,7 +23029,8 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -23053,7 +23061,8 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -23084,7 +23093,8 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -23116,7 +23126,8 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -23147,7 +23158,8 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -23179,7 +23191,8 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -23210,7 +23223,8 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -23241,7 +23255,8 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -23272,7 +23287,8 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -23303,7 +23319,8 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -23343,7 +23360,8 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -23409,7 +23427,8 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -23475,7 +23494,8 @@ where
         request.set_content_md5_header();
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -23531,7 +23551,8 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -23584,7 +23605,8 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -23637,7 +23659,8 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -23690,7 +23713,8 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -23741,7 +23765,8 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -23794,7 +23819,8 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -23847,7 +23873,8 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -23899,7 +23926,8 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -23952,7 +23980,8 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -24003,7 +24032,8 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -24055,7 +24085,8 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -24108,7 +24139,8 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -24161,7 +24193,8 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -24212,7 +24245,8 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -24248,7 +24282,8 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -24299,7 +24334,8 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -24350,7 +24386,8 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -24401,7 +24438,8 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -24452,7 +24490,8 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -24567,7 +24606,8 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -24733,7 +24773,8 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -24791,7 +24832,8 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -24849,7 +24891,8 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -24882,7 +24925,8 @@ where
         let mut request = SignedRequest::new("HEAD", "s3", &self.region, &request_uri);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -24962,7 +25006,8 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -25133,7 +25178,8 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -25190,7 +25236,8 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -25247,7 +25294,8 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -25293,7 +25341,8 @@ where
         let mut request = SignedRequest::new("GET", "s3", &self.region, &request_uri);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -25362,7 +25411,8 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -25431,7 +25481,8 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -25499,7 +25550,8 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -25574,7 +25626,8 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -25631,7 +25684,8 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -25701,7 +25755,8 @@ where
         request.set_payload(Some(writer.into_inner()));
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -25767,7 +25822,8 @@ where
         }
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -25806,7 +25862,8 @@ where
         request.set_payload(Some(writer.into_inner()));
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -25845,7 +25902,8 @@ where
         request.set_content_md5_header();
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -25886,7 +25944,8 @@ where
         request.set_payload(Some(writer.into_inner()));
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -25925,7 +25984,8 @@ where
         request.set_payload(Some(writer.into_inner()));
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -25971,7 +26031,8 @@ where
         request.set_content_md5_header();
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -26014,7 +26075,8 @@ where
         request.set_content_md5_header();
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -26055,7 +26117,8 @@ where
         request.set_payload(Some(writer.into_inner()));
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -26094,7 +26157,8 @@ where
         request.set_payload(Some(writer.into_inner()));
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -26135,7 +26199,8 @@ where
         request.set_payload(Some(writer.into_inner()));
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -26173,7 +26238,8 @@ where
         request.set_payload(Some(writer.into_inner()));
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -26218,7 +26284,8 @@ where
         request.set_payload(Some(writer.into_inner()));
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -26260,7 +26327,8 @@ where
         request.set_content_md5_header();
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -26301,7 +26369,8 @@ where
         request.set_payload(Some(writer.into_inner()));
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -26339,7 +26408,8 @@ where
         request.set_content_md5_header();
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -26384,7 +26454,8 @@ where
         request.set_payload(Some(writer.into_inner()));
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -26425,7 +26496,8 @@ where
         request.set_payload(Some(writer.into_inner()));
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -26566,7 +26638,8 @@ where
         }
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -26705,7 +26778,8 @@ where
         }
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -26769,7 +26843,8 @@ where
         request.set_payload(Some(writer.into_inner()));
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -26841,7 +26916,8 @@ where
         }
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -26929,7 +27005,8 @@ where
         request.set_payload(Some(writer.into_inner()));
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -27016,7 +27093,8 @@ where
         }
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {
@@ -27184,7 +27262,8 @@ where
         request.set_params(params);
 
         let future = self.inner.sign_and_dispatch(request, |response| {
-            if response.status != StatusCode::Ok && response.status != StatusCode::NoContent
+            if response.status != StatusCode::Ok
+                && response.status != StatusCode::NoContent
                 && response.status != StatusCode::PartialContent
             {
                 return future::Either::B(response.buffer().from_err().and_then(|response| {

--- a/rusoto/services/sdb/src/generated.rs
+++ b/rusoto/services/sdb/src/generated.rs
@@ -44,7 +44,7 @@ enum DeserializerNext {
     Element(String),
 }
 /// <p></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Attribute {
     /// <p></p>
     pub alternate_name_encoding: Option<String>,
@@ -191,7 +191,7 @@ impl AttributeNameListSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct BatchDeleteAttributesRequest {
     /// <p>The name of the domain in which the attributes are being deleted.</p>
     pub domain_name: String,
@@ -220,7 +220,7 @@ impl BatchDeleteAttributesRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct BatchPutAttributesRequest {
     /// <p>The name of the domain in which the attributes are being stored.</p>
     pub domain_name: String,
@@ -249,7 +249,7 @@ impl BatchPutAttributesRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateDomainRequest {
     /// <p>The name of the domain to create. The name can range between 3 and 255 characters and can contain the following characters: a-z, A-Z, 0-9, &#39;_&#39;, &#39;-&#39;, and &#39;.&#39;.</p>
     pub domain_name: String,
@@ -271,7 +271,7 @@ impl CreateDomainRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeletableItem {
     pub attributes: Option<Vec<Attribute>>,
     pub name: String,
@@ -311,7 +311,7 @@ impl DeletableItemListSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteAttributesRequest {
     /// <p>A list of Attributes. Similar to columns on a spreadsheet, attributes represent categories of data that can be assigned to items.</p>
     pub attributes: Option<Vec<Attribute>>,
@@ -357,7 +357,7 @@ impl DeleteAttributesRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteDomainRequest {
     /// <p>The name of the domain to delete.</p>
     pub domain_name: String,
@@ -379,7 +379,7 @@ impl DeleteDomainRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DomainMetadataRequest {
     /// <p>The name of the domain for which to display the metadata of.</p>
     pub domain_name: String,
@@ -401,7 +401,7 @@ impl DomainMetadataRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DomainMetadataResult {
     /// <p>The number of unique attribute names in the domain.</p>
     pub attribute_name_count: Option<i64>,
@@ -516,7 +516,7 @@ impl DomainNameListDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetAttributesRequest {
     /// <p>The names of the attributes.</p>
     pub attribute_names: Option<Vec<String>>,
@@ -561,7 +561,7 @@ impl GetAttributesRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetAttributesResult {
     /// <p>The list of attributes returned by the operation.</p>
     pub attributes: Option<Vec<Attribute>>,
@@ -624,7 +624,7 @@ impl IntegerDeserializer {
     }
 }
 /// <p></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Item {
     /// <p></p>
     pub alternate_name_encoding: Option<String>,
@@ -708,7 +708,7 @@ impl ItemListDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListDomainsRequest {
     /// <p>The maximum number of domain names you want returned. The range is 1 to 100. The default setting is 100.</p>
     pub max_number_of_domains: Option<i64>,
@@ -740,7 +740,7 @@ impl ListDomainsRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListDomainsResult {
     /// <p>A list of domain names that match the expression.</p>
     pub domain_names: Option<Vec<String>>,
@@ -808,7 +808,7 @@ impl LongDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PutAttributesRequest {
     /// <p>The list of attributes.</p>
     pub attributes: Vec<ReplaceableAttribute>,
@@ -853,7 +853,7 @@ impl PutAttributesRequestSerializer {
 }
 
 /// <p></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ReplaceableAttribute {
     /// <p>The name of the replaceable attribute.</p>
     pub name: String,
@@ -901,7 +901,7 @@ impl ReplaceableAttributeListSerializer {
 }
 
 /// <p></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ReplaceableItem {
     /// <p>The list of attributes for a replaceable item.</p>
     pub attributes: Vec<ReplaceableAttribute>,
@@ -941,7 +941,7 @@ impl ReplaceableItemListSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SelectRequest {
     /// <p>Determines whether or not strong consistency should be enforced when data is read from SimpleDB. If <code>true</code>, any data previously written to SimpleDB will be returned. Otherwise, results will be consistent eventually, and the client may not see data that was written immediately before your read.</p>
     pub consistent_read: Option<bool>,
@@ -979,7 +979,7 @@ impl SelectRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SelectResult {
     /// <p>A list of items that match the select expression.</p>
     pub items: Option<Vec<Item>>,
@@ -1045,7 +1045,7 @@ impl StringDeserializer {
     }
 }
 /// <p> Specifies the conditions under which data should be updated. If an update condition is specified for a request, the data will only be updated if the condition is satisfied. For example, if an attribute with a specific name and value exists, or if a specific attribute doesn't exist. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateCondition {
     /// <p>A value specifying whether or not the specified attribute must exist with the specified value in order for the update condition to be satisfied. Specify <code>true</code> if the attribute must exist for the update condition to be satisfied. Specify <code>false</code> if the attribute should not exist in order for the update condition to be satisfied.</p>
     pub exists: Option<bool>,

--- a/rusoto/services/sdb/src/generated.rs
+++ b/rusoto/services/sdb/src/generated.rs
@@ -29,8 +29,9 @@ use hyper::StatusCode;
 use rusoto_core::param::{Params, ServiceParams};
 use rusoto_core::signature::SignedRequest;
 use rusoto_core::xmlerror::*;
-use rusoto_core::xmlutil::{characters, end_element, find_start_element, peek_at_name, skip_tree,
-                           start_element};
+use rusoto_core::xmlutil::{
+    characters, end_element, find_start_element, peek_at_name, skip_tree, start_element,
+};
 use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
 use std::str::FromStr;
 use xml::reader::ParserConfig;

--- a/rusoto/services/secretsmanager/src/generated.rs
+++ b/rusoto/services/secretsmanager/src/generated.rs
@@ -675,7 +675,8 @@ impl CancelRotateSecretError {
     pub fn from_body(body: &str) -> CancelRotateSecretError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -781,7 +782,8 @@ impl CreateSecretError {
     pub fn from_body(body: &str) -> CreateSecretError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -893,7 +895,8 @@ impl DeleteSecretError {
     pub fn from_body(body: &str) -> DeleteSecretError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -985,7 +988,8 @@ impl DescribeSecretError {
     pub fn from_body(body: &str) -> DescribeSecretError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1071,7 +1075,8 @@ impl GetRandomPasswordError {
     pub fn from_body(body: &str) -> GetRandomPasswordError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1167,7 +1172,8 @@ impl GetSecretValueError {
     pub fn from_body(body: &str) -> GetSecretValueError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1265,7 +1271,8 @@ impl ListSecretVersionIdsError {
     pub fn from_body(body: &str) -> ListSecretVersionIdsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1357,7 +1364,8 @@ impl ListSecretsError {
     pub fn from_body(body: &str) -> ListSecretsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1455,7 +1463,8 @@ impl PutSecretValueError {
     pub fn from_body(body: &str) -> PutSecretValueError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1563,7 +1572,8 @@ impl RestoreSecretError {
     pub fn from_body(body: &str) -> RestoreSecretError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1659,7 +1669,8 @@ impl RotateSecretError {
     pub fn from_body(body: &str) -> RotateSecretError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1753,7 +1764,8 @@ impl TagResourceError {
     pub fn from_body(body: &str) -> TagResourceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1843,7 +1855,8 @@ impl UntagResourceError {
     pub fn from_body(body: &str) -> UntagResourceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1943,7 +1956,8 @@ impl UpdateSecretError {
     pub fn from_body(body: &str) -> UpdateSecretError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2057,7 +2071,8 @@ impl UpdateSecretVersionStageError {
     pub fn from_body(body: &str) -> UpdateSecretVersionStageError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/secretsmanager/src/generated.rs
+++ b/rusoto/services/secretsmanager/src/generated.rs
@@ -30,14 +30,14 @@ use rusoto_core::signature::SignedRequest;
 use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CancelRotateSecretRequest {
     /// <p>Specifies the secret for which you want to cancel a rotation request. You can specify either the Amazon Resource Name (ARN) or the friendly name of the secret.</p>
     #[serde(rename = "SecretId")]
     pub secret_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CancelRotateSecretResponse {
     /// <p>The ARN of the secret for which rotation was canceled.</p>
     #[serde(rename = "ARN")]
@@ -53,7 +53,7 @@ pub struct CancelRotateSecretResponse {
     pub version_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateSecretRequest {
     /// <p>(Optional) If you include <code>SecretString</code> or <code>SecretBinary</code>, then an initial version is created as part of the secret, and this parameter specifies a unique identifier for the new version. </p> <note> <p>If you use the AWS CLI or one of the AWS SDK to call this operation, then you can leave this parameter empty. The CLI or SDK generates a random UUID for you and includes as the value for this parameter in the request. If you don't use the SDK and instead generate a raw HTTP request to the AWS Secrets Manager service endpoint, then you must generate a <code>ClientRequestToken</code> yourself for the new version and include that value in the request.</p> </note> <p>This value helps ensure idempotency. Secrets Manager uses this value to prevent the accidental creation of duplicate versions if there are failures and retries during a rotation. We recommend that you generate a <a href="https://wikipedia.org/wiki/Universally_unique_identifier">UUID-type</a> value to ensure uniqueness of your versions within the specified secret. </p> <ul> <li> <p>If the <code>ClientRequestToken</code> value isn't already associated with a version of the secret then a new version of the secret is created. </p> </li> <li> <p>If a version with this value already exists and that version's <code>SecretString</code> and <code>SecretBinary</code> values are the same as those in the request, then the request is ignored (the operation is idempotent).</p> </li> <li> <p>If a version with this value already exists and that version's <code>SecretString</code> and <code>SecretBinary</code> values are different from those in the request then the request fails because you cannot modify an existing version. Instead, use <a>PutSecretValue</a> to create a new version.</p> </li> </ul> <p>This value becomes the <code>SecretVersionId</code> of the new version.</p>
     #[serde(rename = "ClientRequestToken")]
@@ -88,7 +88,7 @@ pub struct CreateSecretRequest {
     pub tags: Option<Vec<Tag>>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateSecretResponse {
     /// <p><p>The Amazon Resource Name (ARN) of the secret that you just created.</p> <note> <p>AWS Secrets Manager automatically adds several random characters to the name at the end of the ARN when you initially create a secret. This affects only the ARN and not the actual friendly name. This ensures that if you create a new secret with the same name as an old secret that you previously deleted, then users with access to the old secret <i>don&#39;t</i> automatically get access to the new secret because the ARNs are different.</p> </note></p>
     #[serde(rename = "ARN")]
@@ -104,7 +104,7 @@ pub struct CreateSecretResponse {
     pub version_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteSecretRequest {
     /// <p>(Optional) Specifies the number of days that AWS Secrets Manager waits before it can delete the secret.</p> <p>This value can range from 7 to 30 days. The default value is 30.</p>
     #[serde(rename = "RecoveryWindowInDays")]
@@ -115,7 +115,7 @@ pub struct DeleteSecretRequest {
     pub secret_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteSecretResponse {
     /// <p>The ARN of the secret that is now scheduled for deletion.</p>
     #[serde(rename = "ARN")]
@@ -131,14 +131,14 @@ pub struct DeleteSecretResponse {
     pub name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeSecretRequest {
     /// <p>The identifier of the secret whose details you want to retrieve. You can specify either the Amazon Resource Name (ARN) or the friendly name of the secret.</p>
     #[serde(rename = "SecretId")]
     pub secret_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeSecretResponse {
     /// <p>The ARN of the secret.</p>
     #[serde(rename = "ARN")]
@@ -194,7 +194,7 @@ pub struct DescribeSecretResponse {
     pub version_ids_to_stages: Option<::std::collections::HashMap<String, Vec<String>>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetRandomPasswordRequest {
     /// <p>A string that includes characters that should not be included in the generated password. The default is that all characters from the included sets can be used.</p>
     #[serde(rename = "ExcludeCharacters")]
@@ -230,7 +230,7 @@ pub struct GetRandomPasswordRequest {
     pub require_each_included_type: Option<bool>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetRandomPasswordResponse {
     /// <p>A string with the generated password.</p>
     #[serde(rename = "RandomPassword")]
@@ -238,7 +238,7 @@ pub struct GetRandomPasswordResponse {
     pub random_password: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetSecretValueRequest {
     /// <p>Specifies the secret containing the version that you want to retrieve. You can specify either the Amazon Resource Name (ARN) or the friendly name of the secret.</p>
     #[serde(rename = "SecretId")]
@@ -253,7 +253,7 @@ pub struct GetSecretValueRequest {
     pub version_stage: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetSecretValueResponse {
     /// <p>The ARN of the secret.</p>
     #[serde(rename = "ARN")]
@@ -289,7 +289,7 @@ pub struct GetSecretValueResponse {
     pub version_stages: Option<Vec<String>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListSecretVersionIdsRequest {
     /// <p>(Optional) Specifies that you want the results to include versions that do not have any staging labels attached to them. Such versions are considered deprecated and are subject to deletion by Secrets Manager as needed.</p>
     #[serde(rename = "IncludeDeprecated")]
@@ -308,7 +308,7 @@ pub struct ListSecretVersionIdsRequest {
     pub secret_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListSecretVersionIdsResponse {
     /// <p><p>The Amazon Resource Name (ARN) for the secret.</p> <note> <p>AWS Secrets Manager automatically adds several random characters to the name at the end of the ARN when you initially create a secret. This affects only the ARN and not the actual friendly name. This ensures that if you create a new secret with the same name as an old secret that you previously deleted, then users with access to the old secret <i>don&#39;t</i> automatically get access to the new secret because the ARNs are different.</p> </note></p>
     #[serde(rename = "ARN")]
@@ -328,7 +328,7 @@ pub struct ListSecretVersionIdsResponse {
     pub versions: Option<Vec<SecretVersionsListEntry>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListSecretsRequest {
     /// <p>(Optional) Limits the number of results that you want to include in the response. If you don't include this parameter, it defaults to a value that's specific to the operation. If additional items exist beyond the maximum you specify, the <code>NextToken</code> response element is present and has a value (isn't null). Include that value as the <code>NextToken</code> request parameter in the next call to the operation to get the next part of the results. Note that AWS Secrets Manager might return fewer results than the maximum even when there are more results available. You should check <code>NextToken</code> after every operation to ensure that you receive all of the results.</p>
     #[serde(rename = "MaxResults")]
@@ -340,7 +340,7 @@ pub struct ListSecretsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListSecretsResponse {
     /// <p>If present in the response, this value indicates that there's more output available than what's included in the current response. This can occur even when the response includes no values at all, such as when you ask for a filtered view of a very long list. Use this value in the <code>NextToken</code> request parameter in a subsequent call to the operation to continue processing and get the next part of the output. You should repeat this until the <code>NextToken</code> response element comes back empty (as <code>null</code>).</p>
     #[serde(rename = "NextToken")]
@@ -352,7 +352,7 @@ pub struct ListSecretsResponse {
     pub secret_list: Option<Vec<SecretListEntry>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PutSecretValueRequest {
     /// <p>(Optional) Specifies a unique identifier for the new version of the secret. </p> <note> <p>If you use the AWS CLI or one of the AWS SDK to call this operation, then you can leave this parameter empty. The CLI or SDK generates a random UUID for you and includes that in the request. If you don't use the SDK and instead generate a raw HTTP request to the AWS Secrets Manager service endpoint, then you must generate a <code>ClientRequestToken</code> yourself for new versions and include that value in the request. </p> </note> <p>This value helps ensure idempotency. Secrets Manager uses this value to prevent the accidental creation of duplicate versions if there are failures and retries during the Lambda rotation function's processing. We recommend that you generate a <a href="https://wikipedia.org/wiki/Universally_unique_identifier">UUID-type</a> value to ensure uniqueness within the specified secret. </p> <ul> <li> <p>If the <code>ClientRequestToken</code> value isn't already associated with a version of the secret then a new version of the secret is created. </p> </li> <li> <p>If a version with this value already exists and that version's <code>SecretString</code> or <code>SecretBinary</code> values are the same as those in the request then the request is ignored (the operation is idempotent). </p> </li> <li> <p>If a version with this value already exists and that version's <code>SecretString</code> and <code>SecretBinary</code> values are different from those in the request then the request fails because you cannot modify an existing secret version. You can only create new versions to store new secret values.</p> </li> </ul> <p>This value becomes the <code>SecretVersionId</code> of the new version.</p>
     #[serde(rename = "ClientRequestToken")]
@@ -379,7 +379,7 @@ pub struct PutSecretValueRequest {
     pub version_stages: Option<Vec<String>>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PutSecretValueResponse {
     /// <p>The Amazon Resource Name (ARN) for the secret for which you just created a version.</p>
     #[serde(rename = "ARN")]
@@ -399,14 +399,14 @@ pub struct PutSecretValueResponse {
     pub version_stages: Option<Vec<String>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RestoreSecretRequest {
     /// <p>Specifies the secret that you want to restore from a previously scheduled deletion. You can specify either the Amazon Resource Name (ARN) or the friendly name of the secret.</p>
     #[serde(rename = "SecretId")]
     pub secret_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RestoreSecretResponse {
     /// <p>The ARN of the secret that was restored.</p>
     #[serde(rename = "ARN")]
@@ -418,7 +418,7 @@ pub struct RestoreSecretResponse {
     pub name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RotateSecretRequest {
     /// <p>(Optional) Specifies a unique identifier for the new version of the secret that helps ensure idempotency. </p> <p>If you use the AWS CLI or one of the AWS SDK to call this operation, then you can leave this parameter empty. The CLI or SDK generates a random UUID for you and includes that in the request for this parameter. If you don't use the SDK and instead generate a raw HTTP request to the AWS Secrets Manager service endpoint, then you must generate a <code>ClientRequestToken</code> yourself for new versions and include that value in the request.</p> <p>You only need to specify your own value if you are implementing your own retry logic and want to ensure that a given secret is not created twice. We recommend that you generate a <a href="https://wikipedia.org/wiki/Universally_unique_identifier">UUID-type</a> value to ensure uniqueness within the specified secret. </p> <p>Secrets Manager uses this value to prevent the accidental creation of duplicate versions if there are failures and retries during the function's processing.</p> <ul> <li> <p>If the <code>ClientRequestToken</code> value isn't already associated with a version of the secret then a new version of the secret is created. </p> </li> <li> <p>If a version with this value already exists and that version's <code>SecretString</code> and <code>SecretBinary</code> values are the same as the request, then the request is ignored (the operation is idempotent). </p> </li> <li> <p>If a version with this value already exists and that version's <code>SecretString</code> and <code>SecretBinary</code> values are different from the request then an error occurs because you cannot modify an existing secret value.</p> </li> </ul> <p>This value becomes the <code>SecretVersionId</code> of the new version.</p>
     #[serde(rename = "ClientRequestToken")]
@@ -437,7 +437,7 @@ pub struct RotateSecretRequest {
     pub secret_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RotateSecretResponse {
     /// <p>The ARN of the secret.</p>
     #[serde(rename = "ARN")]
@@ -454,7 +454,7 @@ pub struct RotateSecretResponse {
 }
 
 /// <p>A structure that defines the rotation configuration for the secret.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RotationRulesType {
     /// <p>Specifies the number of days between automatic scheduled rotations of the secret.</p>
     #[serde(rename = "AutomaticallyAfterDays")]
@@ -463,7 +463,7 @@ pub struct RotationRulesType {
 }
 
 /// <p>A structure that contains the details about a secret. It does not include the encrypted <code>SecretString</code> and <code>SecretBinary</code> values. To get those values, use the <a>GetSecretValue</a> operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SecretListEntry {
     /// <p>The Amazon Resource Name (ARN) of the secret.</p> <p>For more information about ARNs in AWS Secrets Manager, see <a href="http://docs.aws.amazon.com/http:/docs.aws.amazon.com/secretsmanager/latest/userguide/reference_iam-permissions.html#iam-resources">Policy Resources</a> in the <i>AWS Secrets Manager User Guide</i>.</p>
     #[serde(rename = "ARN")]
@@ -520,7 +520,7 @@ pub struct SecretListEntry {
 }
 
 /// <p>A structure that contains information about one version of a secret.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SecretVersionsListEntry {
     /// <p>The date and time this version of the secret was created.</p>
     #[serde(rename = "CreatedDate")]
@@ -541,7 +541,7 @@ pub struct SecretVersionsListEntry {
 }
 
 /// <p>A structure that contains information about a tag.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Tag {
     /// <p>The key identifier, or name, of the tag.</p>
     #[serde(rename = "Key")]
@@ -553,7 +553,7 @@ pub struct Tag {
     pub value: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct TagResourceRequest {
     /// <p>The identifier for the secret that you want to attach tags to. You can specify either the Amazon Resource Name (ARN) or the friendly name of the secret.</p>
     #[serde(rename = "SecretId")]
@@ -563,7 +563,7 @@ pub struct TagResourceRequest {
     pub tags: Vec<Tag>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UntagResourceRequest {
     /// <p>The identifier for the secret that you want to remove tags from. You can specify either the Amazon Resource Name (ARN) or the friendly name of the secret.</p>
     #[serde(rename = "SecretId")]
@@ -573,7 +573,7 @@ pub struct UntagResourceRequest {
     pub tag_keys: Vec<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateSecretRequest {
     /// <p>(Optional) If you want to add a new version to the secret, this parameter specifies a unique identifier for the new version that helps ensure idempotency. </p> <p>If you use the AWS CLI or one of the AWS SDK to call this operation, then you can leave this parameter empty. The CLI or SDK generates a random UUID for you and includes that in the request. If you don't use the SDK and instead generate a raw HTTP request to the AWS Secrets Manager service endpoint, then you must generate a <code>ClientRequestToken</code> yourself for new versions and include that value in the request.</p> <p>You typically only need to interact with this value if you implement your own retry logic and want to ensure that a given secret is not created twice. We recommend that you generate a <a href="https://wikipedia.org/wiki/Universally_unique_identifier">UUID-type</a> value to ensure uniqueness within the specified secret. </p> <p>Secrets Manager uses this value to prevent the accidental creation of duplicate versions if there are failures and retries during the Lambda rotation function's processing.</p> <ul> <li> <p>If the <code>ClientRequestToken</code> value isn't already associated with a version of the secret then a new version of the secret is created. </p> </li> <li> <p>If a version with this value already exists and that version's <code>SecretString</code> and <code>SecretBinary</code> values are the same as those in the request then the request is ignored (the operation is idempotent). </p> </li> <li> <p>If a version with this value already exists and that version's <code>SecretString</code> and <code>SecretBinary</code> values are different from the request then an error occurs because you cannot modify an existing secret value.</p> </li> </ul> <p>This value becomes the <code>SecretVersionId</code> of the new version.</p>
     #[serde(rename = "ClientRequestToken")]
@@ -604,7 +604,7 @@ pub struct UpdateSecretRequest {
     pub secret_string: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateSecretResponse {
     /// <p><p>The ARN of this secret.</p> <note> <p>AWS Secrets Manager automatically adds several random characters to the name at the end of the ARN when you initially create a secret. This affects only the ARN and not the actual friendly name. This ensures that if you create a new secret with the same name as an old secret that you previously deleted, then users with access to the old secret <i>don&#39;t</i> automatically get access to the new secret because the ARNs are different.</p> </note></p>
     #[serde(rename = "ARN")]
@@ -620,7 +620,7 @@ pub struct UpdateSecretResponse {
     pub version_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateSecretVersionStageRequest {
     /// <p>(Optional) The secret version ID that you want to add the staging labels to.</p> <p>If any of the staging labels are already attached to a different version of the secret, then they are removed from that version before adding them to this version.</p>
     #[serde(rename = "MoveToVersionId")]
@@ -638,7 +638,7 @@ pub struct UpdateSecretVersionStageRequest {
     pub version_stage: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateSecretVersionStageResponse {
     /// <p>The ARN of the secret with the staging labels that were modified.</p>
     #[serde(rename = "ARN")]

--- a/rusoto/services/serverlessrepo/src/generated.rs
+++ b/rusoto/services/serverlessrepo/src/generated.rs
@@ -31,7 +31,7 @@ use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 /// <p>Details about the application.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Application {
     /// <p>The application Amazon Resource Name (ARN).</p>
     pub application_id: String,
@@ -59,7 +59,7 @@ pub struct Application {
 }
 
 /// <p>List of application details.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ApplicationPage {
     /// <p>Array of application summaries.</p>
     pub applications: Vec<ApplicationSummary>,
@@ -68,14 +68,14 @@ pub struct ApplicationPage {
 }
 
 /// <p>Policy statements applied to the application.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ApplicationPolicy {
     /// <p>Array of policy statements applied to the application.</p>
     pub statements: Vec<ApplicationPolicyStatement>,
 }
 
 /// <p>Policy statement applied to the application.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ApplicationPolicyStatement {
     /// <p>A list of supported actions:</p><p>
     /// GetApplication
@@ -99,7 +99,7 @@ pub struct ApplicationPolicyStatement {
 }
 
 /// <p>Summary of details about the application.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ApplicationSummary {
     /// <p>The application ARN.</p>
     #[serde(rename = "ApplicationId")]
@@ -133,7 +133,7 @@ pub struct ApplicationSummary {
 }
 
 /// <p>List of version summaries for the application.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ApplicationVersionPage {
     /// <p>The token to request the next page of results.</p>
     pub next_token: Option<String>,
@@ -142,7 +142,7 @@ pub struct ApplicationVersionPage {
 }
 
 /// <p>Details of the change set.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ChangeSetDetails {
     /// <p>The application Amazon Resource Name (ARN).</p>
     pub application_id: String,
@@ -157,7 +157,7 @@ pub struct ChangeSetDetails {
 }
 
 /// <p>Create application request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateApplicationInput {
     /// <p>The name of the author publishing the app.</p><p>Min Length=1. Max Length=127.</p><p>Pattern "^[a-z0-9](([a-z0-9]|-(?!-))*[a-z0-9])?$";</p>
     pub author: String,
@@ -192,7 +192,7 @@ pub struct CreateApplicationInput {
     pub template_url: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateApplicationRequest {
     /// <p>The name of the author publishing the app.</p><p>Min Length=1. Max Length=127.</p><p>Pattern "^[a-z0-9](([a-z0-9]|-(?!-))*[a-z0-9])?$";</p>
     #[serde(rename = "Author")]
@@ -255,7 +255,7 @@ pub struct CreateApplicationRequest {
     pub template_url: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateApplicationResponse {
     /// <p>The application Amazon Resource Name (ARN).</p>
     #[serde(rename = "ApplicationId")]
@@ -305,7 +305,7 @@ pub struct CreateApplicationResponse {
 }
 
 /// <p>Create version request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateApplicationVersionInput {
     /// <p>A link to a public repository for the source code of your application.</p>
     pub source_code_url: Option<String>,
@@ -315,7 +315,7 @@ pub struct CreateApplicationVersionInput {
     pub template_url: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateApplicationVersionRequest {
     /// <p>The ID of the application to get.</p>
     #[serde(rename = "ApplicationId")]
@@ -337,7 +337,7 @@ pub struct CreateApplicationVersionRequest {
     pub template_url: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateApplicationVersionResponse {
     /// <p>The application Amazon Resource Name (ARN).</p>
     #[serde(rename = "ApplicationId")]
@@ -368,7 +368,7 @@ pub struct CreateApplicationVersionResponse {
 }
 
 /// <p>Create application ChangeSet request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateCloudFormationChangeSetInput {
     /// <p>A list of parameter values for the parameters of the application.</p>
     pub parameter_overrides: Option<Vec<ParameterValue>>,
@@ -382,7 +382,7 @@ pub struct CreateCloudFormationChangeSetInput {
     pub stack_name: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateCloudFormationChangeSetRequest {
     /// <p>The ID of the application to get.</p>
     #[serde(rename = "ApplicationId")]
@@ -405,7 +405,7 @@ pub struct CreateCloudFormationChangeSetRequest {
     pub stack_name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateCloudFormationChangeSetResponse {
     /// <p>The application Amazon Resource Name (ARN).</p>
     #[serde(rename = "ApplicationId")]
@@ -427,21 +427,21 @@ pub struct CreateCloudFormationChangeSetResponse {
     pub stack_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteApplicationRequest {
     /// <p>The ID of the application to get.</p>
     #[serde(rename = "ApplicationId")]
     pub application_id: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetApplicationPolicyRequest {
     /// <p>The ID of the application to get.</p>
     #[serde(rename = "ApplicationId")]
     pub application_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetApplicationPolicyResponse {
     /// <p>Array of policy statements applied to the application.</p>
     #[serde(rename = "Statements")]
@@ -449,7 +449,7 @@ pub struct GetApplicationPolicyResponse {
     pub statements: Option<Vec<ApplicationPolicyStatement>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetApplicationRequest {
     /// <p>The ID of the application to get.</p>
     #[serde(rename = "ApplicationId")]
@@ -460,7 +460,7 @@ pub struct GetApplicationRequest {
     pub semantic_version: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetApplicationResponse {
     /// <p>The application Amazon Resource Name (ARN).</p>
     #[serde(rename = "ApplicationId")]
@@ -509,7 +509,7 @@ pub struct GetApplicationResponse {
     pub version: Option<Version>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListApplicationVersionsRequest {
     /// <p>The ID of the application to get.</p>
     #[serde(rename = "ApplicationId")]
@@ -524,7 +524,7 @@ pub struct ListApplicationVersionsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListApplicationVersionsResponse {
     /// <p>The token to request the next page of results.</p>
     #[serde(rename = "NextToken")]
@@ -536,7 +536,7 @@ pub struct ListApplicationVersionsResponse {
     pub versions: Option<Vec<VersionSummary>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListApplicationsRequest {
     /// <p>The total number of items to return.</p>
     #[serde(rename = "MaxItems")]
@@ -548,7 +548,7 @@ pub struct ListApplicationsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListApplicationsResponse {
     /// <p>Array of application summaries.</p>
     #[serde(rename = "Applications")]
@@ -561,7 +561,7 @@ pub struct ListApplicationsResponse {
 }
 
 /// <p>Parameters supported by the application.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ParameterDefinition {
     /// <p>A regular expression that represents the patterns to allow for String types.</p>
     #[serde(rename = "AllowedPattern")]
@@ -633,7 +633,7 @@ pub struct ParameterDefinition {
 }
 
 /// <p>Parameter value of the application.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ParameterValue {
     /// <p>The key associated with the parameter. If you don't specify a key and value for a particular parameter, AWS CloudFormation
     /// uses the default value that is specified in your template.</p>
@@ -644,7 +644,7 @@ pub struct ParameterValue {
     pub value: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PutApplicationPolicyRequest {
     /// <p>The ID of the application to get.</p>
     #[serde(rename = "ApplicationId")]
@@ -655,7 +655,7 @@ pub struct PutApplicationPolicyRequest {
     pub statements: Option<Vec<ApplicationPolicyStatement>>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PutApplicationPolicyResponse {
     /// <p>Array of policy statements applied to the application.</p>
     #[serde(rename = "Statements")]
@@ -664,7 +664,7 @@ pub struct PutApplicationPolicyResponse {
 }
 
 /// <p>Update application request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateApplicationInput {
     /// <p>The name of the author publishing the app.</p><p>Min Length=1. Max Length=127.</p><p>Pattern "^[a-z0-9](([a-z0-9]|-(?!-))*[a-z0-9])?$";</p>
     pub author: Option<String>,
@@ -681,7 +681,7 @@ pub struct UpdateApplicationInput {
     pub readme_url: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateApplicationRequest {
     /// <p>The ID of the application to get.</p>
     #[serde(rename = "ApplicationId")]
@@ -713,7 +713,7 @@ pub struct UpdateApplicationRequest {
     pub readme_url: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateApplicationResponse {
     /// <p>The application Amazon Resource Name (ARN).</p>
     #[serde(rename = "ApplicationId")]
@@ -763,7 +763,7 @@ pub struct UpdateApplicationResponse {
 }
 
 /// <p>Application version details.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Version {
     /// <p>The application Amazon Resource Name (ARN).</p>
     #[serde(rename = "ApplicationId")]
@@ -789,7 +789,7 @@ pub struct Version {
 }
 
 /// <p>Application version summary.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct VersionSummary {
     /// <p>The application Amazon Resource Name (ARN).</p>
     #[serde(rename = "ApplicationId")]

--- a/rusoto/services/serverlessrepo/src/generated.rs
+++ b/rusoto/services/serverlessrepo/src/generated.rs
@@ -835,7 +835,8 @@ impl CreateApplicationError {
     pub fn from_body(body: &str) -> CreateApplicationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -939,7 +940,8 @@ impl CreateApplicationVersionError {
     pub fn from_body(body: &str) -> CreateApplicationVersionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1043,7 +1045,8 @@ impl CreateCloudFormationChangeSetError {
     pub fn from_body(body: &str) -> CreateCloudFormationChangeSetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1149,7 +1152,8 @@ impl DeleteApplicationError {
     pub fn from_body(body: &str) -> DeleteApplicationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1257,7 +1261,8 @@ impl GetApplicationError {
     pub fn from_body(body: &str) -> GetApplicationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1359,7 +1364,8 @@ impl GetApplicationPolicyError {
     pub fn from_body(body: &str) -> GetApplicationPolicyError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1463,7 +1469,8 @@ impl ListApplicationVersionsError {
     pub fn from_body(body: &str) -> ListApplicationVersionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1567,7 +1574,8 @@ impl ListApplicationsError {
     pub fn from_body(body: &str) -> ListApplicationsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1665,7 +1673,8 @@ impl PutApplicationPolicyError {
     pub fn from_body(body: &str) -> PutApplicationPolicyError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1771,7 +1780,8 @@ impl UpdateApplicationError {
     pub fn from_body(body: &str) -> UpdateApplicationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/servicecatalog/src/generated.rs
+++ b/rusoto/services/servicecatalog/src/generated.rs
@@ -2657,7 +2657,8 @@ impl AcceptPortfolioShareError {
     pub fn from_body(body: &str) -> AcceptPortfolioShareError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2749,7 +2750,8 @@ impl AssociatePrincipalWithPortfolioError {
     pub fn from_body(body: &str) -> AssociatePrincipalWithPortfolioError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2847,7 +2849,8 @@ impl AssociateProductWithPortfolioError {
     pub fn from_body(body: &str) -> AssociateProductWithPortfolioError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2949,7 +2952,8 @@ impl AssociateTagOptionWithResourceError {
     pub fn from_body(body: &str) -> AssociateTagOptionWithResourceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3059,7 +3063,8 @@ impl CopyProductError {
     pub fn from_body(body: &str) -> CopyProductError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3147,7 +3152,8 @@ impl CreateConstraintError {
     pub fn from_body(body: &str) -> CreateConstraintError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3241,7 +3247,8 @@ impl CreatePortfolioError {
     pub fn from_body(body: &str) -> CreatePortfolioError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3331,7 +3338,8 @@ impl CreatePortfolioShareError {
     pub fn from_body(body: &str) -> CreatePortfolioShareError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3423,7 +3431,8 @@ impl CreateProductError {
     pub fn from_body(body: &str) -> CreateProductError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3513,7 +3522,8 @@ impl CreateProvisionedProductPlanError {
     pub fn from_body(body: &str) -> CreateProvisionedProductPlanError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3609,7 +3619,8 @@ impl CreateProvisioningArtifactError {
     pub fn from_body(body: &str) -> CreateProvisioningArtifactError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3705,7 +3716,8 @@ impl CreateTagOptionError {
     pub fn from_body(body: &str) -> CreateTagOptionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3793,7 +3805,8 @@ impl DeleteConstraintError {
     pub fn from_body(body: &str) -> DeleteConstraintError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3881,7 +3894,8 @@ impl DeletePortfolioError {
     pub fn from_body(body: &str) -> DeletePortfolioError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3971,7 +3985,8 @@ impl DeletePortfolioShareError {
     pub fn from_body(body: &str) -> DeletePortfolioShareError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4057,7 +4072,8 @@ impl DeleteProductError {
     pub fn from_body(body: &str) -> DeleteProductError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4149,7 +4165,8 @@ impl DeleteProvisionedProductPlanError {
     pub fn from_body(body: &str) -> DeleteProvisionedProductPlanError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4241,7 +4258,8 @@ impl DeleteProvisioningArtifactError {
     pub fn from_body(body: &str) -> DeleteProvisioningArtifactError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4337,7 +4355,8 @@ impl DeleteTagOptionError {
     pub fn from_body(body: &str) -> DeleteTagOptionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4423,7 +4442,8 @@ impl DescribeConstraintError {
     pub fn from_body(body: &str) -> DescribeConstraintError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4503,7 +4523,8 @@ impl DescribeCopyProductStatusError {
     pub fn from_body(body: &str) -> DescribeCopyProductStatusError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4585,7 +4606,8 @@ impl DescribePortfolioError {
     pub fn from_body(body: &str) -> DescribePortfolioError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4667,7 +4689,8 @@ impl DescribeProductError {
     pub fn from_body(body: &str) -> DescribeProductError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4749,7 +4772,8 @@ impl DescribeProductAsAdminError {
     pub fn from_body(body: &str) -> DescribeProductAsAdminError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4831,7 +4855,8 @@ impl DescribeProductViewError {
     pub fn from_body(body: &str) -> DescribeProductViewError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4915,7 +4940,8 @@ impl DescribeProvisionedProductError {
     pub fn from_body(body: &str) -> DescribeProvisionedProductError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4999,7 +5025,8 @@ impl DescribeProvisionedProductPlanError {
     pub fn from_body(body: &str) -> DescribeProvisionedProductPlanError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5087,7 +5114,8 @@ impl DescribeProvisioningArtifactError {
     pub fn from_body(body: &str) -> DescribeProvisioningArtifactError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5171,7 +5199,8 @@ impl DescribeProvisioningParametersError {
     pub fn from_body(body: &str) -> DescribeProvisioningParametersError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5259,7 +5288,8 @@ impl DescribeRecordError {
     pub fn from_body(body: &str) -> DescribeRecordError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5339,7 +5369,8 @@ impl DescribeTagOptionError {
     pub fn from_body(body: &str) -> DescribeTagOptionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5425,7 +5456,8 @@ impl DisassociatePrincipalFromPortfolioError {
     pub fn from_body(body: &str) -> DisassociatePrincipalFromPortfolioError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5517,7 +5549,8 @@ impl DisassociateProductFromPortfolioError {
     pub fn from_body(body: &str) -> DisassociateProductFromPortfolioError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5613,7 +5646,8 @@ impl DisassociateTagOptionFromResourceError {
     pub fn from_body(body: &str) -> DisassociateTagOptionFromResourceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5705,7 +5739,8 @@ impl ExecuteProvisionedProductPlanError {
     pub fn from_body(body: &str) -> ExecuteProvisionedProductPlanError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5797,7 +5832,8 @@ impl ListAcceptedPortfolioSharesError {
     pub fn from_body(body: &str) -> ListAcceptedPortfolioSharesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5881,7 +5917,8 @@ impl ListConstraintsForPortfolioError {
     pub fn from_body(body: &str) -> ListConstraintsForPortfolioError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5971,7 +6008,8 @@ impl ListLaunchPathsError {
     pub fn from_body(body: &str) -> ListLaunchPathsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6053,7 +6091,8 @@ impl ListPortfolioAccessError {
     pub fn from_body(body: &str) -> ListPortfolioAccessError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6133,7 +6172,8 @@ impl ListPortfoliosError {
     pub fn from_body(body: &str) -> ListPortfoliosError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6213,7 +6253,8 @@ impl ListPortfoliosForProductError {
     pub fn from_body(body: &str) -> ListPortfoliosForProductError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6301,7 +6342,8 @@ impl ListPrincipalsForPortfolioError {
     pub fn from_body(body: &str) -> ListPrincipalsForPortfolioError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6391,7 +6433,8 @@ impl ListProvisionedProductPlansError {
     pub fn from_body(body: &str) -> ListProvisionedProductPlansError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6481,7 +6524,8 @@ impl ListProvisioningArtifactsError {
     pub fn from_body(body: &str) -> ListProvisioningArtifactsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6569,7 +6613,8 @@ impl ListRecordHistoryError {
     pub fn from_body(body: &str) -> ListRecordHistoryError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6653,7 +6698,8 @@ impl ListResourcesForTagOptionError {
     pub fn from_body(body: &str) -> ListResourcesForTagOptionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6749,7 +6795,8 @@ impl ListTagOptionsError {
     pub fn from_body(body: &str) -> ListTagOptionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6835,7 +6882,8 @@ impl ProvisionProductError {
     pub fn from_body(body: &str) -> ProvisionProductError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6921,7 +6969,8 @@ impl RejectPortfolioShareError {
     pub fn from_body(body: &str) -> RejectPortfolioShareError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7001,7 +7050,8 @@ impl ScanProvisionedProductsError {
     pub fn from_body(body: &str) -> ScanProvisionedProductsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7081,7 +7131,8 @@ impl SearchProductsError {
     pub fn from_body(body: &str) -> SearchProductsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7161,7 +7212,8 @@ impl SearchProductsAsAdminError {
     pub fn from_body(body: &str) -> SearchProductsAsAdminError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7245,7 +7297,8 @@ impl SearchProvisionedProductsError {
     pub fn from_body(body: &str) -> SearchProvisionedProductsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7327,7 +7380,8 @@ impl TerminateProvisionedProductError {
     pub fn from_body(body: &str) -> TerminateProvisionedProductError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7411,7 +7465,8 @@ impl UpdateConstraintError {
     pub fn from_body(body: &str) -> UpdateConstraintError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7499,7 +7554,8 @@ impl UpdatePortfolioError {
     pub fn from_body(body: &str) -> UpdatePortfolioError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7593,7 +7649,8 @@ impl UpdateProductError {
     pub fn from_body(body: &str) -> UpdateProductError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7681,7 +7738,8 @@ impl UpdateProvisionedProductError {
     pub fn from_body(body: &str) -> UpdateProvisionedProductError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7769,7 +7827,8 @@ impl UpdateProvisioningArtifactError {
     pub fn from_body(body: &str) -> UpdateProvisioningArtifactError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7863,7 +7922,8 @@ impl UpdateTagOptionError {
     pub fn from_body(body: &str) -> UpdateTagOptionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/servicecatalog/src/generated.rs
+++ b/rusoto/services/servicecatalog/src/generated.rs
@@ -30,7 +30,7 @@ use rusoto_core::signature::SignedRequest;
 use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AcceptPortfolioShareInput {
     /// <p><p>The language code.</p> <ul> <li> <p> <code>en</code> - English (default)</p> </li> <li> <p> <code>jp</code> - Japanese</p> </li> <li> <p> <code>zh</code> - Chinese</p> </li> </ul></p>
     #[serde(rename = "AcceptLanguage")]
@@ -41,11 +41,11 @@ pub struct AcceptPortfolioShareInput {
     pub portfolio_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AcceptPortfolioShareOutput {}
 
 /// <p>The access level to use to filter results.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AccessLevelFilter {
     /// <p><p>The access level.</p> <ul> <li> <p> <code>Account</code> - Filter results based on the account.</p> </li> <li> <p> <code>Role</code> - Filter results based on the federated role of the specified user.</p> </li> <li> <p> <code>User</code> - Filter results based on the specified user.</p> </li> </ul></p>
     #[serde(rename = "Key")]
@@ -57,7 +57,7 @@ pub struct AccessLevelFilter {
     pub value: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AssociatePrincipalWithPortfolioInput {
     /// <p><p>The language code.</p> <ul> <li> <p> <code>en</code> - English (default)</p> </li> <li> <p> <code>jp</code> - Japanese</p> </li> <li> <p> <code>zh</code> - Chinese</p> </li> </ul></p>
     #[serde(rename = "AcceptLanguage")]
@@ -74,10 +74,10 @@ pub struct AssociatePrincipalWithPortfolioInput {
     pub principal_type: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AssociatePrincipalWithPortfolioOutput {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AssociateProductWithPortfolioInput {
     /// <p><p>The language code.</p> <ul> <li> <p> <code>en</code> - English (default)</p> </li> <li> <p> <code>jp</code> - Japanese</p> </li> <li> <p> <code>zh</code> - Chinese</p> </li> </ul></p>
     #[serde(rename = "AcceptLanguage")]
@@ -95,10 +95,10 @@ pub struct AssociateProductWithPortfolioInput {
     pub source_portfolio_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AssociateProductWithPortfolioOutput {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AssociateTagOptionWithResourceInput {
     /// <p>The resource identifier.</p>
     #[serde(rename = "ResourceId")]
@@ -108,11 +108,11 @@ pub struct AssociateTagOptionWithResourceInput {
     pub tag_option_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AssociateTagOptionWithResourceOutput {}
 
 /// <p>Information about a CloudWatch dashboard.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CloudWatchDashboard {
     /// <p>The name of the CloudWatch dashboard.</p>
     #[serde(rename = "Name")]
@@ -121,7 +121,7 @@ pub struct CloudWatchDashboard {
 }
 
 /// <p>Information about a constraint.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ConstraintDetail {
     /// <p>The identifier of the constraint.</p>
     #[serde(rename = "ConstraintId")]
@@ -142,7 +142,7 @@ pub struct ConstraintDetail {
 }
 
 /// <p>Summary information about a constraint.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ConstraintSummary {
     /// <p>The description of the constraint.</p>
     #[serde(rename = "Description")]
@@ -154,7 +154,7 @@ pub struct ConstraintSummary {
     pub type_: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CopyProductInput {
     /// <p><p>The language code.</p> <ul> <li> <p> <code>en</code> - English (default)</p> </li> <li> <p> <code>jp</code> - Japanese</p> </li> <li> <p> <code>zh</code> - Chinese</p> </li> </ul></p>
     #[serde(rename = "AcceptLanguage")]
@@ -185,7 +185,7 @@ pub struct CopyProductInput {
     pub target_product_name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CopyProductOutput {
     /// <p>The token to use to track the progress of the operation.</p>
     #[serde(rename = "CopyProductToken")]
@@ -193,7 +193,7 @@ pub struct CopyProductOutput {
     pub copy_product_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateConstraintInput {
     /// <p><p>The language code.</p> <ul> <li> <p> <code>en</code> - English (default)</p> </li> <li> <p> <code>jp</code> - Japanese</p> </li> <li> <p> <code>zh</code> - Chinese</p> </li> </ul></p>
     #[serde(rename = "AcceptLanguage")]
@@ -220,7 +220,7 @@ pub struct CreateConstraintInput {
     pub type_: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateConstraintOutput {
     /// <p>Information about the constraint.</p>
     #[serde(rename = "ConstraintDetail")]
@@ -236,7 +236,7 @@ pub struct CreateConstraintOutput {
     pub status: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreatePortfolioInput {
     /// <p><p>The language code.</p> <ul> <li> <p> <code>en</code> - English (default)</p> </li> <li> <p> <code>jp</code> - Japanese</p> </li> <li> <p> <code>zh</code> - Chinese</p> </li> </ul></p>
     #[serde(rename = "AcceptLanguage")]
@@ -261,7 +261,7 @@ pub struct CreatePortfolioInput {
     pub tags: Option<Vec<Tag>>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreatePortfolioOutput {
     /// <p>Information about the portfolio.</p>
     #[serde(rename = "PortfolioDetail")]
@@ -273,7 +273,7 @@ pub struct CreatePortfolioOutput {
     pub tags: Option<Vec<Tag>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreatePortfolioShareInput {
     /// <p><p>The language code.</p> <ul> <li> <p> <code>en</code> - English (default)</p> </li> <li> <p> <code>jp</code> - Japanese</p> </li> <li> <p> <code>zh</code> - Chinese</p> </li> </ul></p>
     #[serde(rename = "AcceptLanguage")]
@@ -287,10 +287,10 @@ pub struct CreatePortfolioShareInput {
     pub portfolio_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreatePortfolioShareOutput {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateProductInput {
     /// <p><p>The language code.</p> <ul> <li> <p> <code>en</code> - English (default)</p> </li> <li> <p> <code>jp</code> - Japanese</p> </li> <li> <p> <code>zh</code> - Chinese</p> </li> </ul></p>
     #[serde(rename = "AcceptLanguage")]
@@ -337,7 +337,7 @@ pub struct CreateProductInput {
     pub tags: Option<Vec<Tag>>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateProductOutput {
     /// <p>Information about the product view.</p>
     #[serde(rename = "ProductViewDetail")]
@@ -353,7 +353,7 @@ pub struct CreateProductOutput {
     pub tags: Option<Vec<Tag>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateProvisionedProductPlanInput {
     /// <p><p>The language code.</p> <ul> <li> <p> <code>en</code> - English (default)</p> </li> <li> <p> <code>jp</code> - Japanese</p> </li> <li> <p> <code>zh</code> - Chinese</p> </li> </ul></p>
     #[serde(rename = "AcceptLanguage")]
@@ -395,7 +395,7 @@ pub struct CreateProvisionedProductPlanInput {
     pub tags: Option<Vec<Tag>>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateProvisionedProductPlanOutput {
     /// <p>The plan identifier.</p>
     #[serde(rename = "PlanId")]
@@ -419,7 +419,7 @@ pub struct CreateProvisionedProductPlanOutput {
     pub provisioning_artifact_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateProvisioningArtifactInput {
     /// <p><p>The language code.</p> <ul> <li> <p> <code>en</code> - English (default)</p> </li> <li> <p> <code>jp</code> - Japanese</p> </li> <li> <p> <code>zh</code> - Chinese</p> </li> </ul></p>
     #[serde(rename = "AcceptLanguage")]
@@ -436,7 +436,7 @@ pub struct CreateProvisioningArtifactInput {
     pub product_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateProvisioningArtifactOutput {
     /// <p>The URL of the CloudFormation template in Amazon S3, in JSON format.</p>
     #[serde(rename = "Info")]
@@ -452,7 +452,7 @@ pub struct CreateProvisioningArtifactOutput {
     pub status: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateTagOptionInput {
     /// <p>The TagOption key.</p>
     #[serde(rename = "Key")]
@@ -462,7 +462,7 @@ pub struct CreateTagOptionInput {
     pub value: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateTagOptionOutput {
     /// <p>Information about the TagOption.</p>
     #[serde(rename = "TagOptionDetail")]
@@ -470,7 +470,7 @@ pub struct CreateTagOptionOutput {
     pub tag_option_detail: Option<TagOptionDetail>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteConstraintInput {
     /// <p><p>The language code.</p> <ul> <li> <p> <code>en</code> - English (default)</p> </li> <li> <p> <code>jp</code> - Japanese</p> </li> <li> <p> <code>zh</code> - Chinese</p> </li> </ul></p>
     #[serde(rename = "AcceptLanguage")]
@@ -481,10 +481,10 @@ pub struct DeleteConstraintInput {
     pub id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteConstraintOutput {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeletePortfolioInput {
     /// <p><p>The language code.</p> <ul> <li> <p> <code>en</code> - English (default)</p> </li> <li> <p> <code>jp</code> - Japanese</p> </li> <li> <p> <code>zh</code> - Chinese</p> </li> </ul></p>
     #[serde(rename = "AcceptLanguage")]
@@ -495,10 +495,10 @@ pub struct DeletePortfolioInput {
     pub id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeletePortfolioOutput {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeletePortfolioShareInput {
     /// <p><p>The language code.</p> <ul> <li> <p> <code>en</code> - English (default)</p> </li> <li> <p> <code>jp</code> - Japanese</p> </li> <li> <p> <code>zh</code> - Chinese</p> </li> </ul></p>
     #[serde(rename = "AcceptLanguage")]
@@ -512,10 +512,10 @@ pub struct DeletePortfolioShareInput {
     pub portfolio_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeletePortfolioShareOutput {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteProductInput {
     /// <p><p>The language code.</p> <ul> <li> <p> <code>en</code> - English (default)</p> </li> <li> <p> <code>jp</code> - Japanese</p> </li> <li> <p> <code>zh</code> - Chinese</p> </li> </ul></p>
     #[serde(rename = "AcceptLanguage")]
@@ -526,10 +526,10 @@ pub struct DeleteProductInput {
     pub id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteProductOutput {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteProvisionedProductPlanInput {
     /// <p><p>The language code.</p> <ul> <li> <p> <code>en</code> - English (default)</p> </li> <li> <p> <code>jp</code> - Japanese</p> </li> <li> <p> <code>zh</code> - Chinese</p> </li> </ul></p>
     #[serde(rename = "AcceptLanguage")]
@@ -544,10 +544,10 @@ pub struct DeleteProvisionedProductPlanInput {
     pub plan_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteProvisionedProductPlanOutput {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteProvisioningArtifactInput {
     /// <p><p>The language code.</p> <ul> <li> <p> <code>en</code> - English (default)</p> </li> <li> <p> <code>jp</code> - Japanese</p> </li> <li> <p> <code>zh</code> - Chinese</p> </li> </ul></p>
     #[serde(rename = "AcceptLanguage")]
@@ -561,20 +561,20 @@ pub struct DeleteProvisioningArtifactInput {
     pub provisioning_artifact_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteProvisioningArtifactOutput {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteTagOptionInput {
     /// <p>The TagOption identifier.</p>
     #[serde(rename = "Id")]
     pub id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteTagOptionOutput {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeConstraintInput {
     /// <p><p>The language code.</p> <ul> <li> <p> <code>en</code> - English (default)</p> </li> <li> <p> <code>jp</code> - Japanese</p> </li> <li> <p> <code>zh</code> - Chinese</p> </li> </ul></p>
     #[serde(rename = "AcceptLanguage")]
@@ -585,7 +585,7 @@ pub struct DescribeConstraintInput {
     pub id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeConstraintOutput {
     /// <p>Information about the constraint.</p>
     #[serde(rename = "ConstraintDetail")]
@@ -601,7 +601,7 @@ pub struct DescribeConstraintOutput {
     pub status: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeCopyProductStatusInput {
     /// <p><p>The language code.</p> <ul> <li> <p> <code>en</code> - English (default)</p> </li> <li> <p> <code>jp</code> - Japanese</p> </li> <li> <p> <code>zh</code> - Chinese</p> </li> </ul></p>
     #[serde(rename = "AcceptLanguage")]
@@ -612,7 +612,7 @@ pub struct DescribeCopyProductStatusInput {
     pub copy_product_token: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeCopyProductStatusOutput {
     /// <p>The status of the copy product operation.</p>
     #[serde(rename = "CopyProductStatus")]
@@ -628,7 +628,7 @@ pub struct DescribeCopyProductStatusOutput {
     pub target_product_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribePortfolioInput {
     /// <p><p>The language code.</p> <ul> <li> <p> <code>en</code> - English (default)</p> </li> <li> <p> <code>jp</code> - Japanese</p> </li> <li> <p> <code>zh</code> - Chinese</p> </li> </ul></p>
     #[serde(rename = "AcceptLanguage")]
@@ -639,7 +639,7 @@ pub struct DescribePortfolioInput {
     pub id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribePortfolioOutput {
     /// <p>Information about the portfolio.</p>
     #[serde(rename = "PortfolioDetail")]
@@ -655,7 +655,7 @@ pub struct DescribePortfolioOutput {
     pub tags: Option<Vec<Tag>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeProductAsAdminInput {
     /// <p><p>The language code.</p> <ul> <li> <p> <code>en</code> - English (default)</p> </li> <li> <p> <code>jp</code> - Japanese</p> </li> <li> <p> <code>zh</code> - Chinese</p> </li> </ul></p>
     #[serde(rename = "AcceptLanguage")]
@@ -666,7 +666,7 @@ pub struct DescribeProductAsAdminInput {
     pub id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeProductAsAdminOutput {
     /// <p>Information about the product view.</p>
     #[serde(rename = "ProductViewDetail")]
@@ -686,7 +686,7 @@ pub struct DescribeProductAsAdminOutput {
     pub tags: Option<Vec<Tag>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeProductInput {
     /// <p><p>The language code.</p> <ul> <li> <p> <code>en</code> - English (default)</p> </li> <li> <p> <code>jp</code> - Japanese</p> </li> <li> <p> <code>zh</code> - Chinese</p> </li> </ul></p>
     #[serde(rename = "AcceptLanguage")]
@@ -697,7 +697,7 @@ pub struct DescribeProductInput {
     pub id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeProductOutput {
     /// <p>Summary information about the product view.</p>
     #[serde(rename = "ProductViewSummary")]
@@ -709,7 +709,7 @@ pub struct DescribeProductOutput {
     pub provisioning_artifacts: Option<Vec<ProvisioningArtifact>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeProductViewInput {
     /// <p><p>The language code.</p> <ul> <li> <p> <code>en</code> - English (default)</p> </li> <li> <p> <code>jp</code> - Japanese</p> </li> <li> <p> <code>zh</code> - Chinese</p> </li> </ul></p>
     #[serde(rename = "AcceptLanguage")]
@@ -720,7 +720,7 @@ pub struct DescribeProductViewInput {
     pub id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeProductViewOutput {
     /// <p>Summary information about the product.</p>
     #[serde(rename = "ProductViewSummary")]
@@ -732,7 +732,7 @@ pub struct DescribeProductViewOutput {
     pub provisioning_artifacts: Option<Vec<ProvisioningArtifact>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeProvisionedProductInput {
     /// <p><p>The language code.</p> <ul> <li> <p> <code>en</code> - English (default)</p> </li> <li> <p> <code>jp</code> - Japanese</p> </li> <li> <p> <code>zh</code> - Chinese</p> </li> </ul></p>
     #[serde(rename = "AcceptLanguage")]
@@ -743,7 +743,7 @@ pub struct DescribeProvisionedProductInput {
     pub id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeProvisionedProductOutput {
     /// <p>Any CloudWatch dashboards that were created when provisioning the product.</p>
     #[serde(rename = "CloudWatchDashboards")]
@@ -755,7 +755,7 @@ pub struct DescribeProvisionedProductOutput {
     pub provisioned_product_detail: Option<ProvisionedProductDetail>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeProvisionedProductPlanInput {
     /// <p><p>The language code.</p> <ul> <li> <p> <code>en</code> - English (default)</p> </li> <li> <p> <code>jp</code> - Japanese</p> </li> <li> <p> <code>zh</code> - Chinese</p> </li> </ul></p>
     #[serde(rename = "AcceptLanguage")]
@@ -774,7 +774,7 @@ pub struct DescribeProvisionedProductPlanInput {
     pub plan_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeProvisionedProductPlanOutput {
     /// <p>The page token to use to retrieve the next set of results. If there are no additional results, this value is null.</p>
     #[serde(rename = "NextPageToken")]
@@ -790,7 +790,7 @@ pub struct DescribeProvisionedProductPlanOutput {
     pub resource_changes: Option<Vec<ResourceChange>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeProvisioningArtifactInput {
     /// <p><p>The language code.</p> <ul> <li> <p> <code>en</code> - English (default)</p> </li> <li> <p> <code>jp</code> - Japanese</p> </li> <li> <p> <code>zh</code> - Chinese</p> </li> </ul></p>
     #[serde(rename = "AcceptLanguage")]
@@ -808,7 +808,7 @@ pub struct DescribeProvisioningArtifactInput {
     pub verbose: Option<bool>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeProvisioningArtifactOutput {
     /// <p>The URL of the CloudFormation template in Amazon S3.</p>
     #[serde(rename = "Info")]
@@ -824,7 +824,7 @@ pub struct DescribeProvisioningArtifactOutput {
     pub status: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeProvisioningParametersInput {
     /// <p><p>The language code.</p> <ul> <li> <p> <code>en</code> - English (default)</p> </li> <li> <p> <code>jp</code> - Japanese</p> </li> <li> <p> <code>zh</code> - Chinese</p> </li> </ul></p>
     #[serde(rename = "AcceptLanguage")]
@@ -842,7 +842,7 @@ pub struct DescribeProvisioningParametersInput {
     pub provisioning_artifact_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeProvisioningParametersOutput {
     /// <p>Information about the constraints used to provision the product.</p>
     #[serde(rename = "ConstraintSummaries")]
@@ -862,7 +862,7 @@ pub struct DescribeProvisioningParametersOutput {
     pub usage_instructions: Option<Vec<UsageInstruction>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeRecordInput {
     /// <p><p>The language code.</p> <ul> <li> <p> <code>en</code> - English (default)</p> </li> <li> <p> <code>jp</code> - Japanese</p> </li> <li> <p> <code>zh</code> - Chinese</p> </li> </ul></p>
     #[serde(rename = "AcceptLanguage")]
@@ -881,7 +881,7 @@ pub struct DescribeRecordInput {
     pub page_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeRecordOutput {
     /// <p>The page token to use to retrieve the next set of results. If there are no additional results, this value is null.</p>
     #[serde(rename = "NextPageToken")]
@@ -897,14 +897,14 @@ pub struct DescribeRecordOutput {
     pub record_outputs: Option<Vec<RecordOutput>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeTagOptionInput {
     /// <p>The TagOption identifier.</p>
     #[serde(rename = "Id")]
     pub id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeTagOptionOutput {
     /// <p>Information about the TagOption.</p>
     #[serde(rename = "TagOptionDetail")]
@@ -912,7 +912,7 @@ pub struct DescribeTagOptionOutput {
     pub tag_option_detail: Option<TagOptionDetail>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DisassociatePrincipalFromPortfolioInput {
     /// <p><p>The language code.</p> <ul> <li> <p> <code>en</code> - English (default)</p> </li> <li> <p> <code>jp</code> - Japanese</p> </li> <li> <p> <code>zh</code> - Chinese</p> </li> </ul></p>
     #[serde(rename = "AcceptLanguage")]
@@ -926,10 +926,10 @@ pub struct DisassociatePrincipalFromPortfolioInput {
     pub principal_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DisassociatePrincipalFromPortfolioOutput {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DisassociateProductFromPortfolioInput {
     /// <p><p>The language code.</p> <ul> <li> <p> <code>en</code> - English (default)</p> </li> <li> <p> <code>jp</code> - Japanese</p> </li> <li> <p> <code>zh</code> - Chinese</p> </li> </ul></p>
     #[serde(rename = "AcceptLanguage")]
@@ -943,10 +943,10 @@ pub struct DisassociateProductFromPortfolioInput {
     pub product_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DisassociateProductFromPortfolioOutput {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DisassociateTagOptionFromResourceInput {
     /// <p>The resource identifier.</p>
     #[serde(rename = "ResourceId")]
@@ -956,10 +956,10 @@ pub struct DisassociateTagOptionFromResourceInput {
     pub tag_option_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DisassociateTagOptionFromResourceOutput {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ExecuteProvisionedProductPlanInput {
     /// <p><p>The language code.</p> <ul> <li> <p> <code>en</code> - English (default)</p> </li> <li> <p> <code>jp</code> - Japanese</p> </li> <li> <p> <code>zh</code> - Chinese</p> </li> </ul></p>
     #[serde(rename = "AcceptLanguage")]
@@ -973,7 +973,7 @@ pub struct ExecuteProvisionedProductPlanInput {
     pub plan_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ExecuteProvisionedProductPlanOutput {
     /// <p>Information about the result of provisioning the product.</p>
     #[serde(rename = "RecordDetail")]
@@ -982,7 +982,7 @@ pub struct ExecuteProvisionedProductPlanOutput {
 }
 
 /// <p>Summary information about a product path for a user.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct LaunchPathSummary {
     /// <p>The constraints on the portfolio-product relationship.</p>
     #[serde(rename = "ConstraintSummaries")]
@@ -1002,7 +1002,7 @@ pub struct LaunchPathSummary {
     pub tags: Option<Vec<Tag>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListAcceptedPortfolioSharesInput {
     /// <p><p>The language code.</p> <ul> <li> <p> <code>en</code> - English (default)</p> </li> <li> <p> <code>jp</code> - Japanese</p> </li> <li> <p> <code>zh</code> - Chinese</p> </li> </ul></p>
     #[serde(rename = "AcceptLanguage")]
@@ -1018,7 +1018,7 @@ pub struct ListAcceptedPortfolioSharesInput {
     pub page_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListAcceptedPortfolioSharesOutput {
     /// <p>The page token to use to retrieve the next set of results. If there are no additional results, this value is null.</p>
     #[serde(rename = "NextPageToken")]
@@ -1030,7 +1030,7 @@ pub struct ListAcceptedPortfolioSharesOutput {
     pub portfolio_details: Option<Vec<PortfolioDetail>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListConstraintsForPortfolioInput {
     /// <p><p>The language code.</p> <ul> <li> <p> <code>en</code> - English (default)</p> </li> <li> <p> <code>jp</code> - Japanese</p> </li> <li> <p> <code>zh</code> - Chinese</p> </li> </ul></p>
     #[serde(rename = "AcceptLanguage")]
@@ -1053,7 +1053,7 @@ pub struct ListConstraintsForPortfolioInput {
     pub product_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListConstraintsForPortfolioOutput {
     /// <p>Information about the constraints.</p>
     #[serde(rename = "ConstraintDetails")]
@@ -1065,7 +1065,7 @@ pub struct ListConstraintsForPortfolioOutput {
     pub next_page_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListLaunchPathsInput {
     /// <p><p>The language code.</p> <ul> <li> <p> <code>en</code> - English (default)</p> </li> <li> <p> <code>jp</code> - Japanese</p> </li> <li> <p> <code>zh</code> - Chinese</p> </li> </ul></p>
     #[serde(rename = "AcceptLanguage")]
@@ -1084,7 +1084,7 @@ pub struct ListLaunchPathsInput {
     pub product_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListLaunchPathsOutput {
     /// <p>Information about the launch path.</p>
     #[serde(rename = "LaunchPathSummaries")]
@@ -1096,7 +1096,7 @@ pub struct ListLaunchPathsOutput {
     pub next_page_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListPortfolioAccessInput {
     /// <p><p>The language code.</p> <ul> <li> <p> <code>en</code> - English (default)</p> </li> <li> <p> <code>jp</code> - Japanese</p> </li> <li> <p> <code>zh</code> - Chinese</p> </li> </ul></p>
     #[serde(rename = "AcceptLanguage")]
@@ -1107,7 +1107,7 @@ pub struct ListPortfolioAccessInput {
     pub portfolio_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListPortfolioAccessOutput {
     /// <p>Information about the AWS accounts with access to the portfolio.</p>
     #[serde(rename = "AccountIds")]
@@ -1119,7 +1119,7 @@ pub struct ListPortfolioAccessOutput {
     pub next_page_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListPortfoliosForProductInput {
     /// <p><p>The language code.</p> <ul> <li> <p> <code>en</code> - English (default)</p> </li> <li> <p> <code>jp</code> - Japanese</p> </li> <li> <p> <code>zh</code> - Chinese</p> </li> </ul></p>
     #[serde(rename = "AcceptLanguage")]
@@ -1138,7 +1138,7 @@ pub struct ListPortfoliosForProductInput {
     pub product_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListPortfoliosForProductOutput {
     /// <p>The page token to use to retrieve the next set of results. If there are no additional results, this value is null.</p>
     #[serde(rename = "NextPageToken")]
@@ -1150,7 +1150,7 @@ pub struct ListPortfoliosForProductOutput {
     pub portfolio_details: Option<Vec<PortfolioDetail>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListPortfoliosInput {
     /// <p><p>The language code.</p> <ul> <li> <p> <code>en</code> - English (default)</p> </li> <li> <p> <code>jp</code> - Japanese</p> </li> <li> <p> <code>zh</code> - Chinese</p> </li> </ul></p>
     #[serde(rename = "AcceptLanguage")]
@@ -1166,7 +1166,7 @@ pub struct ListPortfoliosInput {
     pub page_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListPortfoliosOutput {
     /// <p>The page token to use to retrieve the next set of results. If there are no additional results, this value is null.</p>
     #[serde(rename = "NextPageToken")]
@@ -1178,7 +1178,7 @@ pub struct ListPortfoliosOutput {
     pub portfolio_details: Option<Vec<PortfolioDetail>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListPrincipalsForPortfolioInput {
     /// <p><p>The language code.</p> <ul> <li> <p> <code>en</code> - English (default)</p> </li> <li> <p> <code>jp</code> - Japanese</p> </li> <li> <p> <code>zh</code> - Chinese</p> </li> </ul></p>
     #[serde(rename = "AcceptLanguage")]
@@ -1197,7 +1197,7 @@ pub struct ListPrincipalsForPortfolioInput {
     pub portfolio_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListPrincipalsForPortfolioOutput {
     /// <p>The page token to use to retrieve the next set of results. If there are no additional results, this value is null.</p>
     #[serde(rename = "NextPageToken")]
@@ -1209,7 +1209,7 @@ pub struct ListPrincipalsForPortfolioOutput {
     pub principals: Option<Vec<Principal>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListProvisionedProductPlansInput {
     /// <p><p>The language code.</p> <ul> <li> <p> <code>en</code> - English (default)</p> </li> <li> <p> <code>jp</code> - Japanese</p> </li> <li> <p> <code>zh</code> - Chinese</p> </li> </ul></p>
     #[serde(rename = "AcceptLanguage")]
@@ -1233,7 +1233,7 @@ pub struct ListProvisionedProductPlansInput {
     pub provision_product_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListProvisionedProductPlansOutput {
     /// <p>The page token to use to retrieve the next set of results. If there are no additional results, this value is null.</p>
     #[serde(rename = "NextPageToken")]
@@ -1245,7 +1245,7 @@ pub struct ListProvisionedProductPlansOutput {
     pub provisioned_product_plans: Option<Vec<ProvisionedProductPlanSummary>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListProvisioningArtifactsInput {
     /// <p><p>The language code.</p> <ul> <li> <p> <code>en</code> - English (default)</p> </li> <li> <p> <code>jp</code> - Japanese</p> </li> <li> <p> <code>zh</code> - Chinese</p> </li> </ul></p>
     #[serde(rename = "AcceptLanguage")]
@@ -1256,7 +1256,7 @@ pub struct ListProvisioningArtifactsInput {
     pub product_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListProvisioningArtifactsOutput {
     /// <p>The page token to use to retrieve the next set of results. If there are no additional results, this value is null.</p>
     #[serde(rename = "NextPageToken")]
@@ -1268,7 +1268,7 @@ pub struct ListProvisioningArtifactsOutput {
     pub provisioning_artifact_details: Option<Vec<ProvisioningArtifactDetail>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListRecordHistoryInput {
     /// <p><p>The language code.</p> <ul> <li> <p> <code>en</code> - English (default)</p> </li> <li> <p> <code>jp</code> - Japanese</p> </li> <li> <p> <code>zh</code> - Chinese</p> </li> </ul></p>
     #[serde(rename = "AcceptLanguage")]
@@ -1292,7 +1292,7 @@ pub struct ListRecordHistoryInput {
     pub search_filter: Option<ListRecordHistorySearchFilter>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListRecordHistoryOutput {
     /// <p>The page token to use to retrieve the next set of results. If there are no additional results, this value is null.</p>
     #[serde(rename = "NextPageToken")]
@@ -1305,7 +1305,7 @@ pub struct ListRecordHistoryOutput {
 }
 
 /// <p>The search filter to use when listing history records.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListRecordHistorySearchFilter {
     /// <p><p>The filter key.</p> <ul> <li> <p> <code>product</code> - Filter results based on the specified product identifier.</p> </li> <li> <p> <code>provisionedproduct</code> - Filter results based on the provisioned product identifier.</p> </li> </ul></p>
     #[serde(rename = "Key")]
@@ -1317,7 +1317,7 @@ pub struct ListRecordHistorySearchFilter {
     pub value: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListResourcesForTagOptionInput {
     /// <p>The maximum number of items to return with this call.</p>
     #[serde(rename = "PageSize")]
@@ -1336,7 +1336,7 @@ pub struct ListResourcesForTagOptionInput {
     pub tag_option_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListResourcesForTagOptionOutput {
     /// <p>The page token for the next set of results. To retrieve the first set of results, use null.</p>
     #[serde(rename = "PageToken")]
@@ -1349,7 +1349,7 @@ pub struct ListResourcesForTagOptionOutput {
 }
 
 /// <p>Filters to use when listing TagOptions.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListTagOptionsFilters {
     /// <p>The active state.</p>
     #[serde(rename = "Active")]
@@ -1365,7 +1365,7 @@ pub struct ListTagOptionsFilters {
     pub value: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListTagOptionsInput {
     /// <p>The search filters. If no search filters are specified, the output includes all TagOptions.</p>
     #[serde(rename = "Filters")]
@@ -1381,7 +1381,7 @@ pub struct ListTagOptionsInput {
     pub page_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListTagOptionsOutput {
     /// <p>The page token for the next set of results. To retrieve the first set of results, use null.</p>
     #[serde(rename = "PageToken")]
@@ -1394,7 +1394,7 @@ pub struct ListTagOptionsOutput {
 }
 
 /// <p>The constraints that the administrator has put on the parameter.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ParameterConstraints {
     /// <p>The values that the administrator has allowed for the parameter.</p>
     #[serde(rename = "AllowedValues")]
@@ -1403,7 +1403,7 @@ pub struct ParameterConstraints {
 }
 
 /// <p>Information about a portfolio.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PortfolioDetail {
     /// <p>The ARN assigned to the portfolio.</p>
     #[serde(rename = "ARN")]
@@ -1432,7 +1432,7 @@ pub struct PortfolioDetail {
 }
 
 /// <p>Information about a principal.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Principal {
     /// <p>The ARN of the principal (IAM user, role, or group).</p>
     #[serde(rename = "PrincipalARN")]
@@ -1445,7 +1445,7 @@ pub struct Principal {
 }
 
 /// <p>A single product view aggregation value/count pair, containing metadata about each product to which the calling user has access.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ProductViewAggregationValue {
     /// <p>An approximate count of the products that match the value.</p>
     #[serde(rename = "ApproximateCount")]
@@ -1458,7 +1458,7 @@ pub struct ProductViewAggregationValue {
 }
 
 /// <p>Information about a product view.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ProductViewDetail {
     /// <p>The UTC time stamp of the creation time.</p>
     #[serde(rename = "CreatedTime")]
@@ -1479,7 +1479,7 @@ pub struct ProductViewDetail {
 }
 
 /// <p>Summary information about a product view.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ProductViewSummary {
     /// <p>The distributor of the product. Contact the product administrator for the significance of this value.</p>
     #[serde(rename = "Distributor")]
@@ -1527,7 +1527,7 @@ pub struct ProductViewSummary {
     pub type_: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ProvisionProductInput {
     /// <p><p>The language code.</p> <ul> <li> <p> <code>en</code> - English (default)</p> </li> <li> <p> <code>jp</code> - Japanese</p> </li> <li> <p> <code>zh</code> - Chinese</p> </li> </ul></p>
     #[serde(rename = "AcceptLanguage")]
@@ -1563,7 +1563,7 @@ pub struct ProvisionProductInput {
     pub tags: Option<Vec<Tag>>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ProvisionProductOutput {
     /// <p>Information about the result of provisioning the product.</p>
     #[serde(rename = "RecordDetail")]
@@ -1572,7 +1572,7 @@ pub struct ProvisionProductOutput {
 }
 
 /// <p>Information about a provisioned product.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ProvisionedProductAttribute {
     /// <p>The ARN of the provisioned product.</p>
     #[serde(rename = "Arn")]
@@ -1637,7 +1637,7 @@ pub struct ProvisionedProductAttribute {
 }
 
 /// <p>Information about a provisioned product.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ProvisionedProductDetail {
     /// <p>The ARN of the provisioned product.</p>
     #[serde(rename = "Arn")]
@@ -1678,7 +1678,7 @@ pub struct ProvisionedProductDetail {
 }
 
 /// <p>Information about a plan.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ProvisionedProductPlanDetails {
     /// <p>The UTC time stamp of the creation time.</p>
     #[serde(rename = "CreatedTime")]
@@ -1743,7 +1743,7 @@ pub struct ProvisionedProductPlanDetails {
 }
 
 /// <p>Summary information about a plan.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ProvisionedProductPlanSummary {
     /// <p>The plan identifier.</p>
     #[serde(rename = "PlanId")]
@@ -1772,7 +1772,7 @@ pub struct ProvisionedProductPlanSummary {
 }
 
 /// <p>Information about a provisioning artifact. A provisioning artifact is also known as a product version.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ProvisioningArtifact {
     /// <p>The UTC time stamp of the creation time.</p>
     #[serde(rename = "CreatedTime")]
@@ -1793,7 +1793,7 @@ pub struct ProvisioningArtifact {
 }
 
 /// <p>Information about a provisioning artifact (also known as a version) for a product.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ProvisioningArtifactDetail {
     /// <p>Indicates whether the product version is active.</p>
     #[serde(rename = "Active")]
@@ -1822,7 +1822,7 @@ pub struct ProvisioningArtifactDetail {
 }
 
 /// <p>Information about a parameter used to provision a product.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ProvisioningArtifactParameter {
     /// <p>The default value.</p>
     #[serde(rename = "DefaultValue")]
@@ -1851,7 +1851,7 @@ pub struct ProvisioningArtifactParameter {
 }
 
 /// <p>Information about a provisioning artifact (also known as a version) for a product.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ProvisioningArtifactProperties {
     /// <p>The description of the provisioning artifact, including how it differs from the previous provisioning artifact.</p>
     #[serde(rename = "Description")]
@@ -1871,7 +1871,7 @@ pub struct ProvisioningArtifactProperties {
 }
 
 /// <p>Summary information about a provisioning artifact (also known as a version) for a product.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ProvisioningArtifactSummary {
     /// <p>The UTC time stamp of the creation time.</p>
     #[serde(rename = "CreatedTime")]
@@ -1896,7 +1896,7 @@ pub struct ProvisioningArtifactSummary {
 }
 
 /// <p>Information about a parameter used to provision a product.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ProvisioningParameter {
     /// <p>The parameter key.</p>
     #[serde(rename = "Key")]
@@ -1909,7 +1909,7 @@ pub struct ProvisioningParameter {
 }
 
 /// <p>Information about a request operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RecordDetail {
     /// <p>The UTC time stamp of the creation time.</p>
     #[serde(rename = "CreatedTime")]
@@ -1966,7 +1966,7 @@ pub struct RecordDetail {
 }
 
 /// <p>The error code and description resulting from an operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RecordError {
     /// <p>The numeric value of the error.</p>
     #[serde(rename = "Code")]
@@ -1979,7 +1979,7 @@ pub struct RecordError {
 }
 
 /// <p>The output for the product created as the result of a request. For example, the output for a CloudFormation-backed product that creates an S3 bucket would include the S3 bucket URL.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RecordOutput {
     /// <p>The description of the output.</p>
     #[serde(rename = "Description")]
@@ -1996,7 +1996,7 @@ pub struct RecordOutput {
 }
 
 /// <p>Information about a tag, which is a key-value pair.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RecordTag {
     /// <p>The key for this tag.</p>
     #[serde(rename = "Key")]
@@ -2008,7 +2008,7 @@ pub struct RecordTag {
     pub value: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RejectPortfolioShareInput {
     /// <p><p>The language code.</p> <ul> <li> <p> <code>en</code> - English (default)</p> </li> <li> <p> <code>jp</code> - Japanese</p> </li> <li> <p> <code>zh</code> - Chinese</p> </li> </ul></p>
     #[serde(rename = "AcceptLanguage")]
@@ -2019,11 +2019,11 @@ pub struct RejectPortfolioShareInput {
     pub portfolio_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RejectPortfolioShareOutput {}
 
 /// <p>Information about a resource change that will occur when a plan is executed.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ResourceChange {
     /// <p>The change action.</p>
     #[serde(rename = "Action")]
@@ -2056,7 +2056,7 @@ pub struct ResourceChange {
 }
 
 /// <p>Information about a change to a resource attribute.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ResourceChangeDetail {
     /// <p>The ID of the entity that caused the change.</p>
     #[serde(rename = "CausingEntity")]
@@ -2073,7 +2073,7 @@ pub struct ResourceChangeDetail {
 }
 
 /// <p>Information about a resource.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ResourceDetail {
     /// <p>The ARN of the resource.</p>
     #[serde(rename = "ARN")]
@@ -2098,7 +2098,7 @@ pub struct ResourceDetail {
 }
 
 /// <p>Information about a change to a resource attribute.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ResourceTargetDefinition {
     /// <p>The attribute to be changed.</p>
     #[serde(rename = "Attribute")]
@@ -2114,7 +2114,7 @@ pub struct ResourceTargetDefinition {
     pub requires_recreation: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ScanProvisionedProductsInput {
     /// <p><p>The language code.</p> <ul> <li> <p> <code>en</code> - English (default)</p> </li> <li> <p> <code>jp</code> - Japanese</p> </li> <li> <p> <code>zh</code> - Chinese</p> </li> </ul></p>
     #[serde(rename = "AcceptLanguage")]
@@ -2134,7 +2134,7 @@ pub struct ScanProvisionedProductsInput {
     pub page_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ScanProvisionedProductsOutput {
     /// <p>The page token to use to retrieve the next set of results. If there are no additional results, this value is null.</p>
     #[serde(rename = "NextPageToken")]
@@ -2146,7 +2146,7 @@ pub struct ScanProvisionedProductsOutput {
     pub provisioned_products: Option<Vec<ProvisionedProductDetail>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SearchProductsAsAdminInput {
     /// <p><p>The language code.</p> <ul> <li> <p> <code>en</code> - English (default)</p> </li> <li> <p> <code>jp</code> - Japanese</p> </li> <li> <p> <code>zh</code> - Chinese</p> </li> </ul></p>
     #[serde(rename = "AcceptLanguage")]
@@ -2182,7 +2182,7 @@ pub struct SearchProductsAsAdminInput {
     pub sort_order: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SearchProductsAsAdminOutput {
     /// <p>The page token to use to retrieve the next set of results. If there are no additional results, this value is null.</p>
     #[serde(rename = "NextPageToken")]
@@ -2194,7 +2194,7 @@ pub struct SearchProductsAsAdminOutput {
     pub product_view_details: Option<Vec<ProductViewDetail>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SearchProductsInput {
     /// <p><p>The language code.</p> <ul> <li> <p> <code>en</code> - English (default)</p> </li> <li> <p> <code>jp</code> - Japanese</p> </li> <li> <p> <code>zh</code> - Chinese</p> </li> </ul></p>
     #[serde(rename = "AcceptLanguage")]
@@ -2222,7 +2222,7 @@ pub struct SearchProductsInput {
     pub sort_order: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SearchProductsOutput {
     /// <p>The page token to use to retrieve the next set of results. If there are no additional results, this value is null.</p>
     #[serde(rename = "NextPageToken")]
@@ -2239,7 +2239,7 @@ pub struct SearchProductsOutput {
     pub product_view_summaries: Option<Vec<ProductViewSummary>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SearchProvisionedProductsInput {
     /// <p><p>The language code.</p> <ul> <li> <p> <code>en</code> - English (default)</p> </li> <li> <p> <code>jp</code> - Japanese</p> </li> <li> <p> <code>zh</code> - Chinese</p> </li> </ul></p>
     #[serde(rename = "AcceptLanguage")]
@@ -2271,7 +2271,7 @@ pub struct SearchProvisionedProductsInput {
     pub sort_order: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SearchProvisionedProductsOutput {
     /// <p>The page token to use to retrieve the next set of results. If there are no additional results, this value is null.</p>
     #[serde(rename = "NextPageToken")]
@@ -2288,7 +2288,7 @@ pub struct SearchProvisionedProductsOutput {
 }
 
 /// <p>Information about a tag. A tag is a key-value pair. Tags are propagated to the resources created when provisioning a product.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Tag {
     /// <p>The tag key.</p>
     #[serde(rename = "Key")]
@@ -2299,7 +2299,7 @@ pub struct Tag {
 }
 
 /// <p>Information about a TagOption.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct TagOptionDetail {
     /// <p>The TagOption active state.</p>
     #[serde(rename = "Active")]
@@ -2320,7 +2320,7 @@ pub struct TagOptionDetail {
 }
 
 /// <p>Summary information about a TagOption.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct TagOptionSummary {
     /// <p>The TagOption key.</p>
     #[serde(rename = "Key")]
@@ -2332,7 +2332,7 @@ pub struct TagOptionSummary {
     pub values: Option<Vec<String>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct TerminateProvisionedProductInput {
     /// <p><p>The language code.</p> <ul> <li> <p> <code>en</code> - English (default)</p> </li> <li> <p> <code>jp</code> - Japanese</p> </li> <li> <p> <code>zh</code> - Chinese</p> </li> </ul></p>
     #[serde(rename = "AcceptLanguage")]
@@ -2355,7 +2355,7 @@ pub struct TerminateProvisionedProductInput {
     pub terminate_token: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct TerminateProvisionedProductOutput {
     /// <p>Information about the result of this request.</p>
     #[serde(rename = "RecordDetail")]
@@ -2363,7 +2363,7 @@ pub struct TerminateProvisionedProductOutput {
     pub record_detail: Option<RecordDetail>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateConstraintInput {
     /// <p><p>The language code.</p> <ul> <li> <p> <code>en</code> - English (default)</p> </li> <li> <p> <code>jp</code> - Japanese</p> </li> <li> <p> <code>zh</code> - Chinese</p> </li> </ul></p>
     #[serde(rename = "AcceptLanguage")]
@@ -2378,7 +2378,7 @@ pub struct UpdateConstraintInput {
     pub id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateConstraintOutput {
     /// <p>Information about the constraint.</p>
     #[serde(rename = "ConstraintDetail")]
@@ -2394,7 +2394,7 @@ pub struct UpdateConstraintOutput {
     pub status: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdatePortfolioInput {
     /// <p><p>The language code.</p> <ul> <li> <p> <code>en</code> - English (default)</p> </li> <li> <p> <code>jp</code> - Japanese</p> </li> <li> <p> <code>zh</code> - Chinese</p> </li> </ul></p>
     #[serde(rename = "AcceptLanguage")]
@@ -2425,7 +2425,7 @@ pub struct UpdatePortfolioInput {
     pub remove_tags: Option<Vec<String>>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdatePortfolioOutput {
     /// <p>Information about the portfolio.</p>
     #[serde(rename = "PortfolioDetail")]
@@ -2437,7 +2437,7 @@ pub struct UpdatePortfolioOutput {
     pub tags: Option<Vec<Tag>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateProductInput {
     /// <p><p>The language code.</p> <ul> <li> <p> <code>en</code> - English (default)</p> </li> <li> <p> <code>jp</code> - Japanese</p> </li> <li> <p> <code>zh</code> - Chinese</p> </li> </ul></p>
     #[serde(rename = "AcceptLanguage")]
@@ -2484,7 +2484,7 @@ pub struct UpdateProductInput {
     pub support_url: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateProductOutput {
     /// <p>Information about the product view.</p>
     #[serde(rename = "ProductViewDetail")]
@@ -2496,7 +2496,7 @@ pub struct UpdateProductOutput {
     pub tags: Option<Vec<Tag>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateProvisionedProductInput {
     /// <p><p>The language code.</p> <ul> <li> <p> <code>en</code> - English (default)</p> </li> <li> <p> <code>jp</code> - Japanese</p> </li> <li> <p> <code>zh</code> - Chinese</p> </li> </ul></p>
     #[serde(rename = "AcceptLanguage")]
@@ -2531,7 +2531,7 @@ pub struct UpdateProvisionedProductInput {
     pub update_token: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateProvisionedProductOutput {
     /// <p>Information about the result of the request.</p>
     #[serde(rename = "RecordDetail")]
@@ -2539,7 +2539,7 @@ pub struct UpdateProvisionedProductOutput {
     pub record_detail: Option<RecordDetail>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateProvisioningArtifactInput {
     /// <p><p>The language code.</p> <ul> <li> <p> <code>en</code> - English (default)</p> </li> <li> <p> <code>jp</code> - Japanese</p> </li> <li> <p> <code>zh</code> - Chinese</p> </li> </ul></p>
     #[serde(rename = "AcceptLanguage")]
@@ -2565,7 +2565,7 @@ pub struct UpdateProvisioningArtifactInput {
     pub provisioning_artifact_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateProvisioningArtifactOutput {
     /// <p>The URL of the CloudFormation template in Amazon S3.</p>
     #[serde(rename = "Info")]
@@ -2582,7 +2582,7 @@ pub struct UpdateProvisioningArtifactOutput {
 }
 
 /// <p>The parameter key-value pair used to update a provisioned product.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct UpdateProvisioningParameter {
     /// <p>The parameter key.</p>
     #[serde(rename = "Key")]
@@ -2598,7 +2598,7 @@ pub struct UpdateProvisioningParameter {
     pub value: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateTagOptionInput {
     /// <p>The updated active state.</p>
     #[serde(rename = "Active")]
@@ -2613,7 +2613,7 @@ pub struct UpdateTagOptionInput {
     pub value: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateTagOptionOutput {
     /// <p>Information about the TagOption.</p>
     #[serde(rename = "TagOptionDetail")]
@@ -2622,7 +2622,7 @@ pub struct UpdateTagOptionOutput {
 }
 
 /// <p>Additional information provided by the administrator.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UsageInstruction {
     /// <p>The usage instruction type for the value.</p>
     #[serde(rename = "Type")]

--- a/rusoto/services/ses/src/generated.rs
+++ b/rusoto/services/ses/src/generated.rs
@@ -44,7 +44,7 @@ enum DeserializerNext {
     Element(String),
 }
 /// <p>When included in a receipt rule, this action adds a header to the received email.</p> <p>For information about adding a header using a receipt rule, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-action-add-header.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AddHeaderAction {
     /// <p>The name of the header to add. Must be between 1 and 50 characters, inclusive, and consist of alphanumeric (a-z, A-Z, 0-9) characters and dashes only.</p>
     pub header_name: String,
@@ -212,7 +212,7 @@ impl BehaviorOnMXFailureDeserializer {
     }
 }
 /// <p>Represents the body of the message. You can specify text, HTML, or both. If you use both, then the message should display correctly in the widest variety of email clients.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Body {
     /// <p>The content of the message, in HTML format. Use this for email clients that can process HTML. You can include clickable links, formatted text, and much more in an HTML message.</p>
     pub html: Option<Content>,
@@ -239,7 +239,7 @@ impl BodySerializer {
 }
 
 /// <p>When included in a receipt rule, this action rejects the received email by returning a bounce response to the sender and, optionally, publishes a notification to Amazon Simple Notification Service (Amazon SNS).</p> <p>For information about sending a bounce message in response to a received email, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-action-bounce.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct BounceAction {
     /// <p>Human-readable text to include in the bounce message.</p>
     pub message: String,
@@ -393,7 +393,7 @@ impl BounceStatusCodeDeserializer {
     }
 }
 /// <p>Recipient-related information to include in the Delivery Status Notification (DSN) when an email that Amazon SES receives on your behalf bounces.</p> <p>For information about receiving email through Amazon SES, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct BouncedRecipientInfo {
     /// <p>The reason for the bounce. You must provide either this parameter or <code>RecipientDsnFields</code>.</p>
     pub bounce_type: Option<String>,
@@ -452,7 +452,7 @@ impl BouncedRecipientInfoListSerializer {
 }
 
 /// <p>An array that contains one or more Destinations, as well as the tags and replacement data associated with each of those Destinations.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct BulkEmailDestination {
     pub destination: Destination,
     /// <p>A list of tags, in the form of name/value pairs, to apply to an email that you send using <code>SendBulkTemplatedEmail</code>. Tags correspond to characteristics of the email that you define, so that you can publish email sending events.</p>
@@ -503,7 +503,7 @@ impl BulkEmailDestinationListSerializer {
 }
 
 /// <p>An object that contains the response from the <code>SendBulkTemplatedEmail</code> operation.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct BulkEmailDestinationStatus {
     /// <p>A description of an error that prevented a message being sent using the <code>SendBulkTemplatedEmail</code> operation.</p>
     pub error: Option<String>,
@@ -632,7 +632,7 @@ impl CidrDeserializer {
     }
 }
 /// <p>Represents a request to create a receipt rule set by cloning an existing one. You use receipt rule sets to receive email with Amazon SES. For more information, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CloneReceiptRuleSetRequest {
     /// <p>The name of the rule set to clone.</p>
     pub original_rule_set_name: String,
@@ -661,7 +661,7 @@ impl CloneReceiptRuleSetRequestSerializer {
 }
 
 /// <p>An empty element returned on a successful request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CloneReceiptRuleSetResponse {}
 
 struct CloneReceiptRuleSetResponseDeserializer;
@@ -681,7 +681,7 @@ impl CloneReceiptRuleSetResponseDeserializer {
     }
 }
 /// <p>Contains information associated with an Amazon CloudWatch event destination to which email sending events are published.</p> <p>Event destinations, such as Amazon CloudWatch, are associated with configuration sets, which enable you to publish email sending events. For information about using configuration sets, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CloudWatchDestination {
     /// <p>A list of dimensions upon which to categorize your emails when you publish email sending events to Amazon CloudWatch.</p>
     pub dimension_configurations: Vec<CloudWatchDimensionConfiguration>,
@@ -749,7 +749,7 @@ impl CloudWatchDestinationSerializer {
 }
 
 /// <p>Contains the dimension configuration to use when you publish email sending events to Amazon CloudWatch.</p> <p>For information about publishing email sending events to Amazon CloudWatch, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CloudWatchDimensionConfiguration {
     /// <p><p>The default value of the dimension that is published to Amazon CloudWatch if you do not provide the value of the dimension when you send an email. The default value must:</p> <ul> <li> <p>This value can only contain ASCII letters (a-z, A-Z), numbers (0-9), underscores (_), or dashes (-).</p> </li> <li> <p>Contain less than 256 characters.</p> </li> </ul></p>
     pub default_dimension_value: String,
@@ -897,7 +897,7 @@ impl CloudWatchDimensionConfigurationsSerializer {
 }
 
 /// <p>The name of the configuration set.</p> <p>Configuration sets let you create groups of rules that you can apply to the emails you send using Amazon SES. For more information about using configuration sets, see <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/using-configuration-sets.html">Using Amazon SES Configuration Sets</a> in the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ConfigurationSet {
     /// <p><p>The name of the configuration set. The name must meet the following requirements:</p> <ul> <li> <p>Contain only letters (a-z, A-Z), numbers (0-9), underscores (_), or dashes (-).</p> </li> <li> <p>Contain 64 characters or fewer.</p> </li> </ul></p>
     pub name: String,
@@ -1028,7 +1028,7 @@ impl ConfigurationSetsDeserializer {
     }
 }
 /// <p>Represents textual data, plus an optional character set specification.</p> <p>By default, the text must be 7-bit ASCII, due to the constraints of the SMTP protocol. If the text must contain any other characters, then you must also specify a character set. Examples include UTF-8, ISO-8859-1, and Shift_JIS.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Content {
     /// <p>The character set of the content.</p>
     pub charset: Option<String>,
@@ -1073,7 +1073,7 @@ impl CounterDeserializer {
     }
 }
 /// <p>Represents a request to create a configuration set event destination. A configuration set event destination, which can be either Amazon CloudWatch or Amazon Kinesis Firehose, describes an AWS service in which Amazon SES publishes the email sending events associated with a configuration set. For information about using configuration sets, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateConfigurationSetEventDestinationRequest {
     /// <p>The name of the configuration set that the event destination should be associated with.</p>
     pub configuration_set_name: String,
@@ -1107,7 +1107,7 @@ impl CreateConfigurationSetEventDestinationRequestSerializer {
 }
 
 /// <p>An empty element returned on a successful request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateConfigurationSetEventDestinationResponse {}
 
 struct CreateConfigurationSetEventDestinationResponseDeserializer;
@@ -1127,7 +1127,7 @@ impl CreateConfigurationSetEventDestinationResponseDeserializer {
     }
 }
 /// <p>Represents a request to create a configuration set. Configuration sets enable you to publish email sending events. For information about using configuration sets, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateConfigurationSetRequest {
     /// <p>A data structure that contains the name of the configuration set.</p>
     pub configuration_set: ConfigurationSet,
@@ -1151,7 +1151,7 @@ impl CreateConfigurationSetRequestSerializer {
 }
 
 /// <p>An empty element returned on a successful request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateConfigurationSetResponse {}
 
 struct CreateConfigurationSetResponseDeserializer;
@@ -1171,7 +1171,7 @@ impl CreateConfigurationSetResponseDeserializer {
     }
 }
 /// <p>Represents a request to create an open and click tracking option object in a configuration set. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateConfigurationSetTrackingOptionsRequest {
     /// <p>The name of the configuration set that the tracking options should be associated with.</p>
     pub configuration_set_name: String,
@@ -1204,7 +1204,7 @@ impl CreateConfigurationSetTrackingOptionsRequestSerializer {
 }
 
 /// <p>An empty element returned on a successful request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateConfigurationSetTrackingOptionsResponse {}
 
 struct CreateConfigurationSetTrackingOptionsResponseDeserializer;
@@ -1224,7 +1224,7 @@ impl CreateConfigurationSetTrackingOptionsResponseDeserializer {
     }
 }
 /// <p>Represents a request to create a custom verification email template.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateCustomVerificationEmailTemplateRequest {
     /// <p>The URL that the recipient of the verification email is sent to if his or her address is not successfully verified.</p>
     pub failure_redirection_url: String,
@@ -1281,7 +1281,7 @@ impl CreateCustomVerificationEmailTemplateRequestSerializer {
 }
 
 /// <p>Represents a request to create a new IP address filter. You use IP address filters when you receive email with Amazon SES. For more information, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateReceiptFilterRequest {
     /// <p>A data structure that describes the IP address filter to create, which consists of a name, an IP address range, and whether to allow or block mail from it.</p>
     pub filter: ReceiptFilter,
@@ -1301,7 +1301,7 @@ impl CreateReceiptFilterRequestSerializer {
 }
 
 /// <p>An empty element returned on a successful request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateReceiptFilterResponse {}
 
 struct CreateReceiptFilterResponseDeserializer;
@@ -1321,7 +1321,7 @@ impl CreateReceiptFilterResponseDeserializer {
     }
 }
 /// <p>Represents a request to create a receipt rule. You use receipt rules to receive email with Amazon SES. For more information, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateReceiptRuleRequest {
     /// <p>The name of an existing rule after which the new rule will be placed. If this parameter is null, the new rule will be inserted at the beginning of the rule list.</p>
     pub after: Option<String>,
@@ -1355,7 +1355,7 @@ impl CreateReceiptRuleRequestSerializer {
 }
 
 /// <p>An empty element returned on a successful request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateReceiptRuleResponse {}
 
 struct CreateReceiptRuleResponseDeserializer;
@@ -1375,7 +1375,7 @@ impl CreateReceiptRuleResponseDeserializer {
     }
 }
 /// <p>Represents a request to create an empty receipt rule set. You use receipt rule sets to receive email with Amazon SES. For more information, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateReceiptRuleSetRequest {
     /// <p><p>The name of the rule set to create. The name must:</p> <ul> <li> <p>This value can only contain ASCII letters (a-z, A-Z), numbers (0-9), underscores (_), or dashes (-).</p> </li> <li> <p>Start and end with a letter or number.</p> </li> <li> <p>Contain less than 64 characters.</p> </li> </ul></p>
     pub rule_set_name: String,
@@ -1398,7 +1398,7 @@ impl CreateReceiptRuleSetRequestSerializer {
 }
 
 /// <p>An empty element returned on a successful request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateReceiptRuleSetResponse {}
 
 struct CreateReceiptRuleSetResponseDeserializer;
@@ -1418,7 +1418,7 @@ impl CreateReceiptRuleSetResponseDeserializer {
     }
 }
 /// <p>Represents a request to create an email template. For more information, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-personalized-email-api.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateTemplateRequest {
     /// <p>The content of the email, composed of a subject line, an HTML part, and a text-only part.</p>
     pub template: Template,
@@ -1437,7 +1437,7 @@ impl CreateTemplateRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateTemplateResponse {}
 
 struct CreateTemplateResponseDeserializer;
@@ -1485,7 +1485,7 @@ impl CustomRedirectDomainDeserializer {
     }
 }
 /// <p>Contains information about a custom verification email template.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CustomVerificationEmailTemplate {
     /// <p>The URL that the recipient of the verification email is sent to if his or her address is not successfully verified.</p>
     pub failure_redirection_url: Option<String>,
@@ -1626,7 +1626,7 @@ impl DefaultDimensionValueDeserializer {
     }
 }
 /// <p>Represents a request to delete a configuration set event destination. Configuration set event destinations are associated with configuration sets, which enable you to publish email sending events. For information about using configuration sets, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteConfigurationSetEventDestinationRequest {
     /// <p>The name of the configuration set from which to delete the event destination.</p>
     pub configuration_set_name: String,
@@ -1659,7 +1659,7 @@ impl DeleteConfigurationSetEventDestinationRequestSerializer {
 }
 
 /// <p>An empty element returned on a successful request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteConfigurationSetEventDestinationResponse {}
 
 struct DeleteConfigurationSetEventDestinationResponseDeserializer;
@@ -1679,7 +1679,7 @@ impl DeleteConfigurationSetEventDestinationResponseDeserializer {
     }
 }
 /// <p>Represents a request to delete a configuration set. Configuration sets enable you to publish email sending events. For information about using configuration sets, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteConfigurationSetRequest {
     /// <p>The name of the configuration set to delete.</p>
     pub configuration_set_name: String,
@@ -1702,7 +1702,7 @@ impl DeleteConfigurationSetRequestSerializer {
 }
 
 /// <p>An empty element returned on a successful request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteConfigurationSetResponse {}
 
 struct DeleteConfigurationSetResponseDeserializer;
@@ -1722,7 +1722,7 @@ impl DeleteConfigurationSetResponseDeserializer {
     }
 }
 /// <p>Represents a request to delete open and click tracking options in a configuration set. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteConfigurationSetTrackingOptionsRequest {
     /// <p>The name of the configuration set from which you want to delete the tracking options.</p>
     pub configuration_set_name: String,
@@ -1749,7 +1749,7 @@ impl DeleteConfigurationSetTrackingOptionsRequestSerializer {
 }
 
 /// <p>An empty element returned on a successful request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteConfigurationSetTrackingOptionsResponse {}
 
 struct DeleteConfigurationSetTrackingOptionsResponseDeserializer;
@@ -1769,7 +1769,7 @@ impl DeleteConfigurationSetTrackingOptionsResponseDeserializer {
     }
 }
 /// <p>Represents a request to delete an existing custom verification email template.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteCustomVerificationEmailTemplateRequest {
     /// <p>The name of the custom verification email template that you want to delete.</p>
     pub template_name: String,
@@ -1796,7 +1796,7 @@ impl DeleteCustomVerificationEmailTemplateRequestSerializer {
 }
 
 /// <p>Represents a request to delete a sending authorization policy for an identity. Sending authorization is an Amazon SES feature that enables you to authorize other senders to use your identities. For information, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteIdentityPolicyRequest {
     /// <p>The identity that is associated with the policy that you want to delete. You can specify the identity by using its name or by using its Amazon Resource Name (ARN). Examples: <code>user@example.com</code>, <code>example.com</code>, <code>arn:aws:ses:us-east-1:123456789012:identity/example.com</code>.</p> <p>To successfully call this API, you must own the identity.</p>
     pub identity: String,
@@ -1825,7 +1825,7 @@ impl DeleteIdentityPolicyRequestSerializer {
 }
 
 /// <p>An empty element returned on a successful request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteIdentityPolicyResponse {}
 
 struct DeleteIdentityPolicyResponseDeserializer;
@@ -1845,7 +1845,7 @@ impl DeleteIdentityPolicyResponseDeserializer {
     }
 }
 /// <p>Represents a request to delete one of your Amazon SES identities (an email address or domain).</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteIdentityRequest {
     /// <p>The identity to be removed from the list of identities for the AWS Account.</p>
     pub identity: String,
@@ -1868,7 +1868,7 @@ impl DeleteIdentityRequestSerializer {
 }
 
 /// <p>An empty element returned on a successful request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteIdentityResponse {}
 
 struct DeleteIdentityResponseDeserializer;
@@ -1888,7 +1888,7 @@ impl DeleteIdentityResponseDeserializer {
     }
 }
 /// <p>Represents a request to delete an IP address filter. You use IP address filters when you receive email with Amazon SES. For more information, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteReceiptFilterRequest {
     /// <p>The name of the IP address filter to delete.</p>
     pub filter_name: String,
@@ -1911,7 +1911,7 @@ impl DeleteReceiptFilterRequestSerializer {
 }
 
 /// <p>An empty element returned on a successful request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteReceiptFilterResponse {}
 
 struct DeleteReceiptFilterResponseDeserializer;
@@ -1931,7 +1931,7 @@ impl DeleteReceiptFilterResponseDeserializer {
     }
 }
 /// <p>Represents a request to delete a receipt rule. You use receipt rules to receive email with Amazon SES. For more information, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteReceiptRuleRequest {
     /// <p>The name of the receipt rule to delete.</p>
     pub rule_name: String,
@@ -1960,7 +1960,7 @@ impl DeleteReceiptRuleRequestSerializer {
 }
 
 /// <p>An empty element returned on a successful request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteReceiptRuleResponse {}
 
 struct DeleteReceiptRuleResponseDeserializer;
@@ -1980,7 +1980,7 @@ impl DeleteReceiptRuleResponseDeserializer {
     }
 }
 /// <p>Represents a request to delete a receipt rule set and all of the receipt rules it contains. You use receipt rule sets to receive email with Amazon SES. For more information, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteReceiptRuleSetRequest {
     /// <p>The name of the receipt rule set to delete.</p>
     pub rule_set_name: String,
@@ -2003,7 +2003,7 @@ impl DeleteReceiptRuleSetRequestSerializer {
 }
 
 /// <p>An empty element returned on a successful request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteReceiptRuleSetResponse {}
 
 struct DeleteReceiptRuleSetResponseDeserializer;
@@ -2023,7 +2023,7 @@ impl DeleteReceiptRuleSetResponseDeserializer {
     }
 }
 /// <p>Represents a request to delete an email template. For more information, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-personalized-email-api.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteTemplateRequest {
     /// <p>The name of the template to be deleted.</p>
     pub template_name: String,
@@ -2045,7 +2045,7 @@ impl DeleteTemplateRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteTemplateResponse {}
 
 struct DeleteTemplateResponseDeserializer;
@@ -2065,7 +2065,7 @@ impl DeleteTemplateResponseDeserializer {
     }
 }
 /// <p>Represents a request to delete an email address from the list of email addresses you have attempted to verify under your AWS account.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteVerifiedEmailAddressRequest {
     /// <p>An email address to be removed from the list of verified addresses.</p>
     pub email_address: String,
@@ -2088,7 +2088,7 @@ impl DeleteVerifiedEmailAddressRequestSerializer {
 }
 
 /// <p>Represents a request to return the metadata and receipt rules for the receipt rule set that is currently active. You use receipt rule sets to receive email with Amazon SES. For more information, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeActiveReceiptRuleSetRequest {}
 
 /// Serialize `DescribeActiveReceiptRuleSetRequest` contents to a `SignedRequest`.
@@ -2103,7 +2103,7 @@ impl DescribeActiveReceiptRuleSetRequestSerializer {
 }
 
 /// <p>Represents the metadata and receipt rules for the receipt rule set that is currently active.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeActiveReceiptRuleSetResponse {
     /// <p>The metadata for the currently active receipt rule set. The metadata consists of the rule set name and a timestamp of when the rule set was created.</p>
     pub metadata: Option<ReceiptRuleSetMetadata>,
@@ -2158,7 +2158,7 @@ impl DescribeActiveReceiptRuleSetResponseDeserializer {
     }
 }
 /// <p>Represents a request to return the details of a configuration set. Configuration sets enable you to publish email sending events. For information about using configuration sets, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeConfigurationSetRequest {
     /// <p>A list of configuration set attributes to return.</p>
     pub configuration_set_attribute_names: Option<Vec<String>>,
@@ -2190,7 +2190,7 @@ impl DescribeConfigurationSetRequestSerializer {
 }
 
 /// <p>Represents the details of a configuration set. Configuration sets enable you to publish email sending events. For information about using configuration sets, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeConfigurationSetResponse {
     /// <p>The configuration set object associated with the specified configuration set.</p>
     pub configuration_set: Option<ConfigurationSet>,
@@ -2259,7 +2259,7 @@ impl DescribeConfigurationSetResponseDeserializer {
     }
 }
 /// <p>Represents a request to return the details of a receipt rule. You use receipt rules to receive email with Amazon SES. For more information, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeReceiptRuleRequest {
     /// <p>The name of the receipt rule.</p>
     pub rule_name: String,
@@ -2288,7 +2288,7 @@ impl DescribeReceiptRuleRequestSerializer {
 }
 
 /// <p>Represents the details of a receipt rule.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeReceiptRuleResponse {
     /// <p>A data structure that contains the specified receipt rule's name, actions, recipients, domains, enabled status, scan status, and Transport Layer Security (TLS) policy.</p>
     pub rule: Option<ReceiptRule>,
@@ -2334,7 +2334,7 @@ impl DescribeReceiptRuleResponseDeserializer {
     }
 }
 /// <p>Represents a request to return the details of a receipt rule set. You use receipt rule sets to receive email with Amazon SES. For more information, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeReceiptRuleSetRequest {
     /// <p>The name of the receipt rule set to describe.</p>
     pub rule_set_name: String,
@@ -2357,7 +2357,7 @@ impl DescribeReceiptRuleSetRequestSerializer {
 }
 
 /// <p>Represents the details of the specified receipt rule set.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DescribeReceiptRuleSetResponse {
     /// <p>The metadata for the receipt rule set, which consists of the rule set name and the timestamp of when the rule set was created.</p>
     pub metadata: Option<ReceiptRuleSetMetadata>,
@@ -2412,7 +2412,7 @@ impl DescribeReceiptRuleSetResponseDeserializer {
     }
 }
 /// <p><p>Represents the destination of the message, consisting of To:, CC:, and BCC: fields.</p> <note> <p>Amazon SES does not support the SMTPUTF8 extension, as described in <a href="https://tools.ietf.org/html/rfc6531">RFC6531</a>. For this reason, the <i>local part</i> of a destination email address (the part of the email address that precedes the @ sign) may only contain <a href="https://en.wikipedia.org/wiki/Email_address#Local-part">7-bit ASCII characters</a>. If the <i>domain part</i> of an address (the part after the @ sign) contains non-ASCII characters, they must be encoded using Punycode, as described in <a href="https://tools.ietf.org/html/rfc3492.html">RFC3492</a>.</p> </note></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Destination {
     /// <p>The BCC: field(s) of the message.</p>
     pub bcc_addresses: Option<Vec<String>>,
@@ -2537,7 +2537,7 @@ impl SesErrorDeserializer {
     }
 }
 /// <p>Contains information about the event destination that the specified email sending events will be published to.</p> <note> <p>When you create or update an event destination, you must provide one, and only one, destination. The destination can be Amazon CloudWatch, Amazon Kinesis Firehose or Amazon Simple Notification Service (Amazon SNS).</p> </note> <p>Event destinations are associated with configuration sets, which enable you to publish email sending events to Amazon CloudWatch, Amazon Kinesis Firehose, or Amazon Simple Notification Service (Amazon SNS). For information about using configuration sets, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct EventDestination {
     /// <p>An object that contains the names, default values, and sources of the dimensions associated with an Amazon CloudWatch event destination.</p>
     pub cloud_watch_destination: Option<CloudWatchDestination>,
@@ -2795,7 +2795,7 @@ impl EventTypesSerializer {
 }
 
 /// <p>Additional X-headers to include in the Delivery Status Notification (DSN) when an email that Amazon SES receives on your behalf bounces.</p> <p>For information about receiving email through Amazon SES, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ExtensionField {
     /// <p>The name of the header to add. Must be between 1 and 50 characters, inclusive, and consist of alphanumeric (a-z, A-Z, 0-9) characters and dashes only.</p>
     pub name: String,
@@ -2863,7 +2863,7 @@ impl FromAddressDeserializer {
     }
 }
 /// <p>Represents a request to return the email sending status for your Amazon SES account.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetAccountSendingEnabledResponse {
     /// <p>Describes whether email sending is enabled or disabled for your Amazon SES account.</p>
     pub enabled: Option<bool>,
@@ -2910,7 +2910,7 @@ impl GetAccountSendingEnabledResponseDeserializer {
     }
 }
 /// <p>Represents a request to retrieve an existing custom verification email template.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetCustomVerificationEmailTemplateRequest {
     /// <p>The name of the custom verification email template that you want to retrieve.</p>
     pub template_name: String,
@@ -2933,7 +2933,7 @@ impl GetCustomVerificationEmailTemplateRequestSerializer {
 }
 
 /// <p>The content of the custom verification email template.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetCustomVerificationEmailTemplateResponse {
     /// <p>The URL that the recipient of the verification email is sent to if his or her address is not successfully verified.</p>
     pub failure_redirection_url: Option<String>,
@@ -3023,7 +3023,7 @@ impl GetCustomVerificationEmailTemplateResponseDeserializer {
     }
 }
 /// <p>Represents a request for the status of Amazon SES Easy DKIM signing for an identity. For domain identities, this request also returns the DKIM tokens that are required for Easy DKIM signing, and whether Amazon SES successfully verified that these tokens were published. For more information about Easy DKIM, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/easy-dkim.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetIdentityDkimAttributesRequest {
     /// <p>A list of one or more verified identities - email addresses, domains, or both.</p>
     pub identities: Vec<String>,
@@ -3047,7 +3047,7 @@ impl GetIdentityDkimAttributesRequestSerializer {
 }
 
 /// <p>Represents the status of Amazon SES Easy DKIM signing for an identity. For domain identities, this response also contains the DKIM tokens that are required for Easy DKIM signing, and whether Amazon SES successfully verified that these tokens were published.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetIdentityDkimAttributesResponse {
     /// <p>The DKIM attributes for an email address or a domain.</p>
     pub dkim_attributes: ::std::collections::HashMap<String, IdentityDkimAttributes>,
@@ -3096,7 +3096,7 @@ impl GetIdentityDkimAttributesResponseDeserializer {
     }
 }
 /// <p>Represents a request to return the Amazon SES custom MAIL FROM attributes for a list of identities. For information about using a custom MAIL FROM domain, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/mail-from.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetIdentityMailFromDomainAttributesRequest {
     /// <p>A list of one or more identities.</p>
     pub identities: Vec<String>,
@@ -3124,7 +3124,7 @@ impl GetIdentityMailFromDomainAttributesRequestSerializer {
 }
 
 /// <p>Represents the custom MAIL FROM attributes for a list of identities.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetIdentityMailFromDomainAttributesResponse {
     /// <p>A map of identities to custom MAIL FROM attributes.</p>
     pub mail_from_domain_attributes:
@@ -3175,7 +3175,7 @@ impl GetIdentityMailFromDomainAttributesResponseDeserializer {
     }
 }
 /// <p>Represents a request to return the notification attributes for a list of identities you verified with Amazon SES. For information about Amazon SES notifications, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/notifications.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetIdentityNotificationAttributesRequest {
     /// <p>A list of one or more identities. You can specify an identity by using its name or by using its Amazon Resource Name (ARN). Examples: <code>user@example.com</code>, <code>example.com</code>, <code>arn:aws:ses:us-east-1:123456789012:identity/example.com</code>.</p>
     pub identities: Vec<String>,
@@ -3199,7 +3199,7 @@ impl GetIdentityNotificationAttributesRequestSerializer {
 }
 
 /// <p>Represents the notification attributes for a list of identities.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetIdentityNotificationAttributesResponse {
     /// <p>A map of Identity to IdentityNotificationAttributes.</p>
     pub notification_attributes:
@@ -3250,7 +3250,7 @@ impl GetIdentityNotificationAttributesResponseDeserializer {
     }
 }
 /// <p>Represents a request to return the requested sending authorization policies for an identity. Sending authorization is an Amazon SES feature that enables you to authorize other senders to use your identities. For information, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetIdentityPoliciesRequest {
     /// <p>The identity for which the policies will be retrieved. You can specify an identity by using its name or by using its Amazon Resource Name (ARN). Examples: <code>user@example.com</code>, <code>example.com</code>, <code>arn:aws:ses:us-east-1:123456789012:identity/example.com</code>.</p> <p>To successfully call this API, you must own the identity.</p>
     pub identity: String,
@@ -3280,7 +3280,7 @@ impl GetIdentityPoliciesRequestSerializer {
 }
 
 /// <p>Represents the requested sending authorization policies.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetIdentityPoliciesResponse {
     /// <p>A map of policy names to policies.</p>
     pub policies: ::std::collections::HashMap<String, String>,
@@ -3326,7 +3326,7 @@ impl GetIdentityPoliciesResponseDeserializer {
     }
 }
 /// <p>Represents a request to return the Amazon SES verification status of a list of identities. For domain identities, this request also returns the verification token. For information about verifying identities with Amazon SES, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-addresses-and-domains.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetIdentityVerificationAttributesRequest {
     /// <p>A list of identities.</p>
     pub identities: Vec<String>,
@@ -3350,7 +3350,7 @@ impl GetIdentityVerificationAttributesRequestSerializer {
 }
 
 /// <p>The Amazon SES verification status of a list of identities. For domain identities, this response also contains the verification token.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetIdentityVerificationAttributesResponse {
     /// <p>A map of Identities to IdentityVerificationAttributes objects.</p>
     pub verification_attributes:
@@ -3401,7 +3401,7 @@ impl GetIdentityVerificationAttributesResponseDeserializer {
     }
 }
 /// <p>Represents your Amazon SES daily sending quota, maximum send rate, and the number of emails you have sent in the last 24 hours.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetSendQuotaResponse {
     /// <p>The maximum number of emails the user is allowed to send in a 24-hour interval. A value of -1 signifies an unlimited quota.</p>
     pub max_24_hour_send: Option<f64>,
@@ -3465,7 +3465,7 @@ impl GetSendQuotaResponseDeserializer {
     }
 }
 /// <p>Represents a list of data points. This list contains aggregated data from the previous two weeks of your sending activity with Amazon SES.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetSendStatisticsResponse {
     /// <p>A list of data points, each of which represents 15 minutes of activity.</p>
     pub send_data_points: Option<Vec<SendDataPoint>>,
@@ -3512,7 +3512,7 @@ impl GetSendStatisticsResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetTemplateRequest {
     /// <p>The name of the template you want to retrieve.</p>
     pub template_name: String,
@@ -3534,7 +3534,7 @@ impl GetTemplateRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetTemplateResponse {
     pub template: Option<Template>,
 }
@@ -3636,7 +3636,7 @@ impl IdentityDeserializer {
     }
 }
 /// <p>Represents the DKIM attributes of a verified email address or a domain.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct IdentityDkimAttributes {
     /// <p>True if DKIM signing is enabled for email sent from the identity; false otherwise. The default value is true.</p>
     pub dkim_enabled: bool,
@@ -3751,7 +3751,7 @@ impl IdentityListSerializer {
 }
 
 /// <p>Represents the custom MAIL FROM domain attributes of a verified identity (email address or domain).</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct IdentityMailFromDomainAttributes {
     /// <p>The action that Amazon SES takes if it cannot successfully read the required MX record when you send an email. A value of <code>UseDefaultValue</code> indicates that if Amazon SES cannot read the required MX record, it uses amazonses.com (or a subdomain of that) as the MAIL FROM domain. A value of <code>RejectMessage</code> indicates that if Amazon SES cannot read the required MX record, Amazon SES returns a <code>MailFromDomainNotVerified</code> error and does not send the email.</p> <p>The custom MAIL FROM setup states that result in this behavior are <code>Pending</code>, <code>Failed</code>, and <code>TemporaryFailure</code>.</p>
     pub behavior_on_mx_failure: String,
@@ -3818,7 +3818,7 @@ impl IdentityMailFromDomainAttributesDeserializer {
     }
 }
 /// <p>Represents the notification attributes of an identity, including whether an identity has Amazon Simple Notification Service (Amazon SNS) topics set for bounce, complaint, and/or delivery notifications, and whether feedback forwarding is enabled for bounce and complaint notifications.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct IdentityNotificationAttributes {
     /// <p>The Amazon Resource Name (ARN) of the Amazon SNS topic where Amazon SES will publish bounce notifications.</p>
     pub bounce_topic: String,
@@ -3916,7 +3916,7 @@ impl IdentityNotificationAttributesDeserializer {
     }
 }
 /// <p>Represents the verification attributes of a single identity.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct IdentityVerificationAttributes {
     /// <p>The verification status of the identity: "Pending", "Success", "Failed", or "TemporaryFailure".</p>
     pub verification_status: String,
@@ -3987,7 +3987,7 @@ impl InvocationTypeDeserializer {
     }
 }
 /// <p>Contains the delivery stream ARN and the IAM role ARN associated with an Amazon Kinesis Firehose event destination.</p> <p>Event destinations, such as Amazon Kinesis Firehose, are associated with configuration sets, which enable you to publish email sending events. For information about using configuration sets, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct KinesisFirehoseDestination {
     /// <p>The ARN of the Amazon Kinesis Firehose stream that email sending events should be published to.</p>
     pub delivery_stream_arn: String,
@@ -4064,7 +4064,7 @@ impl KinesisFirehoseDestinationSerializer {
 }
 
 /// <p>When included in a receipt rule, this action calls an AWS Lambda function and, optionally, publishes a notification to Amazon Simple Notification Service (Amazon SNS).</p> <p>To enable Amazon SES to call your AWS Lambda function or to publish to an Amazon SNS topic of another account, Amazon SES must have permission to access those resources. For information about giving permissions, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-permissions.html">Amazon SES Developer Guide</a>.</p> <p>For information about using AWS Lambda actions in receipt rules, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-action-lambda.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct LambdaAction {
     /// <p>The Amazon Resource Name (ARN) of the AWS Lambda function. An example of an AWS Lambda function ARN is <code>arn:aws:lambda:us-west-2:account-id:function:MyFunction</code>. For more information about AWS Lambda, see the <a href="http://docs.aws.amazon.com/lambda/latest/dg/welcome.html">AWS Lambda Developer Guide</a>.</p>
     pub function_arn: String,
@@ -4171,7 +4171,7 @@ impl LastFreshStartDeserializer {
     }
 }
 /// <p>Represents a request to list the configuration sets associated with your AWS account. Configuration sets enable you to publish email sending events. For information about using configuration sets, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListConfigurationSetsRequest {
     /// <p>The number of configuration sets to return.</p>
     pub max_items: Option<i64>,
@@ -4204,7 +4204,7 @@ impl ListConfigurationSetsRequestSerializer {
 }
 
 /// <p>A list of configuration sets associated with your AWS account. Configuration sets enable you to publish email sending events. For information about using configuration sets, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListConfigurationSetsResponse {
     /// <p>A list of configuration sets.</p>
     pub configuration_sets: Option<Vec<ConfigurationSet>>,
@@ -4258,7 +4258,7 @@ impl ListConfigurationSetsResponseDeserializer {
     }
 }
 /// <p>Represents a request to list the existing custom verification email templates for your account.</p> <p>For more information about custom verification email templates, see <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/custom-verification-emails.html">Using Custom Verification Email Templates</a> in the <i>Amazon SES Developer Guide</i>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListCustomVerificationEmailTemplatesRequest {
     /// <p>The maximum number of custom verification email templates to return. This value must be at least 1 and less than or equal to 50. If you do not specify a value, or if you specify a value less than 1 or greater than 50, the operation will return up to 50 results.</p>
     pub max_results: Option<i64>,
@@ -4295,7 +4295,7 @@ impl ListCustomVerificationEmailTemplatesRequestSerializer {
 }
 
 /// <p>A paginated list of custom verification email templates.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListCustomVerificationEmailTemplatesResponse {
     /// <p>A list of the custom verification email templates that exist in your account.</p>
     pub custom_verification_email_templates: Option<Vec<CustomVerificationEmailTemplate>>,
@@ -4352,7 +4352,7 @@ impl ListCustomVerificationEmailTemplatesResponseDeserializer {
     }
 }
 /// <p>Represents a request to return a list of all identities (email addresses and domains) that you have attempted to verify under your AWS account, regardless of verification status.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListIdentitiesRequest {
     /// <p>The type of the identities to list. Possible values are "EmailAddress" and "Domain". If this parameter is omitted, then all identities will be listed.</p>
     pub identity_type: Option<String>,
@@ -4393,7 +4393,7 @@ impl ListIdentitiesRequestSerializer {
 }
 
 /// <p>A list of all identities that you have attempted to verify under your AWS account, regardless of verification status.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListIdentitiesResponse {
     /// <p>A list of identities.</p>
     pub identities: Vec<String>,
@@ -4446,7 +4446,7 @@ impl ListIdentitiesResponseDeserializer {
     }
 }
 /// <p>Represents a request to return a list of sending authorization policies that are attached to an identity. Sending authorization is an Amazon SES feature that enables you to authorize other senders to use your identities. For information, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListIdentityPoliciesRequest {
     /// <p>The identity that is associated with the policy for which the policies will be listed. You can specify an identity by using its name or by using its Amazon Resource Name (ARN). Examples: <code>user@example.com</code>, <code>example.com</code>, <code>arn:aws:ses:us-east-1:123456789012:identity/example.com</code>.</p> <p>To successfully call this API, you must own the identity.</p>
     pub identity: String,
@@ -4469,7 +4469,7 @@ impl ListIdentityPoliciesRequestSerializer {
 }
 
 /// <p>A list of names of sending authorization policies that apply to an identity.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListIdentityPoliciesResponse {
     /// <p>A list of names of policies that apply to the specified identity.</p>
     pub policy_names: Vec<String>,
@@ -4518,7 +4518,7 @@ impl ListIdentityPoliciesResponseDeserializer {
     }
 }
 /// <p>Represents a request to list the IP address filters that exist under your AWS account. You use IP address filters when you receive email with Amazon SES. For more information, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListReceiptFiltersRequest {}
 
 /// Serialize `ListReceiptFiltersRequest` contents to a `SignedRequest`.
@@ -4533,7 +4533,7 @@ impl ListReceiptFiltersRequestSerializer {
 }
 
 /// <p>A list of IP address filters that exist under your AWS account.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListReceiptFiltersResponse {
     /// <p>A list of IP address filter data structures, which each consist of a name, an IP address range, and whether to allow or block mail from it.</p>
     pub filters: Option<Vec<ReceiptFilter>>,
@@ -4581,7 +4581,7 @@ impl ListReceiptFiltersResponseDeserializer {
     }
 }
 /// <p>Represents a request to list the receipt rule sets that exist under your AWS account. You use receipt rule sets to receive email with Amazon SES. For more information, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListReceiptRuleSetsRequest {
     /// <p>A token returned from a previous call to <code>ListReceiptRuleSets</code> to indicate the position in the receipt rule set list.</p>
     pub next_token: Option<String>,
@@ -4606,7 +4606,7 @@ impl ListReceiptRuleSetsRequestSerializer {
 }
 
 /// <p>A list of receipt rule sets that exist under your AWS account.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListReceiptRuleSetsResponse {
     /// <p>A token indicating that there are additional receipt rule sets available to be listed. Pass this token to successive calls of <code>ListReceiptRuleSets</code> to retrieve up to 100 receipt rule sets at a time.</p>
     pub next_token: Option<String>,
@@ -4659,7 +4659,7 @@ impl ListReceiptRuleSetsResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListTemplatesRequest {
     /// <p>The maximum number of templates to return. This value must be at least 1 and less than or equal to 10. If you do not specify a value, or if you specify a value less than 1 or greater than 10, the operation will return up to 10 results.</p>
     pub max_items: Option<i64>,
@@ -4691,7 +4691,7 @@ impl ListTemplatesRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListTemplatesResponse {
     /// <p>A token indicating that there are additional email templates available to be listed. Pass this token to a subsequent call to <code>ListTemplates</code> to retrieve the next 50 email templates.</p>
     pub next_token: Option<String>,
@@ -4747,7 +4747,7 @@ impl ListTemplatesResponseDeserializer {
     }
 }
 /// <p>A list of email addresses that you have verified with Amazon SES under your AWS account.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListVerifiedEmailAddressesResponse {
     /// <p>A list of email addresses that have been verified.</p>
     pub verified_email_addresses: Option<Vec<String>>,
@@ -4863,7 +4863,7 @@ impl MaxSendRateDeserializer {
     }
 }
 /// <p>Represents the message to be sent, composed of a subject and a body.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Message {
     /// <p>The message body.</p>
     pub body: Body,
@@ -4886,7 +4886,7 @@ impl MessageSerializer {
 }
 
 /// <p>Message-related information to include in the Delivery Status Notification (DSN) when an email that Amazon SES receives on your behalf bounces.</p> <p>For information about receiving email through Amazon SES, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct MessageDsn {
     /// <p>When the message was received by the reporting mail transfer agent (MTA), in <a href="https://www.ietf.org/rfc/rfc0822.txt">RFC 822</a> date-time format.</p>
     pub arrival_date: Option<String>,
@@ -4940,7 +4940,7 @@ impl MessageIdDeserializer {
     }
 }
 /// <p>Contains the name and value of a tag that you can provide to <code>SendEmail</code> or <code>SendRawEmail</code> to apply to an email.</p> <p>Message tags, which you use with configuration sets, enable you to publish email sending events. For information about using configuration sets, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct MessageTag {
     /// <p><p>The name of the tag. The name must:</p> <ul> <li> <p>This value can only contain ASCII letters (a-z, A-Z), numbers (0-9), underscores (_), or dashes (-).</p> </li> <li> <p>Contain less than 256 characters.</p> </li> </ul></p>
     pub name: String,
@@ -5137,7 +5137,7 @@ impl PolicyNameListSerializer {
 }
 
 /// <p>Represents a request to add or update a sending authorization policy for an identity. Sending authorization is an Amazon SES feature that enables you to authorize other senders to use your identities. For information, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PutIdentityPolicyRequest {
     /// <p>The identity that the policy will apply to. You can specify an identity by using its name or by using its Amazon Resource Name (ARN). Examples: <code>user@example.com</code>, <code>example.com</code>, <code>arn:aws:ses:us-east-1:123456789012:identity/example.com</code>.</p> <p>To successfully call this API, you must own the identity.</p>
     pub identity: String,
@@ -5172,7 +5172,7 @@ impl PutIdentityPolicyRequestSerializer {
 }
 
 /// <p>An empty element returned on a successful request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PutIdentityPolicyResponse {}
 
 struct PutIdentityPolicyResponseDeserializer;
@@ -5192,7 +5192,7 @@ impl PutIdentityPolicyResponseDeserializer {
     }
 }
 /// <p>Represents the raw data of the message.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RawMessage {
     /// <p>The raw data of the message. This data needs to base64-encoded if you are accessing Amazon SES directly through the HTTPS interface. If you are accessing Amazon SES using an AWS SDK, the SDK takes care of the base 64-encoding for you. In all cases, the client must ensure that the message format complies with Internet email standards regarding email header fields, MIME types, and MIME encoding.</p> <p>The To:, CC:, and BCC: headers in the raw message can contain a group list.</p> <p>If you are using <code>SendRawEmail</code> with sending authorization, you can include X-headers in the raw message to specify the "Source," "From," and "Return-Path" addresses. For more information, see the documentation for <code>SendRawEmail</code>. </p> <important> <p>Do not include these X-headers in the DKIM signature, because they are removed by Amazon SES before sending the email.</p> </important> <p>For more information, go to the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-raw.html">Amazon SES Developer Guide</a>.</p>
     pub data: Vec<u8>,
@@ -5217,7 +5217,7 @@ impl RawMessageSerializer {
 }
 
 /// <p>An action that Amazon SES can take when it receives an email on behalf of one or more email addresses or domains that you own. An instance of this data type can represent only one action.</p> <p>For information about setting up receipt rules, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-receipt-rules.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ReceiptAction {
     /// <p>Adds a header to the received email.</p>
     pub add_header_action: Option<AddHeaderAction>,
@@ -5425,7 +5425,7 @@ impl ReceiptActionsListSerializer {
 }
 
 /// <p>A receipt IP address filter enables you to specify whether to accept or reject mail originating from an IP address or range of IP addresses.</p> <p>For information about setting up IP address filters, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-ip-filters.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ReceiptFilter {
     /// <p>A structure that provides the IP addresses to block or allow, and whether to block or allow incoming mail from them.</p>
     pub ip_filter: ReceiptIpFilter,
@@ -5569,7 +5569,7 @@ impl ReceiptFilterPolicyDeserializer {
     }
 }
 /// <p>A receipt IP address filter enables you to specify whether to accept or reject mail originating from an IP address or range of IP addresses.</p> <p>For information about setting up IP address filters, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-ip-filters.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ReceiptIpFilter {
     /// <p>A single IP address or a range of IP addresses that you want to block or allow, specified in Classless Inter-Domain Routing (CIDR) notation. An example of a single email address is 10.0.0.1. An example of a range of IP addresses is 10.0.0.1/24. For more information about CIDR notation, see <a href="https://tools.ietf.org/html/rfc2317">RFC 2317</a>.</p>
     pub cidr: String,
@@ -5643,7 +5643,7 @@ impl ReceiptIpFilterSerializer {
 }
 
 /// <p>Receipt rules enable you to specify which actions Amazon SES should take when it receives mail on behalf of one or more email addresses or domains that you own.</p> <p>Each receipt rule defines a set of email addresses or domains that it applies to. If the email addresses or domains match at least one recipient address of the message, Amazon SES executes all of the receipt rule's actions on the message.</p> <p>For information about setting up receipt rules, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-receipt-rules.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ReceiptRule {
     /// <p>An ordered list of actions to perform on messages that match at least one of the recipient email addresses or domains specified in the receipt rule.</p>
     pub actions: Option<Vec<ReceiptAction>>,
@@ -5797,7 +5797,7 @@ impl ReceiptRuleNamesListSerializer {
 }
 
 /// <p>Information about a receipt rule set.</p> <p>A receipt rule set is a collection of rules that specify what Amazon SES should do with mail it receives on behalf of your account's verified domains.</p> <p>For information about setting up receipt rule sets, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-receipt-rule-set.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ReceiptRuleSetMetadata {
     /// <p>The date and time the receipt rule set was created.</p>
     pub created_timestamp: Option<String>,
@@ -5963,7 +5963,7 @@ impl RecipientDeserializer {
     }
 }
 /// <p>Recipient-related information to include in the Delivery Status Notification (DSN) when an email that Amazon SES receives on your behalf bounces.</p> <p>For information about receiving email through Amazon SES, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RecipientDsnFields {
     /// <p>The action performed by the reporting mail transfer agent (MTA) as a result of its attempt to deliver the message to the recipient address. This is required by <a href="https://tools.ietf.org/html/rfc3464">RFC 3464</a>.</p>
     pub action: String,
@@ -6099,7 +6099,7 @@ impl RenderedTemplateDeserializer {
     }
 }
 /// <p>Represents a request to reorder the receipt rules within a receipt rule set. You use receipt rule sets to receive email with Amazon SES. For more information, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ReorderReceiptRuleSetRequest {
     /// <p>A list of the specified receipt rule set's receipt rules in the order that you want to put them.</p>
     pub rule_names: Vec<String>,
@@ -6129,7 +6129,7 @@ impl ReorderReceiptRuleSetRequestSerializer {
 }
 
 /// <p>An empty element returned on a successful request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ReorderReceiptRuleSetResponse {}
 
 struct ReorderReceiptRuleSetResponseDeserializer;
@@ -6149,7 +6149,7 @@ impl ReorderReceiptRuleSetResponseDeserializer {
     }
 }
 /// <p>Contains information about the reputation settings for a configuration set.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ReputationOptions {
     /// <p>The date and time at which the reputation metrics for the configuration set were last reset. Resetting these metrics is known as a <i>fresh start</i>.</p> <p>When you disable email sending for a configuration set using <a>UpdateConfigurationSetSendingEnabled</a> and later re-enable it, the reputation metrics for the configuration set (but not for the entire Amazon SES account) are reset.</p> <p>If email sending for the configuration set has never been disabled and later re-enabled, the value of this attribute is <code>null</code>.</p>
     pub last_fresh_start: Option<String>,
@@ -6213,7 +6213,7 @@ impl ReputationOptionsDeserializer {
     }
 }
 /// <p>When included in a receipt rule, this action saves the received message to an Amazon Simple Storage Service (Amazon S3) bucket and, optionally, publishes a notification to Amazon Simple Notification Service (Amazon SNS).</p> <p>To enable Amazon SES to write emails to your Amazon S3 bucket, use an AWS KMS key to encrypt your emails, or publish to an Amazon SNS topic of another account, Amazon SES must have permission to access those resources. For information about giving permissions, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-permissions.html">Amazon SES Developer Guide</a>.</p> <note> <p>When you save your emails to an Amazon S3 bucket, the maximum email size (including headers) is 30 MB. Emails larger than that will bounce.</p> </note> <p>For information about specifying Amazon S3 actions in receipt rules, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-action-s3.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct S3Action {
     /// <p>The name of the Amazon S3 bucket that incoming email will be saved to.</p>
     pub bucket_name: String,
@@ -6346,7 +6346,7 @@ impl S3KeyPrefixDeserializer {
     }
 }
 /// <p>When included in a receipt rule, this action publishes a notification to Amazon Simple Notification Service (Amazon SNS). This action includes a complete copy of the email content in the Amazon SNS notifications. Amazon SNS notifications for all other actions simply provide information about the email. They do not include the email content itself.</p> <p>If you own the Amazon SNS topic, you don't need to do anything to give Amazon SES permission to publish emails to it. However, if you don't own the Amazon SNS topic, you need to attach a policy to the topic to give Amazon SES permissions to access it. For information about giving permissions, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-permissions.html">Amazon SES Developer Guide</a>.</p> <important> <p>You can only publish emails that are 150 KB or less (including the header) to Amazon SNS. Larger emails will bounce. If you anticipate emails larger than 150 KB, use the S3 action instead.</p> </important> <p>For information about using a receipt rule to publish an Amazon SNS notification, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-action-sns.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SNSAction {
     /// <p>The encoding to use for the email within the Amazon SNS notification. UTF-8 is easier to use, but may not preserve all special characters when a message was encoded with a different encoding format. Base64 preserves all special characters. The default value is UTF-8.</p>
     pub encoding: Option<String>,
@@ -6438,7 +6438,7 @@ impl SNSActionEncodingDeserializer {
     }
 }
 /// <p>Contains the topic ARN associated with an Amazon Simple Notification Service (Amazon SNS) event destination.</p> <p>Event destinations, such as Amazon SNS, are associated with configuration sets, which enable you to publish email sending events. For information about using configuration sets, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SNSDestination {
     /// <p>The ARN of the Amazon SNS topic that email sending events will be published to. An example of an Amazon SNS topic ARN is <code>arn:aws:sns:us-west-2:123456789012:MyTopic</code>. For more information about Amazon SNS topics, see the <a href="http://docs.aws.amazon.com/sns/latest/dg/CreateTopic.html">Amazon SNS Developer Guide</a>.</p>
     pub topic_arn: String,
@@ -6503,7 +6503,7 @@ impl SNSDestinationSerializer {
 }
 
 /// <p>Represents a request to send a bounce message to the sender of an email you received through Amazon SES.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SendBounceRequest {
     /// <p>The address to use in the "From" header of the bounce message. This must be an identity that you have verified with Amazon SES.</p>
     pub bounce_sender: String,
@@ -6564,7 +6564,7 @@ impl SendBounceRequestSerializer {
 }
 
 /// <p>Represents a unique message ID.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SendBounceResponse {
     /// <p>The message ID of the bounce message.</p>
     pub message_id: Option<String>,
@@ -6611,7 +6611,7 @@ impl SendBounceResponseDeserializer {
     }
 }
 /// <p>Represents a request to send a templated email to multiple destinations using Amazon SES. For more information, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-personalized-email-api.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SendBulkTemplatedEmailRequest {
     /// <p>The name of the configuration set to use when you send an email using <code>SendBulkTemplatedEmail</code>.</p>
     pub configuration_set_name: Option<String>,
@@ -6712,7 +6712,7 @@ impl SendBulkTemplatedEmailRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SendBulkTemplatedEmailResponse {
     /// <p>The unique message identifier returned from the <code>SendBulkTemplatedEmail</code> action.</p>
     pub status: Vec<BulkEmailDestinationStatus>,
@@ -6760,7 +6760,7 @@ impl SendBulkTemplatedEmailResponseDeserializer {
     }
 }
 /// <p>Represents a request to send a custom verification email to a specified recipient.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SendCustomVerificationEmailRequest {
     /// <p>Name of a configuration set to use when sending the verification email.</p>
     pub configuration_set_name: Option<String>,
@@ -6797,7 +6797,7 @@ impl SendCustomVerificationEmailRequestSerializer {
 }
 
 /// <p>The response received when attempting to send the custom verification email.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SendCustomVerificationEmailResponse {
     /// <p>The unique message identifier returned from the <code>SendCustomVerificationEmail</code> operation.</p>
     pub message_id: Option<String>,
@@ -6844,7 +6844,7 @@ impl SendCustomVerificationEmailResponseDeserializer {
     }
 }
 /// <p>Represents sending statistics data. Each <code>SendDataPoint</code> contains statistics for a 15-minute period of sending activity. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SendDataPoint {
     /// <p>Number of emails that have bounced.</p>
     pub bounces: Option<i64>,
@@ -6959,7 +6959,7 @@ impl SendDataPointListDeserializer {
     }
 }
 /// <p>Represents a request to send a single formatted email using Amazon SES. For more information, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-formatted.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SendEmailRequest {
     /// <p>The name of the configuration set to use when you send an email using <code>SendEmail</code>.</p>
     pub configuration_set_name: Option<String>,
@@ -7042,7 +7042,7 @@ impl SendEmailRequestSerializer {
 }
 
 /// <p>Represents a unique message ID.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SendEmailResponse {
     /// <p>The unique message identifier returned from the <code>SendEmail</code> action. </p>
     pub message_id: String,
@@ -7089,7 +7089,7 @@ impl SendEmailResponseDeserializer {
     }
 }
 /// <p>Represents a request to send a single raw email using Amazon SES. For more information, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-raw.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SendRawEmailRequest {
     /// <p>The name of the configuration set to use when you send an email using <code>SendRawEmail</code>.</p>
     pub configuration_set_name: Option<String>,
@@ -7171,7 +7171,7 @@ impl SendRawEmailRequestSerializer {
 }
 
 /// <p>Represents a unique message ID.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SendRawEmailResponse {
     /// <p>The unique message identifier returned from the <code>SendRawEmail</code> action. </p>
     pub message_id: String,
@@ -7218,7 +7218,7 @@ impl SendRawEmailResponseDeserializer {
     }
 }
 /// <p>Represents a request to send a templated email using Amazon SES. For more information, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-personalized-email-api.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SendTemplatedEmailRequest {
     /// <p>The name of the configuration set to use when you send an email using <code>SendTemplatedEmail</code>.</p>
     pub configuration_set_name: Option<String>,
@@ -7317,7 +7317,7 @@ impl SendTemplatedEmailRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SendTemplatedEmailResponse {
     /// <p>The unique message identifier returned from the <code>SendTemplatedEmail</code> action. </p>
     pub message_id: String,
@@ -7378,7 +7378,7 @@ impl SentLast24HoursDeserializer {
     }
 }
 /// <p>Represents a request to set a receipt rule set as the active receipt rule set. You use receipt rule sets to receive email with Amazon SES. For more information, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SetActiveReceiptRuleSetRequest {
     /// <p>The name of the receipt rule set to make active. Setting this value to null disables all email receiving.</p>
     pub rule_set_name: Option<String>,
@@ -7403,7 +7403,7 @@ impl SetActiveReceiptRuleSetRequestSerializer {
 }
 
 /// <p>An empty element returned on a successful request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SetActiveReceiptRuleSetResponse {}
 
 struct SetActiveReceiptRuleSetResponseDeserializer;
@@ -7423,7 +7423,7 @@ impl SetActiveReceiptRuleSetResponseDeserializer {
     }
 }
 /// <p>Represents a request to enable or disable Amazon SES Easy DKIM signing for an identity. For more information about setting up Easy DKIM, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/easy-dkim.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SetIdentityDkimEnabledRequest {
     /// <p>Sets whether DKIM signing is enabled for an identity. Set to <code>true</code> to enable DKIM signing for this identity; <code>false</code> to disable it. </p>
     pub dkim_enabled: bool,
@@ -7452,7 +7452,7 @@ impl SetIdentityDkimEnabledRequestSerializer {
 }
 
 /// <p>An empty element returned on a successful request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SetIdentityDkimEnabledResponse {}
 
 struct SetIdentityDkimEnabledResponseDeserializer;
@@ -7472,7 +7472,7 @@ impl SetIdentityDkimEnabledResponseDeserializer {
     }
 }
 /// <p>Represents a request to enable or disable whether Amazon SES forwards you bounce and complaint notifications through email. For information about email feedback forwarding, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/notifications-via-email.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SetIdentityFeedbackForwardingEnabledRequest {
     /// <p>Sets whether Amazon SES will forward bounce and complaint notifications as email. <code>true</code> specifies that Amazon SES will forward bounce and complaint notifications as email, in addition to any Amazon SNS topic publishing otherwise specified. <code>false</code> specifies that Amazon SES will publish bounce and complaint notifications only through Amazon SNS. This value can only be set to <code>false</code> when Amazon SNS topics are set for both <code>Bounce</code> and <code>Complaint</code> notification types.</p>
     pub forwarding_enabled: bool,
@@ -7505,7 +7505,7 @@ impl SetIdentityFeedbackForwardingEnabledRequestSerializer {
 }
 
 /// <p>An empty element returned on a successful request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SetIdentityFeedbackForwardingEnabledResponse {}
 
 struct SetIdentityFeedbackForwardingEnabledResponseDeserializer;
@@ -7525,7 +7525,7 @@ impl SetIdentityFeedbackForwardingEnabledResponseDeserializer {
     }
 }
 /// <p>Represents a request to set whether Amazon SES includes the original email headers in the Amazon SNS notifications of a specified type. For information about notifications, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/notifications-via-sns.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SetIdentityHeadersInNotificationsEnabledRequest {
     /// <p>Sets whether Amazon SES includes the original email headers in Amazon SNS notifications of the specified notification type. A value of <code>true</code> specifies that Amazon SES will include headers in notifications, and a value of <code>false</code> specifies that Amazon SES will not include headers in notifications.</p> <p>This value can only be set when <code>NotificationType</code> is already set to use a particular Amazon SNS topic.</p>
     pub enabled: bool,
@@ -7564,7 +7564,7 @@ impl SetIdentityHeadersInNotificationsEnabledRequestSerializer {
 }
 
 /// <p>An empty element returned on a successful request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SetIdentityHeadersInNotificationsEnabledResponse {}
 
 struct SetIdentityHeadersInNotificationsEnabledResponseDeserializer;
@@ -7584,7 +7584,7 @@ impl SetIdentityHeadersInNotificationsEnabledResponseDeserializer {
     }
 }
 /// <p>Represents a request to enable or disable the Amazon SES custom MAIL FROM domain setup for a verified identity. For information about using a custom MAIL FROM domain, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/mail-from.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SetIdentityMailFromDomainRequest {
     /// <p>The action that you want Amazon SES to take if it cannot successfully read the required MX record when you send an email. If you choose <code>UseDefaultValue</code>, Amazon SES will use amazonses.com (or a subdomain of that) as the MAIL FROM domain. If you choose <code>RejectMessage</code>, Amazon SES will return a <code>MailFromDomainNotVerified</code> error and not send the email.</p> <p>The action specified in <code>BehaviorOnMXFailure</code> is taken when the custom MAIL FROM domain setup is in the <code>Pending</code>, <code>Failed</code>, and <code>TemporaryFailure</code> states.</p>
     pub behavior_on_mx_failure: Option<String>,
@@ -7623,7 +7623,7 @@ impl SetIdentityMailFromDomainRequestSerializer {
 }
 
 /// <p>An empty element returned on a successful request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SetIdentityMailFromDomainResponse {}
 
 struct SetIdentityMailFromDomainResponseDeserializer;
@@ -7643,7 +7643,7 @@ impl SetIdentityMailFromDomainResponseDeserializer {
     }
 }
 /// <p>Represents a request to specify the Amazon SNS topic to which Amazon SES will publish bounce, complaint, or delivery notifications for emails sent with that identity as the Source. For information about Amazon SES notifications, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/notifications-via-sns.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SetIdentityNotificationTopicRequest {
     /// <p>The identity for which the Amazon SNS topic will be set. You can specify an identity by using its name or by using its Amazon Resource Name (ARN). Examples: <code>user@example.com</code>, <code>example.com</code>, <code>arn:aws:ses:us-east-1:123456789012:identity/example.com</code>.</p>
     pub identity: String,
@@ -7680,7 +7680,7 @@ impl SetIdentityNotificationTopicRequestSerializer {
 }
 
 /// <p>An empty element returned on a successful request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SetIdentityNotificationTopicResponse {}
 
 struct SetIdentityNotificationTopicResponseDeserializer;
@@ -7700,7 +7700,7 @@ impl SetIdentityNotificationTopicResponseDeserializer {
     }
 }
 /// <p>Represents a request to set the position of a receipt rule in a receipt rule set. You use receipt rule sets to receive email with Amazon SES. For more information, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SetReceiptRulePositionRequest {
     /// <p>The name of the receipt rule after which to place the specified receipt rule.</p>
     pub after: Option<String>,
@@ -7737,7 +7737,7 @@ impl SetReceiptRulePositionRequestSerializer {
 }
 
 /// <p>An empty element returned on a successful request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SetReceiptRulePositionResponse {}
 
 struct SetReceiptRulePositionResponseDeserializer;
@@ -7757,7 +7757,7 @@ impl SetReceiptRulePositionResponseDeserializer {
     }
 }
 /// <p>When included in a receipt rule, this action terminates the evaluation of the receipt rule set and, optionally, publishes a notification to Amazon Simple Notification Service (Amazon SNS).</p> <p>For information about setting a stop action in a receipt rule, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-action-stop.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct StopAction {
     /// <p>The name of the RuleSet that is being stopped.</p>
     pub scope: String,
@@ -7889,7 +7889,7 @@ impl SuccessRedirectionURLDeserializer {
     }
 }
 /// <p>The content of the email, composed of a subject line, an HTML part, and a text-only part.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Template {
     /// <p>The HTML body of the email.</p>
     pub html_part: Option<String>,
@@ -8005,7 +8005,7 @@ impl TemplateContentDeserializer {
     }
 }
 /// <p>Contains information about an email template.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct TemplateMetadata {
     /// <p>The time and date the template was created.</p>
     pub created_timestamp: Option<String>,
@@ -8114,7 +8114,7 @@ impl TemplateNameDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct TestRenderTemplateRequest {
     /// <p>A list of replacement values to apply to the template. This parameter is a JSON object, typically consisting of key-value pairs in which the keys correspond to replacement tags in the email template.</p>
     pub template_data: String,
@@ -8142,7 +8142,7 @@ impl TestRenderTemplateRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct TestRenderTemplateResponse {
     /// <p>The complete MIME message rendered by applying the data in the TemplateData parameter to the template specified in the TemplateName parameter.</p>
     pub rendered_template: Option<String>,
@@ -8232,7 +8232,7 @@ impl TlsPolicyDeserializer {
     }
 }
 /// <p>A domain that is used to redirect email recipients to an Amazon SES-operated domain. This domain captures open and click events generated by Amazon SES emails.</p> <p>For more information, see <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/configure-custom-open-click-domains.html">Configuring Custom Domains to Handle Open and Click Tracking</a> in the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/Welcome.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct TrackingOptions {
     /// <p>The custom subdomain that will be used to redirect email recipients to the Amazon SES event tracking domain.</p>
     pub custom_redirect_domain: Option<String>,
@@ -8301,7 +8301,7 @@ impl TrackingOptionsSerializer {
 }
 
 /// <p>Represents a request to enable or disable the email sending capabilities for your entire Amazon SES account.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateAccountSendingEnabledRequest {
     /// <p>Describes whether email sending is enabled or disabled for your Amazon SES account.</p>
     pub enabled: Option<bool>,
@@ -8326,7 +8326,7 @@ impl UpdateAccountSendingEnabledRequestSerializer {
 }
 
 /// <p>Represents a request to update the event destination of a configuration set. Configuration sets enable you to publish email sending events. For information about using configuration sets, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateConfigurationSetEventDestinationRequest {
     /// <p>The name of the configuration set that contains the event destination that you want to update.</p>
     pub configuration_set_name: String,
@@ -8360,7 +8360,7 @@ impl UpdateConfigurationSetEventDestinationRequestSerializer {
 }
 
 /// <p>An empty element returned on a successful request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateConfigurationSetEventDestinationResponse {}
 
 struct UpdateConfigurationSetEventDestinationResponseDeserializer;
@@ -8380,7 +8380,7 @@ impl UpdateConfigurationSetEventDestinationResponseDeserializer {
     }
 }
 /// <p>Represents a request to modify the reputation metric publishing settings for a configuration set.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateConfigurationSetReputationMetricsEnabledRequest {
     /// <p>The name of the configuration set that you want to update.</p>
     pub configuration_set_name: String,
@@ -8413,7 +8413,7 @@ impl UpdateConfigurationSetReputationMetricsEnabledRequestSerializer {
 }
 
 /// <p>Represents a request to enable or disable the email sending capabilities for a specific configuration set.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateConfigurationSetSendingEnabledRequest {
     /// <p>The name of the configuration set that you want to update.</p>
     pub configuration_set_name: String,
@@ -8446,7 +8446,7 @@ impl UpdateConfigurationSetSendingEnabledRequestSerializer {
 }
 
 /// <p>Represents a request to update the tracking options for a configuration set. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateConfigurationSetTrackingOptionsRequest {
     /// <p>The name of the configuration set for which you want to update the custom tracking domain.</p>
     pub configuration_set_name: String,
@@ -8479,7 +8479,7 @@ impl UpdateConfigurationSetTrackingOptionsRequestSerializer {
 }
 
 /// <p>An empty element returned on a successful request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateConfigurationSetTrackingOptionsResponse {}
 
 struct UpdateConfigurationSetTrackingOptionsResponseDeserializer;
@@ -8499,7 +8499,7 @@ impl UpdateConfigurationSetTrackingOptionsResponseDeserializer {
     }
 }
 /// <p>Represents a request to update an existing custom verification email template.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateCustomVerificationEmailTemplateRequest {
     /// <p>The URL that the recipient of the verification email is sent to if his or her address is not successfully verified.</p>
     pub failure_redirection_url: Option<String>,
@@ -8566,7 +8566,7 @@ impl UpdateCustomVerificationEmailTemplateRequestSerializer {
 }
 
 /// <p>Represents a request to update a receipt rule. You use receipt rules to receive email with Amazon SES. For more information, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateReceiptRuleRequest {
     /// <p>A data structure that contains the updated receipt rule information.</p>
     pub rule: ReceiptRule,
@@ -8592,7 +8592,7 @@ impl UpdateReceiptRuleRequestSerializer {
 }
 
 /// <p>An empty element returned on a successful request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateReceiptRuleResponse {}
 
 struct UpdateReceiptRuleResponseDeserializer;
@@ -8611,7 +8611,7 @@ impl UpdateReceiptRuleResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateTemplateRequest {
     pub template: Template,
 }
@@ -8629,7 +8629,7 @@ impl UpdateTemplateRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateTemplateResponse {}
 
 struct UpdateTemplateResponseDeserializer;
@@ -8745,7 +8745,7 @@ impl VerificationTokenListDeserializer {
     }
 }
 /// <p>Represents a request to generate the CNAME records needed to set up Easy DKIM with Amazon SES. For more information about setting up Easy DKIM, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/easy-dkim.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct VerifyDomainDkimRequest {
     /// <p>The name of the domain to be verified for Easy DKIM signing.</p>
     pub domain: String,
@@ -8768,7 +8768,7 @@ impl VerifyDomainDkimRequestSerializer {
 }
 
 /// <p>Returns CNAME records that you must publish to the DNS server of your domain to set up Easy DKIM with Amazon SES.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct VerifyDomainDkimResponse {
     /// <p>A set of character strings that represent the domain's identity. If the identity is an email address, the tokens represent the domain of that address.</p> <p>Using these tokens, you will need to create DNS CNAME records that point to DKIM public keys hosted by Amazon SES. Amazon Web Services will eventually detect that you have updated your DNS records; this detection process may take up to 72 hours. Upon successful detection, Amazon SES will be able to DKIM-sign emails originating from that domain.</p> <p>For more information about creating DNS records using DKIM tokens, go to the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/easy-dkim-dns-records.html">Amazon SES Developer Guide</a>.</p>
     pub dkim_tokens: Vec<String>,
@@ -8817,7 +8817,7 @@ impl VerifyDomainDkimResponseDeserializer {
     }
 }
 /// <p>Represents a request to begin Amazon SES domain verification and to generate the TXT records that you must publish to the DNS server of your domain to complete the verification. For information about domain verification, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-domains.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct VerifyDomainIdentityRequest {
     /// <p>The domain to be verified.</p>
     pub domain: String,
@@ -8840,7 +8840,7 @@ impl VerifyDomainIdentityRequestSerializer {
 }
 
 /// <p>Returns a TXT record that you must publish to the DNS server of your domain to complete domain verification with Amazon SES.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct VerifyDomainIdentityResponse {
     /// <p>A TXT record that you must place in the DNS settings of the domain to complete domain verification with Amazon SES.</p> <p>As Amazon SES searches for the TXT record, the domain's verification status is "Pending". When Amazon SES detects the record, the domain's verification status changes to "Success". If Amazon SES is unable to detect the record within 72 hours, the domain's verification status changes to "Failed." In that case, if you still want to verify the domain, you must restart the verification process from the beginning.</p>
     pub verification_token: String,
@@ -8889,7 +8889,7 @@ impl VerifyDomainIdentityResponseDeserializer {
     }
 }
 /// <p>Represents a request to begin email address verification with Amazon SES. For information about email address verification, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-email-addresses.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct VerifyEmailAddressRequest {
     /// <p>The email address to be verified.</p>
     pub email_address: String,
@@ -8912,7 +8912,7 @@ impl VerifyEmailAddressRequestSerializer {
 }
 
 /// <p>Represents a request to begin email address verification with Amazon SES. For information about email address verification, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-email-addresses.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct VerifyEmailIdentityRequest {
     /// <p>The email address to be verified.</p>
     pub email_address: String,
@@ -8935,7 +8935,7 @@ impl VerifyEmailIdentityRequestSerializer {
 }
 
 /// <p>An empty element returned on a successful request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct VerifyEmailIdentityResponse {}
 
 struct VerifyEmailIdentityResponseDeserializer;
@@ -8955,7 +8955,7 @@ impl VerifyEmailIdentityResponseDeserializer {
     }
 }
 /// <p>When included in a receipt rule, this action calls Amazon WorkMail and, optionally, publishes a notification to Amazon Simple Notification Service (Amazon SNS). You will typically not use this action directly because Amazon WorkMail adds the rule automatically during its setup procedure.</p> <p>For information using a receipt rule to call Amazon WorkMail, see the <a href="http://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-action-workmail.html">Amazon SES Developer Guide</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct WorkmailAction {
     /// <p>The ARN of the Amazon WorkMail organization. An example of an Amazon WorkMail organization ARN is <code>arn:aws:workmail:us-west-2:123456789012:organization/m-68755160c4cb4e29a2b2f8fb58f359d7</code>. For information about Amazon WorkMail organizations, see the <a href="http://docs.aws.amazon.com/workmail/latest/adminguide/organizations_overview.html">Amazon WorkMail Administrator Guide</a>.</p>
     pub organization_arn: String,

--- a/rusoto/services/ses/src/generated.rs
+++ b/rusoto/services/ses/src/generated.rs
@@ -29,8 +29,9 @@ use hyper::StatusCode;
 use rusoto_core::param::{Params, ServiceParams};
 use rusoto_core::signature::SignedRequest;
 use rusoto_core::xmlerror::*;
-use rusoto_core::xmlutil::{characters, end_element, find_start_element, peek_at_name, skip_tree,
-                           start_element};
+use rusoto_core::xmlutil::{
+    characters, end_element, find_start_element, peek_at_name, skip_tree, start_element,
+};
 use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
 use std::str::FromStr;
 use xml::reader::ParserConfig;

--- a/rusoto/services/shield/src/generated.rs
+++ b/rusoto/services/shield/src/generated.rs
@@ -31,7 +31,7 @@ use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 /// <p>The details of a DDoS attack.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AttackDetail {
     /// <p>List of counters that describe the attack for the specified time period.</p>
     #[serde(rename = "AttackCounters")]
@@ -68,7 +68,7 @@ pub struct AttackDetail {
 }
 
 /// <p>Details of the described attack.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AttackProperty {
     /// <p>The type of DDoS event that was observed. <code>NETWORK</code> indicates layer 3 and layer 4 events and <code>APPLICATION</code> indicates layer 7 events.</p>
     #[serde(rename = "AttackLayer")]
@@ -93,7 +93,7 @@ pub struct AttackProperty {
 }
 
 /// <p>Summarizes all DDoS attacks for a specified time period.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AttackSummary {
     /// <p>The unique identifier (ID) of the attack.</p>
     #[serde(rename = "AttackId")]
@@ -118,7 +118,7 @@ pub struct AttackSummary {
 }
 
 /// <p>Describes the attack.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AttackVectorDescription {
     /// <p><p>The attack type. Valid values:</p> <ul> <li> <p>UDP<em>TRAFFIC</p> </li> <li> <p>UDP</em>FRAGMENT</p> </li> <li> <p>GENERIC<em>UDP</em>REFLECTION</p> </li> <li> <p>DNS<em>REFLECTION</p> </li> <li> <p>NTP</em>REFLECTION</p> </li> <li> <p>CHARGEN<em>REFLECTION</p> </li> <li> <p>SSDP</em>REFLECTION</p> </li> <li> <p>PORT<em>MAPPER</p> </li> <li> <p>RIP</em>REFLECTION</p> </li> <li> <p>SNMP<em>REFLECTION</p> </li> <li> <p>MSSQL</em>REFLECTION</p> </li> <li> <p>NET<em>BIOS</em>REFLECTION</p> </li> <li> <p>SYN<em>FLOOD</p> </li> <li> <p>ACK</em>FLOOD</p> </li> <li> <p>REQUEST_FLOOD</p> </li> </ul></p>
     #[serde(rename = "VectorType")]
@@ -126,7 +126,7 @@ pub struct AttackVectorDescription {
 }
 
 /// <p>A contributor to the attack and their contribution.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Contributor {
     /// <p>The name of the contributor. This is dependent on the <code>AttackPropertyIdentifier</code>. For example, if the <code>AttackPropertyIdentifier</code> is <code>SOURCE_COUNTRY</code>, the <code>Name</code> could be <code>United States</code>.</p>
     #[serde(rename = "Name")]
@@ -138,7 +138,7 @@ pub struct Contributor {
     pub value: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateProtectionRequest {
     /// <p>Friendly name for the <code>Protection</code> you are creating.</p>
     #[serde(rename = "Name")]
@@ -148,7 +148,7 @@ pub struct CreateProtectionRequest {
     pub resource_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateProtectionResponse {
     /// <p>The unique identifier (ID) for the <a>Protection</a> object that is created.</p>
     #[serde(rename = "ProtectionId")]
@@ -156,36 +156,36 @@ pub struct CreateProtectionResponse {
     pub protection_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateSubscriptionRequest {}
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateSubscriptionResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteProtectionRequest {
     /// <p>The unique identifier (ID) for the <a>Protection</a> object to be deleted.</p>
     #[serde(rename = "ProtectionId")]
     pub protection_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteProtectionResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteSubscriptionRequest {}
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteSubscriptionResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeAttackRequest {
     /// <p>The unique identifier (ID) for the attack that to be described.</p>
     #[serde(rename = "AttackId")]
     pub attack_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeAttackResponse {
     /// <p>The attack that is described.</p>
     #[serde(rename = "Attack")]
@@ -193,14 +193,14 @@ pub struct DescribeAttackResponse {
     pub attack: Option<AttackDetail>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeProtectionRequest {
     /// <p>The unique identifier (ID) for the <a>Protection</a> object that is described.</p>
     #[serde(rename = "ProtectionId")]
     pub protection_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeProtectionResponse {
     /// <p>The <a>Protection</a> object that is described.</p>
     #[serde(rename = "Protection")]
@@ -208,10 +208,10 @@ pub struct DescribeProtectionResponse {
     pub protection: Option<Protection>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeSubscriptionRequest {}
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeSubscriptionResponse {
     /// <p>The AWS Shield Advanced subscription details for an account.</p>
     #[serde(rename = "Subscription")]
@@ -219,17 +219,17 @@ pub struct DescribeSubscriptionResponse {
     pub subscription: Option<Subscription>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetSubscriptionStateRequest {}
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetSubscriptionStateResponse {
     /// <p>The status of the subscription.</p>
     #[serde(rename = "SubscriptionState")]
     pub subscription_state: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListAttacksRequest {
     /// <p>The end of the time period for the attacks. This is a <code>timestamp</code> type. The sample request above indicates a <code>number</code> type because the default used by WAF is Unix time in seconds. However any valid <a href="http://docs.aws.amazon.com/cli/latest/userguide/cli-using-param.html#parameter-types">timestamp format</a> is allowed. </p>
     #[serde(rename = "EndTime")]
@@ -253,7 +253,7 @@ pub struct ListAttacksRequest {
     pub start_time: Option<TimeRange>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListAttacksResponse {
     /// <p>The attack information for the specified time range.</p>
     #[serde(rename = "AttackSummaries")]
@@ -265,7 +265,7 @@ pub struct ListAttacksResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListProtectionsRequest {
     /// <p>The maximum number of <a>Protection</a> objects to be returned. If this is left blank the first 20 results will be returned.</p>
     #[serde(rename = "MaxResults")]
@@ -277,7 +277,7 @@ pub struct ListProtectionsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListProtectionsResponse {
     /// <p>If you specify a value for <code>MaxResults</code> and you have more Protections than the value of MaxResults, AWS Shield Advanced returns a NextToken value in the response that allows you to list another group of Protections. For the second and subsequent ListProtections requests, specify the value of NextToken from the previous response to get information about another batch of Protections.</p>
     #[serde(rename = "NextToken")]
@@ -290,7 +290,7 @@ pub struct ListProtectionsResponse {
 }
 
 /// <p>The mitigation applied to a DDoS attack.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Mitigation {
     /// <p>The name of the mitigation taken for this attack.</p>
     #[serde(rename = "MitigationName")]
@@ -299,7 +299,7 @@ pub struct Mitigation {
 }
 
 /// <p>An object that represents a resource that is under DDoS protection.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Protection {
     /// <p>The unique identifier (ID) of the protection.</p>
     #[serde(rename = "Id")]
@@ -316,7 +316,7 @@ pub struct Protection {
 }
 
 /// <p>The attack information for the specified SubResource.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SubResourceSummary {
     /// <p>The list of attack types and associated counters.</p>
     #[serde(rename = "AttackVectors")]
@@ -337,7 +337,7 @@ pub struct SubResourceSummary {
 }
 
 /// <p>Information about the AWS Shield Advanced subscription for an account.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Subscription {
     /// <p>The start time of the subscription, in Unix time in seconds. For more information see <a href="http://docs.aws.amazon.com/cli/latest/userguide/cli-using-param.html#parameter-types">timestamp</a>.</p>
     #[serde(rename = "StartTime")]
@@ -350,7 +350,7 @@ pub struct Subscription {
 }
 
 /// <p>A summary of information about the attack.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SummarizedAttackVector {
     /// <p>The list of counters that describe the details of the attack.</p>
     #[serde(rename = "VectorCounters")]
@@ -362,7 +362,7 @@ pub struct SummarizedAttackVector {
 }
 
 /// <p>The counter that describes a DDoS attack.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SummarizedCounter {
     /// <p>The average value of the counter for a specified time period.</p>
     #[serde(rename = "Average")]
@@ -391,7 +391,7 @@ pub struct SummarizedCounter {
 }
 
 /// <p>The time range.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct TimeRange {
     /// <p>The start time, in Unix time in seconds. For more information see <a href="http://docs.aws.amazon.com/cli/latest/userguide/cli-using-param.html#parameter-types">timestamp</a>.</p>
     #[serde(rename = "FromInclusive")]

--- a/rusoto/services/shield/src/generated.rs
+++ b/rusoto/services/shield/src/generated.rs
@@ -434,7 +434,8 @@ impl CreateProtectionError {
     pub fn from_body(body: &str) -> CreateProtectionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -538,7 +539,8 @@ impl CreateSubscriptionError {
     pub fn from_body(body: &str) -> CreateSubscriptionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -626,7 +628,8 @@ impl DeleteProtectionError {
     pub fn from_body(body: &str) -> DeleteProtectionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -716,7 +719,8 @@ impl DeleteSubscriptionError {
     pub fn from_body(body: &str) -> DeleteSubscriptionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -806,7 +810,8 @@ impl DescribeAttackError {
     pub fn from_body(body: &str) -> DescribeAttackError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -890,7 +895,8 @@ impl DescribeProtectionError {
     pub fn from_body(body: &str) -> DescribeProtectionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -976,7 +982,8 @@ impl DescribeSubscriptionError {
     pub fn from_body(body: &str) -> DescribeSubscriptionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1060,7 +1067,8 @@ impl GetSubscriptionStateError {
     pub fn from_body(body: &str) -> GetSubscriptionStateError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1144,7 +1152,8 @@ impl ListAttacksError {
     pub fn from_body(body: &str) -> ListAttacksError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1232,7 +1241,8 @@ impl ListProtectionsError {
     pub fn from_body(body: &str) -> ListProtectionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/sms/src/generated.rs
+++ b/rusoto/services/sms/src/generated.rs
@@ -31,7 +31,7 @@ use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 /// <p>Object representing a Connector</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Connector {
     #[serde(rename = "associatedOn")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -65,7 +65,7 @@ pub struct Connector {
     pub vm_manager_type: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateReplicationJobRequest {
     #[serde(rename = "description")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -84,38 +84,38 @@ pub struct CreateReplicationJobRequest {
     pub server_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateReplicationJobResponse {
     #[serde(rename = "replicationJobId")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub replication_job_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteReplicationJobRequest {
     #[serde(rename = "replicationJobId")]
     pub replication_job_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteReplicationJobResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteServerCatalogRequest {}
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteServerCatalogResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DisassociateConnectorRequest {
     #[serde(rename = "connectorId")]
     pub connector_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DisassociateConnectorResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetConnectorsRequest {
     #[serde(rename = "maxResults")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -125,7 +125,7 @@ pub struct GetConnectorsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetConnectorsResponse {
     #[serde(rename = "connectorList")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -135,7 +135,7 @@ pub struct GetConnectorsResponse {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetReplicationJobsRequest {
     #[serde(rename = "maxResults")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -148,7 +148,7 @@ pub struct GetReplicationJobsRequest {
     pub replication_job_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetReplicationJobsResponse {
     #[serde(rename = "nextToken")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -158,7 +158,7 @@ pub struct GetReplicationJobsResponse {
     pub replication_job_list: Option<Vec<ReplicationJob>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetReplicationRunsRequest {
     #[serde(rename = "maxResults")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -170,7 +170,7 @@ pub struct GetReplicationRunsRequest {
     pub replication_job_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetReplicationRunsResponse {
     #[serde(rename = "nextToken")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -183,7 +183,7 @@ pub struct GetReplicationRunsResponse {
     pub replication_run_list: Option<Vec<ReplicationRun>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetServersRequest {
     #[serde(rename = "maxResults")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -193,7 +193,7 @@ pub struct GetServersRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetServersResponse {
     #[serde(rename = "lastModifiedOn")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -209,14 +209,14 @@ pub struct GetServersResponse {
     pub server_list: Option<Vec<Server>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ImportServerCatalogRequest {}
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ImportServerCatalogResponse {}
 
 /// <p>Object representing a Replication Job</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ReplicationJob {
     #[serde(rename = "description")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -263,7 +263,7 @@ pub struct ReplicationJob {
 }
 
 /// <p>Object representing a Replication Run</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ReplicationRun {
     #[serde(rename = "amiId")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -292,7 +292,7 @@ pub struct ReplicationRun {
 }
 
 /// <p>Object representing a server</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Server {
     #[serde(rename = "replicationJobId")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -311,7 +311,7 @@ pub struct Server {
     pub vm_server: Option<VmServer>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StartOnDemandReplicationRunRequest {
     #[serde(rename = "description")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -320,14 +320,14 @@ pub struct StartOnDemandReplicationRunRequest {
     pub replication_job_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StartOnDemandReplicationRunResponse {
     #[serde(rename = "replicationRunId")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub replication_run_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateReplicationJobRequest {
     #[serde(rename = "description")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -348,11 +348,11 @@ pub struct UpdateReplicationJobRequest {
     pub role_name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateReplicationJobResponse {}
 
 /// <p>Object representing a VM server</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct VmServer {
     #[serde(rename = "vmManagerName")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -372,7 +372,7 @@ pub struct VmServer {
 }
 
 /// <p>Object representing a server&#39;s location</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct VmServerAddress {
     #[serde(rename = "vmId")]
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/rusoto/services/sms/src/generated.rs
+++ b/rusoto/services/sms/src/generated.rs
@@ -415,7 +415,8 @@ impl CreateReplicationJobError {
     pub fn from_body(body: &str) -> CreateReplicationJobError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -543,7 +544,8 @@ impl DeleteReplicationJobError {
     pub fn from_body(body: &str) -> DeleteReplicationJobError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -653,7 +655,8 @@ impl DeleteServerCatalogError {
     pub fn from_body(body: &str) -> DeleteServerCatalogError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -753,7 +756,8 @@ impl DisassociateConnectorError {
     pub fn from_body(body: &str) -> DisassociateConnectorError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -851,7 +855,8 @@ impl GetConnectorsError {
     pub fn from_body(body: &str) -> GetConnectorsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -933,7 +938,8 @@ impl GetReplicationJobsError {
     pub fn from_body(body: &str) -> GetReplicationJobsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1027,7 +1033,8 @@ impl GetReplicationRunsError {
     pub fn from_body(body: &str) -> GetReplicationRunsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1117,7 +1124,8 @@ impl GetServersError {
     pub fn from_body(body: &str) -> GetServersError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1201,7 +1209,8 @@ impl ImportServerCatalogError {
     pub fn from_body(body: &str) -> ImportServerCatalogError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1307,7 +1316,8 @@ impl StartOnDemandReplicationRunError {
     pub fn from_body(body: &str) -> StartOnDemandReplicationRunError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1425,7 +1435,8 @@ impl UpdateReplicationJobError {
     pub fn from_body(body: &str) -> UpdateReplicationJobError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/snowball/src/generated.rs
+++ b/rusoto/services/snowball/src/generated.rs
@@ -859,7 +859,8 @@ impl CancelClusterError {
     pub fn from_body(body: &str) -> CancelClusterError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -949,7 +950,8 @@ impl CancelJobError {
     pub fn from_body(body: &str) -> CancelJobError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1035,7 +1037,8 @@ impl CreateAddressError {
     pub fn from_body(body: &str) -> CreateAddressError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1121,7 +1124,8 @@ impl CreateClusterError {
     pub fn from_body(body: &str) -> CreateClusterError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1213,7 +1217,8 @@ impl CreateJobError {
     pub fn from_body(body: &str) -> CreateJobError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1301,7 +1306,8 @@ impl DescribeAddressError {
     pub fn from_body(body: &str) -> DescribeAddressError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1381,7 +1387,8 @@ impl DescribeAddressesError {
     pub fn from_body(body: &str) -> DescribeAddressesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1465,7 +1472,8 @@ impl DescribeClusterError {
     pub fn from_body(body: &str) -> DescribeClusterError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1543,7 +1551,8 @@ impl DescribeJobError {
     pub fn from_body(body: &str) -> DescribeJobError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1623,7 +1632,8 @@ impl GetJobManifestError {
     pub fn from_body(body: &str) -> GetJobManifestError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1707,7 +1717,8 @@ impl GetJobUnlockCodeError {
     pub fn from_body(body: &str) -> GetJobUnlockCodeError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1787,7 +1798,8 @@ impl GetSnowballUsageError {
     pub fn from_body(body: &str) -> GetSnowballUsageError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1863,7 +1875,8 @@ impl ListClusterJobsError {
     pub fn from_body(body: &str) -> ListClusterJobsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1945,7 +1958,8 @@ impl ListClustersError {
     pub fn from_body(body: &str) -> ListClustersError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2023,7 +2037,8 @@ impl ListJobsError {
     pub fn from_body(body: &str) -> ListJobsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2105,7 +2120,8 @@ impl UpdateClusterError {
     pub fn from_body(body: &str) -> UpdateClusterError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2203,7 +2219,8 @@ impl UpdateJobError {
     pub fn from_body(body: &str) -> UpdateJobError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/snowball/src/generated.rs
+++ b/rusoto/services/snowball/src/generated.rs
@@ -31,7 +31,7 @@ use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 /// <p>The address that you want the Snowball or Snowballs associated with a specific job to be shipped to. Addresses are validated at the time of creation. The address you provide must be located within the serviceable area of your region. Although no individual elements of the <code>Address</code> are required, if the address is invalid or unsupported, then an exception is thrown.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Address {
     /// <p>The unique ID for an address.</p>
     #[serde(rename = "AddressId")]
@@ -91,28 +91,28 @@ pub struct Address {
     pub street_3: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CancelClusterRequest {
     /// <p>The 39-character ID for the cluster that you want to cancel, for example <code>CID123e4567-e89b-12d3-a456-426655440000</code>.</p>
     #[serde(rename = "ClusterId")]
     pub cluster_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CancelClusterResult {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CancelJobRequest {
     /// <p>The 39-character job ID for the job that you want to cancel, for example <code>JID123e4567-e89b-12d3-a456-426655440000</code>.</p>
     #[serde(rename = "JobId")]
     pub job_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CancelJobResult {}
 
 /// <p>Contains a cluster's state, a cluster's ID, and other important information.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ClusterListEntry {
     /// <p>The 39-character ID for the cluster that you want to list, for example <code>CID123e4567-e89b-12d3-a456-426655440000</code>.</p>
     #[serde(rename = "ClusterId")]
@@ -133,7 +133,7 @@ pub struct ClusterListEntry {
 }
 
 /// <p>Contains metadata about a specific cluster.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ClusterMetadata {
     /// <p>The automatically generated ID for a specific address.</p>
     #[serde(rename = "AddressId")]
@@ -189,14 +189,14 @@ pub struct ClusterMetadata {
     pub snowball_type: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateAddressRequest {
     /// <p>The address that you want the Snowball shipped to.</p>
     #[serde(rename = "Address")]
     pub address: Address,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateAddressResult {
     /// <p>The automatically generated ID for a specific address. You'll use this ID when you create a job to specify which address you want the Snowball for that job shipped to.</p>
     #[serde(rename = "AddressId")]
@@ -204,7 +204,7 @@ pub struct CreateAddressResult {
     pub address_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateClusterRequest {
     /// <p>The ID for the address that you want the cluster shipped to.</p>
     #[serde(rename = "AddressId")]
@@ -243,7 +243,7 @@ pub struct CreateClusterRequest {
     pub snowball_type: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateClusterResult {
     /// <p>The automatically generated ID for a cluster.</p>
     #[serde(rename = "ClusterId")]
@@ -251,7 +251,7 @@ pub struct CreateClusterResult {
     pub cluster_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateJobRequest {
     /// <p>The ID for the address that you want the Snowball shipped to.</p>
     #[serde(rename = "AddressId")]
@@ -303,7 +303,7 @@ pub struct CreateJobRequest {
     pub snowball_type: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateJobResult {
     /// <p>The automatically generated ID for a job, for example <code>JID123e4567-e89b-12d3-a456-426655440000</code>.</p>
     #[serde(rename = "JobId")]
@@ -312,7 +312,7 @@ pub struct CreateJobResult {
 }
 
 /// <p>Defines the real-time status of a Snowball's data transfer while the appliance is at AWS. This data is only available while a job has a <code>JobState</code> value of <code>InProgress</code>, for both import and export jobs.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DataTransfer {
     /// <p>The number of bytes transferred between a Snowball and Amazon S3.</p>
     #[serde(rename = "BytesTransferred")]
@@ -332,14 +332,14 @@ pub struct DataTransfer {
     pub total_objects: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeAddressRequest {
     /// <p>The automatically generated ID for a specific address.</p>
     #[serde(rename = "AddressId")]
     pub address_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeAddressResult {
     /// <p>The address that you want the Snowball or Snowballs associated with a specific job to be shipped to.</p>
     #[serde(rename = "Address")]
@@ -347,7 +347,7 @@ pub struct DescribeAddressResult {
     pub address: Option<Address>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeAddressesRequest {
     /// <p>The number of <code>ADDRESS</code> objects to return.</p>
     #[serde(rename = "MaxResults")]
@@ -359,7 +359,7 @@ pub struct DescribeAddressesRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeAddressesResult {
     /// <p>The Snowball shipping addresses that were created for this account.</p>
     #[serde(rename = "Addresses")]
@@ -371,14 +371,14 @@ pub struct DescribeAddressesResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeClusterRequest {
     /// <p>The automatically generated ID for a cluster.</p>
     #[serde(rename = "ClusterId")]
     pub cluster_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeClusterResult {
     /// <p>Information about a specific cluster, including shipping information, cluster status, and other important metadata.</p>
     #[serde(rename = "ClusterMetadata")]
@@ -386,14 +386,14 @@ pub struct DescribeClusterResult {
     pub cluster_metadata: Option<ClusterMetadata>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeJobRequest {
     /// <p>The automatically generated ID for a job, for example <code>JID123e4567-e89b-12d3-a456-426655440000</code>.</p>
     #[serde(rename = "JobId")]
     pub job_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeJobResult {
     /// <p>Information about a specific job, including shipping information, job status, and other important metadata.</p>
     #[serde(rename = "JobMetadata")]
@@ -406,7 +406,7 @@ pub struct DescribeJobResult {
 }
 
 /// <p>The container for the <a>EventTriggerDefinition$EventResourceARN</a>.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct EventTriggerDefinition {
     /// <p>The Amazon Resource Name (ARN) for any local Amazon S3 resource that is an AWS Lambda function's event trigger associated with this job.</p>
     #[serde(rename = "EventResourceARN")]
@@ -414,14 +414,14 @@ pub struct EventTriggerDefinition {
     pub event_resource_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetJobManifestRequest {
     /// <p>The ID for a job that you want to get the manifest file for, for example <code>JID123e4567-e89b-12d3-a456-426655440000</code>.</p>
     #[serde(rename = "JobId")]
     pub job_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetJobManifestResult {
     /// <p>The Amazon S3 presigned URL for the manifest file associated with the specified <code>JobId</code> value.</p>
     #[serde(rename = "ManifestURI")]
@@ -429,14 +429,14 @@ pub struct GetJobManifestResult {
     pub manifest_uri: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetJobUnlockCodeRequest {
     /// <p>The ID for the job that you want to get the <code>UnlockCode</code> value for, for example <code>JID123e4567-e89b-12d3-a456-426655440000</code>.</p>
     #[serde(rename = "JobId")]
     pub job_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetJobUnlockCodeResult {
     /// <p>The <code>UnlockCode</code> value for the specified job. The <code>UnlockCode</code> value can be accessed for up to 90 days after the job has been created.</p>
     #[serde(rename = "UnlockCode")]
@@ -444,10 +444,10 @@ pub struct GetJobUnlockCodeResult {
     pub unlock_code: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetSnowballUsageRequest {}
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetSnowballUsageResult {
     /// <p>The service limit for number of Snowballs this account can have at once. The default service limit is 1 (one).</p>
     #[serde(rename = "SnowballLimit")]
@@ -460,7 +460,7 @@ pub struct GetSnowballUsageResult {
 }
 
 /// <p>Each <code>JobListEntry</code> object contains a job's state, a job's ID, and a value that indicates whether the job is a job part, in the case of an export job.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct JobListEntry {
     /// <p>The creation date for this job.</p>
     #[serde(rename = "CreationDate")]
@@ -493,7 +493,7 @@ pub struct JobListEntry {
 }
 
 /// <p>Contains job logs. Whenever Snowball is used to import data into or export data out of Amazon S3, you'll have the option of downloading a PDF job report. Job logs are returned as a part of the response syntax of the <code>DescribeJob</code> action in the <code>JobMetadata</code> data type. The job logs can be accessed for up to 60 minutes after this request has been made. To access any of the job logs after 60 minutes have passed, you'll have to make another call to the <code>DescribeJob</code> action.</p> <p>For import jobs, the PDF job report becomes available at the end of the import process. For export jobs, your job report typically becomes available while the Snowball for your job part is being delivered to you.</p> <p>The job report provides you insight into the state of your Amazon S3 data transfer. The report includes details about your job or job part for your records.</p> <p>For deeper visibility into the status of your transferred objects, you can look at the two associated logs: a success log and a failure log. The logs are saved in comma-separated value (CSV) format, and the name of each log includes the ID of the job or job part that the log describes.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct JobLogs {
     /// <p>A link to an Amazon S3 presigned URL where the job completion report is located.</p>
     #[serde(rename = "JobCompletionReportURI")]
@@ -510,7 +510,7 @@ pub struct JobLogs {
 }
 
 /// <p>Contains information about a specific job including shipping information, job status, and other important metadata. This information is returned as a part of the response syntax of the <code>DescribeJob</code> action.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct JobMetadata {
     /// <p>The ID for the address that you want the Snowball shipped to.</p>
     #[serde(rename = "AddressId")]
@@ -583,7 +583,7 @@ pub struct JobMetadata {
 }
 
 /// <p>Contains an array of <code>S3Resource</code> objects. Each <code>S3Resource</code> object represents an Amazon S3 bucket that your transferred data will be exported from or imported into.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct JobResource {
     /// <p>The Python-language Lambda functions for this job.</p>
     #[serde(rename = "LambdaResources")]
@@ -596,7 +596,7 @@ pub struct JobResource {
 }
 
 /// <p>Contains a key range. For export jobs, a <code>S3Resource</code> object can have an optional <code>KeyRange</code> value. The length of the range is defined at job creation, and has either an inclusive <code>BeginMarker</code>, an inclusive <code>EndMarker</code>, or both. Ranges are UTF-8 binary sorted.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct KeyRange {
     /// <p>The key that starts an optional key range for an export job. Ranges are inclusive and UTF-8 binary sorted.</p>
     #[serde(rename = "BeginMarker")]
@@ -609,7 +609,7 @@ pub struct KeyRange {
 }
 
 /// <p>Identifies </p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct LambdaResource {
     /// <p>The array of ARNs for <a>S3Resource</a> objects to trigger the <a>LambdaResource</a> objects associated with this job.</p>
     #[serde(rename = "EventTriggers")]
@@ -621,7 +621,7 @@ pub struct LambdaResource {
     pub lambda_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListClusterJobsRequest {
     /// <p>The 39-character ID for the cluster that you want to list, for example <code>CID123e4567-e89b-12d3-a456-426655440000</code>.</p>
     #[serde(rename = "ClusterId")]
@@ -636,7 +636,7 @@ pub struct ListClusterJobsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListClusterJobsResult {
     /// <p>Each <code>JobListEntry</code> object contains a job's state, a job's ID, and a value that indicates whether the job is a job part, in the case of export jobs. </p>
     #[serde(rename = "JobListEntries")]
@@ -648,7 +648,7 @@ pub struct ListClusterJobsResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListClustersRequest {
     /// <p>The number of <code>ClusterListEntry</code> objects to return.</p>
     #[serde(rename = "MaxResults")]
@@ -660,7 +660,7 @@ pub struct ListClustersRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListClustersResult {
     /// <p>Each <code>ClusterListEntry</code> object contains a cluster's state, a cluster's ID, and other important status information.</p>
     #[serde(rename = "ClusterListEntries")]
@@ -672,7 +672,7 @@ pub struct ListClustersResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListJobsRequest {
     /// <p>The number of <code>JobListEntry</code> objects to return.</p>
     #[serde(rename = "MaxResults")]
@@ -684,7 +684,7 @@ pub struct ListJobsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListJobsResult {
     /// <p>Each <code>JobListEntry</code> object contains a job's state, a job's ID, and a value that indicates whether the job is a job part, in the case of export jobs. </p>
     #[serde(rename = "JobListEntries")]
@@ -697,7 +697,7 @@ pub struct ListJobsResult {
 }
 
 /// <p>The Amazon Simple Notification Service (Amazon SNS) notification settings associated with a specific job. The <code>Notification</code> object is returned as a part of the response syntax of the <code>DescribeJob</code> action in the <code>JobMetadata</code> data type.</p> <p>When the notification settings are defined during job creation, you can choose to notify based on a specific set of job states using the <code>JobStatesToNotify</code> array of strings, or you can specify that you want to have Amazon SNS notifications sent out for all job states with <code>NotifyAll</code> set to true.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Notification {
     /// <p>The list of job states that will trigger a notification for this job.</p>
     #[serde(rename = "JobStatesToNotify")]
@@ -714,7 +714,7 @@ pub struct Notification {
 }
 
 /// <p>Each <code>S3Resource</code> object represents an Amazon S3 bucket that your transferred data will be exported from or imported into. For export jobs, this object can have an optional <code>KeyRange</code> value. The length of the range is defined at job creation, and has either an inclusive <code>BeginMarker</code>, an inclusive <code>EndMarker</code>, or both. Ranges are UTF-8 binary sorted.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct S3Resource {
     /// <p>The Amazon Resource Name (ARN) of an Amazon S3 bucket.</p>
     #[serde(rename = "BucketArn")]
@@ -727,7 +727,7 @@ pub struct S3Resource {
 }
 
 /// <p>The <code>Status</code> and <code>TrackingNumber</code> information for an inbound or outbound shipment.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Shipment {
     /// <p>Status information for a shipment.</p>
     #[serde(rename = "Status")]
@@ -740,7 +740,7 @@ pub struct Shipment {
 }
 
 /// <p>A job's shipping information, including inbound and outbound tracking numbers and shipping speed options.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ShippingDetails {
     /// <p>The <code>Status</code> and <code>TrackingNumber</code> values for a Snowball being returned to AWS for a particular job.</p>
     #[serde(rename = "InboundShipment")]
@@ -756,7 +756,7 @@ pub struct ShippingDetails {
     pub shipping_option: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateClusterRequest {
     /// <p>The ID of the updated <a>Address</a> object.</p>
     #[serde(rename = "AddressId")]
@@ -791,10 +791,10 @@ pub struct UpdateClusterRequest {
     pub shipping_option: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateClusterResult {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateJobRequest {
     /// <p>The ID of the updated <a>Address</a> object.</p>
     #[serde(rename = "AddressId")]
@@ -833,7 +833,7 @@ pub struct UpdateJobRequest {
     pub snowball_capacity_preference: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateJobResult {}
 
 /// Errors returned by CancelCluster

--- a/rusoto/services/sns/src/generated.rs
+++ b/rusoto/services/sns/src/generated.rs
@@ -69,7 +69,7 @@ impl ActionsListSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AddPermissionInput {
     /// <p>The AWS account IDs of the users (principals) who will be given access to the specified actions. The users must have AWS accounts, but do not need to be signed up for this service.</p>
     pub aws_account_id: Vec<String>,
@@ -154,7 +154,7 @@ impl BooleanDeserializer {
     }
 }
 /// <p>The input for the <code>CheckIfPhoneNumberIsOptedOut</code> action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CheckIfPhoneNumberIsOptedOutInput {
     /// <p>The phone number for which you want to check the opt out status.</p>
     pub phone_number: String,
@@ -177,7 +177,7 @@ impl CheckIfPhoneNumberIsOptedOutInputSerializer {
 }
 
 /// <p>The response from the <code>CheckIfPhoneNumberIsOptedOut</code> action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CheckIfPhoneNumberIsOptedOutResponse {
     /// <p><p>Indicates whether the phone number is opted out:</p> <ul> <li> <p> <code>true</code> – The phone number is opted out, meaning you cannot publish SMS messages to it.</p> </li> <li> <p> <code>false</code> – The phone number is opted in, meaning you can publish SMS messages to it.</p> </li> </ul></p>
     pub is_opted_out: Option<bool>,
@@ -224,7 +224,7 @@ impl CheckIfPhoneNumberIsOptedOutResponseDeserializer {
     }
 }
 /// <p>Input for ConfirmSubscription action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ConfirmSubscriptionInput {
     /// <p>Disallows unauthenticated unsubscribes of the subscription. If the value of this parameter is <code>true</code> and the request has an AWS signature, then only the topic owner and the subscription owner can unsubscribe the endpoint. The unsubscribe action requires AWS authentication. </p>
     pub authenticate_on_unsubscribe: Option<String>,
@@ -261,7 +261,7 @@ impl ConfirmSubscriptionInputSerializer {
 }
 
 /// <p>Response for ConfirmSubscriptions action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ConfirmSubscriptionResponse {
     /// <p>The ARN of the created subscription.</p>
     pub subscription_arn: Option<String>,
@@ -309,7 +309,7 @@ impl ConfirmSubscriptionResponseDeserializer {
     }
 }
 /// <p>Response from CreateEndpoint action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateEndpointResponse {
     /// <p>EndpointArn returned from CreateEndpoint action.</p>
     pub endpoint_arn: Option<String>,
@@ -356,7 +356,7 @@ impl CreateEndpointResponseDeserializer {
     }
 }
 /// <p>Input for CreatePlatformApplication action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreatePlatformApplicationInput {
     /// <p>For a list of attributes, see <a href="http://docs.aws.amazon.com/sns/latest/api/API_SetPlatformApplicationAttributes.html">SetPlatformApplicationAttributes</a> </p>
     pub attributes: ::std::collections::HashMap<String, String>,
@@ -392,7 +392,7 @@ impl CreatePlatformApplicationInputSerializer {
 }
 
 /// <p>Response from CreatePlatformApplication action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreatePlatformApplicationResponse {
     /// <p>PlatformApplicationArn is returned.</p>
     pub platform_application_arn: Option<String>,
@@ -441,7 +441,7 @@ impl CreatePlatformApplicationResponseDeserializer {
     }
 }
 /// <p>Input for CreatePlatformEndpoint action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreatePlatformEndpointInput {
     /// <p>For a list of attributes, see <a href="http://docs.aws.amazon.com/sns/latest/api/API_SetEndpointAttributes.html">SetEndpointAttributes</a>.</p>
     pub attributes: Option<::std::collections::HashMap<String, String>>,
@@ -487,7 +487,7 @@ impl CreatePlatformEndpointInputSerializer {
 }
 
 /// <p>Input for CreateTopic action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateTopicInput {
     /// <p>The name of the topic you want to create.</p> <p>Constraints: Topic names must be made up of only uppercase and lowercase ASCII letters, numbers, underscores, and hyphens, and must be between 1 and 256 characters long.</p>
     pub name: String,
@@ -510,7 +510,7 @@ impl CreateTopicInputSerializer {
 }
 
 /// <p>Response from CreateTopic action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateTopicResponse {
     /// <p>The Amazon Resource Name (ARN) assigned to the created topic.</p>
     pub topic_arn: Option<String>,
@@ -569,7 +569,7 @@ impl DelegatesListSerializer {
 }
 
 /// <p>Input for DeleteEndpoint action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteEndpointInput {
     /// <p>EndpointArn of endpoint to delete.</p>
     pub endpoint_arn: String,
@@ -592,7 +592,7 @@ impl DeleteEndpointInputSerializer {
 }
 
 /// <p>Input for DeletePlatformApplication action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeletePlatformApplicationInput {
     /// <p>PlatformApplicationArn of platform application object to delete.</p>
     pub platform_application_arn: String,
@@ -614,7 +614,7 @@ impl DeletePlatformApplicationInputSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteTopicInput {
     /// <p>The ARN of the topic you want to delete.</p>
     pub topic_arn: String,
@@ -651,7 +651,7 @@ impl EndpointDeserializer {
     }
 }
 /// <p>Input for GetEndpointAttributes action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetEndpointAttributesInput {
     /// <p>EndpointArn for GetEndpointAttributes input.</p>
     pub endpoint_arn: String,
@@ -674,7 +674,7 @@ impl GetEndpointAttributesInputSerializer {
 }
 
 /// <p>Response from GetEndpointAttributes of the EndpointArn.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetEndpointAttributesResponse {
     /// <p><p>Attributes include the following:</p> <ul> <li> <p> <code>CustomUserData</code> -- arbitrary user data to associate with the endpoint. Amazon SNS does not use this data. The data must be in UTF-8 format and less than 2KB.</p> </li> <li> <p> <code>Enabled</code> -- flag that enables/disables delivery to the endpoint. Amazon SNS will set this to false when a notification service indicates to Amazon SNS that the endpoint is invalid. Users can set it back to true, typically after updating Token.</p> </li> <li> <p> <code>Token</code> -- device token, also referred to as a registration id, for an app and mobile device. This is returned from the notification service when an app and mobile device are registered with the notification service.</p> </li> </ul></p>
     pub attributes: Option<::std::collections::HashMap<String, String>>,
@@ -723,7 +723,7 @@ impl GetEndpointAttributesResponseDeserializer {
     }
 }
 /// <p>Input for GetPlatformApplicationAttributes action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetPlatformApplicationAttributesInput {
     /// <p>PlatformApplicationArn for GetPlatformApplicationAttributesInput.</p>
     pub platform_application_arn: String,
@@ -746,7 +746,7 @@ impl GetPlatformApplicationAttributesInputSerializer {
 }
 
 /// <p>Response for GetPlatformApplicationAttributes action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetPlatformApplicationAttributesResponse {
     /// <p><p>Attributes include the following:</p> <ul> <li> <p> <code>EventEndpointCreated</code> -- Topic ARN to which EndpointCreated event notifications should be sent.</p> </li> <li> <p> <code>EventEndpointDeleted</code> -- Topic ARN to which EndpointDeleted event notifications should be sent.</p> </li> <li> <p> <code>EventEndpointUpdated</code> -- Topic ARN to which EndpointUpdate event notifications should be sent.</p> </li> <li> <p> <code>EventDeliveryFailure</code> -- Topic ARN to which DeliveryFailure event notifications should be sent upon Direct Publish delivery failure (permanent) to one of the application&#39;s endpoints.</p> </li> </ul></p>
     pub attributes: Option<::std::collections::HashMap<String, String>>,
@@ -795,7 +795,7 @@ impl GetPlatformApplicationAttributesResponseDeserializer {
     }
 }
 /// <p>The input for the <code>GetSMSAttributes</code> request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetSMSAttributesInput {
     /// <p>A list of the individual attribute names, such as <code>MonthlySpendLimit</code>, for which you want values.</p> <p>For all attribute names, see <a href="http://docs.aws.amazon.com/sns/latest/api/API_SetSMSAttributes.html">SetSMSAttributes</a>.</p> <p>If you don't use this parameter, Amazon SNS returns all SMS attributes.</p>
     pub attributes: Option<Vec<String>>,
@@ -821,7 +821,7 @@ impl GetSMSAttributesInputSerializer {
 }
 
 /// <p>The response from the <code>GetSMSAttributes</code> request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetSMSAttributesResponse {
     /// <p>The SMS attribute names and their values.</p>
     pub attributes: Option<::std::collections::HashMap<String, String>>,
@@ -870,7 +870,7 @@ impl GetSMSAttributesResponseDeserializer {
     }
 }
 /// <p>Input for GetSubscriptionAttributes.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetSubscriptionAttributesInput {
     /// <p>The ARN of the subscription whose properties you want to get.</p>
     pub subscription_arn: String,
@@ -893,7 +893,7 @@ impl GetSubscriptionAttributesInputSerializer {
 }
 
 /// <p>Response for GetSubscriptionAttributes action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetSubscriptionAttributesResponse {
     /// <p><p>A map of the subscription&#39;s attributes. Attributes in this map include the following:</p> <ul> <li> <p> <code>SubscriptionArn</code> -- the subscription&#39;s ARN</p> </li> <li> <p> <code>TopicArn</code> -- the topic ARN that the subscription is associated with</p> </li> <li> <p> <code>Owner</code> -- the AWS account ID of the subscription&#39;s owner</p> </li> <li> <p> <code>ConfirmationWasAuthenticated</code> -- true if the subscription confirmation request was authenticated</p> </li> <li> <p> <code>DeliveryPolicy</code> -- the JSON serialization of the subscription&#39;s delivery policy</p> </li> <li> <p> <code>EffectiveDeliveryPolicy</code> -- the JSON serialization of the effective delivery policy that takes into account the topic delivery policy and account system defaults</p> </li> </ul></p>
     pub attributes: Option<::std::collections::HashMap<String, String>>,
@@ -941,7 +941,7 @@ impl GetSubscriptionAttributesResponseDeserializer {
     }
 }
 /// <p>Input for GetTopicAttributes action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetTopicAttributesInput {
     /// <p>The ARN of the topic whose properties you want to get.</p>
     pub topic_arn: String,
@@ -964,7 +964,7 @@ impl GetTopicAttributesInputSerializer {
 }
 
 /// <p>Response for GetTopicAttributes action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetTopicAttributesResponse {
     /// <p><p>A map of the topic&#39;s attributes. Attributes in this map include the following:</p> <ul> <li> <p> <code>TopicArn</code> -- the topic&#39;s ARN</p> </li> <li> <p> <code>Owner</code> -- the AWS account ID of the topic&#39;s owner</p> </li> <li> <p> <code>Policy</code> -- the JSON serialization of the topic&#39;s access control policy</p> </li> <li> <p> <code>DisplayName</code> -- the human-readable name used in the &quot;From&quot; field for notifications to email and email-json endpoints</p> </li> <li> <p> <code>SubscriptionsPending</code> -- the number of subscriptions pending confirmation on this topic</p> </li> <li> <p> <code>SubscriptionsConfirmed</code> -- the number of confirmed subscriptions on this topic</p> </li> <li> <p> <code>SubscriptionsDeleted</code> -- the number of deleted subscriptions on this topic</p> </li> <li> <p> <code>DeliveryPolicy</code> -- the JSON serialization of the topic&#39;s delivery policy</p> </li> <li> <p> <code>EffectiveDeliveryPolicy</code> -- the JSON serialization of the effective delivery policy that takes into account system defaults</p> </li> </ul></p>
     pub attributes: Option<::std::collections::HashMap<String, String>>,
@@ -1013,7 +1013,7 @@ impl GetTopicAttributesResponseDeserializer {
     }
 }
 /// <p>Input for ListEndpointsByPlatformApplication action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListEndpointsByPlatformApplicationInput {
     /// <p>NextToken string is used when calling ListEndpointsByPlatformApplication action to retrieve additional records that are available after the first page results.</p>
     pub next_token: Option<String>,
@@ -1044,7 +1044,7 @@ impl ListEndpointsByPlatformApplicationInputSerializer {
 }
 
 /// <p>Response for ListEndpointsByPlatformApplication action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListEndpointsByPlatformApplicationResponse {
     /// <p>Endpoints returned for ListEndpointsByPlatformApplication action.</p>
     pub endpoints: Option<Vec<String>>,
@@ -1181,7 +1181,7 @@ impl ListOfPlatformApplicationsDeserializer {
     }
 }
 /// <p>The input for the <code>ListPhoneNumbersOptedOut</code> action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListPhoneNumbersOptedOutInput {
     /// <p>A <code>NextToken</code> string is used when you call the <code>ListPhoneNumbersOptedOut</code> action to retrieve additional records that are available after the first page of results.</p>
     pub next_token: Option<String>,
@@ -1206,7 +1206,7 @@ impl ListPhoneNumbersOptedOutInputSerializer {
 }
 
 /// <p>The response from the <code>ListPhoneNumbersOptedOut</code> action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListPhoneNumbersOptedOutResponse {
     /// <p>A <code>NextToken</code> string is returned when you call the <code>ListPhoneNumbersOptedOut</code> action if additional records are available after the first page of results.</p>
     pub next_token: Option<String>,
@@ -1261,7 +1261,7 @@ impl ListPhoneNumbersOptedOutResponseDeserializer {
     }
 }
 /// <p>Input for ListPlatformApplications action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListPlatformApplicationsInput {
     /// <p>NextToken string is used when calling ListPlatformApplications action to retrieve additional records that are available after the first page results.</p>
     pub next_token: Option<String>,
@@ -1286,7 +1286,7 @@ impl ListPlatformApplicationsInputSerializer {
 }
 
 /// <p>Response for ListPlatformApplications action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListPlatformApplicationsResponse {
     /// <p>NextToken string is returned when calling ListPlatformApplications action if additional records are available after the first page results.</p>
     pub next_token: Option<String>,
@@ -1354,7 +1354,7 @@ impl ListStringSerializer {
 }
 
 /// <p>Input for ListSubscriptionsByTopic action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListSubscriptionsByTopicInput {
     /// <p>Token returned by the previous <code>ListSubscriptionsByTopic</code> request.</p>
     pub next_token: Option<String>,
@@ -1385,7 +1385,7 @@ impl ListSubscriptionsByTopicInputSerializer {
 }
 
 /// <p>Response for ListSubscriptionsByTopic action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListSubscriptionsByTopicResponse {
     /// <p>Token to pass along to the next <code>ListSubscriptionsByTopic</code> request. This element is returned if there are more subscriptions to retrieve.</p>
     pub next_token: Option<String>,
@@ -1440,7 +1440,7 @@ impl ListSubscriptionsByTopicResponseDeserializer {
     }
 }
 /// <p>Input for ListSubscriptions action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListSubscriptionsInput {
     /// <p>Token returned by the previous <code>ListSubscriptions</code> request.</p>
     pub next_token: Option<String>,
@@ -1465,7 +1465,7 @@ impl ListSubscriptionsInputSerializer {
 }
 
 /// <p>Response for ListSubscriptions action</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListSubscriptionsResponse {
     /// <p>Token to pass along to the next <code>ListSubscriptions</code> request. This element is returned if there are more subscriptions to retrieve.</p>
     pub next_token: Option<String>,
@@ -1519,7 +1519,7 @@ impl ListSubscriptionsResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListTopicsInput {
     /// <p>Token returned by the previous <code>ListTopics</code> request.</p>
     pub next_token: Option<String>,
@@ -1544,7 +1544,7 @@ impl ListTopicsInputSerializer {
 }
 
 /// <p>Response for ListTopics action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListTopicsResponse {
     /// <p>Token to pass along to the next <code>ListTopics</code> request. This element is returned if there are additional topics to retrieve.</p>
     pub next_token: Option<String>,
@@ -1657,7 +1657,7 @@ impl MessageAttributeMapSerializer {
 }
 
 /// <p>The user-specified message attribute value. For string data types, the value attribute has the same restrictions on the content as the message body. For more information, see <a href="http://docs.aws.amazon.com/sns/latest/api/API_Publish.html">Publish</a>.</p> <p>Name, type, and value must not be empty or null. In addition, the message body should not be empty or null. All parts of the message attribute, including name, type, and value, are included in the message size restriction, which is currently 256 KB (262,144 bytes). For more information, see <a href="http://docs.aws.amazon.com/sns/latest/dg/SNSMessageAttributes.html">Using Amazon SNS Message Attributes</a>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct MessageAttributeValue {
     /// <p>Binary type attributes can store any binary data, for example, compressed data, encrypted data, or images.</p>
     pub binary_value: Option<Vec<u8>>,
@@ -1726,7 +1726,7 @@ impl NextTokenDeserializer {
     }
 }
 /// <p>Input for the OptInPhoneNumber action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct OptInPhoneNumberInput {
     /// <p>The phone number to opt in.</p>
     pub phone_number: String,
@@ -1749,7 +1749,7 @@ impl OptInPhoneNumberInputSerializer {
 }
 
 /// <p>The response for the OptInPhoneNumber action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct OptInPhoneNumberResponse {}
 
 struct OptInPhoneNumberResponseDeserializer;
@@ -1823,7 +1823,7 @@ impl PhoneNumberListDeserializer {
     }
 }
 /// <p>Platform application object.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PlatformApplication {
     /// <p>Attributes for platform application object.</p>
     pub attributes: Option<::std::collections::HashMap<String, String>>,
@@ -1894,7 +1894,7 @@ impl ProtocolDeserializer {
     }
 }
 /// <p>Input for Publish action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PublishInput {
     /// <p><p>The message you want to send to the topic.</p> <p>If you want to send the same message to all transport protocols, include the text of the message as a String value.</p> <p>If you want to send different messages for each transport protocol, set the value of the <code>MessageStructure</code> parameter to <code>json</code> and use a JSON object for the <code>Message</code> parameter. </p> <p>Constraints: Messages must be UTF-8 encoded strings at most 256 KB in size (262144 bytes, not 262144 characters).</p> <p>JSON-specific constraints:</p> <ul> <li> <p>Keys in the JSON object that correspond to supported transport protocols must have simple JSON string values.</p> </li> <li> <p>The values will be parsed (unescaped) before they are used in outgoing messages.</p> </li> <li> <p>Outbound notifications are JSON encoded (meaning that the characters will be reescaped for sending).</p> </li> <li> <p>Values have a minimum length of 0 (the empty string, &quot;&quot;, is allowed).</p> </li> <li> <p>Values have a maximum length bounded by the overall message size (so, including multiple protocols may limit message sizes).</p> </li> <li> <p>Non-string values will cause the key to be ignored.</p> </li> <li> <p>Keys that do not correspond to supported transport protocols are ignored.</p> </li> <li> <p>Duplicate keys are not allowed.</p> </li> <li> <p>Failure to parse or validate any key or value in the message will cause the <code>Publish</code> call to return an error (no partial delivery).</p> </li> </ul></p>
     pub message: String,
@@ -1966,7 +1966,7 @@ impl PublishInputSerializer {
 }
 
 /// <p>Response for Publish action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PublishResponse {
     /// <p>Unique identifier assigned to the published message.</p> <p>Length Constraint: Maximum 100 characters</p>
     pub message_id: Option<String>,
@@ -2013,7 +2013,7 @@ impl PublishResponseDeserializer {
     }
 }
 /// <p>Input for RemovePermission action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RemovePermissionInput {
     /// <p>The unique label of the statement you want to remove.</p>
     pub label: String,
@@ -2042,7 +2042,7 @@ impl RemovePermissionInputSerializer {
 }
 
 /// <p>Input for SetEndpointAttributes action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SetEndpointAttributesInput {
     /// <p><p>A map of the endpoint attributes. Attributes in this map include the following:</p> <ul> <li> <p> <code>CustomUserData</code> -- arbitrary user data to associate with the endpoint. Amazon SNS does not use this data. The data must be in UTF-8 format and less than 2KB.</p> </li> <li> <p> <code>Enabled</code> -- flag that enables/disables delivery to the endpoint. Amazon SNS will set this to false when a notification service indicates to Amazon SNS that the endpoint is invalid. Users can set it back to true, typically after updating Token.</p> </li> <li> <p> <code>Token</code> -- device token, also referred to as a registration id, for an app and mobile device. This is returned from the notification service when an app and mobile device are registered with the notification service.</p> </li> </ul></p>
     pub attributes: ::std::collections::HashMap<String, String>,
@@ -2072,7 +2072,7 @@ impl SetEndpointAttributesInputSerializer {
 }
 
 /// <p>Input for SetPlatformApplicationAttributes action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SetPlatformApplicationAttributesInput {
     /// <p><p>A map of the platform application attributes. Attributes in this map include the following:</p> <ul> <li> <p> <code>PlatformCredential</code> -- The credential received from the notification service. For APNS/APNS<em>SANDBOX, PlatformCredential is private key. For GCM, PlatformCredential is &quot;API key&quot;. For ADM, PlatformCredential is &quot;client secret&quot;.</p> </li> <li> <p> <code>PlatformPrincipal</code> -- The principal received from the notification service. For APNS/APNS</em>SANDBOX, PlatformPrincipal is SSL certificate. For GCM, PlatformPrincipal is not applicable. For ADM, PlatformPrincipal is &quot;client id&quot;.</p> </li> <li> <p> <code>EventEndpointCreated</code> -- Topic ARN to which EndpointCreated event notifications should be sent.</p> </li> <li> <p> <code>EventEndpointDeleted</code> -- Topic ARN to which EndpointDeleted event notifications should be sent.</p> </li> <li> <p> <code>EventEndpointUpdated</code> -- Topic ARN to which EndpointUpdate event notifications should be sent.</p> </li> <li> <p> <code>EventDeliveryFailure</code> -- Topic ARN to which DeliveryFailure event notifications should be sent upon Direct Publish delivery failure (permanent) to one of the application&#39;s endpoints.</p> </li> <li> <p> <code>SuccessFeedbackRoleArn</code> -- IAM role ARN used to give Amazon SNS write access to use CloudWatch Logs on your behalf.</p> </li> <li> <p> <code>FailureFeedbackRoleArn</code> -- IAM role ARN used to give Amazon SNS write access to use CloudWatch Logs on your behalf.</p> </li> <li> <p> <code>SuccessFeedbackSampleRate</code> -- Sample rate percentage (0-100) of successfully delivered messages.</p> </li> </ul></p>
     pub attributes: ::std::collections::HashMap<String, String>,
@@ -2102,7 +2102,7 @@ impl SetPlatformApplicationAttributesInputSerializer {
 }
 
 /// <p>The input for the SetSMSAttributes action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SetSMSAttributesInput {
     /// <p>The default settings for sending SMS messages from your account. You can set values for the following attribute names:</p> <p> <code>MonthlySpendLimit</code> – The maximum amount in USD that you are willing to spend each month to send SMS messages. When Amazon SNS determines that sending an SMS message would incur a cost that exceeds this limit, it stops sending SMS messages within minutes.</p> <important> <p>Amazon SNS stops sending SMS messages within minutes of the limit being crossed. During that interval, if you continue to send SMS messages, you will incur costs that exceed your limit.</p> </important> <p>By default, the spend limit is set to the maximum allowed by Amazon SNS. If you want to exceed the maximum, contact <a href="https://aws.amazon.com/premiumsupport/">AWS Support</a> or your AWS sales representative for a service limit increase.</p> <p> <code>DeliveryStatusIAMRole</code> – The ARN of the IAM role that allows Amazon SNS to write logs about SMS deliveries in CloudWatch Logs. For each SMS message that you send, Amazon SNS writes a log that includes the message price, the success or failure status, the reason for failure (if the message failed), the message dwell time, and other information.</p> <p> <code>DeliveryStatusSuccessSamplingRate</code> – The percentage of successful SMS deliveries for which Amazon SNS will write logs in CloudWatch Logs. The value can be an integer from 0 - 100. For example, to write logs only for failed deliveries, set this value to <code>0</code>. To write logs for 10% of your successful deliveries, set it to <code>10</code>.</p> <p> <code>DefaultSenderID</code> – A string, such as your business brand, that is displayed as the sender on the receiving device. Support for sender IDs varies by country. The sender ID can be 1 - 11 alphanumeric characters, and it must contain at least one letter.</p> <p> <code>DefaultSMSType</code> – The type of SMS message that you will send by default. You can assign the following values:</p> <ul> <li> <p> <code>Promotional</code> – (Default) Noncritical messages, such as marketing messages. Amazon SNS optimizes the message delivery to incur the lowest cost.</p> </li> <li> <p> <code>Transactional</code> – Critical messages that support customer transactions, such as one-time passcodes for multi-factor authentication. Amazon SNS optimizes the message delivery to achieve the highest reliability.</p> </li> </ul> <p> <code>UsageReportS3Bucket</code> – The name of the Amazon S3 bucket to receive daily SMS usage reports from Amazon SNS. Each day, Amazon SNS will deliver a usage report as a CSV file to the bucket. The report includes the following information for each SMS message that was successfully delivered by your account:</p> <ul> <li> <p>Time that the message was published (in UTC)</p> </li> <li> <p>Message ID</p> </li> <li> <p>Destination phone number</p> </li> <li> <p>Message type</p> </li> <li> <p>Delivery status</p> </li> <li> <p>Message price (in USD)</p> </li> <li> <p>Part number (a message is split into multiple parts if it is too long for a single message)</p> </li> <li> <p>Total number of parts</p> </li> </ul> <p>To receive the report, the bucket must have a policy that allows the Amazon SNS service principle to perform the <code>s3:PutObject</code> and <code>s3:GetBucketLocation</code> actions.</p> <p>For an example bucket policy and usage report, see <a href="http://docs.aws.amazon.com/sns/latest/dg/sms_stats.html">Monitoring SMS Activity</a> in the <i>Amazon SNS Developer Guide</i>.</p>
     pub attributes: ::std::collections::HashMap<String, String>,
@@ -2126,7 +2126,7 @@ impl SetSMSAttributesInputSerializer {
 }
 
 /// <p>The response for the SetSMSAttributes action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SetSMSAttributesResponse {}
 
 struct SetSMSAttributesResponseDeserializer;
@@ -2146,7 +2146,7 @@ impl SetSMSAttributesResponseDeserializer {
     }
 }
 /// <p>Input for SetSubscriptionAttributes action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SetSubscriptionAttributesInput {
     /// <p>The name of the attribute you want to set. Only a subset of the subscriptions attributes are mutable.</p> <p>Valid values: <code>DeliveryPolicy</code> | <code>RawMessageDelivery</code> </p>
     pub attribute_name: String,
@@ -2183,7 +2183,7 @@ impl SetSubscriptionAttributesInputSerializer {
 }
 
 /// <p>Input for SetTopicAttributes action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SetTopicAttributesInput {
     /// <p>The name of the attribute you want to set. Only a subset of the topic's attributes are mutable.</p> <p>Valid values: <code>Policy</code> | <code>DisplayName</code> | <code>DeliveryPolicy</code> </p>
     pub attribute_name: String,
@@ -2234,7 +2234,7 @@ impl StringDeserializer {
     }
 }
 /// <p>Input for Subscribe action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SubscribeInput {
     /// <p><p>The endpoint that you want to receive notifications. Endpoints vary by protocol:</p> <ul> <li> <p>For the <code>http</code> protocol, the endpoint is an URL beginning with &quot;http://&quot;</p> </li> <li> <p>For the <code>https</code> protocol, the endpoint is a URL beginning with &quot;https://&quot;</p> </li> <li> <p>For the <code>email</code> protocol, the endpoint is an email address</p> </li> <li> <p>For the <code>email-json</code> protocol, the endpoint is an email address</p> </li> <li> <p>For the <code>sms</code> protocol, the endpoint is a phone number of an SMS-enabled device</p> </li> <li> <p>For the <code>sqs</code> protocol, the endpoint is the ARN of an Amazon SQS queue</p> </li> <li> <p>For the <code>application</code> protocol, the endpoint is the EndpointArn of a mobile app and device.</p> </li> <li> <p>For the <code>lambda</code> protocol, the endpoint is the ARN of an AWS Lambda function.</p> </li> </ul></p>
     pub endpoint: Option<String>,
@@ -2271,7 +2271,7 @@ impl SubscribeInputSerializer {
 }
 
 /// <p>Response for Subscribe action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SubscribeResponse {
     /// <p>The ARN of the subscription, if the service was able to create a subscription immediately (without requiring endpoint owner confirmation).</p>
     pub subscription_arn: Option<String>,
@@ -2319,7 +2319,7 @@ impl SubscribeResponseDeserializer {
     }
 }
 /// <p>A wrapper type for the attributes of an Amazon SNS subscription.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Subscription {
     /// <p>The subscription's endpoint (format depends on the protocol).</p>
     pub endpoint: Option<String>,
@@ -2467,7 +2467,7 @@ impl SubscriptionsListDeserializer {
     }
 }
 /// <p>A wrapper type for the topic's Amazon Resource Name (ARN). To retrieve a topic's attributes, use <code>GetTopicAttributes</code>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Topic {
     /// <p>The topic's ARN.</p>
     pub topic_arn: Option<String>,
@@ -2591,7 +2591,7 @@ impl TopicsListDeserializer {
     }
 }
 /// <p>Input for Unsubscribe action.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UnsubscribeInput {
     /// <p>The ARN of the subscription to be deleted.</p>
     pub subscription_arn: String,

--- a/rusoto/services/sns/src/generated.rs
+++ b/rusoto/services/sns/src/generated.rs
@@ -29,8 +29,9 @@ use hyper::StatusCode;
 use rusoto_core::param::{Params, ServiceParams};
 use rusoto_core::signature::SignedRequest;
 use rusoto_core::xmlerror::*;
-use rusoto_core::xmlutil::{characters, end_element, find_start_element, peek_at_name, skip_tree,
-                           start_element};
+use rusoto_core::xmlutil::{
+    characters, end_element, find_start_element, peek_at_name, skip_tree, start_element,
+};
 use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
 use std::str::FromStr;
 use xml::reader::ParserConfig;

--- a/rusoto/services/sqs/src/generated.rs
+++ b/rusoto/services/sqs/src/generated.rs
@@ -67,7 +67,7 @@ impl ActionNameListSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AddPermissionRequest {
     /// <p>The AWS account number of the <a href="http://docs.aws.amazon.com/general/latest/gr/glos-chap.html#P">principal</a> who is given permission. The principal must have an AWS account, but does not need to be signed up for Amazon SQS. For information about locating the AWS account identification, see <a href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/AWSCredentials.html">Your AWS Identifiers</a> in the <i>Amazon Simple Queue Service Developer Guide</i>.</p>
     pub aws_account_ids: Vec<String>,
@@ -121,7 +121,7 @@ impl AttributeNameListSerializer {
 }
 
 /// <p>This is used in the responses of batch API to give a detailed description of the result of an action on each entry in the request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct BatchResultErrorEntry {
     /// <p>An error code representing why the action failed on this entry.</p>
     pub code: String,
@@ -293,7 +293,7 @@ impl BooleanDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ChangeMessageVisibilityBatchRequest {
     /// <p>A list of receipt handles of the messages for which the visibility timeout must be changed.</p>
     pub entries: Vec<ChangeMessageVisibilityBatchRequestEntry>,
@@ -323,7 +323,7 @@ impl ChangeMessageVisibilityBatchRequestSerializer {
 }
 
 /// <p>Encloses a receipt handle and an entry id for each message in <code> <a>ChangeMessageVisibilityBatch</a>.</code> </p> <important> <p>All of the following list parameters must be prefixed with <code>ChangeMessageVisibilityBatchRequestEntry.n</code>, where <code>n</code> is an integer value starting with <code>1</code>. For example, a parameter list for this action might look like this:</p> </important> <p> <code>&amp;amp;ChangeMessageVisibilityBatchRequestEntry.1.Id=change_visibility_msg_2</code> </p> <p> <code>&amp;amp;ChangeMessageVisibilityBatchRequestEntry.1.ReceiptHandle=&lt;replaceable&gt;Your_Receipt_Handle&lt;/replaceable&gt;</code> </p> <p> <code>&amp;amp;ChangeMessageVisibilityBatchRequestEntry.1.VisibilityTimeout=45</code> </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ChangeMessageVisibilityBatchRequestEntry {
     /// <p><p>An identifier for this particular receipt handle used to communicate the result.</p> <note> <p>The <code>Id</code>s of a batch request need to be unique within a request</p> </note></p>
     pub id: String,
@@ -372,7 +372,7 @@ impl ChangeMessageVisibilityBatchRequestEntryListSerializer {
 }
 
 /// <p>For each message in the batch, the response contains a <code> <a>ChangeMessageVisibilityBatchResultEntry</a> </code> tag if the message succeeds or a <code> <a>BatchResultErrorEntry</a> </code> tag if the message fails.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ChangeMessageVisibilityBatchResult {
     /// <p>A list of <code> <a>BatchResultErrorEntry</a> </code> items.</p>
     pub failed: Vec<BatchResultErrorEntry>,
@@ -428,7 +428,7 @@ impl ChangeMessageVisibilityBatchResultDeserializer {
     }
 }
 /// <p>Encloses the <code>Id</code> of an entry in <code> <a>ChangeMessageVisibilityBatch</a>.</code> </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ChangeMessageVisibilityBatchResultEntry {
     /// <p>Represents a message whose visibility timeout has been changed successfully.</p>
     pub id: String,
@@ -502,7 +502,7 @@ impl ChangeMessageVisibilityBatchResultEntryListDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ChangeMessageVisibilityRequest {
     /// <p>The URL of the Amazon SQS queue whose message's visibility is changed.</p> <p>Queue URLs are case-sensitive.</p>
     pub queue_url: String,
@@ -537,7 +537,7 @@ impl ChangeMessageVisibilityRequestSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateQueueRequest {
     /// <p><p>A map of attributes with their corresponding values.</p> <p>The following lists the names, descriptions, and values of the special request parameters that the <code>CreateQueue</code> action uses:</p> <ul> <li> <p> <code>DelaySeconds</code> - The length of time, in seconds, for which the delivery of all messages in the queue is delayed. Valid values: An integer from 0 to 900 seconds (15 minutes). The default is 0 (zero). </p> </li> <li> <p> <code>MaximumMessageSize</code> - The limit of how many bytes a message can contain before Amazon SQS rejects it. Valid values: An integer from 1,024 bytes (1 KiB) to 262,144 bytes (256 KiB). The default is 262,144 (256 KiB). </p> </li> <li> <p> <code>MessageRetentionPeriod</code> - The length of time, in seconds, for which Amazon SQS retains a message. Valid values: An integer from 60 seconds (1 minute) to 1,209,600 seconds (14 days). The default is 345,600 (4 days). </p> </li> <li> <p> <code>Policy</code> - The queue&#39;s policy. A valid AWS policy. For more information about policy structure, see <a href="http://docs.aws.amazon.com/IAM/latest/UserGuide/PoliciesOverview.html">Overview of AWS IAM Policies</a> in the <i>Amazon IAM User Guide</i>. </p> </li> <li> <p> <code>ReceiveMessageWaitTimeSeconds</code> - The length of time, in seconds, for which a <code> <a>ReceiveMessage</a> </code> action waits for a message to arrive. Valid values: An integer from 0 to 20 (seconds). The default is 0 (zero). </p> </li> <li> <p> <code>RedrivePolicy</code> - The string that includes the parameters for the dead-letter queue functionality of the source queue. For more information about the redrive policy and dead-letter queues, see <a href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-dead-letter-queues.html">Using Amazon SQS Dead-Letter Queues</a> in the <i>Amazon Simple Queue Service Developer Guide</i>. </p> <ul> <li> <p> <code>deadLetterTargetArn</code> - The Amazon Resource Name (ARN) of the dead-letter queue to which Amazon SQS moves messages after the value of <code>maxReceiveCount</code> is exceeded.</p> </li> <li> <p> <code>maxReceiveCount</code> - The number of times a message is delivered to the source queue before being moved to the dead-letter queue.</p> </li> </ul> <note> <p>The dead-letter queue of a FIFO queue must also be a FIFO queue. Similarly, the dead-letter queue of a standard queue must also be a standard queue.</p> </note> </li> <li> <p> <code>VisibilityTimeout</code> - The visibility timeout for the queue. Valid values: An integer from 0 to 43,200 (12 hours). The default is 30. For more information about the visibility timeout, see <a href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html">Visibility Timeout</a> in the <i>Amazon Simple Queue Service Developer Guide</i>.</p> </li> </ul> <p>The following attributes apply only to <a href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-server-side-encryption.html">server-side-encryption</a>:</p> <ul> <li> <p> <code>KmsMasterKeyId</code> - The ID of an AWS-managed customer master key (CMK) for Amazon SQS or a custom CMK. For more information, see <a href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-server-side-encryption.html#sqs-sse-key-terms">Key Terms</a>. While the alias of the AWS-managed CMK for Amazon SQS is always <code>alias/aws/sqs</code>, the alias of a custom CMK can, for example, be <code>alias/<i>MyAlias</i> </code>. For more examples, see <a href="http://docs.aws.amazon.com/kms/latest/APIReference/API_DescribeKey.html#API_DescribeKey_RequestParameters">KeyId</a> in the <i>AWS Key Management Service API Reference</i>. </p> </li> <li> <p> <code>KmsDataKeyReusePeriodSeconds</code> - The length of time, in seconds, for which Amazon SQS can reuse a <a href="http://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#data-keys">data key</a> to encrypt or decrypt messages before calling AWS KMS again. An integer representing seconds, between 60 seconds (1 minute) and 86,400 seconds (24 hours). The default is 300 (5 minutes). A shorter time period provides better security but results in more calls to KMS which might incur charges after Free Tier. For more information, see <a href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-server-side-encryption.html#sqs-how-does-the-data-key-reuse-period-work">How Does the Data Key Reuse Period Work?</a>. </p> </li> </ul> <p>The following attributes apply only to <a href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html">FIFO (first-in-first-out) queues</a>:</p> <ul> <li> <p> <code>FifoQueue</code> - Designates a queue as FIFO. Valid values: <code>true</code>, <code>false</code>. You can provide this attribute only during queue creation. You can&#39;t change it for an existing queue. When you set this attribute, you must also provide the <code>MessageGroupId</code> for your messages explicitly.</p> <p>For more information, see <a href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html#FIFO-queues-understanding-logic">FIFO Queue Logic</a> in the <i>Amazon Simple Queue Service Developer Guide</i>.</p> </li> <li> <p> <code>ContentBasedDeduplication</code> - Enables content-based deduplication. Valid values: <code>true</code>, <code>false</code>. For more information, see <a href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html#FIFO-queues-exactly-once-processing">Exactly-Once Processing</a> in the <i>Amazon Simple Queue Service Developer Guide</i>. </p> <ul> <li> <p>Every message must have a unique <code>MessageDeduplicationId</code>,</p> <ul> <li> <p>You may provide a <code>MessageDeduplicationId</code> explicitly.</p> </li> <li> <p>If you aren&#39;t able to provide a <code>MessageDeduplicationId</code> and you enable <code>ContentBasedDeduplication</code> for your queue, Amazon SQS uses a SHA-256 hash to generate the <code>MessageDeduplicationId</code> using the body of the message (but not the attributes of the message). </p> </li> <li> <p>If you don&#39;t provide a <code>MessageDeduplicationId</code> and the queue doesn&#39;t have <code>ContentBasedDeduplication</code> set, the action fails with an error.</p> </li> <li> <p>If the queue has <code>ContentBasedDeduplication</code> set, your <code>MessageDeduplicationId</code> overrides the generated one.</p> </li> </ul> </li> <li> <p>When <code>ContentBasedDeduplication</code> is in effect, messages with identical content sent within the deduplication interval are treated as duplicates and only one copy of the message is delivered.</p> </li> <li> <p>If you send one message with <code>ContentBasedDeduplication</code> enabled and then another message with a <code>MessageDeduplicationId</code> that is the same as the one generated for the first <code>MessageDeduplicationId</code>, the two messages are treated as duplicates and only one copy of the message is delivered. </p> </li> </ul> </li> </ul> <p>Any other valid special request parameters (such as the following) are ignored:</p> <ul> <li> <p> <code>ApproximateNumberOfMessages</code> </p> </li> <li> <p> <code>ApproximateNumberOfMessagesDelayed</code> </p> </li> <li> <p> <code>ApproximateNumberOfMessagesNotVisible</code> </p> </li> <li> <p> <code>CreatedTimestamp</code> </p> </li> <li> <p> <code>LastModifiedTimestamp</code> </p> </li> <li> <p> <code>QueueArn</code> </p> </li> </ul></p>
     pub attributes: Option<::std::collections::HashMap<String, String>>,
@@ -569,7 +569,7 @@ impl CreateQueueRequestSerializer {
 }
 
 /// <p>Returns the <code>QueueUrl</code> attribute of the created queue.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct CreateQueueResult {
     /// <p>The URL of the created Amazon SQS queue.</p>
     pub queue_url: Option<String>,
@@ -616,7 +616,7 @@ impl CreateQueueResultDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteMessageBatchRequest {
     /// <p>A list of receipt handles for the messages to be deleted.</p>
     pub entries: Vec<DeleteMessageBatchRequestEntry>,
@@ -646,7 +646,7 @@ impl DeleteMessageBatchRequestSerializer {
 }
 
 /// <p>Encloses a receipt handle and an identifier for it.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteMessageBatchRequestEntry {
     /// <p><p>An identifier for this particular receipt handle. This is used to communicate the result.</p> <note> <p>The <code>Id</code>s of a batch request need to be unique within a request</p> </note></p>
     pub id: String,
@@ -683,7 +683,7 @@ impl DeleteMessageBatchRequestEntryListSerializer {
 }
 
 /// <p>For each message in the batch, the response contains a <code> <a>DeleteMessageBatchResultEntry</a> </code> tag if the message is deleted or a <code> <a>BatchResultErrorEntry</a> </code> tag if the message can't be deleted.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteMessageBatchResult {
     /// <p>A list of <code> <a>BatchResultErrorEntry</a> </code> items.</p>
     pub failed: Vec<BatchResultErrorEntry>,
@@ -741,7 +741,7 @@ impl DeleteMessageBatchResultDeserializer {
     }
 }
 /// <p>Encloses the <code>Id</code> of an entry in <code> <a>DeleteMessageBatch</a>.</code> </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteMessageBatchResultEntry {
     /// <p>Represents a successfully deleted message.</p>
     pub id: String,
@@ -814,7 +814,7 @@ impl DeleteMessageBatchResultEntryListDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteMessageRequest {
     /// <p>The URL of the Amazon SQS queue from which messages are deleted.</p> <p>Queue URLs are case-sensitive.</p>
     pub queue_url: String,
@@ -843,7 +843,7 @@ impl DeleteMessageRequestSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DeleteQueueRequest {
     /// <p>The URL of the Amazon SQS queue to delete.</p> <p>Queue URLs are case-sensitive.</p>
     pub queue_url: String,
@@ -866,7 +866,7 @@ impl DeleteQueueRequestSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetQueueAttributesRequest {
     /// <p><p>A list of attributes for which to retrieve information.</p> <note> <p>In the future, new attributes might be added. If you write code that calls this action, we recommend that you structure your code so that it can handle new attributes gracefully.</p> </note> <p>The following attributes are supported:</p> <ul> <li> <p> <code>All</code> - Returns all values. </p> </li> <li> <p> <code>ApproximateNumberOfMessages</code> - Returns the approximate number of visible messages in a queue. For more information, see <a href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-resources-required-process-messages.html">Resources Required to Process Messages</a> in the <i>Amazon Simple Queue Service Developer Guide</i>. </p> </li> <li> <p> <code>ApproximateNumberOfMessagesDelayed</code> - Returns the approximate number of messages that are waiting to be added to the queue. </p> </li> <li> <p> <code>ApproximateNumberOfMessagesNotVisible</code> - Returns the approximate number of messages that have not timed-out and aren&#39;t deleted. For more information, see <a href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-resources-required-process-messages.html">Resources Required to Process Messages</a> in the <i>Amazon Simple Queue Service Developer Guide</i>. </p> </li> <li> <p> <code>CreatedTimestamp</code> - Returns the time when the queue was created in seconds (<a href="http://en.wikipedia.org/wiki/Unix_time">epoch time</a>).</p> </li> <li> <p> <code>DelaySeconds</code> - Returns the default delay on the queue in seconds.</p> </li> <li> <p> <code>LastModifiedTimestamp</code> - Returns the time when the queue was last changed in seconds (<a href="http://en.wikipedia.org/wiki/Unix_time">epoch time</a>).</p> </li> <li> <p> <code>MaximumMessageSize</code> - Returns the limit of how many bytes a message can contain before Amazon SQS rejects it.</p> </li> <li> <p> <code>MessageRetentionPeriod</code> - Returns the length of time, in seconds, for which Amazon SQS retains a message.</p> </li> <li> <p> <code>Policy</code> - Returns the policy of the queue.</p> </li> <li> <p> <code>QueueArn</code> - Returns the Amazon resource name (ARN) of the queue.</p> </li> <li> <p> <code>ReceiveMessageWaitTimeSeconds</code> - Returns the length of time, in seconds, for which the <code>ReceiveMessage</code> action waits for a message to arrive. </p> </li> <li> <p> <code>RedrivePolicy</code> - Returns the string that includes the parameters for dead-letter queue functionality of the source queue. For more information about the redrive policy and dead-letter queues, see <a href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-dead-letter-queues.html">Using Amazon SQS Dead-Letter Queues</a> in the <i>Amazon Simple Queue Service Developer Guide</i>. </p> <ul> <li> <p> <code>deadLetterTargetArn</code> - The Amazon Resource Name (ARN) of the dead-letter queue to which Amazon SQS moves messages after the value of <code>maxReceiveCount</code> is exceeded.</p> </li> <li> <p> <code>maxReceiveCount</code> - The number of times a message is delivered to the source queue before being moved to the dead-letter queue.</p> </li> </ul> </li> <li> <p> <code>VisibilityTimeout</code> - Returns the visibility timeout for the queue. For more information about the visibility timeout, see <a href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html">Visibility Timeout</a> in the <i>Amazon Simple Queue Service Developer Guide</i>. </p> </li> </ul> <p>The following attributes apply only to <a href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-server-side-encryption.html">server-side-encryption</a>:</p> <ul> <li> <p> <code>KmsMasterKeyId</code> - Returns the ID of an AWS-managed customer master key (CMK) for Amazon SQS or a custom CMK. For more information, see <a href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-server-side-encryption.html#sqs-sse-key-terms">Key Terms</a>. </p> </li> <li> <p> <code>KmsDataKeyReusePeriodSeconds</code> - Returns the length of time, in seconds, for which Amazon SQS can reuse a data key to encrypt or decrypt messages before calling AWS KMS again. For more information, see <a href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-server-side-encryption.html#sqs-how-does-the-data-key-reuse-period-work">How Does the Data Key Reuse Period Work?</a>. </p> </li> </ul> <p>The following attributes apply only to <a href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html">FIFO (first-in-first-out) queues</a>:</p> <ul> <li> <p> <code>FifoQueue</code> - Returns whether the queue is FIFO. For more information, see <a href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html#FIFO-queues-understanding-logic">FIFO Queue Logic</a> in the <i>Amazon Simple Queue Service Developer Guide</i>.</p> <note> <p>To determine whether a queue is <a href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html">FIFO</a>, you can check whether <code>QueueName</code> ends with the <code>.fifo</code> suffix.</p> </note> </li> <li> <p> <code>ContentBasedDeduplication</code> - Returns whether content-based deduplication is enabled for the queue. For more information, see <a href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html#FIFO-queues-exactly-once-processing">Exactly-Once Processing</a> in the <i>Amazon Simple Queue Service Developer Guide</i>. </p> </li> </ul></p>
     pub attribute_names: Option<Vec<String>>,
@@ -898,7 +898,7 @@ impl GetQueueAttributesRequestSerializer {
 }
 
 /// <p>A list of returned queue attributes.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetQueueAttributesResult {
     /// <p>A map of attributes to their respective values.</p>
     pub attributes: Option<::std::collections::HashMap<String, String>>,
@@ -947,7 +947,7 @@ impl GetQueueAttributesResultDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetQueueUrlRequest {
     /// <p>The name of the queue whose URL must be fetched. Maximum 80 characters. Valid values: alphanumeric characters, hyphens (<code>-</code>), and underscores (<code>_</code>).</p> <p>Queue names are case-sensitive.</p>
     pub queue_name: String,
@@ -978,7 +978,7 @@ impl GetQueueUrlRequestSerializer {
 }
 
 /// <p>For more information, see <a href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/UnderstandingResponses.html">Responses</a> in the <i>Amazon Simple Queue Service Developer Guide</i>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetQueueUrlResult {
     /// <p>The URL of the queue.</p>
     pub queue_url: Option<String>,
@@ -1025,7 +1025,7 @@ impl GetQueueUrlResultDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListDeadLetterSourceQueuesRequest {
     /// <p>The URL of a dead-letter queue.</p> <p>Queue URLs are case-sensitive.</p>
     pub queue_url: String,
@@ -1048,7 +1048,7 @@ impl ListDeadLetterSourceQueuesRequestSerializer {
 }
 
 /// <p>A list of your dead letter source queues.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListDeadLetterSourceQueuesResult {
     /// <p>A list of source queue URLs that have the <code>RedrivePolicy</code> queue attribute configured with a dead-letter queue.</p>
     pub queue_urls: Vec<String>,
@@ -1094,7 +1094,7 @@ impl ListDeadLetterSourceQueuesResultDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListQueueTagsRequest {
     /// <p>The URL of the queue.</p>
     pub queue_url: String,
@@ -1116,7 +1116,7 @@ impl ListQueueTagsRequestSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListQueueTagsResult {
     /// <p>The list of all tags added to the specified queue.</p>
     pub tags: Option<::std::collections::HashMap<String, String>>,
@@ -1162,7 +1162,7 @@ impl ListQueueTagsResultDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListQueuesRequest {
     /// <p>A string to use for filtering the list results. Only those queues whose name begins with the specified string are returned.</p> <p>Queue names are case-sensitive.</p>
     pub queue_name_prefix: Option<String>,
@@ -1187,7 +1187,7 @@ impl ListQueuesRequestSerializer {
 }
 
 /// <p>A list of your queues.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ListQueuesResult {
     /// <p>A list of queue URLs, up to 1,000 entries.</p>
     pub queue_urls: Option<Vec<String>>,
@@ -1235,7 +1235,7 @@ impl ListQueuesResultDeserializer {
     }
 }
 /// <p>An Amazon SQS message.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Message {
     /// <p> <code>SenderId</code>, <code>SentTimestamp</code>, <code>ApproximateReceiveCount</code>, and/or <code>ApproximateFirstReceiveTimestamp</code>. <code>SentTimestamp</code> and <code>ApproximateFirstReceiveTimestamp</code> are each returned as an integer representing the <a href="http://en.wikipedia.org/wiki/Unix_time">epoch time</a> in milliseconds.</p>
     pub attributes: Option<::std::collections::HashMap<String, String>>,
@@ -1336,7 +1336,7 @@ impl MessageAttributeNameListSerializer {
 }
 
 /// <p>The user-specified message attribute value. For string data types, the <code>Value</code> attribute has the same restrictions on the content as the message body. For more information, see <code> <a>SendMessage</a>.</code> </p> <p> <code>Name</code>, <code>type</code>, <code>value</code> and the message body must not be empty or null. All parts of the message attribute, including <code>Name</code>, <code>Type</code>, and <code>Value</code>, are part of the message size restriction (256 KB or 262,144 bytes).</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct MessageAttributeValue {
     /// <p>Not implemented. Reserved for future use.</p>
     pub binary_list_values: Option<Vec<Vec<u8>>>,
@@ -1559,7 +1559,7 @@ impl MessageSystemAttributeNameDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct PurgeQueueRequest {
     /// <p>The URL of the queue from which the <code>PurgeQueue</code> action deletes messages.</p> <p>Queue URLs are case-sensitive.</p>
     pub queue_url: String,
@@ -1658,7 +1658,7 @@ impl QueueUrlListDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ReceiveMessageRequest {
     /// <p><p>A list of attributes that need to be returned along with each message. These attributes include:</p> <ul> <li> <p> <code>All</code> - Returns all values.</p> </li> <li> <p> <code>ApproximateFirstReceiveTimestamp</code> - Returns the time the message was first received from the queue (<a href="http://en.wikipedia.org/wiki/Unix_time">epoch time</a> in milliseconds).</p> </li> <li> <p> <code>ApproximateReceiveCount</code> - Returns the number of times a message has been received from the queue but not deleted.</p> </li> <li> <p> <code>SenderId</code> </p> <ul> <li> <p>For an IAM user, returns the IAM user ID, for example <code>ABCDEFGHI1JKLMNOPQ23R</code>.</p> </li> <li> <p>For an IAM role, returns the IAM role ID, for example <code>ABCDE1F2GH3I4JK5LMNOP:i-a123b456</code>.</p> </li> </ul> </li> <li> <p> <code>SentTimestamp</code> - Returns the time the message was sent to the queue (<a href="http://en.wikipedia.org/wiki/Unix_time">epoch time</a> in milliseconds).</p> </li> <li> <p> <code>MessageDeduplicationId</code> - Returns the value provided by the sender that calls the <code> <a>SendMessage</a> </code> action.</p> </li> <li> <p> <code>MessageGroupId</code> - Returns the value provided by the sender that calls the <code> <a>SendMessage</a> </code> action. Messages with the same <code>MessageGroupId</code> are returned in sequence.</p> </li> <li> <p> <code>SequenceNumber</code> - Returns the value provided by Amazon SQS.</p> </li> </ul> <p>Any other valid special request parameters (such as the following) are ignored:</p> <ul> <li> <p> <code>ApproximateNumberOfMessages</code> </p> </li> <li> <p> <code>ApproximateNumberOfMessagesDelayed</code> </p> </li> <li> <p> <code>ApproximateNumberOfMessagesNotVisible</code> </p> </li> <li> <p> <code>CreatedTimestamp</code> </p> </li> <li> <p> <code>ContentBasedDeduplication</code> </p> </li> <li> <p> <code>DelaySeconds</code> </p> </li> <li> <p> <code>FifoQueue</code> </p> </li> <li> <p> <code>LastModifiedTimestamp</code> </p> </li> <li> <p> <code>MaximumMessageSize</code> </p> </li> <li> <p> <code>MessageRetentionPeriod</code> </p> </li> <li> <p> <code>Policy</code> </p> </li> <li> <p> <code>QueueArn</code>, </p> </li> <li> <p> <code>ReceiveMessageWaitTimeSeconds</code> </p> </li> <li> <p> <code>RedrivePolicy</code> </p> </li> <li> <p> <code>VisibilityTimeout</code> </p> </li> </ul></p>
     pub attribute_names: Option<Vec<String>>,
@@ -1731,7 +1731,7 @@ impl ReceiveMessageRequestSerializer {
 }
 
 /// <p>A list of received messages.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct ReceiveMessageResult {
     /// <p>A list of messages.</p>
     pub messages: Option<Vec<Message>>,
@@ -1778,7 +1778,7 @@ impl ReceiveMessageResultDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RemovePermissionRequest {
     /// <p>The identification of the permission to remove. This is the label added using the <code> <a>AddPermission</a> </code> action.</p>
     pub label: String,
@@ -1807,7 +1807,7 @@ impl RemovePermissionRequestSerializer {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SendMessageBatchRequest {
     /// <p>A list of <code> <a>SendMessageBatchRequestEntry</a> </code> items.</p>
     pub entries: Vec<SendMessageBatchRequestEntry>,
@@ -1837,7 +1837,7 @@ impl SendMessageBatchRequestSerializer {
 }
 
 /// <p>Contains the details of a single Amazon SQS message along with an <code>Id</code>.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SendMessageBatchRequestEntry {
     /// <p><p>The length of time, in seconds, for which a specific message is delayed. Valid values: 0 to 900. Maximum: 15 minutes. Messages with a positive <code>DelaySeconds</code> value become available for processing after the delay period is finished. If you don&#39;t specify a value, the default value for the queue is applied. </p> <note> <p>When you set <code>FifoQueue</code>, you can&#39;t set <code>DelaySeconds</code> per message. You can set this parameter only on a queue level.</p> </note></p>
     pub delay_seconds: Option<i64>,
@@ -1907,7 +1907,7 @@ impl SendMessageBatchRequestEntryListSerializer {
 }
 
 /// <p>For each message in the batch, the response contains a <code> <a>SendMessageBatchResultEntry</a> </code> tag if the message succeeds or a <code> <a>BatchResultErrorEntry</a> </code> tag if the message fails.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SendMessageBatchResult {
     /// <p>A list of <code> <a>BatchResultErrorEntry</a> </code> items with error details about each message that can't be enqueued.</p>
     pub failed: Vec<BatchResultErrorEntry>,
@@ -1965,7 +1965,7 @@ impl SendMessageBatchResultDeserializer {
     }
 }
 /// <p>Encloses a <code>MessageId</code> for a successfully-enqueued message in a <code> <a>SendMessageBatch</a>.</code> </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SendMessageBatchResultEntry {
     /// <p>An identifier for the message in this batch.</p>
     pub id: String,
@@ -2064,7 +2064,7 @@ impl SendMessageBatchResultEntryListDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SendMessageRequest {
     /// <p><p> The length of time, in seconds, for which to delay a specific message. Valid values: 0 to 900. Maximum: 15 minutes. Messages with a positive <code>DelaySeconds</code> value become available for processing after the delay period is finished. If you don&#39;t specify a value, the default value for the queue applies. </p> <note> <p>When you set <code>FifoQueue</code>, you can&#39;t set <code>DelaySeconds</code> per message. You can set this parameter only on a queue level.</p> </note></p>
     pub delay_seconds: Option<i64>,
@@ -2126,7 +2126,7 @@ impl SendMessageRequestSerializer {
 }
 
 /// <p>The <code>MD5OfMessageBody</code> and <code>MessageId</code> elements.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SendMessageResult {
     /// <p>An MD5 digest of the non-URL-encoded message attribute string. You can use this attribute to verify that Amazon SQS received the message correctly. Amazon SQS URL-decodes the message before creating the MD5 digest. For information about MD5, see <a href="https://www.ietf.org/rfc/rfc1321.txt">RFC1321</a>.</p>
     pub md5_of_message_attributes: Option<String>,
@@ -2196,7 +2196,7 @@ impl SendMessageResultDeserializer {
     }
 }
 /// <p><p/></p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct SetQueueAttributesRequest {
     /// <p><p>A map of attributes to set.</p> <p>The following lists the names, descriptions, and values of the special request parameters that the <code>SetQueueAttributes</code> action uses:</p> <ul> <li> <p> <code>DelaySeconds</code> - The length of time, in seconds, for which the delivery of all messages in the queue is delayed. Valid values: An integer from 0 to 900 (15 minutes). The default is 0 (zero). </p> </li> <li> <p> <code>MaximumMessageSize</code> - The limit of how many bytes a message can contain before Amazon SQS rejects it. Valid values: An integer from 1,024 bytes (1 KiB) up to 262,144 bytes (256 KiB). The default is 262,144 (256 KiB). </p> </li> <li> <p> <code>MessageRetentionPeriod</code> - The length of time, in seconds, for which Amazon SQS retains a message. Valid values: An integer representing seconds, from 60 (1 minute) to 1,209,600 (14 days). The default is 345,600 (4 days). </p> </li> <li> <p> <code>Policy</code> - The queue&#39;s policy. A valid AWS policy. For more information about policy structure, see <a href="http://docs.aws.amazon.com/IAM/latest/UserGuide/PoliciesOverview.html">Overview of AWS IAM Policies</a> in the <i>Amazon IAM User Guide</i>. </p> </li> <li> <p> <code>ReceiveMessageWaitTimeSeconds</code> - The length of time, in seconds, for which a <code> <a>ReceiveMessage</a> </code> action waits for a message to arrive. Valid values: an integer from 0 to 20 (seconds). The default is 0. </p> </li> <li> <p> <code>RedrivePolicy</code> - The string that includes the parameters for the dead-letter queue functionality of the source queue. For more information about the redrive policy and dead-letter queues, see <a href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-dead-letter-queues.html">Using Amazon SQS Dead-Letter Queues</a> in the <i>Amazon Simple Queue Service Developer Guide</i>. </p> <ul> <li> <p> <code>deadLetterTargetArn</code> - The Amazon Resource Name (ARN) of the dead-letter queue to which Amazon SQS moves messages after the value of <code>maxReceiveCount</code> is exceeded.</p> </li> <li> <p> <code>maxReceiveCount</code> - The number of times a message is delivered to the source queue before being moved to the dead-letter queue.</p> </li> </ul> <note> <p>The dead-letter queue of a FIFO queue must also be a FIFO queue. Similarly, the dead-letter queue of a standard queue must also be a standard queue.</p> </note> </li> <li> <p> <code>VisibilityTimeout</code> - The visibility timeout for the queue. Valid values: an integer from 0 to 43,200 (12 hours). The default is 30. For more information about the visibility timeout, see <a href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html">Visibility Timeout</a> in the <i>Amazon Simple Queue Service Developer Guide</i>.</p> </li> </ul> <p>The following attributes apply only to <a href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-server-side-encryption.html">server-side-encryption</a>:</p> <ul> <li> <p> <code>KmsMasterKeyId</code> - The ID of an AWS-managed customer master key (CMK) for Amazon SQS or a custom CMK. For more information, see <a href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-server-side-encryption.html#sqs-sse-key-terms">Key Terms</a>. While the alias of the AWS-managed CMK for Amazon SQS is always <code>alias/aws/sqs</code>, the alias of a custom CMK can, for example, be <code>alias/<i>MyAlias</i> </code>. For more examples, see <a href="http://docs.aws.amazon.com/kms/latest/APIReference/API_DescribeKey.html#API_DescribeKey_RequestParameters">KeyId</a> in the <i>AWS Key Management Service API Reference</i>. </p> </li> <li> <p> <code>KmsDataKeyReusePeriodSeconds</code> - The length of time, in seconds, for which Amazon SQS can reuse a <a href="http://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#data-keys">data key</a> to encrypt or decrypt messages before calling AWS KMS again. An integer representing seconds, between 60 seconds (1 minute) and 86,400 seconds (24 hours). The default is 300 (5 minutes). A shorter time period provides better security but results in more calls to KMS which might incur charges after Free Tier. For more information, see <a href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-server-side-encryption.html#sqs-how-does-the-data-key-reuse-period-work">How Does the Data Key Reuse Period Work?</a>. </p> </li> </ul> <p>The following attribute applies only to <a href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html">FIFO (first-in-first-out) queues</a>:</p> <ul> <li> <p> <code>ContentBasedDeduplication</code> - Enables content-based deduplication. For more information, see <a href="http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html#FIFO-queues-exactly-once-processing">Exactly-Once Processing</a> in the <i>Amazon Simple Queue Service Developer Guide</i>. </p> <ul> <li> <p>Every message must have a unique <code>MessageDeduplicationId</code>,</p> <ul> <li> <p>You may provide a <code>MessageDeduplicationId</code> explicitly.</p> </li> <li> <p>If you aren&#39;t able to provide a <code>MessageDeduplicationId</code> and you enable <code>ContentBasedDeduplication</code> for your queue, Amazon SQS uses a SHA-256 hash to generate the <code>MessageDeduplicationId</code> using the body of the message (but not the attributes of the message). </p> </li> <li> <p>If you don&#39;t provide a <code>MessageDeduplicationId</code> and the queue doesn&#39;t have <code>ContentBasedDeduplication</code> set, the action fails with an error.</p> </li> <li> <p>If the queue has <code>ContentBasedDeduplication</code> set, your <code>MessageDeduplicationId</code> overrides the generated one.</p> </li> </ul> </li> <li> <p>When <code>ContentBasedDeduplication</code> is in effect, messages with identical content sent within the deduplication interval are treated as duplicates and only one copy of the message is delivered.</p> </li> <li> <p>If you send one message with <code>ContentBasedDeduplication</code> enabled and then another message with a <code>MessageDeduplicationId</code> that is the same as the one generated for the first <code>MessageDeduplicationId</code>, the two messages are treated as duplicates and only one copy of the message is delivered. </p> </li> </ul> </li> </ul> <p>Any other valid special request parameters (such as the following) are ignored:</p> <ul> <li> <p> <code>ApproximateNumberOfMessages</code> </p> </li> <li> <p> <code>ApproximateNumberOfMessagesDelayed</code> </p> </li> <li> <p> <code>ApproximateNumberOfMessagesNotVisible</code> </p> </li> <li> <p> <code>CreatedTimestamp</code> </p> </li> <li> <p> <code>LastModifiedTimestamp</code> </p> </li> <li> <p> <code>QueueArn</code> </p> </li> </ul></p>
     pub attributes: ::std::collections::HashMap<String, String>,
@@ -2357,7 +2357,7 @@ impl TagMapSerializer {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct TagQueueRequest {
     /// <p>The URL of the queue.</p>
     pub queue_url: String,
@@ -2396,7 +2396,7 @@ impl TagValueDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct UntagQueueRequest {
     /// <p>The URL of the queue.</p>
     pub queue_url: String,

--- a/rusoto/services/sqs/src/generated.rs
+++ b/rusoto/services/sqs/src/generated.rs
@@ -29,8 +29,9 @@ use hyper::StatusCode;
 use rusoto_core::param::{Params, ServiceParams};
 use rusoto_core::signature::SignedRequest;
 use rusoto_core::xmlerror::*;
-use rusoto_core::xmlutil::{characters, end_element, find_start_element, peek_at_name, skip_tree,
-                           start_element};
+use rusoto_core::xmlutil::{
+    characters, end_element, find_start_element, peek_at_name, skip_tree, start_element,
+};
 use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
 use std::str::FromStr;
 use xml::reader::ParserConfig;

--- a/rusoto/services/ssm/src/generated.rs
+++ b/rusoto/services/ssm/src/generated.rs
@@ -5686,7 +5686,8 @@ impl AddTagsToResourceError {
     pub fn from_body(body: &str) -> AddTagsToResourceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5784,7 +5785,8 @@ impl CancelCommandError {
     pub fn from_body(body: &str) -> CancelCommandError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5874,7 +5876,8 @@ impl CreateActivationError {
     pub fn from_body(body: &str) -> CreateActivationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5972,7 +5975,8 @@ impl CreateAssociationError {
     pub fn from_body(body: &str) -> CreateAssociationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6112,7 +6116,8 @@ impl CreateAssociationBatchError {
     pub fn from_body(body: &str) -> CreateAssociationBatchError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6248,7 +6253,8 @@ impl CreateDocumentError {
     pub fn from_body(body: &str) -> CreateDocumentError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6352,7 +6358,8 @@ impl CreateMaintenanceWindowError {
     pub fn from_body(body: &str) -> CreateMaintenanceWindowError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6448,7 +6455,8 @@ impl CreatePatchBaselineError {
     pub fn from_body(body: &str) -> CreatePatchBaselineError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6544,7 +6552,8 @@ impl CreateResourceDataSyncError {
     pub fn from_body(body: &str) -> CreateResourceDataSyncError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6648,7 +6657,8 @@ impl DeleteActivationError {
     pub fn from_body(body: &str) -> DeleteActivationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6746,7 +6756,8 @@ impl DeleteAssociationError {
     pub fn from_body(body: &str) -> DeleteAssociationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6848,7 +6859,8 @@ impl DeleteDocumentError {
     pub fn from_body(body: &str) -> DeleteDocumentError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6938,7 +6950,8 @@ impl DeleteMaintenanceWindowError {
     pub fn from_body(body: &str) -> DeleteMaintenanceWindowError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7020,7 +7033,8 @@ impl DeleteParameterError {
     pub fn from_body(body: &str) -> DeleteParameterError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7102,7 +7116,8 @@ impl DeleteParametersError {
     pub fn from_body(body: &str) -> DeleteParametersError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7182,7 +7197,8 @@ impl DeletePatchBaselineError {
     pub fn from_body(body: &str) -> DeletePatchBaselineError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7268,7 +7284,8 @@ impl DeleteResourceDataSyncError {
     pub fn from_body(body: &str) -> DeleteResourceDataSyncError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7356,7 +7373,8 @@ impl DeregisterManagedInstanceError {
     pub fn from_body(body: &str) -> DeregisterManagedInstanceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7442,7 +7460,8 @@ impl DeregisterPatchBaselineForPatchGroupError {
     pub fn from_body(body: &str) -> DeregisterPatchBaselineForPatchGroupError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7534,7 +7553,8 @@ impl DeregisterTargetFromMaintenanceWindowError {
     pub fn from_body(body: &str) -> DeregisterTargetFromMaintenanceWindowError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7632,7 +7652,8 @@ impl DeregisterTaskFromMaintenanceWindowError {
     pub fn from_body(body: &str) -> DeregisterTaskFromMaintenanceWindowError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7724,7 +7745,8 @@ impl DescribeActivationsError {
     pub fn from_body(body: &str) -> DescribeActivationsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7820,7 +7842,8 @@ impl DescribeAssociationError {
     pub fn from_body(body: &str) -> DescribeAssociationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7924,7 +7947,8 @@ impl DescribeAutomationExecutionsError {
     pub fn from_body(body: &str) -> DescribeAutomationExecutionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8026,7 +8050,8 @@ impl DescribeAutomationStepExecutionsError {
     pub fn from_body(body: &str) -> DescribeAutomationStepExecutionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8128,7 +8153,8 @@ impl DescribeAvailablePatchesError {
     pub fn from_body(body: &str) -> DescribeAvailablePatchesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8212,7 +8238,8 @@ impl DescribeDocumentError {
     pub fn from_body(body: &str) -> DescribeDocumentError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8302,7 +8329,8 @@ impl DescribeDocumentPermissionError {
     pub fn from_body(body: &str) -> DescribeDocumentPermissionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8396,7 +8424,8 @@ impl DescribeEffectiveInstanceAssociationsError {
     pub fn from_body(body: &str) -> DescribeEffectiveInstanceAssociationsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8498,7 +8527,8 @@ impl DescribeEffectivePatchesForPatchBaselineError {
     pub fn from_body(body: &str) -> DescribeEffectivePatchesForPatchBaselineError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8608,7 +8638,8 @@ impl DescribeInstanceAssociationsStatusError {
     pub fn from_body(body: &str) -> DescribeInstanceAssociationsStatusError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8710,7 +8741,8 @@ impl DescribeInstanceInformationError {
     pub fn from_body(body: &str) -> DescribeInstanceInformationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8812,7 +8844,8 @@ impl DescribeInstancePatchStatesError {
     pub fn from_body(body: &str) -> DescribeInstancePatchStatesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8900,7 +8933,8 @@ impl DescribeInstancePatchStatesForPatchGroupError {
     pub fn from_body(body: &str) -> DescribeInstancePatchStatesForPatchGroupError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9004,7 +9038,8 @@ impl DescribeInstancePatchesError {
     pub fn from_body(body: &str) -> DescribeInstancePatchesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9098,7 +9133,8 @@ impl DescribeMaintenanceWindowExecutionTaskInvocationsError {
     pub fn from_body(body: &str) -> DescribeMaintenanceWindowExecutionTaskInvocationsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9206,7 +9242,8 @@ impl DescribeMaintenanceWindowExecutionTasksError {
     pub fn from_body(body: &str) -> DescribeMaintenanceWindowExecutionTasksError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9296,7 +9333,8 @@ impl DescribeMaintenanceWindowExecutionsError {
     pub fn from_body(body: &str) -> DescribeMaintenanceWindowExecutionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9380,7 +9418,8 @@ impl DescribeMaintenanceWindowTargetsError {
     pub fn from_body(body: &str) -> DescribeMaintenanceWindowTargetsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9468,7 +9507,8 @@ impl DescribeMaintenanceWindowTasksError {
     pub fn from_body(body: &str) -> DescribeMaintenanceWindowTasksError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9554,7 +9594,8 @@ impl DescribeMaintenanceWindowsError {
     pub fn from_body(body: &str) -> DescribeMaintenanceWindowsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9642,7 +9683,8 @@ impl DescribeParametersError {
     pub fn from_body(body: &str) -> DescribeParametersError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9738,7 +9780,8 @@ impl DescribePatchBaselinesError {
     pub fn from_body(body: &str) -> DescribePatchBaselinesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9820,7 +9863,8 @@ impl DescribePatchGroupStateError {
     pub fn from_body(body: &str) -> DescribePatchGroupStateError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9904,7 +9948,8 @@ impl DescribePatchGroupsError {
     pub fn from_body(body: &str) -> DescribePatchGroupsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9986,7 +10031,8 @@ impl GetAutomationExecutionError {
     pub fn from_body(body: &str) -> GetAutomationExecutionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -10080,7 +10126,8 @@ impl GetCommandInvocationError {
     pub fn from_body(body: &str) -> GetCommandInvocationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -10176,7 +10223,8 @@ impl GetDefaultPatchBaselineError {
     pub fn from_body(body: &str) -> GetDefaultPatchBaselineError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -10258,7 +10306,8 @@ impl GetDeployablePatchSnapshotForInstanceError {
     pub fn from_body(body: &str) -> GetDeployablePatchSnapshotForInstanceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -10354,7 +10403,8 @@ impl GetDocumentError {
     pub fn from_body(body: &str) -> GetDocumentError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -10448,7 +10498,8 @@ impl GetInventoryError {
     pub fn from_body(body: &str) -> GetInventoryError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -10546,7 +10597,8 @@ impl GetInventorySchemaError {
     pub fn from_body(body: &str) -> GetInventorySchemaError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -10636,7 +10688,8 @@ impl GetMaintenanceWindowError {
     pub fn from_body(body: &str) -> GetMaintenanceWindowError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -10722,7 +10775,8 @@ impl GetMaintenanceWindowExecutionError {
     pub fn from_body(body: &str) -> GetMaintenanceWindowExecutionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -10810,7 +10864,8 @@ impl GetMaintenanceWindowExecutionTaskError {
     pub fn from_body(body: &str) -> GetMaintenanceWindowExecutionTaskError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -10900,7 +10955,8 @@ impl GetMaintenanceWindowExecutionTaskInvocationError {
     pub fn from_body(body: &str) -> GetMaintenanceWindowExecutionTaskInvocationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -10998,7 +11054,8 @@ impl GetMaintenanceWindowTaskError {
     pub fn from_body(body: &str) -> GetMaintenanceWindowTaskError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -11088,7 +11145,8 @@ impl GetParameterError {
     pub fn from_body(body: &str) -> GetParameterError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -11182,7 +11240,8 @@ impl GetParameterHistoryError {
     pub fn from_body(body: &str) -> GetParameterHistoryError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -11276,7 +11335,8 @@ impl GetParametersError {
     pub fn from_body(body: &str) -> GetParametersError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -11366,7 +11426,8 @@ impl GetParametersByPathError {
     pub fn from_body(body: &str) -> GetParametersByPathError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -11470,7 +11531,8 @@ impl GetPatchBaselineError {
     pub fn from_body(body: &str) -> GetPatchBaselineError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -11556,7 +11618,8 @@ impl GetPatchBaselineForPatchGroupError {
     pub fn from_body(body: &str) -> GetPatchBaselineForPatchGroupError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -11642,7 +11705,8 @@ impl ListAssociationVersionsError {
     pub fn from_body(body: &str) -> ListAssociationVersionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -11734,7 +11798,8 @@ impl ListAssociationsError {
     pub fn from_body(body: &str) -> ListAssociationsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -11824,7 +11889,8 @@ impl ListCommandInvocationsError {
     pub fn from_body(body: &str) -> ListCommandInvocationsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -11928,7 +11994,8 @@ impl ListCommandsError {
     pub fn from_body(body: &str) -> ListCommandsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -12030,7 +12097,8 @@ impl ListComplianceItemsError {
     pub fn from_body(body: &str) -> ListComplianceItemsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -12130,7 +12198,8 @@ impl ListComplianceSummariesError {
     pub fn from_body(body: &str) -> ListComplianceSummariesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -12222,7 +12291,8 @@ impl ListDocumentVersionsError {
     pub fn from_body(body: &str) -> ListDocumentVersionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -12314,7 +12384,8 @@ impl ListDocumentsError {
     pub fn from_body(body: &str) -> ListDocumentsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -12408,7 +12479,8 @@ impl ListInventoryEntriesError {
     pub fn from_body(body: &str) -> ListInventoryEntriesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -12508,7 +12580,8 @@ impl ListResourceComplianceSummariesError {
     pub fn from_body(body: &str) -> ListResourceComplianceSummariesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -12600,7 +12673,8 @@ impl ListResourceDataSyncError {
     pub fn from_body(body: &str) -> ListResourceDataSyncError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -12688,7 +12762,8 @@ impl ListTagsForResourceError {
     pub fn from_body(body: &str) -> ListTagsForResourceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -12784,7 +12859,8 @@ impl ModifyDocumentPermissionError {
     pub fn from_body(body: &str) -> ModifyDocumentPermissionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -12898,7 +12974,8 @@ impl PutComplianceItemsError {
     pub fn from_body(body: &str) -> PutComplianceItemsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -13026,7 +13103,8 @@ impl PutInventoryError {
     pub fn from_body(body: &str) -> PutInventoryError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -13174,7 +13252,8 @@ impl PutParameterError {
     pub fn from_body(body: &str) -> PutParameterError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -13296,7 +13375,8 @@ impl RegisterDefaultPatchBaselineError {
     pub fn from_body(body: &str) -> RegisterDefaultPatchBaselineError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -13394,7 +13474,8 @@ impl RegisterPatchBaselineForPatchGroupError {
     pub fn from_body(body: &str) -> RegisterPatchBaselineForPatchGroupError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -13506,7 +13587,8 @@ impl RegisterTargetWithMaintenanceWindowError {
     pub fn from_body(body: &str) -> RegisterTargetWithMaintenanceWindowError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -13616,7 +13698,8 @@ impl RegisterTaskWithMaintenanceWindowError {
     pub fn from_body(body: &str) -> RegisterTaskWithMaintenanceWindowError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -13726,7 +13809,8 @@ impl RemoveTagsFromResourceError {
     pub fn from_body(body: &str) -> RemoveTagsFromResourceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -13820,7 +13904,8 @@ impl SendAutomationSignalError {
     pub fn from_body(body: &str) -> SendAutomationSignalError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -13936,7 +14021,8 @@ impl SendCommandError {
     pub fn from_body(body: &str) -> SendCommandError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -14060,7 +14146,8 @@ impl StartAutomationExecutionError {
     pub fn from_body(body: &str) -> StartAutomationExecutionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -14178,7 +14265,8 @@ impl StopAutomationExecutionError {
     pub fn from_body(body: &str) -> StopAutomationExecutionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -14292,7 +14380,8 @@ impl UpdateAssociationError {
     pub fn from_body(body: &str) -> UpdateAssociationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -14430,7 +14519,8 @@ impl UpdateAssociationStatusError {
     pub fn from_body(body: &str) -> UpdateAssociationStatusError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -14546,7 +14636,8 @@ impl UpdateDocumentError {
     pub fn from_body(body: &str) -> UpdateDocumentError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -14662,7 +14753,8 @@ impl UpdateDocumentDefaultVersionError {
     pub fn from_body(body: &str) -> UpdateDocumentDefaultVersionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -14762,7 +14854,8 @@ impl UpdateMaintenanceWindowError {
     pub fn from_body(body: &str) -> UpdateMaintenanceWindowError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -14848,7 +14941,8 @@ impl UpdateMaintenanceWindowTargetError {
     pub fn from_body(body: &str) -> UpdateMaintenanceWindowTargetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -14936,7 +15030,8 @@ impl UpdateMaintenanceWindowTaskError {
     pub fn from_body(body: &str) -> UpdateMaintenanceWindowTaskError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -15022,7 +15117,8 @@ impl UpdateManagedInstanceRoleError {
     pub fn from_body(body: &str) -> UpdateManagedInstanceRoleError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -15108,7 +15204,8 @@ impl UpdatePatchBaselineError {
     pub fn from_body(body: &str) -> UpdatePatchBaselineError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/ssm/src/generated.rs
+++ b/rusoto/services/ssm/src/generated.rs
@@ -31,7 +31,7 @@ use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 /// <p>An activation registers one or more on-premises servers or virtual machines (VMs) with AWS so that you can configure those servers or VMs using Run Command. A server or VM that has been registered with AWS is called a managed instance.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Activation {
     /// <p>The ID created by Systems Manager when you submitted the activation.</p>
     #[serde(rename = "ActivationId")]
@@ -71,7 +71,7 @@ pub struct Activation {
     pub registrations_count: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AddTagsToResourceRequest {
     /// <p><p>The resource ID you want to tag.</p> <p>Use the ID of the resource. Here are some examples:</p> <p>ManagedInstance: mi-012345abcde</p> <p>MaintenanceWindow: mw-012345abcde</p> <p>PatchBaseline: pb-012345abcde</p> <p>For the Document and Parameter values, use the name of the resource.</p> <note> <p>The ManagedInstance type for this API action is only for on-premises managed instances. You must specify the the name of the managed instance in the following format: mi-ID_number. For example, mi-1a2b3c4d5e6f.</p> </note></p>
     #[serde(rename = "ResourceId")]
@@ -84,11 +84,11 @@ pub struct AddTagsToResourceRequest {
     pub tags: Vec<Tag>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AddTagsToResourceResult {}
 
 /// <p>Describes an association of a Systems Manager document and an instance.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Association {
     /// <p>The ID created by the system when you create an association. An association is a binding between a document and a set of targets with a schedule.</p>
     #[serde(rename = "AssociationId")]
@@ -133,7 +133,7 @@ pub struct Association {
 }
 
 /// <p>Describes the parameters for a document.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AssociationDescription {
     /// <p>The association ID.</p>
     #[serde(rename = "AssociationId")]
@@ -202,7 +202,7 @@ pub struct AssociationDescription {
 }
 
 /// <p>Describes a filter.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AssociationFilter {
     /// <p>The name of the filter.</p>
     #[serde(rename = "key")]
@@ -213,7 +213,7 @@ pub struct AssociationFilter {
 }
 
 /// <p>Information about the association.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AssociationOverview {
     /// <p>Returns the number of targets for the association status. For example, if you created an association with two instances, and one of them was successful, this would return the count of instances by status.</p>
     #[serde(rename = "AssociationStatusAggregatedCount")]
@@ -230,7 +230,7 @@ pub struct AssociationOverview {
 }
 
 /// <p>Describes an association status.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct AssociationStatus {
     /// <p>A user-defined string.</p>
     #[serde(rename = "AdditionalInfo")]
@@ -248,7 +248,7 @@ pub struct AssociationStatus {
 }
 
 /// <p>Information about the association version.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AssociationVersionInfo {
     /// <p>The ID created by the system when the association was created.</p>
     #[serde(rename = "AssociationId")]
@@ -293,7 +293,7 @@ pub struct AssociationVersionInfo {
 }
 
 /// <p>Detailed information about the current state of an individual Automation execution.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AutomationExecution {
     /// <p>The execution ID.</p>
     #[serde(rename = "AutomationExecutionId")]
@@ -386,7 +386,7 @@ pub struct AutomationExecution {
 }
 
 /// <p>A filter used to match specific automation executions. This is used to limit the scope of Automation execution information returned.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AutomationExecutionFilter {
     /// <p>One or more keys to limit the results. Valid filter keys include the following: DocumentNamePrefix, ExecutionStatus, ExecutionId, ParentExecutionId, CurrentAction, StartTimeBefore, StartTimeAfter.</p>
     #[serde(rename = "Key")]
@@ -397,7 +397,7 @@ pub struct AutomationExecutionFilter {
 }
 
 /// <p>Details about a specific Automation execution.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AutomationExecutionMetadata {
     /// <p>The execution ID.</p>
     #[serde(rename = "AutomationExecutionId")]
@@ -482,7 +482,7 @@ pub struct AutomationExecutionMetadata {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CancelCommandRequest {
     /// <p>The ID of the command you want to cancel.</p>
     #[serde(rename = "CommandId")]
@@ -494,11 +494,11 @@ pub struct CancelCommandRequest {
 }
 
 /// <p>Whether or not the command was successfully canceled. There is no guarantee that a request can be canceled.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CancelCommandResult {}
 
 /// <p>Describes a command request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Command {
     /// <p>A unique identifier for this command.</p>
     #[serde(rename = "CommandId")]
@@ -583,7 +583,7 @@ pub struct Command {
 }
 
 /// <p>Describes a command filter.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CommandFilter {
     /// <p>The name of the filter.</p>
     #[serde(rename = "key")]
@@ -594,7 +594,7 @@ pub struct CommandFilter {
 }
 
 /// <p>An invocation is copy of a command sent to a specific instance. A command can apply to one or more instances. A command invocation applies to one instance. For example, if a user executes SendCommand against three instances, then a command invocation is created for each requested instance ID. A command invocation returns status and detail information about a command you executed. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CommandInvocation {
     /// <p>The command against which this invocation was requested.</p>
     #[serde(rename = "CommandId")]
@@ -654,7 +654,7 @@ pub struct CommandInvocation {
 }
 
 /// <p>Describes plugin details.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CommandPlugin {
     /// <p>The name of the plugin. Must be one of the following: aws:updateAgent, aws:domainjoin, aws:applications, aws:runPowerShellScript, aws:psmodule, aws:cloudWatch, aws:runShellScript, or aws:updateSSMAgent. </p>
     #[serde(rename = "Name")]
@@ -707,7 +707,7 @@ pub struct CommandPlugin {
 }
 
 /// <p>A summary of the call execution that includes an execution ID, the type of execution (for example, <code>Command</code>), and the date/time of the execution using a datetime object that is saved in the following format: yyyy-MM-dd'T'HH:mm:ss'Z'.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ComplianceExecutionSummary {
     /// <p>An ID created by the system when <code>PutComplianceItems</code> was called. For example, <code>CommandID</code> is a valid execution ID. You can use this ID in subsequent calls.</p>
     #[serde(rename = "ExecutionId")]
@@ -723,7 +723,7 @@ pub struct ComplianceExecutionSummary {
 }
 
 /// <p>Information about the compliance as defined by the resource type. For example, for a patch resource type, <code>Items</code> includes information about the PatchSeverity, Classification, etc.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ComplianceItem {
     /// <p>The compliance type. For example, Association (for a State Manager association), Patch, or Custom:<code>string</code> are all valid compliance types.</p>
     #[serde(rename = "ComplianceType")]
@@ -764,7 +764,7 @@ pub struct ComplianceItem {
 }
 
 /// <p>Information about a compliance item.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ComplianceItemEntry {
     /// <p>A "Key": "Value" tag combination for the compliance item.</p>
     #[serde(rename = "Details")]
@@ -787,7 +787,7 @@ pub struct ComplianceItemEntry {
 }
 
 /// <p>One or more filters. Use a filter to return a more specific list of results.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ComplianceStringFilter {
     /// <p>The name of the filter.</p>
     #[serde(rename = "Key")]
@@ -804,7 +804,7 @@ pub struct ComplianceStringFilter {
 }
 
 /// <p>A summary of compliance information by compliance type.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ComplianceSummaryItem {
     /// <p>The type of compliance item. For example, the compliance type can be Association, Patch, or Custom:string.</p>
     #[serde(rename = "ComplianceType")]
@@ -821,7 +821,7 @@ pub struct ComplianceSummaryItem {
 }
 
 /// <p>A summary of resources that are compliant. The summary is organized according to the resource count for each compliance type.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CompliantSummary {
     /// <p>The total number of resources that are compliant.</p>
     #[serde(rename = "CompliantCount")]
@@ -833,7 +833,7 @@ pub struct CompliantSummary {
     pub severity_summary: Option<SeveritySummary>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateActivationRequest {
     /// <p><p>The name of the registered, managed instance as it will appear in the Amazon EC2 console or when you use the AWS command line tools to list EC2 resources.</p> <important> <p>Do not enter personally identifiable information in this field.</p> </important></p>
     #[serde(rename = "DefaultInstanceName")]
@@ -856,7 +856,7 @@ pub struct CreateActivationRequest {
     pub registration_limit: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateActivationResult {
     /// <p>The code the system generates when it processes the activation. The activation code functions like a password to validate the activation ID. </p>
     #[serde(rename = "ActivationCode")]
@@ -868,7 +868,7 @@ pub struct CreateActivationResult {
     pub activation_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateAssociationBatchRequest {
     /// <p>One or more associations.</p>
     #[serde(rename = "Entries")]
@@ -876,7 +876,7 @@ pub struct CreateAssociationBatchRequest {
 }
 
 /// <p>Describes the association of a Systems Manager document and an instance.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CreateAssociationBatchRequestEntry {
     /// <p>Specify a descriptive name for the association.</p>
     #[serde(rename = "AssociationName")]
@@ -911,7 +911,7 @@ pub struct CreateAssociationBatchRequestEntry {
     pub targets: Option<Vec<Target>>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateAssociationBatchResult {
     /// <p>Information about the associations that failed.</p>
     #[serde(rename = "Failed")]
@@ -923,7 +923,7 @@ pub struct CreateAssociationBatchResult {
     pub successful: Option<Vec<AssociationDescription>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateAssociationRequest {
     /// <p>Specify a descriptive name for the association.</p>
     #[serde(rename = "AssociationName")]
@@ -958,7 +958,7 @@ pub struct CreateAssociationRequest {
     pub targets: Option<Vec<Target>>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateAssociationResult {
     /// <p>Information about the association.</p>
     #[serde(rename = "AssociationDescription")]
@@ -966,7 +966,7 @@ pub struct CreateAssociationResult {
     pub association_description: Option<AssociationDescription>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateDocumentRequest {
     /// <p>A valid JSON or YAML string.</p>
     #[serde(rename = "Content")]
@@ -988,7 +988,7 @@ pub struct CreateDocumentRequest {
     pub target_type: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateDocumentResult {
     /// <p>Information about the Systems Manager document.</p>
     #[serde(rename = "DocumentDescription")]
@@ -996,7 +996,7 @@ pub struct CreateDocumentResult {
     pub document_description: Option<DocumentDescription>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateMaintenanceWindowRequest {
     /// <p>Enables a Maintenance Window task to execute on managed instances, even if you have not registered those instances as targets. If enabled, then you must specify the unregistered instances (by instance ID) when you register a task with the Maintenance Window </p> <p>If you don't enable this option, then you must specify previously-registered targets when you register a task with the Maintenance Window. </p>
     #[serde(rename = "AllowUnassociatedTargets")]
@@ -1023,7 +1023,7 @@ pub struct CreateMaintenanceWindowRequest {
     pub schedule: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateMaintenanceWindowResult {
     /// <p>The ID of the created Maintenance Window.</p>
     #[serde(rename = "WindowId")]
@@ -1031,7 +1031,7 @@ pub struct CreateMaintenanceWindowResult {
     pub window_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreatePatchBaselineRequest {
     /// <p>A set of rules used to include patches in the baseline.</p>
     #[serde(rename = "ApprovalRules")]
@@ -1078,7 +1078,7 @@ pub struct CreatePatchBaselineRequest {
     pub sources: Option<Vec<PatchSource>>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreatePatchBaselineResult {
     /// <p>The ID of the created patch baseline.</p>
     #[serde(rename = "BaselineId")]
@@ -1086,7 +1086,7 @@ pub struct CreatePatchBaselineResult {
     pub baseline_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateResourceDataSyncRequest {
     /// <p>Amazon S3 configuration details for the sync.</p>
     #[serde(rename = "S3Destination")]
@@ -1096,20 +1096,20 @@ pub struct CreateResourceDataSyncRequest {
     pub sync_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateResourceDataSyncResult {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteActivationRequest {
     /// <p>The ID of the activation that you want to delete.</p>
     #[serde(rename = "ActivationId")]
     pub activation_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteActivationResult {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteAssociationRequest {
     /// <p>The association ID that you want to delete.</p>
     #[serde(rename = "AssociationId")]
@@ -1125,27 +1125,27 @@ pub struct DeleteAssociationRequest {
     pub name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteAssociationResult {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteDocumentRequest {
     /// <p>The name of the document.</p>
     #[serde(rename = "Name")]
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteDocumentResult {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteMaintenanceWindowRequest {
     /// <p>The ID of the Maintenance Window to delete.</p>
     #[serde(rename = "WindowId")]
     pub window_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteMaintenanceWindowResult {
     /// <p>The ID of the deleted Maintenance Window.</p>
     #[serde(rename = "WindowId")]
@@ -1153,24 +1153,24 @@ pub struct DeleteMaintenanceWindowResult {
     pub window_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteParameterRequest {
     /// <p>The name of the parameter to delete.</p>
     #[serde(rename = "Name")]
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteParameterResult {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteParametersRequest {
     /// <p>The names of the parameters to delete.</p>
     #[serde(rename = "Names")]
     pub names: Vec<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteParametersResult {
     /// <p>The names of the deleted parameters.</p>
     #[serde(rename = "DeletedParameters")]
@@ -1182,14 +1182,14 @@ pub struct DeleteParametersResult {
     pub invalid_parameters: Option<Vec<String>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeletePatchBaselineRequest {
     /// <p>The ID of the patch baseline to delete.</p>
     #[serde(rename = "BaselineId")]
     pub baseline_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeletePatchBaselineResult {
     /// <p>The ID of the deleted patch baseline.</p>
     #[serde(rename = "BaselineId")]
@@ -1197,27 +1197,27 @@ pub struct DeletePatchBaselineResult {
     pub baseline_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteResourceDataSyncRequest {
     /// <p>The name of the configuration to delete.</p>
     #[serde(rename = "SyncName")]
     pub sync_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteResourceDataSyncResult {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeregisterManagedInstanceRequest {
     /// <p>The ID assigned to the managed instance when you registered it using the activation process. </p>
     #[serde(rename = "InstanceId")]
     pub instance_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeregisterManagedInstanceResult {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeregisterPatchBaselineForPatchGroupRequest {
     /// <p>The ID of the patch baseline to deregister the patch group from.</p>
     #[serde(rename = "BaselineId")]
@@ -1227,7 +1227,7 @@ pub struct DeregisterPatchBaselineForPatchGroupRequest {
     pub patch_group: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeregisterPatchBaselineForPatchGroupResult {
     /// <p>The ID of the patch baseline the patch group was deregistered from.</p>
     #[serde(rename = "BaselineId")]
@@ -1239,7 +1239,7 @@ pub struct DeregisterPatchBaselineForPatchGroupResult {
     pub patch_group: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeregisterTargetFromMaintenanceWindowRequest {
     /// <p>The system checks if the target is being referenced by a task. If the target is being referenced, the system returns an error and does not deregister the target from the Maintenance Window.</p>
     #[serde(rename = "Safe")]
@@ -1253,7 +1253,7 @@ pub struct DeregisterTargetFromMaintenanceWindowRequest {
     pub window_target_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeregisterTargetFromMaintenanceWindowResult {
     /// <p>The ID of the Maintenance Window the target was removed from.</p>
     #[serde(rename = "WindowId")]
@@ -1265,7 +1265,7 @@ pub struct DeregisterTargetFromMaintenanceWindowResult {
     pub window_target_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeregisterTaskFromMaintenanceWindowRequest {
     /// <p>The ID of the Maintenance Window the task should be removed from.</p>
     #[serde(rename = "WindowId")]
@@ -1275,7 +1275,7 @@ pub struct DeregisterTaskFromMaintenanceWindowRequest {
     pub window_task_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeregisterTaskFromMaintenanceWindowResult {
     /// <p>The ID of the Maintenance Window the task was removed from.</p>
     #[serde(rename = "WindowId")]
@@ -1288,7 +1288,7 @@ pub struct DeregisterTaskFromMaintenanceWindowResult {
 }
 
 /// <p>Filter for the DescribeActivation API.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeActivationsFilter {
     /// <p>The name of the filter.</p>
     #[serde(rename = "FilterKey")]
@@ -1300,7 +1300,7 @@ pub struct DescribeActivationsFilter {
     pub filter_values: Option<Vec<String>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeActivationsRequest {
     /// <p>A filter to view information about your activations.</p>
     #[serde(rename = "Filters")]
@@ -1316,7 +1316,7 @@ pub struct DescribeActivationsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeActivationsResult {
     /// <p>A list of activations for your AWS account.</p>
     #[serde(rename = "ActivationList")]
@@ -1328,7 +1328,7 @@ pub struct DescribeActivationsResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeAssociationRequest {
     /// <p>The association ID for which you want information.</p>
     #[serde(rename = "AssociationId")]
@@ -1348,7 +1348,7 @@ pub struct DescribeAssociationRequest {
     pub name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeAssociationResult {
     /// <p>Information about the association.</p>
     #[serde(rename = "AssociationDescription")]
@@ -1356,7 +1356,7 @@ pub struct DescribeAssociationResult {
     pub association_description: Option<AssociationDescription>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeAutomationExecutionsRequest {
     /// <p>Filters used to limit the scope of executions that are requested.</p>
     #[serde(rename = "Filters")]
@@ -1372,7 +1372,7 @@ pub struct DescribeAutomationExecutionsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeAutomationExecutionsResult {
     /// <p>The list of details about each automation execution which has occurred which matches the filter specification, if any.</p>
     #[serde(rename = "AutomationExecutionMetadataList")]
@@ -1384,7 +1384,7 @@ pub struct DescribeAutomationExecutionsResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeAutomationStepExecutionsRequest {
     /// <p>The Automation execution ID for which you want step execution descriptions.</p>
     #[serde(rename = "AutomationExecutionId")]
@@ -1407,7 +1407,7 @@ pub struct DescribeAutomationStepExecutionsRequest {
     pub reverse_order: Option<bool>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeAutomationStepExecutionsResult {
     /// <p>The token to use when requesting the next set of items. If there are no additional items to return, the string is empty.</p>
     #[serde(rename = "NextToken")]
@@ -1419,7 +1419,7 @@ pub struct DescribeAutomationStepExecutionsResult {
     pub step_executions: Option<Vec<StepExecution>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeAvailablePatchesRequest {
     /// <p>Filters used to scope down the returned patches.</p>
     #[serde(rename = "Filters")]
@@ -1435,7 +1435,7 @@ pub struct DescribeAvailablePatchesRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeAvailablePatchesResult {
     /// <p>The token to use when requesting the next set of items. If there are no additional items to return, the string is empty.</p>
     #[serde(rename = "NextToken")]
@@ -1447,7 +1447,7 @@ pub struct DescribeAvailablePatchesResult {
     pub patches: Option<Vec<Patch>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeDocumentPermissionRequest {
     /// <p>The name of the document for which you are the owner.</p>
     #[serde(rename = "Name")]
@@ -1457,7 +1457,7 @@ pub struct DescribeDocumentPermissionRequest {
     pub permission_type: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeDocumentPermissionResponse {
     /// <p>The account IDs that have permission to use this document. The ID can be either an AWS account or <i>All</i>.</p>
     #[serde(rename = "AccountIds")]
@@ -1465,7 +1465,7 @@ pub struct DescribeDocumentPermissionResponse {
     pub account_ids: Option<Vec<String>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeDocumentRequest {
     /// <p>The document version for which you want information. Can be a specific version or the default version.</p>
     #[serde(rename = "DocumentVersion")]
@@ -1476,7 +1476,7 @@ pub struct DescribeDocumentRequest {
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeDocumentResult {
     /// <p>Information about the Systems Manager document.</p>
     #[serde(rename = "Document")]
@@ -1484,7 +1484,7 @@ pub struct DescribeDocumentResult {
     pub document: Option<DocumentDescription>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeEffectiveInstanceAssociationsRequest {
     /// <p>The instance ID for which you want to view all associations.</p>
     #[serde(rename = "InstanceId")]
@@ -1499,7 +1499,7 @@ pub struct DescribeEffectiveInstanceAssociationsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeEffectiveInstanceAssociationsResult {
     /// <p>The associations for the requested instance.</p>
     #[serde(rename = "Associations")]
@@ -1511,7 +1511,7 @@ pub struct DescribeEffectiveInstanceAssociationsResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeEffectivePatchesForPatchBaselineRequest {
     /// <p>The ID of the patch baseline to retrieve the effective patches for.</p>
     #[serde(rename = "BaselineId")]
@@ -1526,7 +1526,7 @@ pub struct DescribeEffectivePatchesForPatchBaselineRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeEffectivePatchesForPatchBaselineResult {
     /// <p>An array of patches and patch status.</p>
     #[serde(rename = "EffectivePatches")]
@@ -1538,7 +1538,7 @@ pub struct DescribeEffectivePatchesForPatchBaselineResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeInstanceAssociationsStatusRequest {
     /// <p>The instance IDs for which you want association status information.</p>
     #[serde(rename = "InstanceId")]
@@ -1553,7 +1553,7 @@ pub struct DescribeInstanceAssociationsStatusRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeInstanceAssociationsStatusResult {
     /// <p>Status information about the association.</p>
     #[serde(rename = "InstanceAssociationStatusInfos")]
@@ -1565,7 +1565,7 @@ pub struct DescribeInstanceAssociationsStatusResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeInstanceInformationRequest {
     /// <p>One or more filters. Use a filter to return a more specific list of instances.</p>
     #[serde(rename = "Filters")]
@@ -1585,7 +1585,7 @@ pub struct DescribeInstanceInformationRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeInstanceInformationResult {
     /// <p>The instance information list.</p>
     #[serde(rename = "InstanceInformationList")]
@@ -1597,7 +1597,7 @@ pub struct DescribeInstanceInformationResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeInstancePatchStatesForPatchGroupRequest {
     /// <p>Each entry in the array is a structure containing:</p> <p>Key (string between 1 and 200 characters)</p> <p> Values (array containing a single string)</p> <p> Type (string "Equal", "NotEqual", "LessThan", "GreaterThan")</p>
     #[serde(rename = "Filters")]
@@ -1616,7 +1616,7 @@ pub struct DescribeInstancePatchStatesForPatchGroupRequest {
     pub patch_group: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeInstancePatchStatesForPatchGroupResult {
     /// <p>The high-level patch state for the requested instances. </p>
     #[serde(rename = "InstancePatchStates")]
@@ -1628,7 +1628,7 @@ pub struct DescribeInstancePatchStatesForPatchGroupResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeInstancePatchStatesRequest {
     /// <p>The ID of the instance whose patch state information should be retrieved.</p>
     #[serde(rename = "InstanceIds")]
@@ -1643,7 +1643,7 @@ pub struct DescribeInstancePatchStatesRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeInstancePatchStatesResult {
     /// <p>The high-level patch state for the requested instances.</p>
     #[serde(rename = "InstancePatchStates")]
@@ -1655,7 +1655,7 @@ pub struct DescribeInstancePatchStatesResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeInstancePatchesRequest {
     /// <p>Each entry in the array is a structure containing:</p> <p>Key (string, between 1 and 128 characters)</p> <p>Values (array of strings, each string between 1 and 256 characters)</p>
     #[serde(rename = "Filters")]
@@ -1674,7 +1674,7 @@ pub struct DescribeInstancePatchesRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeInstancePatchesResult {
     /// <p>The token to use when requesting the next set of items. If there are no additional items to return, the string is empty.</p>
     #[serde(rename = "NextToken")]
@@ -1686,7 +1686,7 @@ pub struct DescribeInstancePatchesResult {
     pub patches: Option<Vec<PatchComplianceData>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeMaintenanceWindowExecutionTaskInvocationsRequest {
     /// <p>Optional filters used to scope down the returned task invocations. The supported filter key is STATUS with the corresponding values PENDING, IN_PROGRESS, SUCCESS, FAILED, TIMED_OUT, CANCELLING, and CANCELLED.</p>
     #[serde(rename = "Filters")]
@@ -1708,7 +1708,7 @@ pub struct DescribeMaintenanceWindowExecutionTaskInvocationsRequest {
     pub window_execution_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeMaintenanceWindowExecutionTaskInvocationsResult {
     /// <p>The token to use when requesting the next set of items. If there are no additional items to return, the string is empty.</p>
     #[serde(rename = "NextToken")]
@@ -1721,7 +1721,7 @@ pub struct DescribeMaintenanceWindowExecutionTaskInvocationsResult {
         Option<Vec<MaintenanceWindowExecutionTaskInvocationIdentity>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeMaintenanceWindowExecutionTasksRequest {
     /// <p>Optional filters used to scope down the returned tasks. The supported filter key is STATUS with the corresponding values PENDING, IN_PROGRESS, SUCCESS, FAILED, TIMED_OUT, CANCELLING, and CANCELLED. </p>
     #[serde(rename = "Filters")]
@@ -1740,7 +1740,7 @@ pub struct DescribeMaintenanceWindowExecutionTasksRequest {
     pub window_execution_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeMaintenanceWindowExecutionTasksResult {
     /// <p>The token to use when requesting the next set of items. If there are no additional items to return, the string is empty.</p>
     #[serde(rename = "NextToken")]
@@ -1752,7 +1752,7 @@ pub struct DescribeMaintenanceWindowExecutionTasksResult {
     pub window_execution_task_identities: Option<Vec<MaintenanceWindowExecutionTaskIdentity>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeMaintenanceWindowExecutionsRequest {
     /// <p>Each entry in the array is a structure containing:</p> <p>Key (string, between 1 and 128 characters)</p> <p>Values (array of strings, each string is between 1 and 256 characters)</p> <p>The supported Keys are ExecutedBefore and ExecutedAfter with the value being a date/time string such as 2016-11-04T05:00:00Z.</p>
     #[serde(rename = "Filters")]
@@ -1771,7 +1771,7 @@ pub struct DescribeMaintenanceWindowExecutionsRequest {
     pub window_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeMaintenanceWindowExecutionsResult {
     /// <p>The token to use when requesting the next set of items. If there are no additional items to return, the string is empty.</p>
     #[serde(rename = "NextToken")]
@@ -1783,7 +1783,7 @@ pub struct DescribeMaintenanceWindowExecutionsResult {
     pub window_executions: Option<Vec<MaintenanceWindowExecution>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeMaintenanceWindowTargetsRequest {
     /// <p>Optional filters that can be used to narrow down the scope of the returned window targets. The supported filter keys are Type, WindowTargetId and OwnerInformation.</p>
     #[serde(rename = "Filters")]
@@ -1802,7 +1802,7 @@ pub struct DescribeMaintenanceWindowTargetsRequest {
     pub window_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeMaintenanceWindowTargetsResult {
     /// <p>The token to use when requesting the next set of items. If there are no additional items to return, the string is empty.</p>
     #[serde(rename = "NextToken")]
@@ -1814,7 +1814,7 @@ pub struct DescribeMaintenanceWindowTargetsResult {
     pub targets: Option<Vec<MaintenanceWindowTarget>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeMaintenanceWindowTasksRequest {
     /// <p>Optional filters used to narrow down the scope of the returned tasks. The supported filter keys are WindowTaskId, TaskArn, Priority, and TaskType.</p>
     #[serde(rename = "Filters")]
@@ -1833,7 +1833,7 @@ pub struct DescribeMaintenanceWindowTasksRequest {
     pub window_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeMaintenanceWindowTasksResult {
     /// <p>The token to use when requesting the next set of items. If there are no additional items to return, the string is empty.</p>
     #[serde(rename = "NextToken")]
@@ -1845,7 +1845,7 @@ pub struct DescribeMaintenanceWindowTasksResult {
     pub tasks: Option<Vec<MaintenanceWindowTask>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeMaintenanceWindowsRequest {
     /// <p>Optional filters used to narrow down the scope of the returned Maintenance Windows. Supported filter keys are Name and Enabled.</p>
     #[serde(rename = "Filters")]
@@ -1861,7 +1861,7 @@ pub struct DescribeMaintenanceWindowsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeMaintenanceWindowsResult {
     /// <p>The token to use when requesting the next set of items. If there are no additional items to return, the string is empty.</p>
     #[serde(rename = "NextToken")]
@@ -1873,7 +1873,7 @@ pub struct DescribeMaintenanceWindowsResult {
     pub window_identities: Option<Vec<MaintenanceWindowIdentity>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeParametersRequest {
     /// <p>One or more filters. Use a filter to return a more specific list of results.</p>
     #[serde(rename = "Filters")]
@@ -1893,7 +1893,7 @@ pub struct DescribeParametersRequest {
     pub parameter_filters: Option<Vec<ParameterStringFilter>>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeParametersResult {
     /// <p>The token to use when requesting the next set of items. If there are no additional items to return, the string is empty.</p>
     #[serde(rename = "NextToken")]
@@ -1905,7 +1905,7 @@ pub struct DescribeParametersResult {
     pub parameters: Option<Vec<ParameterMetadata>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribePatchBaselinesRequest {
     /// <p>Each element in the array is a structure containing: </p> <p>Key: (string, "NAME_PREFIX" or "OWNER")</p> <p>Value: (array of strings, exactly 1 entry, between 1 and 255 characters)</p>
     #[serde(rename = "Filters")]
@@ -1921,7 +1921,7 @@ pub struct DescribePatchBaselinesRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribePatchBaselinesResult {
     /// <p>An array of PatchBaselineIdentity elements.</p>
     #[serde(rename = "BaselineIdentities")]
@@ -1933,14 +1933,14 @@ pub struct DescribePatchBaselinesResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribePatchGroupStateRequest {
     /// <p>The name of the patch group whose patch snapshot should be retrieved.</p>
     #[serde(rename = "PatchGroup")]
     pub patch_group: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribePatchGroupStateResult {
     /// <p>The number of instances in the patch group.</p>
     #[serde(rename = "Instances")]
@@ -1968,7 +1968,7 @@ pub struct DescribePatchGroupStateResult {
     pub instances_with_not_applicable_patches: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribePatchGroupsRequest {
     /// <p>One or more filters. Use a filter to return a more specific list of results.</p>
     #[serde(rename = "Filters")]
@@ -1984,7 +1984,7 @@ pub struct DescribePatchGroupsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribePatchGroupsResult {
     /// <p>Each entry in the array contains:</p> <p>PatchGroup: string (between 1 and 256 characters, Regex: ^([\p{L}\p{Z}\p{N}_.:/=+\-@]*)$)</p> <p>PatchBaselineIdentity: A PatchBaselineIdentity element. </p>
     #[serde(rename = "Mappings")]
@@ -1997,7 +1997,7 @@ pub struct DescribePatchGroupsResult {
 }
 
 /// <p>A default version of a document.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DocumentDefaultVersionDescription {
     /// <p>The default version of the document.</p>
     #[serde(rename = "DefaultVersion")]
@@ -2010,7 +2010,7 @@ pub struct DocumentDefaultVersionDescription {
 }
 
 /// <p>Describes a Systems Manager document. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DocumentDescription {
     /// <p>The date when the document was created.</p>
     #[serde(rename = "CreatedDate")]
@@ -2087,7 +2087,7 @@ pub struct DocumentDescription {
 }
 
 /// <p>Describes a filter.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DocumentFilter {
     /// <p>The name of the filter.</p>
     #[serde(rename = "key")]
@@ -2098,7 +2098,7 @@ pub struct DocumentFilter {
 }
 
 /// <p>Describes the name of a Systems Manager document.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DocumentIdentifier {
     /// <p>The document format, either JSON or YAML.</p>
     #[serde(rename = "DocumentFormat")]
@@ -2139,7 +2139,7 @@ pub struct DocumentIdentifier {
 }
 
 /// <p>One or more filters. Use a filter to return a more specific list of documents.</p> <p>For keys, you can specify one or more tags that have been applied to a document. </p> <p>Other valid values include Owner, Name, PlatformTypes, and DocumentType.</p> <p>Note that only one Owner can be specified in a request. For example: <code>Key=Owner,Values=Self</code>.</p> <p>If you use Name as a key, you can use a name prefix to return a list of documents. For example, in the AWS CLI, to return a list of all documents that begin with <code>Te</code>, run the following command:</p> <p> <code>aws ssm list-documents --filters Key=Name,Values=Te</code> </p> <p>If you specify more than two keys, only documents that are identified by all the tags are returned in the results. If you specify more than two values for a key, documents that are identified by any of the values are returned in the results.</p> <p>To specify a custom key and value pair, use the format <code>Key=tag:[tagName],Values=[valueName]</code>.</p> <p>For example, if you created a Key called region and are using the AWS CLI to call the <code>list-documents</code> command: </p> <p> <code>aws ssm list-documents --filters Key=tag:region,Values=east,west Key=Owner,Values=Self</code> </p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DocumentKeyValuesFilter {
     /// <p>The name of the filter key.</p>
     #[serde(rename = "Key")]
@@ -2152,7 +2152,7 @@ pub struct DocumentKeyValuesFilter {
 }
 
 /// <p>Parameters specified in a System Manager document that execute on the server when the command is run. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DocumentParameter {
     /// <p>If specified, the default values for the parameters. Parameters without a default value are required. Parameters with a default value are optional.</p>
     #[serde(rename = "DefaultValue")]
@@ -2173,7 +2173,7 @@ pub struct DocumentParameter {
 }
 
 /// <p>Version information about the document.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DocumentVersionInfo {
     /// <p>The date the document was created.</p>
     #[serde(rename = "CreatedDate")]
@@ -2198,7 +2198,7 @@ pub struct DocumentVersionInfo {
 }
 
 /// <p>The EffectivePatch structure defines metadata about a patch along with the approval state of the patch in a particular patch baseline. The approval state includes information about whether the patch is currently approved, due to be approved by a rule, explicitly approved, or explicitly rejected and the date the patch was or will be approved.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct EffectivePatch {
     /// <p>Provides metadata for a patch, including information such as the KB ID, severity, classification and a URL for where more information can be obtained about the patch.</p>
     #[serde(rename = "Patch")]
@@ -2211,7 +2211,7 @@ pub struct EffectivePatch {
 }
 
 /// <p>Describes a failed association.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct FailedCreateAssociation {
     /// <p>The association.</p>
     #[serde(rename = "Entry")]
@@ -2228,7 +2228,7 @@ pub struct FailedCreateAssociation {
 }
 
 /// <p>Information about an Automation failure.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct FailureDetails {
     /// <p>Detailed information about the Automation step failure.</p>
     #[serde(rename = "Details")]
@@ -2244,14 +2244,14 @@ pub struct FailureDetails {
     pub failure_type: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetAutomationExecutionRequest {
     /// <p>The unique identifier for an existing automation execution to examine. The execution ID is returned by StartAutomationExecution when the execution of an Automation document is initiated.</p>
     #[serde(rename = "AutomationExecutionId")]
     pub automation_execution_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetAutomationExecutionResult {
     /// <p>Detailed information about the current state of an automation execution.</p>
     #[serde(rename = "AutomationExecution")]
@@ -2259,7 +2259,7 @@ pub struct GetAutomationExecutionResult {
     pub automation_execution: Option<AutomationExecution>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetCommandInvocationRequest {
     /// <p>(Required) The parent command ID of the invocation plugin.</p>
     #[serde(rename = "CommandId")]
@@ -2273,7 +2273,7 @@ pub struct GetCommandInvocationRequest {
     pub plugin_name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetCommandInvocationResult {
     /// <p>The parent command ID of the invocation plugin.</p>
     #[serde(rename = "CommandId")]
@@ -2337,7 +2337,7 @@ pub struct GetCommandInvocationResult {
     pub status_details: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetDefaultPatchBaselineRequest {
     /// <p>Returns the default patch baseline for the specified operating system.</p>
     #[serde(rename = "OperatingSystem")]
@@ -2345,7 +2345,7 @@ pub struct GetDefaultPatchBaselineRequest {
     pub operating_system: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetDefaultPatchBaselineResult {
     /// <p>The ID of the default patch baseline.</p>
     #[serde(rename = "BaselineId")]
@@ -2357,7 +2357,7 @@ pub struct GetDefaultPatchBaselineResult {
     pub operating_system: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetDeployablePatchSnapshotForInstanceRequest {
     /// <p>The ID of the instance for which the appropriate patch snapshot should be retrieved.</p>
     #[serde(rename = "InstanceId")]
@@ -2367,7 +2367,7 @@ pub struct GetDeployablePatchSnapshotForInstanceRequest {
     pub snapshot_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetDeployablePatchSnapshotForInstanceResult {
     /// <p>The ID of the instance.</p>
     #[serde(rename = "InstanceId")]
@@ -2387,7 +2387,7 @@ pub struct GetDeployablePatchSnapshotForInstanceResult {
     pub snapshot_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetDocumentRequest {
     /// <p>Returns the document in the specified format. The document format can be either JSON or YAML. JSON is the default format.</p>
     #[serde(rename = "DocumentFormat")]
@@ -2402,7 +2402,7 @@ pub struct GetDocumentRequest {
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetDocumentResult {
     /// <p>The contents of the Systems Manager document.</p>
     #[serde(rename = "Content")]
@@ -2426,7 +2426,7 @@ pub struct GetDocumentResult {
     pub name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetInventoryRequest {
     /// <p>Returns counts of inventory types based on one or more expressions. For example, if you aggregate by using an expression that uses the <code>AWS:InstanceInformation.PlatformType</code> type, you can see a count of how many Windows and Linux instances exist in your inventoried fleet.</p>
     #[serde(rename = "Aggregators")]
@@ -2450,7 +2450,7 @@ pub struct GetInventoryRequest {
     pub result_attributes: Option<Vec<ResultAttribute>>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetInventoryResult {
     /// <p>Collection of inventory entities such as a collection of instance inventory. </p>
     #[serde(rename = "Entities")]
@@ -2462,7 +2462,7 @@ pub struct GetInventoryResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetInventorySchemaRequest {
     /// <p>Returns inventory schemas that support aggregation. For example, this call returns the <code>AWS:InstanceInformation</code> type, because it supports aggregation based on the <code>PlatformName</code>, <code>PlatformType</code>, and <code>PlatformVersion</code> attributes.</p>
     #[serde(rename = "Aggregator")]
@@ -2486,7 +2486,7 @@ pub struct GetInventorySchemaRequest {
     pub type_name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetInventorySchemaResult {
     /// <p>The token to use when requesting the next set of items. If there are no additional items to return, the string is empty.</p>
     #[serde(rename = "NextToken")]
@@ -2498,14 +2498,14 @@ pub struct GetInventorySchemaResult {
     pub schemas: Option<Vec<InventoryItemSchema>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetMaintenanceWindowExecutionRequest {
     /// <p>The ID of the Maintenance Window execution that includes the task.</p>
     #[serde(rename = "WindowExecutionId")]
     pub window_execution_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetMaintenanceWindowExecutionResult {
     /// <p>The time the Maintenance Window finished executing.</p>
     #[serde(rename = "EndTime")]
@@ -2533,7 +2533,7 @@ pub struct GetMaintenanceWindowExecutionResult {
     pub window_execution_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetMaintenanceWindowExecutionTaskInvocationRequest {
     /// <p>The invocation ID to retrieve.</p>
     #[serde(rename = "InvocationId")]
@@ -2546,7 +2546,7 @@ pub struct GetMaintenanceWindowExecutionTaskInvocationRequest {
     pub window_execution_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetMaintenanceWindowExecutionTaskInvocationResult {
     /// <p>The time that the task finished executing on the target.</p>
     #[serde(rename = "EndTime")]
@@ -2598,7 +2598,7 @@ pub struct GetMaintenanceWindowExecutionTaskInvocationResult {
     pub window_target_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetMaintenanceWindowExecutionTaskRequest {
     /// <p>The ID of the specific task execution in the Maintenance Window task that should be retrieved.</p>
     #[serde(rename = "TaskId")]
@@ -2608,7 +2608,7 @@ pub struct GetMaintenanceWindowExecutionTaskRequest {
     pub window_execution_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetMaintenanceWindowExecutionTaskResult {
     /// <p>The time the task execution completed.</p>
     #[serde(rename = "EndTime")]
@@ -2666,14 +2666,14 @@ pub struct GetMaintenanceWindowExecutionTaskResult {
     pub window_execution_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetMaintenanceWindowRequest {
     /// <p>The ID of the desired Maintenance Window.</p>
     #[serde(rename = "WindowId")]
     pub window_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetMaintenanceWindowResult {
     /// <p>Whether targets must be registered with the Maintenance Window before tasks can be defined for those targets.</p>
     #[serde(rename = "AllowUnassociatedTargets")]
@@ -2717,7 +2717,7 @@ pub struct GetMaintenanceWindowResult {
     pub window_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetMaintenanceWindowTaskRequest {
     /// <p>The Maintenance Window ID that includes the task to retrieve.</p>
     #[serde(rename = "WindowId")]
@@ -2727,7 +2727,7 @@ pub struct GetMaintenanceWindowTaskRequest {
     pub window_task_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetMaintenanceWindowTaskResult {
     /// <p>The retrieved task description.</p>
     #[serde(rename = "Description")]
@@ -2788,7 +2788,7 @@ pub struct GetMaintenanceWindowTaskResult {
     pub window_task_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetParameterHistoryRequest {
     /// <p>The maximum number of items to return for this call. The call also returns a token that you can specify in a subsequent call to get the next set of results.</p>
     #[serde(rename = "MaxResults")]
@@ -2807,7 +2807,7 @@ pub struct GetParameterHistoryRequest {
     pub with_decryption: Option<bool>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetParameterHistoryResult {
     /// <p>The token to use when requesting the next set of items. If there are no additional items to return, the string is empty.</p>
     #[serde(rename = "NextToken")]
@@ -2819,7 +2819,7 @@ pub struct GetParameterHistoryResult {
     pub parameters: Option<Vec<ParameterHistory>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetParameterRequest {
     /// <p>The name of the parameter you want to query.</p>
     #[serde(rename = "Name")]
@@ -2830,7 +2830,7 @@ pub struct GetParameterRequest {
     pub with_decryption: Option<bool>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetParameterResult {
     /// <p>Information about a parameter.</p>
     #[serde(rename = "Parameter")]
@@ -2838,7 +2838,7 @@ pub struct GetParameterResult {
     pub parameter: Option<Parameter>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetParametersByPathRequest {
     /// <p>The maximum number of items to return for this call. The call also returns a token that you can specify in a subsequent call to get the next set of results.</p>
     #[serde(rename = "MaxResults")]
@@ -2865,7 +2865,7 @@ pub struct GetParametersByPathRequest {
     pub with_decryption: Option<bool>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetParametersByPathResult {
     /// <p>The token for the next set of items to return. Use this token to get the next set of results.</p>
     #[serde(rename = "NextToken")]
@@ -2877,7 +2877,7 @@ pub struct GetParametersByPathResult {
     pub parameters: Option<Vec<Parameter>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetParametersRequest {
     /// <p>Names of the parameters for which you want to query information.</p>
     #[serde(rename = "Names")]
@@ -2888,7 +2888,7 @@ pub struct GetParametersRequest {
     pub with_decryption: Option<bool>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetParametersResult {
     /// <p>A list of parameters that are not formatted correctly or do not run when executed.</p>
     #[serde(rename = "InvalidParameters")]
@@ -2900,7 +2900,7 @@ pub struct GetParametersResult {
     pub parameters: Option<Vec<Parameter>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetPatchBaselineForPatchGroupRequest {
     /// <p>Returns he operating system rule specified for patch groups using the patch baseline.</p>
     #[serde(rename = "OperatingSystem")]
@@ -2911,7 +2911,7 @@ pub struct GetPatchBaselineForPatchGroupRequest {
     pub patch_group: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetPatchBaselineForPatchGroupResult {
     /// <p>The ID of the patch baseline that should be used for the patch group.</p>
     #[serde(rename = "BaselineId")]
@@ -2927,14 +2927,14 @@ pub struct GetPatchBaselineForPatchGroupResult {
     pub patch_group: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetPatchBaselineRequest {
     /// <p>The ID of the patch baseline to retrieve.</p>
     #[serde(rename = "BaselineId")]
     pub baseline_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetPatchBaselineResult {
     /// <p>A set of rules used to include patches in the baseline.</p>
     #[serde(rename = "ApprovalRules")]
@@ -2995,7 +2995,7 @@ pub struct GetPatchBaselineResult {
 }
 
 /// <p>Status information about the aggregated associations.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct InstanceAggregatedAssociationOverview {
     /// <p>Detailed status information about the aggregated associations.</p>
     #[serde(rename = "DetailedStatus")]
@@ -3009,7 +3009,7 @@ pub struct InstanceAggregatedAssociationOverview {
 }
 
 /// <p>One or more association documents on the instance. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct InstanceAssociation {
     /// <p>The association ID.</p>
     #[serde(rename = "AssociationId")]
@@ -3030,7 +3030,7 @@ pub struct InstanceAssociation {
 }
 
 /// <p>An Amazon S3 bucket where you want to store the results of this request.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct InstanceAssociationOutputLocation {
     /// <p>An Amazon S3 bucket where you want to store the results of this request.</p>
     #[serde(rename = "S3Location")]
@@ -3039,7 +3039,7 @@ pub struct InstanceAssociationOutputLocation {
 }
 
 /// <p>The URL of Amazon S3 bucket where you want to store the results of this request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct InstanceAssociationOutputUrl {
     /// <p>The URL of Amazon S3 bucket where you want to store the results of this request.</p>
     #[serde(rename = "S3OutputUrl")]
@@ -3048,7 +3048,7 @@ pub struct InstanceAssociationOutputUrl {
 }
 
 /// <p>Status information about the instance association.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct InstanceAssociationStatusInfo {
     /// <p>The association ID.</p>
     #[serde(rename = "AssociationId")]
@@ -3101,7 +3101,7 @@ pub struct InstanceAssociationStatusInfo {
 }
 
 /// <p>Describes a filter for a specific list of instances. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct InstanceInformation {
     /// <p>The activation ID created by Systems Manager when the server or VM was registered.</p>
     #[serde(rename = "ActivationId")]
@@ -3182,7 +3182,7 @@ pub struct InstanceInformation {
 }
 
 /// <p>Describes a filter for a specific list of instances. </p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct InstanceInformationFilter {
     /// <p>The name of the filter. </p>
     #[serde(rename = "key")]
@@ -3193,7 +3193,7 @@ pub struct InstanceInformationFilter {
 }
 
 /// <p>The filters to describe or get information about your managed instances.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct InstanceInformationStringFilter {
     /// <p>The filter key name to describe your instances. For example:</p> <p>"InstanceIds"|"AgentVersion"|"PingStatus"|"PlatformTypes"|"ActivationIds"|"IamRole"|"ResourceType"|"AssociationStatus"|"Tag Key"</p>
     #[serde(rename = "Key")]
@@ -3204,7 +3204,7 @@ pub struct InstanceInformationStringFilter {
 }
 
 /// <p>Defines the high-level patch compliance state for a managed instance, providing information about the number of installed, missing, not applicable, and failed patches along with metadata about the operation when this information was gathered for the instance.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct InstancePatchState {
     /// <p>The ID of the patch baseline used to patch the instance.</p>
     #[serde(rename = "BaselineId")]
@@ -3255,7 +3255,7 @@ pub struct InstancePatchState {
 }
 
 /// <p>Defines a filter used in DescribeInstancePatchStatesForPatchGroup used to scope down the information returned by the API.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct InstancePatchStateFilter {
     /// <p>The key for the filter. Supported values are FailedCount, InstalledCount, InstalledOtherCount, MissingCount and NotApplicableCount.</p>
     #[serde(rename = "Key")]
@@ -3269,7 +3269,7 @@ pub struct InstancePatchStateFilter {
 }
 
 /// <p>Specifies the inventory type and attribute for the aggregation execution.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct InventoryAggregator {
     /// <p>Nested aggregators to further refine aggregation for an inventory type.</p>
     #[serde(rename = "Aggregators")]
@@ -3282,7 +3282,7 @@ pub struct InventoryAggregator {
 }
 
 /// <p>One or more filters. Use a filter to return a more specific list of results.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct InventoryFilter {
     /// <p>The name of the filter key.</p>
     #[serde(rename = "Key")]
@@ -3297,7 +3297,7 @@ pub struct InventoryFilter {
 }
 
 /// <p>Information collected from managed instances based on your inventory policy document</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct InventoryItem {
     /// <p>The time the inventory information was collected.</p>
     #[serde(rename = "CaptureTime")]
@@ -3323,7 +3323,7 @@ pub struct InventoryItem {
 }
 
 /// <p>Attributes are the entries within the inventory item content. It contains name and value.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct InventoryItemAttribute {
     /// <p>The data type of the inventory item attribute. </p>
     #[serde(rename = "DataType")]
@@ -3334,7 +3334,7 @@ pub struct InventoryItemAttribute {
 }
 
 /// <p>The inventory item schema definition. Users can use this to compose inventory query filters.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct InventoryItemSchema {
     /// <p>The schema attributes for inventory. This contains data type and attribute name.</p>
     #[serde(rename = "Attributes")]
@@ -3353,7 +3353,7 @@ pub struct InventoryItemSchema {
 }
 
 /// <p>Inventory query results.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct InventoryResultEntity {
     /// <p>The data section in the inventory result entity JSON.</p>
     #[serde(rename = "Data")]
@@ -3366,7 +3366,7 @@ pub struct InventoryResultEntity {
 }
 
 /// <p>The inventory result item.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct InventoryResultItem {
     /// <p>The time inventory item data was captured.</p>
     #[serde(rename = "CaptureTime")]
@@ -3387,7 +3387,7 @@ pub struct InventoryResultItem {
     pub type_name: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListAssociationVersionsRequest {
     /// <p>The association ID for which you want to view all versions.</p>
     #[serde(rename = "AssociationId")]
@@ -3402,7 +3402,7 @@ pub struct ListAssociationVersionsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListAssociationVersionsResult {
     /// <p>Information about all versions of the association for the specified association ID.</p>
     #[serde(rename = "AssociationVersions")]
@@ -3414,7 +3414,7 @@ pub struct ListAssociationVersionsResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListAssociationsRequest {
     /// <p>One or more filters. Use a filter to return a more specific list of results.</p>
     #[serde(rename = "AssociationFilterList")]
@@ -3430,7 +3430,7 @@ pub struct ListAssociationsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListAssociationsResult {
     /// <p>The associations.</p>
     #[serde(rename = "Associations")]
@@ -3442,7 +3442,7 @@ pub struct ListAssociationsResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListCommandInvocationsRequest {
     /// <p>(Optional) The invocations for a specific command ID.</p>
     #[serde(rename = "CommandId")]
@@ -3470,7 +3470,7 @@ pub struct ListCommandInvocationsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListCommandInvocationsResult {
     /// <p>(Optional) A list of all invocations. </p>
     #[serde(rename = "CommandInvocations")]
@@ -3482,7 +3482,7 @@ pub struct ListCommandInvocationsResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListCommandsRequest {
     /// <p>(Optional) If provided, lists only the specified command.</p>
     #[serde(rename = "CommandId")]
@@ -3506,7 +3506,7 @@ pub struct ListCommandsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListCommandsResult {
     /// <p>(Optional) The list of commands requested by the user. </p>
     #[serde(rename = "Commands")]
@@ -3518,7 +3518,7 @@ pub struct ListCommandsResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListComplianceItemsRequest {
     /// <p>One or more compliance filters. Use a filter to return a more specific list of results.</p>
     #[serde(rename = "Filters")]
@@ -3542,7 +3542,7 @@ pub struct ListComplianceItemsRequest {
     pub resource_types: Option<Vec<String>>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListComplianceItemsResult {
     /// <p>A list of compliance information for the specified resource ID. </p>
     #[serde(rename = "ComplianceItems")]
@@ -3554,7 +3554,7 @@ pub struct ListComplianceItemsResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListComplianceSummariesRequest {
     /// <p>One or more compliance or inventory filters. Use a filter to return a more specific list of results.</p>
     #[serde(rename = "Filters")]
@@ -3570,7 +3570,7 @@ pub struct ListComplianceSummariesRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListComplianceSummariesResult {
     /// <p>A list of compliant and non-compliant summary counts based on compliance types. For example, this call returns State Manager associations, patches, or custom compliance types according to the filter criteria that you specified.</p>
     #[serde(rename = "ComplianceSummaryItems")]
@@ -3582,7 +3582,7 @@ pub struct ListComplianceSummariesResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListDocumentVersionsRequest {
     /// <p>The maximum number of items to return for this call. The call also returns a token that you can specify in a subsequent call to get the next set of results.</p>
     #[serde(rename = "MaxResults")]
@@ -3597,7 +3597,7 @@ pub struct ListDocumentVersionsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListDocumentVersionsResult {
     /// <p>The document versions.</p>
     #[serde(rename = "DocumentVersions")]
@@ -3609,7 +3609,7 @@ pub struct ListDocumentVersionsResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListDocumentsRequest {
     /// <p>One or more filters. Use a filter to return a more specific list of results.</p>
     #[serde(rename = "DocumentFilterList")]
@@ -3629,7 +3629,7 @@ pub struct ListDocumentsRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListDocumentsResult {
     /// <p>The names of the Systems Manager documents.</p>
     #[serde(rename = "DocumentIdentifiers")]
@@ -3641,7 +3641,7 @@ pub struct ListDocumentsResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListInventoryEntriesRequest {
     /// <p>One or more filters. Use a filter to return a more specific list of results.</p>
     #[serde(rename = "Filters")]
@@ -3663,7 +3663,7 @@ pub struct ListInventoryEntriesRequest {
     pub type_name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListInventoryEntriesResult {
     /// <p>The time that inventory information was collected for the instance(s).</p>
     #[serde(rename = "CaptureTime")]
@@ -3691,7 +3691,7 @@ pub struct ListInventoryEntriesResult {
     pub type_name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListResourceComplianceSummariesRequest {
     /// <p>One or more filters. Use a filter to return a more specific list of results.</p>
     #[serde(rename = "Filters")]
@@ -3707,7 +3707,7 @@ pub struct ListResourceComplianceSummariesRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListResourceComplianceSummariesResult {
     /// <p>The token for the next set of items to return. Use this token to get the next set of results.</p>
     #[serde(rename = "NextToken")]
@@ -3719,7 +3719,7 @@ pub struct ListResourceComplianceSummariesResult {
     pub resource_compliance_summary_items: Option<Vec<ResourceComplianceSummaryItem>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListResourceDataSyncRequest {
     /// <p>The maximum number of items to return for this call. The call also returns a token that you can specify in a subsequent call to get the next set of results.</p>
     #[serde(rename = "MaxResults")]
@@ -3731,7 +3731,7 @@ pub struct ListResourceDataSyncRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListResourceDataSyncResult {
     /// <p>The token for the next set of items to return. Use this token to get the next set of results.</p>
     #[serde(rename = "NextToken")]
@@ -3743,7 +3743,7 @@ pub struct ListResourceDataSyncResult {
     pub resource_data_sync_items: Option<Vec<ResourceDataSyncItem>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListTagsForResourceRequest {
     /// <p>The resource ID for which you want to see a list of tags.</p>
     #[serde(rename = "ResourceId")]
@@ -3753,7 +3753,7 @@ pub struct ListTagsForResourceRequest {
     pub resource_type: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListTagsForResourceResult {
     /// <p>A list of tags.</p>
     #[serde(rename = "TagList")]
@@ -3762,7 +3762,7 @@ pub struct ListTagsForResourceResult {
 }
 
 /// <p><p>Information about an Amazon S3 bucket to write instance-level logs to.</p> <note> <p> <code>LoggingInfo</code> has been deprecated. To specify an S3 bucket to contain logs, instead use the <code>OutputS3BucketName</code> and <code>OutputS3KeyPrefix</code> options in the <code>TaskInvocationParameters</code> structure. For information about how Systems Manager handles these options for the supported Maintenance Window task types, see <a>MaintenanceWindowTaskInvocationParameters</a>.</p> </note></p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct LoggingInfo {
     /// <p>The name of an Amazon S3 bucket where execution logs are stored .</p>
     #[serde(rename = "S3BucketName")]
@@ -3777,7 +3777,7 @@ pub struct LoggingInfo {
 }
 
 /// <p>The parameters for an AUTOMATION task type.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct MaintenanceWindowAutomationParameters {
     /// <p>The version of an Automation document to use during task execution.</p>
     #[serde(rename = "DocumentVersion")]
@@ -3790,7 +3790,7 @@ pub struct MaintenanceWindowAutomationParameters {
 }
 
 /// <p>Describes the information about an execution of a Maintenance Window. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct MaintenanceWindowExecution {
     /// <p>The time the execution finished.</p>
     #[serde(rename = "EndTime")]
@@ -3819,7 +3819,7 @@ pub struct MaintenanceWindowExecution {
 }
 
 /// <p>Information about a task execution performed as part of a Maintenance Window execution.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct MaintenanceWindowExecutionTaskIdentity {
     /// <p>The time the task execution finished.</p>
     #[serde(rename = "EndTime")]
@@ -3856,7 +3856,7 @@ pub struct MaintenanceWindowExecutionTaskIdentity {
 }
 
 /// <p>Describes the information about a task invocation for a particular target as part of a task execution performed as part of a Maintenance Window execution.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct MaintenanceWindowExecutionTaskInvocationIdentity {
     /// <p>The time the invocation finished.</p>
     #[serde(rename = "EndTime")]
@@ -3909,7 +3909,7 @@ pub struct MaintenanceWindowExecutionTaskInvocationIdentity {
 }
 
 /// <p>Filter used in the request.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct MaintenanceWindowFilter {
     /// <p>The name of the filter.</p>
     #[serde(rename = "Key")]
@@ -3922,7 +3922,7 @@ pub struct MaintenanceWindowFilter {
 }
 
 /// <p>Information about the Maintenance Window.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct MaintenanceWindowIdentity {
     /// <p>The number of hours before the end of the Maintenance Window that Systems Manager stops scheduling new tasks for execution.</p>
     #[serde(rename = "Cutoff")]
@@ -3951,7 +3951,7 @@ pub struct MaintenanceWindowIdentity {
 }
 
 /// <p><p>The parameters for a LAMBDA task type.</p> <p>For information about specifying and updating task parameters, see <a>RegisterTaskWithMaintenanceWindow</a> and <a>UpdateMaintenanceWindowTask</a>.</p> <note> <p> <code>LoggingInfo</code> has been deprecated. To specify an S3 bucket to contain logs, instead use the <code>OutputS3BucketName</code> and <code>OutputS3KeyPrefix</code> options in the <code>TaskInvocationParameters</code> structure. For information about how Systems Manager handles these options for the supported Maintenance Window task types, see <a>MaintenanceWindowTaskInvocationParameters</a>.</p> <p> <code>TaskParameters</code> has been deprecated. To specify parameters to pass to a task when it runs, instead use the <code>Parameters</code> option in the <code>TaskInvocationParameters</code> structure. For information about how Systems Manager handles these options for the supported Maintenance Window task types, see <a>MaintenanceWindowTaskInvocationParameters</a>.</p> <p>For Lambda tasks, Systems Manager ignores any values specified for TaskParameters and LoggingInfo.</p> </note></p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct MaintenanceWindowLambdaParameters {
     /// <p>Pass client-specific information to the Lambda function that you are invoking. You can then process the client information in your Lambda function as you choose through the context variable.</p>
     #[serde(rename = "ClientContext")]
@@ -3972,7 +3972,7 @@ pub struct MaintenanceWindowLambdaParameters {
 }
 
 /// <p><p>The parameters for a RUN_COMMAND task type.</p> <p>For information about specifying and updating task parameters, see <a>RegisterTaskWithMaintenanceWindow</a> and <a>UpdateMaintenanceWindowTask</a>.</p> <note> <p> <code>LoggingInfo</code> has been deprecated. To specify an S3 bucket to contain logs, instead use the <code>OutputS3BucketName</code> and <code>OutputS3KeyPrefix</code> options in the <code>TaskInvocationParameters</code> structure. For information about how Systems Manager handles these options for the supported Maintenance Window task types, see <a>MaintenanceWindowTaskInvocationParameters</a>.</p> <p> <code>TaskParameters</code> has been deprecated. To specify parameters to pass to a task when it runs, instead use the <code>Parameters</code> option in the <code>TaskInvocationParameters</code> structure. For information about how Systems Manager handles these options for the supported Maintenance Window task types, see <a>MaintenanceWindowTaskInvocationParameters</a>.</p> <p>For Run Command tasks, Systems Manager uses specified values for <code>TaskParameters</code> and <code>LoggingInfo</code> only if no values are specified for <code>TaskInvocationParameters</code>. </p> </note></p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct MaintenanceWindowRunCommandParameters {
     /// <p>Information about the command(s) to execute.</p>
     #[serde(rename = "Comment")]
@@ -4013,7 +4013,7 @@ pub struct MaintenanceWindowRunCommandParameters {
 }
 
 /// <p><p>The parameters for a STEP_FUNCTION task.</p> <p>For information about specifying and updating task parameters, see <a>RegisterTaskWithMaintenanceWindow</a> and <a>UpdateMaintenanceWindowTask</a>.</p> <note> <p> <code>LoggingInfo</code> has been deprecated. To specify an S3 bucket to contain logs, instead use the <code>OutputS3BucketName</code> and <code>OutputS3KeyPrefix</code> options in the <code>TaskInvocationParameters</code> structure. For information about how Systems Manager handles these options for the supported Maintenance Window task types, see <a>MaintenanceWindowTaskInvocationParameters</a>.</p> <p> <code>TaskParameters</code> has been deprecated. To specify parameters to pass to a task when it runs, instead use the <code>Parameters</code> option in the <code>TaskInvocationParameters</code> structure. For information about how Systems Manager handles these options for the supported Maintenance Window task types, see <a>MaintenanceWindowTaskInvocationParameters</a>.</p> <p>For Step Functions tasks, Systems Manager ignores any values specified for <code>TaskParameters</code> and <code>LoggingInfo</code>.</p> </note></p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct MaintenanceWindowStepFunctionsParameters {
     /// <p>The inputs for the STEP_FUNCTION task.</p>
     #[serde(rename = "Input")]
@@ -4026,7 +4026,7 @@ pub struct MaintenanceWindowStepFunctionsParameters {
 }
 
 /// <p>The target registered with the Maintenance Window.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct MaintenanceWindowTarget {
     /// <p>A description of the target.</p>
     #[serde(rename = "Description")]
@@ -4059,7 +4059,7 @@ pub struct MaintenanceWindowTarget {
 }
 
 /// <p>Information about a task defined for a Maintenance Window.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct MaintenanceWindowTask {
     /// <p>A description of the task.</p>
     #[serde(rename = "Description")]
@@ -4117,7 +4117,7 @@ pub struct MaintenanceWindowTask {
 }
 
 /// <p>The parameters for task execution.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct MaintenanceWindowTaskInvocationParameters {
     /// <p>The parameters for an AUTOMATION task type.</p>
     #[serde(rename = "Automation")]
@@ -4138,7 +4138,7 @@ pub struct MaintenanceWindowTaskInvocationParameters {
 }
 
 /// <p>Defines the values for a task parameter.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct MaintenanceWindowTaskParameterValueExpression {
     /// <p>This field contains an array of 0 or more strings, each 1 to 255 characters in length.</p>
     #[serde(rename = "Values")]
@@ -4146,7 +4146,7 @@ pub struct MaintenanceWindowTaskParameterValueExpression {
     pub values: Option<Vec<String>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ModifyDocumentPermissionRequest {
     /// <p>The AWS user accounts that should have access to the document. The account IDs can either be a group of account IDs or <i>All</i>.</p>
     #[serde(rename = "AccountIdsToAdd")]
@@ -4164,11 +4164,11 @@ pub struct ModifyDocumentPermissionRequest {
     pub permission_type: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ModifyDocumentPermissionResponse {}
 
 /// <p>A summary of resources that are not compliant. The summary is organized according to resource type.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct NonCompliantSummary {
     /// <p>The total number of compliance items that are not compliant.</p>
     #[serde(rename = "NonCompliantCount")]
@@ -4181,7 +4181,7 @@ pub struct NonCompliantSummary {
 }
 
 /// <p>Configurations for sending notifications.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct NotificationConfig {
     /// <p>An Amazon Resource Name (ARN) for a Simple Notification Service (SNS) topic. Run Command pushes notifications about command status changes to this topic.</p>
     #[serde(rename = "NotificationArn")]
@@ -4198,7 +4198,7 @@ pub struct NotificationConfig {
 }
 
 /// <p>An Amazon EC2 Systems Manager parameter in Parameter Store.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Parameter {
     /// <p>The name of the parameter.</p>
     #[serde(rename = "Name")]
@@ -4219,7 +4219,7 @@ pub struct Parameter {
 }
 
 /// <p>Information about parameter usage.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ParameterHistory {
     /// <p>Parameter names can include the following letters and symbols.</p> <p>a-zA-Z0-9_.-</p>
     #[serde(rename = "AllowedPattern")]
@@ -4260,7 +4260,7 @@ pub struct ParameterHistory {
 }
 
 /// <p>Metada includes information like the ARN of the last user and the date/time the parameter was last used.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ParameterMetadata {
     /// <p>A parameter name can include only the following letters and symbols.</p> <p>a-zA-Z0-9_.-</p>
     #[serde(rename = "AllowedPattern")]
@@ -4297,7 +4297,7 @@ pub struct ParameterMetadata {
 }
 
 /// <p>One or more filters. Use a filter to return a more specific list of results.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ParameterStringFilter {
     /// <p>The name of the filter.</p>
     #[serde(rename = "Key")]
@@ -4313,7 +4313,7 @@ pub struct ParameterStringFilter {
 }
 
 /// <p>This data type is deprecated. Instead, use <a>ParameterStringFilter</a>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ParametersFilter {
     /// <p>The name of the filter.</p>
     #[serde(rename = "Key")]
@@ -4324,7 +4324,7 @@ pub struct ParametersFilter {
 }
 
 /// <p>Represents metadata about a patch.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Patch {
     /// <p>The classification of the patch (for example, SecurityUpdates, Updates, CriticalUpdates).</p>
     #[serde(rename = "Classification")]
@@ -4381,7 +4381,7 @@ pub struct Patch {
 }
 
 /// <p>Defines the basic information about a patch baseline.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PatchBaselineIdentity {
     /// <p>The description of the patch baseline.</p>
     #[serde(rename = "BaselineDescription")]
@@ -4406,7 +4406,7 @@ pub struct PatchBaselineIdentity {
 }
 
 /// <p>Information about the state of a patch on a particular instance as it relates to the patch baseline used to patch the instance.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PatchComplianceData {
     /// <p>The classification of the patch (for example, SecurityUpdates, Updates, CriticalUpdates).</p>
     #[serde(rename = "Classification")]
@@ -4429,7 +4429,7 @@ pub struct PatchComplianceData {
 }
 
 /// <p><p>Defines a patch filter.</p> <p>A patch filter consists of key/value pairs, but not all keys are valid for all operating system types. For example, the key <code>PRODUCT</code> is valid for all supported operating system types. The key <code>MSRC<em>SEVERITY</code>, however, is valid only for Windows operating systems, and the key <code>SECTION</code> is valid only for Ubuntu operating systems.</p> <p>Refer to the following sections for information about which keys may be used with each major operating system, and which values are valid for each key.</p> <p> <b>Windows Operating Systems</b> </p> <p>The supported keys for Windows operating systems are <code>PRODUCT</code>, <code>CLASSIFICATION</code>, and <code>MSRC</em>SEVERITY</code>. See the following lists for valid values for each of these keys.</p> <p> <i>Supported key:</i> <code>PRODUCT</code> </p> <p> <i>Supported values:</i> </p> <ul> <li> <p> <code>Windows7</code> </p> </li> <li> <p> <code>Windows8</code> </p> </li> <li> <p> <code>Windows8.1</code> </p> </li> <li> <p> <code>Windows8Embedded</code> </p> </li> <li> <p> <code>Windows10</code> </p> </li> <li> <p> <code>Windows10LTSB</code> </p> </li> <li> <p> <code>WindowsServer2008</code> </p> </li> <li> <p> <code>WindowsServer2008R2</code> </p> </li> <li> <p> <code>WindowsServer2012</code> </p> </li> <li> <p> <code>WindowsServer2012R2</code> </p> </li> <li> <p> <code>WindowsServer2016</code> </p> </li> </ul> <p> <i>Supported key:</i> <code>CLASSIFICATION</code> </p> <p> <i>Supported values:</i> </p> <ul> <li> <p> <code>CriticalUpdates</code> </p> </li> <li> <p> <code>DefinitionUpdates</code> </p> </li> <li> <p> <code>Drivers</code> </p> </li> <li> <p> <code>FeaturePacks</code> </p> </li> <li> <p> <code>SecurityUpdates</code> </p> </li> <li> <p> <code>ServicePacks</code> </p> </li> <li> <p> <code>Tools</code> </p> </li> <li> <p> <code>UpdateRollups</code> </p> </li> <li> <p> <code>Updates</code> </p> </li> <li> <p> <code>Upgrades</code> </p> </li> </ul> <p> <i>Supported key:</i> <code>MSRC_SEVERITY</code> </p> <p> <i>Supported values:</i> </p> <ul> <li> <p> <code>Critical</code> </p> </li> <li> <p> <code>Important</code> </p> </li> <li> <p> <code>Moderate</code> </p> </li> <li> <p> <code>Low</code> </p> </li> <li> <p> <code>Unspecified</code> </p> </li> </ul> <p> <b>Ubuntu Operating Systems</b> </p> <p>The supported keys for Ubuntu operating systems are <code>PRODUCT</code>, <code>PRIORITY</code>, and <code>SECTION</code>. See the following lists for valid values for each of these keys.</p> <p> <i>Supported key:</i> <code>PRODUCT</code> </p> <p> <i>Supported values:</i> </p> <ul> <li> <p> <code>Ubuntu14.04</code> </p> </li> <li> <p> <code>Ubuntu16.04</code> </p> </li> </ul> <p> <i>Supported key:</i> <code>PRIORITY</code> </p> <p> <i>Supported values:</i> </p> <ul> <li> <p> <code>Required</code> </p> </li> <li> <p> <code>Important</code> </p> </li> <li> <p> <code>Standard</code> </p> </li> <li> <p> <code>Optional</code> </p> </li> <li> <p> <code>Extra</code> </p> </li> </ul> <p> <i>Supported key:</i> <code>SECTION</code> </p> <p>Only the length of the key value is validated. Minimum length is 1. Maximum length is 64.</p> <p> <b>Amazon Linux Operating Systems</b> </p> <p>The supported keys for Amazon Linux operating systems are <code>PRODUCT</code>, <code>CLASSIFICATION</code>, and <code>SEVERITY</code>. See the following lists for valid values for each of these keys.</p> <p> <i>Supported key:</i> <code>PRODUCT</code> </p> <p> <i>Supported values:</i> </p> <ul> <li> <p> <code>AmazonLinux2012.03</code> </p> </li> <li> <p> <code>AmazonLinux2012.09</code> </p> </li> <li> <p> <code>AmazonLinux2013.03</code> </p> </li> <li> <p> <code>AmazonLinux2013.09</code> </p> </li> <li> <p> <code>AmazonLinux2014.03</code> </p> </li> <li> <p> <code>AmazonLinux2014.09</code> </p> </li> <li> <p> <code>AmazonLinux2015.03</code> </p> </li> <li> <p> <code>AmazonLinux2015.09</code> </p> </li> <li> <p> <code>AmazonLinux2016.03</code> </p> </li> <li> <p> <code>AmazonLinux2016.09</code> </p> </li> <li> <p> <code>AmazonLinux2017.03</code> </p> </li> <li> <p> <code>AmazonLinux2017.09</code> </p> </li> </ul> <p> <i>Supported key:</i> <code>CLASSIFICATION</code> </p> <p> <i>Supported values:</i> </p> <ul> <li> <p> <code>Security</code> </p> </li> <li> <p> <code>Bugfix</code> </p> </li> <li> <p> <code>Enhancement</code> </p> </li> <li> <p> <code>Recommended</code> </p> </li> <li> <p> <code>Newpackage</code> </p> </li> </ul> <p> <i>Supported key:</i> <code>SEVERITY</code> </p> <p> <i>Supported values:</i> </p> <ul> <li> <p> <code>Critical</code> </p> </li> <li> <p> <code>Important</code> </p> </li> <li> <p> <code>Medium</code> </p> </li> <li> <p> <code>Low</code> </p> </li> </ul> <p> <b>RedHat Enterprise Linux (RHEL) Operating Systems</b> </p> <p>The supported keys for RedHat Enterprise Linux operating systems are <code>PRODUCT</code>, <code>CLASSIFICATION</code>, and <code>SEVERITY</code>. See the following lists for valid values for each of these keys.</p> <p> <i>Supported key:</i> <code>PRODUCT</code> </p> <p> <i>Supported values:</i> </p> <ul> <li> <p> <code>RedhatEnterpriseLinux6.5</code> </p> </li> <li> <p> <code>RedhatEnterpriseLinux6.6</code> </p> </li> <li> <p> <code>RedhatEnterpriseLinux6.7</code> </p> </li> <li> <p> <code>RedhatEnterpriseLinux6.8</code> </p> </li> <li> <p> <code>RedhatEnterpriseLinux6.9</code> </p> </li> <li> <p> <code>RedhatEnterpriseLinux7.0</code> </p> </li> <li> <p> <code>RedhatEnterpriseLinux7.1</code> </p> </li> <li> <p> <code>RedhatEnterpriseLinux7.2</code> </p> </li> <li> <p> <code>RedhatEnterpriseLinux7.3</code> </p> </li> <li> <p> <code>RedhatEnterpriseLinux7.4</code> </p> </li> </ul> <p> <i>Supported key:</i> <code>CLASSIFICATION</code> </p> <p> <i>Supported values:</i> </p> <ul> <li> <p> <code>Security</code> </p> </li> <li> <p> <code>Bugfix</code> </p> </li> <li> <p> <code>Enhancement</code> </p> </li> <li> <p> <code>Recommended</code> </p> </li> <li> <p> <code>Newpackage</code> </p> </li> </ul> <p> <i>Supported key:</i> <code>SEVERITY</code> </p> <p> <i>Supported values:</i> </p> <ul> <li> <p> <code>Critical</code> </p> </li> <li> <p> <code>Important</code> </p> </li> <li> <p> <code>Medium</code> </p> </li> <li> <p> <code>Low</code> </p> </li> </ul> <p> <b>SUSE Linux Enterprise Server (SUSE) Operating Systems</b> </p> <p>The supported keys for SUSE operating systems are <code>PRODUCT</code>, <code>CLASSIFICATION</code>, and <code>SEVERITY</code>. See the following lists for valid values for each of these keys.</p> <p> <i>Supported key:</i> <code>PRODUCT</code> </p> <p> <i>Supported values:</i> </p> <ul> <li> <p> <code>Suse12.0</code> </p> </li> <li> <p> <code>Suse12.1</code> </p> </li> <li> <p> <code>Suse12.2</code> </p> </li> <li> <p> <code>Suse12.3</code> </p> </li> <li> <p> <code>Suse12.4</code> </p> </li> <li> <p> <code>Suse12.5</code> </p> </li> <li> <p> <code>Suse12.6</code> </p> </li> <li> <p> <code>Suse12.7</code> </p> </li> <li> <p> <code>Suse12.8</code> </p> </li> <li> <p> <code>Suse12.9</code> </p> </li> </ul> <p> <i>Supported key:</i> <code>CLASSIFICATION</code> </p> <p> <i>Supported values:</i> </p> <ul> <li> <p> <code>Security</code> </p> </li> <li> <p> <code>Recommended</code> </p> </li> <li> <p> <code>Optional</code> </p> </li> <li> <p> <code>Feature</code> </p> </li> <li> <p> <code>Document</code> </p> </li> <li> <p> <code>Yast</code> </p> </li> </ul> <p> <i>Supported key:</i> <code>SEVERITY</code> </p> <p> <i>Supported values:</i> </p> <ul> <li> <p> <code>Critical</code> </p> </li> <li> <p> <code>Important</code> </p> </li> <li> <p> <code>Moderate</code> </p> </li> <li> <p> <code>Low</code> </p> </li> </ul></p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct PatchFilter {
     /// <p>The key for the filter.</p> <p>See <a>PatchFilter</a> for lists of valid keys for each operating system type.</p>
     #[serde(rename = "Key")]
@@ -4440,7 +4440,7 @@ pub struct PatchFilter {
 }
 
 /// <p>A set of patch filters, typically used for approval rules.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct PatchFilterGroup {
     /// <p>The set of patch filters that make up the group.</p>
     #[serde(rename = "PatchFilters")]
@@ -4448,7 +4448,7 @@ pub struct PatchFilterGroup {
 }
 
 /// <p>The mapping between a patch group and the patch baseline the patch group is registered with.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PatchGroupPatchBaselineMapping {
     /// <p>The patch baseline the patch group is registered with.</p>
     #[serde(rename = "BaselineIdentity")]
@@ -4461,7 +4461,7 @@ pub struct PatchGroupPatchBaselineMapping {
 }
 
 /// <p>Defines a filter used in Patch Manager APIs.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PatchOrchestratorFilter {
     /// <p>The key for the filter.</p>
     #[serde(rename = "Key")]
@@ -4474,7 +4474,7 @@ pub struct PatchOrchestratorFilter {
 }
 
 /// <p>Defines an approval rule for a patch baseline.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct PatchRule {
     /// <p>The number of days after the release date of each patch matched by the rule the patch is marked as approved in the patch baseline.</p>
     #[serde(rename = "ApproveAfterDays")]
@@ -4493,7 +4493,7 @@ pub struct PatchRule {
 }
 
 /// <p>A set of rules defining the approval rules for a patch baseline.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct PatchRuleGroup {
     /// <p>The rules that make up the rule group.</p>
     #[serde(rename = "PatchRules")]
@@ -4501,7 +4501,7 @@ pub struct PatchRuleGroup {
 }
 
 /// <p>Information about the patches to use to update the instances, including target operating systems and source repository. Applies to Linux instances only.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct PatchSource {
     /// <p>The value of the yum repo configuration. For example:</p> <p> <code>cachedir=/var/cache/yum/$basesearch</code> </p> <p> <code>$releasever</code> </p> <p> <code>keepcache=0</code> </p> <p> <code>debualevel=2</code> </p>
     #[serde(rename = "Configuration")]
@@ -4515,7 +4515,7 @@ pub struct PatchSource {
 }
 
 /// <p>Information about the approval status of a patch.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PatchStatus {
     /// <p>The date the patch was approved (or will be approved if the status is PENDING_APPROVAL).</p>
     #[serde(rename = "ApprovalDate")]
@@ -4531,7 +4531,7 @@ pub struct PatchStatus {
     pub deployment_status: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PutComplianceItemsRequest {
     /// <p>Specify the compliance type. For example, specify Association (for a State Manager association), Patch, or Custom:<code>string</code>.</p>
     #[serde(rename = "ComplianceType")]
@@ -4554,10 +4554,10 @@ pub struct PutComplianceItemsRequest {
     pub resource_type: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PutComplianceItemsResult {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PutInventoryRequest {
     /// <p>One or more instance IDs where you want to add or update inventory items.</p>
     #[serde(rename = "InstanceId")]
@@ -4567,10 +4567,10 @@ pub struct PutInventoryRequest {
     pub items: Vec<InventoryItem>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PutInventoryResult {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PutParameterRequest {
     /// <p>A regular expression used to validate the parameter value. For example, for String types with values restricted to numbers, you can specify the following: AllowedPattern=^\d+$ </p>
     #[serde(rename = "AllowedPattern")]
@@ -4599,7 +4599,7 @@ pub struct PutParameterRequest {
     pub value: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PutParameterResult {
     /// <p>The new version number of a parameter. If you edit a parameter value, Parameter Store automatically creates a new version and assigns this new version a unique ID. You can reference a parameter version ID in API actions or in Systems Manager documents (SSM documents). By default, if you don't specify a specific version, the system returns the latest parameter value when a parameter is called.</p>
     #[serde(rename = "Version")]
@@ -4607,14 +4607,14 @@ pub struct PutParameterResult {
     pub version: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RegisterDefaultPatchBaselineRequest {
     /// <p>The ID of the patch baseline that should be the default patch baseline.</p>
     #[serde(rename = "BaselineId")]
     pub baseline_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RegisterDefaultPatchBaselineResult {
     /// <p>The ID of the default patch baseline.</p>
     #[serde(rename = "BaselineId")]
@@ -4622,7 +4622,7 @@ pub struct RegisterDefaultPatchBaselineResult {
     pub baseline_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RegisterPatchBaselineForPatchGroupRequest {
     /// <p>The ID of the patch baseline to register the patch group with.</p>
     #[serde(rename = "BaselineId")]
@@ -4632,7 +4632,7 @@ pub struct RegisterPatchBaselineForPatchGroupRequest {
     pub patch_group: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RegisterPatchBaselineForPatchGroupResult {
     /// <p>The ID of the patch baseline the patch group was registered with.</p>
     #[serde(rename = "BaselineId")]
@@ -4644,7 +4644,7 @@ pub struct RegisterPatchBaselineForPatchGroupResult {
     pub patch_group: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RegisterTargetWithMaintenanceWindowRequest {
     /// <p>User-provided idempotency token.</p>
     #[serde(rename = "ClientToken")]
@@ -4673,7 +4673,7 @@ pub struct RegisterTargetWithMaintenanceWindowRequest {
     pub window_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RegisterTargetWithMaintenanceWindowResult {
     /// <p>The ID of the target definition in this Maintenance Window.</p>
     #[serde(rename = "WindowTargetId")]
@@ -4681,7 +4681,7 @@ pub struct RegisterTargetWithMaintenanceWindowResult {
     pub window_target_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RegisterTaskWithMaintenanceWindowRequest {
     /// <p>User-provided idempotency token.</p>
     #[serde(rename = "ClientToken")]
@@ -4735,7 +4735,7 @@ pub struct RegisterTaskWithMaintenanceWindowRequest {
     pub window_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RegisterTaskWithMaintenanceWindowResult {
     /// <p>The id of the task in the Maintenance Window.</p>
     #[serde(rename = "WindowTaskId")]
@@ -4743,7 +4743,7 @@ pub struct RegisterTaskWithMaintenanceWindowResult {
     pub window_task_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RemoveTagsFromResourceRequest {
     /// <p><p>The resource ID for which you want to remove tags. Use the ID of the resource. Here are some examples:</p> <p>ManagedInstance: mi-012345abcde</p> <p>MaintenanceWindow: mw-012345abcde</p> <p>PatchBaseline: pb-012345abcde</p> <p>For the Document and Parameter values, use the name of the resource.</p> <note> <p>The ManagedInstance type for this API action is only for on-premises managed instances. You must specify the the name of the managed instance in the following format: mi-ID_number. For example, mi-1a2b3c4d5e6f.</p> </note></p>
     #[serde(rename = "ResourceId")]
@@ -4756,11 +4756,11 @@ pub struct RemoveTagsFromResourceRequest {
     pub tag_keys: Vec<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RemoveTagsFromResourceResult {}
 
 /// <p>Information about targets that resolved during the Automation execution.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ResolvedTargets {
     /// <p>A list of parameter values sent to targets that resolved during the Automation execution.</p>
     #[serde(rename = "ParameterValues")]
@@ -4773,7 +4773,7 @@ pub struct ResolvedTargets {
 }
 
 /// <p>Compliance summary information for a specific resource. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ResourceComplianceSummaryItem {
     /// <p>The compliance type.</p>
     #[serde(rename = "ComplianceType")]
@@ -4810,7 +4810,7 @@ pub struct ResourceComplianceSummaryItem {
 }
 
 /// <p>Information about a Resource Data Sync configuration, including its current status and last successful sync.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ResourceDataSyncItem {
     /// <p>The status reported by the last sync.</p>
     #[serde(rename = "LastStatus")]
@@ -4843,7 +4843,7 @@ pub struct ResourceDataSyncItem {
 }
 
 /// <p>Information about the target Amazon S3 bucket for the Resource Data Sync.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ResourceDataSyncS3Destination {
     /// <p>The ARN of an encryption key for a destination in Amazon S3. Must belong to the same region as the destination Amazon S3 bucket.</p>
     #[serde(rename = "AWSKMSKeyARN")]
@@ -4865,7 +4865,7 @@ pub struct ResourceDataSyncS3Destination {
 }
 
 /// <p>The inventory item result attribute.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ResultAttribute {
     /// <p>Name of the inventory item type. Valid value: AWS:InstanceInformation. Default Value: AWS:InstanceInformation.</p>
     #[serde(rename = "TypeName")]
@@ -4873,7 +4873,7 @@ pub struct ResultAttribute {
 }
 
 /// <p>An Amazon S3 bucket where you want to store the results of this request.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct S3OutputLocation {
     /// <p>The name of the Amazon S3 bucket.</p>
     #[serde(rename = "OutputS3BucketName")]
@@ -4890,7 +4890,7 @@ pub struct S3OutputLocation {
 }
 
 /// <p>A URL for the Amazon S3 bucket where you want to store the results of this request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct S3OutputUrl {
     /// <p>A URL for an Amazon S3 bucket where you want to store the results of this request.</p>
     #[serde(rename = "OutputUrl")]
@@ -4898,7 +4898,7 @@ pub struct S3OutputUrl {
     pub output_url: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SendAutomationSignalRequest {
     /// <p>The unique identifier for an existing Automation execution that you want to send the signal to.</p>
     #[serde(rename = "AutomationExecutionId")]
@@ -4912,10 +4912,10 @@ pub struct SendAutomationSignalRequest {
     pub signal_type: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SendAutomationSignalResult {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SendCommandRequest {
     /// <p>User-specified information about the command, such as a brief description of what the command should do.</p>
     #[serde(rename = "Comment")]
@@ -4978,7 +4978,7 @@ pub struct SendCommandRequest {
     pub timeout_seconds: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SendCommandResult {
     /// <p>The request as it was received by Systems Manager. Also provides the command ID which can be used future references to this request.</p>
     #[serde(rename = "Command")]
@@ -4987,7 +4987,7 @@ pub struct SendCommandResult {
 }
 
 /// <p>The number of managed instances found for each patch severity level defined in the request filter.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SeveritySummary {
     /// <p>The total number of resources or compliance items that have a severity level of critical. Critical severity is determined by the organization that published the compliance items.</p>
     #[serde(rename = "CriticalCount")]
@@ -5015,7 +5015,7 @@ pub struct SeveritySummary {
     pub unspecified_count: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StartAutomationExecutionRequest {
     /// <p>User-provided idempotency token. The token must be unique, is case insensitive, enforces the UUID format, and can't be reused.</p>
     #[serde(rename = "ClientToken")]
@@ -5054,7 +5054,7 @@ pub struct StartAutomationExecutionRequest {
     pub targets: Option<Vec<Target>>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StartAutomationExecutionResult {
     /// <p>The unique ID of a newly scheduled automation execution.</p>
     #[serde(rename = "AutomationExecutionId")]
@@ -5063,7 +5063,7 @@ pub struct StartAutomationExecutionResult {
 }
 
 /// <p>Detailed information about an the execution state of an Automation step.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StepExecution {
     /// <p>The action this step performs. The action determines the behavior of the step.</p>
     #[serde(rename = "Action")]
@@ -5132,7 +5132,7 @@ pub struct StepExecution {
 }
 
 /// <p>A filter to limit the amount of step execution information returned by the call.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StepExecutionFilter {
     /// <p>One or more keys to limit the results. Valid filter keys include the following: StepName, Action, StepExecutionId, StepExecutionStatus, StartTimeBefore, StartTimeAfter.</p>
     #[serde(rename = "Key")]
@@ -5142,7 +5142,7 @@ pub struct StepExecutionFilter {
     pub values: Vec<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StopAutomationExecutionRequest {
     /// <p>The execution ID of the Automation to stop.</p>
     #[serde(rename = "AutomationExecutionId")]
@@ -5153,11 +5153,11 @@ pub struct StopAutomationExecutionRequest {
     pub type_: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StopAutomationExecutionResult {}
 
 /// <p>Metadata that you assign to your AWS resources. Tags enable you to categorize your resources in different ways, for example, by purpose, owner, or environment. In Systems Manager, you can apply tags to documents, managed instances, Maintenance Windows, Parameter Store parameters, and patch baselines.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Tag {
     /// <p>The name of the tag.</p>
     #[serde(rename = "Key")]
@@ -5168,7 +5168,7 @@ pub struct Tag {
 }
 
 /// <p><p>An array of search criteria that targets instances using a Key,Value combination that you specify. <code>Targets</code> is required if you don&#39;t provide one or more instance IDs in the call.</p> <p/></p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Target {
     /// <p>User-defined criteria for sending commands that target instances that meet the criteria. Key can be tag:&lt;Amazon EC2 tag&gt; or InstanceIds. For more information about how to send commands that target instances using Key,Value parameters, see <a href="http://docs.aws.amazon.com/systems-manager/latest/userguide/send-commands-multiple.html">Executing a Command Using Systems Manager Run Command</a>.</p>
     #[serde(rename = "Key")]
@@ -5180,7 +5180,7 @@ pub struct Target {
     pub values: Option<Vec<String>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateAssociationRequest {
     /// <p>The ID of the association you want to update. </p>
     #[serde(rename = "AssociationId")]
@@ -5219,7 +5219,7 @@ pub struct UpdateAssociationRequest {
     pub targets: Option<Vec<Target>>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateAssociationResult {
     /// <p>The description of the association that was updated.</p>
     #[serde(rename = "AssociationDescription")]
@@ -5227,7 +5227,7 @@ pub struct UpdateAssociationResult {
     pub association_description: Option<AssociationDescription>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateAssociationStatusRequest {
     /// <p>The association status.</p>
     #[serde(rename = "AssociationStatus")]
@@ -5240,7 +5240,7 @@ pub struct UpdateAssociationStatusRequest {
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateAssociationStatusResult {
     /// <p>Information about the association.</p>
     #[serde(rename = "AssociationDescription")]
@@ -5248,7 +5248,7 @@ pub struct UpdateAssociationStatusResult {
     pub association_description: Option<AssociationDescription>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateDocumentDefaultVersionRequest {
     /// <p>The version of a custom document that you want to set as the default version.</p>
     #[serde(rename = "DocumentVersion")]
@@ -5258,7 +5258,7 @@ pub struct UpdateDocumentDefaultVersionRequest {
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateDocumentDefaultVersionResult {
     /// <p>The description of a custom document that you want to set as the default version.</p>
     #[serde(rename = "Description")]
@@ -5266,7 +5266,7 @@ pub struct UpdateDocumentDefaultVersionResult {
     pub description: Option<DocumentDefaultVersionDescription>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateDocumentRequest {
     /// <p>The content in a document that you want to update.</p>
     #[serde(rename = "Content")]
@@ -5288,7 +5288,7 @@ pub struct UpdateDocumentRequest {
     pub target_type: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateDocumentResult {
     /// <p>A description of the document that was updated.</p>
     #[serde(rename = "DocumentDescription")]
@@ -5296,7 +5296,7 @@ pub struct UpdateDocumentResult {
     pub document_description: Option<DocumentDescription>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateMaintenanceWindowRequest {
     /// <p>Whether targets must be registered with the Maintenance Window before tasks can be defined for those targets.</p>
     #[serde(rename = "AllowUnassociatedTargets")]
@@ -5335,7 +5335,7 @@ pub struct UpdateMaintenanceWindowRequest {
     pub window_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateMaintenanceWindowResult {
     /// <p>Whether targets must be registered with the Maintenance Window before tasks can be defined for those targets.</p>
     #[serde(rename = "AllowUnassociatedTargets")]
@@ -5371,7 +5371,7 @@ pub struct UpdateMaintenanceWindowResult {
     pub window_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateMaintenanceWindowTargetRequest {
     /// <p>An optional description for the update.</p>
     #[serde(rename = "Description")]
@@ -5401,7 +5401,7 @@ pub struct UpdateMaintenanceWindowTargetRequest {
     pub window_target_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateMaintenanceWindowTargetResult {
     /// <p>The updated description.</p>
     #[serde(rename = "Description")]
@@ -5429,7 +5429,7 @@ pub struct UpdateMaintenanceWindowTargetResult {
     pub window_target_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateMaintenanceWindowTaskRequest {
     /// <p>The new task description to specify.</p>
     #[serde(rename = "Description")]
@@ -5488,7 +5488,7 @@ pub struct UpdateMaintenanceWindowTaskRequest {
     pub window_task_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateMaintenanceWindowTaskResult {
     /// <p>The updated task description.</p>
     #[serde(rename = "Description")]
@@ -5545,7 +5545,7 @@ pub struct UpdateMaintenanceWindowTaskResult {
     pub window_task_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateManagedInstanceRoleRequest {
     /// <p>The IAM role you want to assign or change.</p>
     #[serde(rename = "IamRole")]
@@ -5555,10 +5555,10 @@ pub struct UpdateManagedInstanceRoleRequest {
     pub instance_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateManagedInstanceRoleResult {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdatePatchBaselineRequest {
     /// <p>A set of rules used to include patches in the baseline.</p>
     #[serde(rename = "ApprovalRules")]
@@ -5605,7 +5605,7 @@ pub struct UpdatePatchBaselineRequest {
     pub sources: Option<Vec<PatchSource>>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdatePatchBaselineResult {
     /// <p>A set of rules used to include patches in the baseline.</p>
     #[serde(rename = "ApprovalRules")]

--- a/rusoto/services/stepfunctions/src/generated.rs
+++ b/rusoto/services/stepfunctions/src/generated.rs
@@ -31,7 +31,7 @@ use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 /// <p>Contains details about an activity which failed during an execution.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ActivityFailedEventDetails {
     /// <p>A more detailed explanation of the cause of the failure.</p>
     #[serde(rename = "cause")]
@@ -44,7 +44,7 @@ pub struct ActivityFailedEventDetails {
 }
 
 /// <p>Contains details about an activity.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ActivityListItem {
     /// <p>The Amazon Resource Name (ARN) that identifies the activity.</p>
     #[serde(rename = "activityArn")]
@@ -58,7 +58,7 @@ pub struct ActivityListItem {
 }
 
 /// <p>Contains details about an activity schedule failure which occurred during an execution.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ActivityScheduleFailedEventDetails {
     /// <p>A more detailed explanation of the cause of the failure.</p>
     #[serde(rename = "cause")]
@@ -71,7 +71,7 @@ pub struct ActivityScheduleFailedEventDetails {
 }
 
 /// <p>Contains details about an activity scheduled during an execution.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ActivityScheduledEventDetails {
     /// <p>The maximum allowed duration between two heartbeats for the activity task.</p>
     #[serde(rename = "heartbeatInSeconds")]
@@ -91,7 +91,7 @@ pub struct ActivityScheduledEventDetails {
 }
 
 /// <p>Contains details about the start of an activity during an execution.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ActivityStartedEventDetails {
     /// <p>The name of the worker that the task is assigned to. These names are provided by the workers when calling <a>GetActivityTask</a>.</p>
     #[serde(rename = "workerName")]
@@ -100,7 +100,7 @@ pub struct ActivityStartedEventDetails {
 }
 
 /// <p>Contains details about an activity which successfully terminated during an execution.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ActivitySucceededEventDetails {
     /// <p>The JSON data output by the activity task.</p>
     #[serde(rename = "output")]
@@ -109,7 +109,7 @@ pub struct ActivitySucceededEventDetails {
 }
 
 /// <p>Contains details about an activity timeout which occurred during an execution.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ActivityTimedOutEventDetails {
     /// <p>A more detailed explanation of the cause of the timeout.</p>
     #[serde(rename = "cause")]
@@ -121,14 +121,14 @@ pub struct ActivityTimedOutEventDetails {
     pub error: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateActivityInput {
     /// <p><p>The name of the activity to create. This name must be unique for your AWS account and region for 90 days. For more information, see <a href="http://docs.aws.amazon.com/step-functions/latest/dg/limits.html#service-limits-state-machine-executions"> Limits Related to State Machine Executions</a> in the <i>AWS Step Functions Developer Guide</i>.</p> <p>A name must <i>not</i> contain:</p> <ul> <li> <p>whitespace</p> </li> <li> <p>brackets <code>&lt; &gt; { } [ ]</code> </p> </li> <li> <p>wildcard characters <code>? *</code> </p> </li> <li> <p>special characters <code>&quot; # % \ ^ | ~ ` $ &amp; , ; : /</code> </p> </li> <li> <p>control characters (<code>U+0000-001F</code>, <code>U+007F-009F</code>)</p> </li> </ul></p>
     #[serde(rename = "name")]
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateActivityOutput {
     /// <p>The Amazon Resource Name (ARN) that identifies the created activity.</p>
     #[serde(rename = "activityArn")]
@@ -138,7 +138,7 @@ pub struct CreateActivityOutput {
     pub creation_date: f64,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateStateMachineInput {
     /// <p>The Amazon States Language definition of the state machine.</p>
     #[serde(rename = "definition")]
@@ -151,7 +151,7 @@ pub struct CreateStateMachineInput {
     pub role_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateStateMachineOutput {
     /// <p>The date the state machine is created.</p>
     #[serde(rename = "creationDate")]
@@ -161,34 +161,34 @@ pub struct CreateStateMachineOutput {
     pub state_machine_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteActivityInput {
     /// <p>The Amazon Resource Name (ARN) of the activity to delete.</p>
     #[serde(rename = "activityArn")]
     pub activity_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteActivityOutput {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteStateMachineInput {
     /// <p>The Amazon Resource Name (ARN) of the state machine to delete.</p>
     #[serde(rename = "stateMachineArn")]
     pub state_machine_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteStateMachineOutput {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeActivityInput {
     /// <p>The Amazon Resource Name (ARN) of the activity to describe.</p>
     #[serde(rename = "activityArn")]
     pub activity_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeActivityOutput {
     /// <p>The Amazon Resource Name (ARN) that identifies the activity.</p>
     #[serde(rename = "activityArn")]
@@ -201,14 +201,14 @@ pub struct DescribeActivityOutput {
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeExecutionInput {
     /// <p>The Amazon Resource Name (ARN) of the execution to describe.</p>
     #[serde(rename = "executionArn")]
     pub execution_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeExecutionOutput {
     /// <p>The Amazon Resource Name (ARN) that identifies the execution.</p>
     #[serde(rename = "executionArn")]
@@ -239,14 +239,14 @@ pub struct DescribeExecutionOutput {
     pub stop_date: Option<f64>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeStateMachineForExecutionInput {
     /// <p>The Amazon Resource Name (ARN) of the execution you want state machine information for.</p>
     #[serde(rename = "executionArn")]
     pub execution_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeStateMachineForExecutionOutput {
     /// <p>The Amazon States Language definition of the state machine.</p>
     #[serde(rename = "definition")]
@@ -265,14 +265,14 @@ pub struct DescribeStateMachineForExecutionOutput {
     pub update_date: f64,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeStateMachineInput {
     /// <p>The Amazon Resource Name (ARN) of the state machine to describe.</p>
     #[serde(rename = "stateMachineArn")]
     pub state_machine_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeStateMachineOutput {
     /// <p>The date the state machine is created.</p>
     #[serde(rename = "creationDate")]
@@ -296,7 +296,7 @@ pub struct DescribeStateMachineOutput {
 }
 
 /// <p>Contains details about an abort of an execution.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ExecutionAbortedEventDetails {
     /// <p>A more detailed explanation of the cause of the failure.</p>
     #[serde(rename = "cause")]
@@ -309,7 +309,7 @@ pub struct ExecutionAbortedEventDetails {
 }
 
 /// <p>Contains details about an execution failure event.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ExecutionFailedEventDetails {
     /// <p>A more detailed explanation of the cause of the failure.</p>
     #[serde(rename = "cause")]
@@ -322,7 +322,7 @@ pub struct ExecutionFailedEventDetails {
 }
 
 /// <p>Contains details about an execution.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ExecutionListItem {
     /// <p>The Amazon Resource Name (ARN) that identifies the execution.</p>
     #[serde(rename = "executionArn")]
@@ -346,7 +346,7 @@ pub struct ExecutionListItem {
 }
 
 /// <p>Contains details about the start of the execution.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ExecutionStartedEventDetails {
     /// <p>The JSON data input to the execution.</p>
     #[serde(rename = "input")]
@@ -359,7 +359,7 @@ pub struct ExecutionStartedEventDetails {
 }
 
 /// <p>Contains details about the successful termination of the execution.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ExecutionSucceededEventDetails {
     /// <p>The JSON data output by the execution.</p>
     #[serde(rename = "output")]
@@ -368,7 +368,7 @@ pub struct ExecutionSucceededEventDetails {
 }
 
 /// <p>Contains details about the execution timeout which occurred during the execution.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ExecutionTimedOutEventDetails {
     /// <p>A more detailed explanation of the cause of the timeout.</p>
     #[serde(rename = "cause")]
@@ -380,7 +380,7 @@ pub struct ExecutionTimedOutEventDetails {
     pub error: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetActivityTaskInput {
     /// <p>The Amazon Resource Name (ARN) of the activity to retrieve tasks from (assigned when you create the task using <a>CreateActivity</a>.)</p>
     #[serde(rename = "activityArn")]
@@ -391,7 +391,7 @@ pub struct GetActivityTaskInput {
     pub worker_name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetActivityTaskOutput {
     /// <p>The string that contains the JSON input data for the task.</p>
     #[serde(rename = "input")]
@@ -403,7 +403,7 @@ pub struct GetActivityTaskOutput {
     pub task_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetExecutionHistoryInput {
     /// <p>The Amazon Resource Name (ARN) of the execution.</p>
     #[serde(rename = "executionArn")]
@@ -422,7 +422,7 @@ pub struct GetExecutionHistoryInput {
     pub reverse_order: Option<bool>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetExecutionHistoryOutput {
     /// <p>The list of events that occurred in the execution.</p>
     #[serde(rename = "events")]
@@ -434,7 +434,7 @@ pub struct GetExecutionHistoryOutput {
 }
 
 /// <p>Contains details about the events of an execution.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct HistoryEvent {
     #[serde(rename = "activityFailedEventDetails")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -513,7 +513,7 @@ pub struct HistoryEvent {
 }
 
 /// <p>Contains details about a lambda function which failed during an execution.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct LambdaFunctionFailedEventDetails {
     /// <p>A more detailed explanation of the cause of the failure.</p>
     #[serde(rename = "cause")]
@@ -526,7 +526,7 @@ pub struct LambdaFunctionFailedEventDetails {
 }
 
 /// <p>Contains details about a failed lambda function schedule event which occurred during an execution.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct LambdaFunctionScheduleFailedEventDetails {
     /// <p>A more detailed explanation of the cause of the failure.</p>
     #[serde(rename = "cause")]
@@ -539,7 +539,7 @@ pub struct LambdaFunctionScheduleFailedEventDetails {
 }
 
 /// <p>Contains details about a lambda function scheduled during an execution.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct LambdaFunctionScheduledEventDetails {
     /// <p>The JSON data input to the lambda function.</p>
     #[serde(rename = "input")]
@@ -555,7 +555,7 @@ pub struct LambdaFunctionScheduledEventDetails {
 }
 
 /// <p>Contains details about a lambda function which failed to start during an execution.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct LambdaFunctionStartFailedEventDetails {
     /// <p>A more detailed explanation of the cause of the failure.</p>
     #[serde(rename = "cause")]
@@ -568,7 +568,7 @@ pub struct LambdaFunctionStartFailedEventDetails {
 }
 
 /// <p>Contains details about a lambda function which successfully terminated during an execution.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct LambdaFunctionSucceededEventDetails {
     /// <p>The JSON data output by the lambda function.</p>
     #[serde(rename = "output")]
@@ -577,7 +577,7 @@ pub struct LambdaFunctionSucceededEventDetails {
 }
 
 /// <p>Contains details about a lambda function timeout which occurred during an execution.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct LambdaFunctionTimedOutEventDetails {
     /// <p>A more detailed explanation of the cause of the timeout.</p>
     #[serde(rename = "cause")]
@@ -589,7 +589,7 @@ pub struct LambdaFunctionTimedOutEventDetails {
     pub error: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListActivitiesInput {
     /// <p>The maximum number of results that are returned per call. You can use <code>nextToken</code> to obtain further pages of results. The default is 100 and the maximum allowed page size is 100. A value of 0 uses the default.</p> <p>This is only an upper limit. The actual number of results returned per call might be fewer than the specified maximum.</p>
     #[serde(rename = "maxResults")]
@@ -601,7 +601,7 @@ pub struct ListActivitiesInput {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListActivitiesOutput {
     /// <p>The list of activities.</p>
     #[serde(rename = "activities")]
@@ -612,7 +612,7 @@ pub struct ListActivitiesOutput {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListExecutionsInput {
     /// <p>The maximum number of results that are returned per call. You can use <code>nextToken</code> to obtain further pages of results. The default is 100 and the maximum allowed page size is 100. A value of 0 uses the default.</p> <p>This is only an upper limit. The actual number of results returned per call might be fewer than the specified maximum.</p>
     #[serde(rename = "maxResults")]
@@ -631,7 +631,7 @@ pub struct ListExecutionsInput {
     pub status_filter: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListExecutionsOutput {
     /// <p>The list of matching executions.</p>
     #[serde(rename = "executions")]
@@ -642,7 +642,7 @@ pub struct ListExecutionsOutput {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListStateMachinesInput {
     /// <p>The maximum number of results that are returned per call. You can use <code>nextToken</code> to obtain further pages of results. The default is 100 and the maximum allowed page size is 100. A value of 0 uses the default.</p> <p>This is only an upper limit. The actual number of results returned per call might be fewer than the specified maximum.</p>
     #[serde(rename = "maxResults")]
@@ -654,7 +654,7 @@ pub struct ListStateMachinesInput {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListStateMachinesOutput {
     /// <p>If a <code>nextToken</code> is returned by a previous call, there are more results available. To retrieve the next page of results, make the call again using the returned token in <code>nextToken</code>. Keep all other arguments unchanged.</p> <p>The configured <code>maxResults</code> determines how many results can be returned in a single call.</p>
     #[serde(rename = "nextToken")]
@@ -664,7 +664,7 @@ pub struct ListStateMachinesOutput {
     pub state_machines: Vec<StateMachineListItem>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SendTaskFailureInput {
     /// <p>A more detailed explanation of the cause of the failure.</p>
     #[serde(rename = "cause")]
@@ -679,20 +679,20 @@ pub struct SendTaskFailureInput {
     pub task_token: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SendTaskFailureOutput {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SendTaskHeartbeatInput {
     /// <p>The token that represents this task. Task tokens are generated by the service when the tasks are assigned to a worker (see <a>GetActivityTaskOutput$taskToken</a>).</p>
     #[serde(rename = "taskToken")]
     pub task_token: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SendTaskHeartbeatOutput {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SendTaskSuccessInput {
     /// <p>The JSON output of the task.</p>
     #[serde(rename = "output")]
@@ -702,10 +702,10 @@ pub struct SendTaskSuccessInput {
     pub task_token: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SendTaskSuccessOutput {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StartExecutionInput {
     /// <p><p>The string that contains the JSON input data for the execution, for example:</p> <p> <code>&quot;input&quot;: &quot;{&quot;first_name&quot; : &quot;test&quot;}&quot;</code> </p> <note> <p>If you don&#39;t include any JSON input data, you still must include the two braces, for example: <code>&quot;input&quot;: &quot;{}&quot;</code> </p> </note></p>
     #[serde(rename = "input")]
@@ -720,7 +720,7 @@ pub struct StartExecutionInput {
     pub state_machine_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StartExecutionOutput {
     /// <p>The Amazon Resource Name (ARN) that identifies the execution.</p>
     #[serde(rename = "executionArn")]
@@ -731,7 +731,7 @@ pub struct StartExecutionOutput {
 }
 
 /// <p>Contains details about a state entered during an execution.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StateEnteredEventDetails {
     /// <p>The string that contains the JSON input data for the state.</p>
     #[serde(rename = "input")]
@@ -743,7 +743,7 @@ pub struct StateEnteredEventDetails {
 }
 
 /// <p>Contains details about an exit from a state during an execution.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StateExitedEventDetails {
     /// <p><p>The name of the state.</p> <p>A name must <i>not</i> contain:</p> <ul> <li> <p>whitespace</p> </li> <li> <p>brackets <code>&lt; &gt; { } [ ]</code> </p> </li> <li> <p>wildcard characters <code>? *</code> </p> </li> <li> <p>special characters <code>&quot; # % \ ^ | ~ ` $ &amp; , ; : /</code> </p> </li> <li> <p>control characters (<code>U+0000-001F</code>, <code>U+007F-009F</code>)</p> </li> </ul></p>
     #[serde(rename = "name")]
@@ -755,7 +755,7 @@ pub struct StateExitedEventDetails {
 }
 
 /// <p>Contains details about the state machine.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StateMachineListItem {
     /// <p>The date the state machine is created.</p>
     #[serde(rename = "creationDate")]
@@ -768,7 +768,7 @@ pub struct StateMachineListItem {
     pub state_machine_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StopExecutionInput {
     /// <p>A more detailed explanation of the cause of the termination.</p>
     #[serde(rename = "cause")]
@@ -783,14 +783,14 @@ pub struct StopExecutionInput {
     pub execution_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StopExecutionOutput {
     /// <p>The date the execution is stopped.</p>
     #[serde(rename = "stopDate")]
     pub stop_date: f64,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateStateMachineInput {
     /// <p>The Amazon States Language definition of the state machine.</p>
     #[serde(rename = "definition")]
@@ -805,7 +805,7 @@ pub struct UpdateStateMachineInput {
     pub state_machine_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateStateMachineOutput {
     /// <p>The date and time the state machine was updated.</p>
     #[serde(rename = "updateDate")]

--- a/rusoto/services/stepfunctions/src/generated.rs
+++ b/rusoto/services/stepfunctions/src/generated.rs
@@ -833,7 +833,8 @@ impl CreateActivityError {
     pub fn from_body(body: &str) -> CreateActivityError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -923,7 +924,8 @@ impl CreateStateMachineError {
     pub fn from_body(body: &str) -> CreateStateMachineError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1027,7 +1029,8 @@ impl DeleteActivityError {
     pub fn from_body(body: &str) -> DeleteActivityError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1103,7 +1106,8 @@ impl DeleteStateMachineError {
     pub fn from_body(body: &str) -> DeleteStateMachineError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1185,7 +1189,8 @@ impl DescribeActivityError {
     pub fn from_body(body: &str) -> DescribeActivityError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1267,7 +1272,8 @@ impl DescribeExecutionError {
     pub fn from_body(body: &str) -> DescribeExecutionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1351,7 +1357,8 @@ impl DescribeStateMachineError {
     pub fn from_body(body: &str) -> DescribeStateMachineError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1439,7 +1446,8 @@ impl DescribeStateMachineForExecutionError {
     pub fn from_body(body: &str) -> DescribeStateMachineForExecutionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1529,7 +1537,8 @@ impl GetActivityTaskError {
     pub fn from_body(body: &str) -> GetActivityTaskError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1619,7 +1628,8 @@ impl GetExecutionHistoryError {
     pub fn from_body(body: &str) -> GetExecutionHistoryError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1707,7 +1717,8 @@ impl ListActivitiesError {
     pub fn from_body(body: &str) -> ListActivitiesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1789,7 +1800,8 @@ impl ListExecutionsError {
     pub fn from_body(body: &str) -> ListExecutionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1873,7 +1885,8 @@ impl ListStateMachinesError {
     pub fn from_body(body: &str) -> ListStateMachinesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1957,7 +1970,8 @@ impl SendTaskFailureError {
     pub fn from_body(body: &str) -> SendTaskFailureError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2047,7 +2061,8 @@ impl SendTaskHeartbeatError {
     pub fn from_body(body: &str) -> SendTaskHeartbeatError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2141,7 +2156,8 @@ impl SendTaskSuccessError {
     pub fn from_body(body: &str) -> SendTaskSuccessError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2243,7 +2259,8 @@ impl StartExecutionError {
     pub fn from_body(body: &str) -> StartExecutionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2343,7 +2360,8 @@ impl StopExecutionError {
     pub fn from_body(body: &str) -> StopExecutionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2431,7 +2449,8 @@ impl UpdateStateMachineError {
     pub fn from_body(body: &str) -> UpdateStateMachineError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/storagegateway/src/generated.rs
+++ b/rusoto/services/storagegateway/src/generated.rs
@@ -2083,7 +2083,8 @@ impl ActivateGatewayError {
     pub fn from_body(body: &str) -> ActivateGatewayError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2167,7 +2168,8 @@ impl AddCacheError {
     pub fn from_body(body: &str) -> AddCacheError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2249,7 +2251,8 @@ impl AddTagsToResourceError {
     pub fn from_body(body: &str) -> AddTagsToResourceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2335,7 +2338,8 @@ impl AddUploadBufferError {
     pub fn from_body(body: &str) -> AddUploadBufferError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2419,7 +2423,8 @@ impl AddWorkingStorageError {
     pub fn from_body(body: &str) -> AddWorkingStorageError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2505,7 +2510,8 @@ impl CancelArchivalError {
     pub fn from_body(body: &str) -> CancelArchivalError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2589,7 +2595,8 @@ impl CancelRetrievalError {
     pub fn from_body(body: &str) -> CancelRetrievalError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2673,7 +2680,8 @@ impl CreateCachediSCSIVolumeError {
     pub fn from_body(body: &str) -> CreateCachediSCSIVolumeError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2761,7 +2769,8 @@ impl CreateNFSFileShareError {
     pub fn from_body(body: &str) -> CreateNFSFileShareError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2849,7 +2858,8 @@ impl CreateSnapshotError {
     pub fn from_body(body: &str) -> CreateSnapshotError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2939,7 +2949,8 @@ impl CreateSnapshotFromVolumeRecoveryPointError {
     pub fn from_body(body: &str) -> CreateSnapshotFromVolumeRecoveryPointError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3037,7 +3048,8 @@ impl CreateStorediSCSIVolumeError {
     pub fn from_body(body: &str) -> CreateStorediSCSIVolumeError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3125,7 +3137,8 @@ impl CreateTapeWithBarcodeError {
     pub fn from_body(body: &str) -> CreateTapeWithBarcodeError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3213,7 +3226,8 @@ impl CreateTapesError {
     pub fn from_body(body: &str) -> CreateTapesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3297,7 +3311,8 @@ impl DeleteBandwidthRateLimitError {
     pub fn from_body(body: &str) -> DeleteBandwidthRateLimitError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3385,7 +3400,8 @@ impl DeleteChapCredentialsError {
     pub fn from_body(body: &str) -> DeleteChapCredentialsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3473,7 +3489,8 @@ impl DeleteFileShareError {
     pub fn from_body(body: &str) -> DeleteFileShareError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3557,7 +3574,8 @@ impl DeleteGatewayError {
     pub fn from_body(body: &str) -> DeleteGatewayError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3641,7 +3659,8 @@ impl DeleteSnapshotScheduleError {
     pub fn from_body(body: &str) -> DeleteSnapshotScheduleError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3729,7 +3748,8 @@ impl DeleteTapeError {
     pub fn from_body(body: &str) -> DeleteTapeError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3811,7 +3831,8 @@ impl DeleteTapeArchiveError {
     pub fn from_body(body: &str) -> DeleteTapeArchiveError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3897,7 +3918,8 @@ impl DeleteVolumeError {
     pub fn from_body(body: &str) -> DeleteVolumeError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3981,7 +4003,8 @@ impl DescribeBandwidthRateLimitError {
     pub fn from_body(body: &str) -> DescribeBandwidthRateLimitError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4069,7 +4092,8 @@ impl DescribeCacheError {
     pub fn from_body(body: &str) -> DescribeCacheError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4153,7 +4177,8 @@ impl DescribeCachediSCSIVolumesError {
     pub fn from_body(body: &str) -> DescribeCachediSCSIVolumesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4241,7 +4266,8 @@ impl DescribeChapCredentialsError {
     pub fn from_body(body: &str) -> DescribeChapCredentialsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4329,7 +4355,8 @@ impl DescribeGatewayInformationError {
     pub fn from_body(body: &str) -> DescribeGatewayInformationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4417,7 +4444,8 @@ impl DescribeMaintenanceStartTimeError {
     pub fn from_body(body: &str) -> DescribeMaintenanceStartTimeError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4507,7 +4535,8 @@ impl DescribeNFSFileSharesError {
     pub fn from_body(body: &str) -> DescribeNFSFileSharesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4595,7 +4624,8 @@ impl DescribeSnapshotScheduleError {
     pub fn from_body(body: &str) -> DescribeSnapshotScheduleError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4683,7 +4713,8 @@ impl DescribeStorediSCSIVolumesError {
     pub fn from_body(body: &str) -> DescribeStorediSCSIVolumesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4771,7 +4802,8 @@ impl DescribeTapeArchivesError {
     pub fn from_body(body: &str) -> DescribeTapeArchivesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4859,7 +4891,8 @@ impl DescribeTapeRecoveryPointsError {
     pub fn from_body(body: &str) -> DescribeTapeRecoveryPointsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4947,7 +4980,8 @@ impl DescribeTapesError {
     pub fn from_body(body: &str) -> DescribeTapesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5031,7 +5065,8 @@ impl DescribeUploadBufferError {
     pub fn from_body(body: &str) -> DescribeUploadBufferError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5119,7 +5154,8 @@ impl DescribeVTLDevicesError {
     pub fn from_body(body: &str) -> DescribeVTLDevicesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5205,7 +5241,8 @@ impl DescribeWorkingStorageError {
     pub fn from_body(body: &str) -> DescribeWorkingStorageError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5293,7 +5330,8 @@ impl DisableGatewayError {
     pub fn from_body(body: &str) -> DisableGatewayError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5377,7 +5415,8 @@ impl ListFileSharesError {
     pub fn from_body(body: &str) -> ListFileSharesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5461,7 +5500,8 @@ impl ListGatewaysError {
     pub fn from_body(body: &str) -> ListGatewaysError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5545,7 +5585,8 @@ impl ListLocalDisksError {
     pub fn from_body(body: &str) -> ListLocalDisksError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5629,7 +5670,8 @@ impl ListTagsForResourceError {
     pub fn from_body(body: &str) -> ListTagsForResourceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5715,7 +5757,8 @@ impl ListTapesError {
     pub fn from_body(body: &str) -> ListTapesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5797,7 +5840,8 @@ impl ListVolumeInitiatorsError {
     pub fn from_body(body: &str) -> ListVolumeInitiatorsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5885,7 +5929,8 @@ impl ListVolumeRecoveryPointsError {
     pub fn from_body(body: &str) -> ListVolumeRecoveryPointsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5973,7 +6018,8 @@ impl ListVolumesError {
     pub fn from_body(body: &str) -> ListVolumesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6057,7 +6103,8 @@ impl NotifyWhenUploadedError {
     pub fn from_body(body: &str) -> NotifyWhenUploadedError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6143,7 +6190,8 @@ impl RefreshCacheError {
     pub fn from_body(body: &str) -> RefreshCacheError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6227,7 +6275,8 @@ impl RemoveTagsFromResourceError {
     pub fn from_body(body: &str) -> RemoveTagsFromResourceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6315,7 +6364,8 @@ impl ResetCacheError {
     pub fn from_body(body: &str) -> ResetCacheError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6397,7 +6447,8 @@ impl RetrieveTapeArchiveError {
     pub fn from_body(body: &str) -> RetrieveTapeArchiveError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6483,7 +6534,8 @@ impl RetrieveTapeRecoveryPointError {
     pub fn from_body(body: &str) -> RetrieveTapeRecoveryPointError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6571,7 +6623,8 @@ impl SetLocalConsolePasswordError {
     pub fn from_body(body: &str) -> SetLocalConsolePasswordError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6659,7 +6712,8 @@ impl ShutdownGatewayError {
     pub fn from_body(body: &str) -> ShutdownGatewayError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6743,7 +6797,8 @@ impl StartGatewayError {
     pub fn from_body(body: &str) -> StartGatewayError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6827,7 +6882,8 @@ impl UpdateBandwidthRateLimitError {
     pub fn from_body(body: &str) -> UpdateBandwidthRateLimitError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6915,7 +6971,8 @@ impl UpdateChapCredentialsError {
     pub fn from_body(body: &str) -> UpdateChapCredentialsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7003,7 +7060,8 @@ impl UpdateGatewayInformationError {
     pub fn from_body(body: &str) -> UpdateGatewayInformationError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7091,7 +7149,8 @@ impl UpdateGatewaySoftwareNowError {
     pub fn from_body(body: &str) -> UpdateGatewaySoftwareNowError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7179,7 +7238,8 @@ impl UpdateMaintenanceStartTimeError {
     pub fn from_body(body: &str) -> UpdateMaintenanceStartTimeError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7267,7 +7327,8 @@ impl UpdateNFSFileShareError {
     pub fn from_body(body: &str) -> UpdateNFSFileShareError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7353,7 +7414,8 @@ impl UpdateSnapshotScheduleError {
     pub fn from_body(body: &str) -> UpdateSnapshotScheduleError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7441,7 +7503,8 @@ impl UpdateVTLDeviceTypeError {
     pub fn from_body(body: &str) -> UpdateVTLDeviceTypeError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/storagegateway/src/generated.rs
+++ b/rusoto/services/storagegateway/src/generated.rs
@@ -31,7 +31,7 @@ use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 /// <p><p>A JSON object containing one or more of the following fields:</p> <ul> <li> <p> <a>ActivateGatewayInput$ActivationKey</a> </p> </li> <li> <p> <a>ActivateGatewayInput$GatewayName</a> </p> </li> <li> <p> <a>ActivateGatewayInput$GatewayRegion</a> </p> </li> <li> <p> <a>ActivateGatewayInput$GatewayTimezone</a> </p> </li> <li> <p> <a>ActivateGatewayInput$GatewayType</a> </p> </li> <li> <p> <a>ActivateGatewayInput$TapeDriveType</a> </p> </li> <li> <p> <a>ActivateGatewayInput$MediumChangerType</a> </p> </li> </ul></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ActivateGatewayInput {
     /// <p>Your gateway activation key. You can obtain the activation key by sending an HTTP GET request with redirects enabled to the gateway IP address (port 80). The redirect URL returned in the response provides you the activation key for your gateway in the query string parameter <code>activationKey</code>. It may also include other activation-related parameters, however, these are merely defaults -- the arguments you pass to the <code>ActivateGateway</code> API call determine the actual configuration of your gateway. </p> <p>For more information, see https://docs.aws.amazon.com/storagegateway/latest/userguide/get-activation-key.html in the Storage Gateway User Guide.</p>
     #[serde(rename = "ActivationKey")]
@@ -60,14 +60,14 @@ pub struct ActivateGatewayInput {
 }
 
 /// <p><p>AWS Storage Gateway returns the Amazon Resource Name (ARN) of the activated gateway. It is a string made of information such as your account, gateway name, and region. This ARN is used to reference the gateway in other API operations as well as resource-based authorization.</p> <note> <p>For gateways activated prior to September 02, 2015, the gateway ARN contains the gateway name rather than the gateway ID. Changing the name of the gateway has no effect on the gateway ARN.</p> </note></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ActivateGatewayOutput {
     #[serde(rename = "GatewayARN")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub gateway_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AddCacheInput {
     #[serde(rename = "DiskIds")]
     pub disk_ids: Vec<String>,
@@ -75,7 +75,7 @@ pub struct AddCacheInput {
     pub gateway_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AddCacheOutput {
     #[serde(rename = "GatewayARN")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -83,7 +83,7 @@ pub struct AddCacheOutput {
 }
 
 /// <p>AddTagsToResourceInput</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AddTagsToResourceInput {
     /// <p>The Amazon Resource Name (ARN) of the resource you want to add tags to.</p>
     #[serde(rename = "ResourceARN")]
@@ -94,7 +94,7 @@ pub struct AddTagsToResourceInput {
 }
 
 /// <p>AddTagsToResourceOutput</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AddTagsToResourceOutput {
     /// <p>The Amazon Resource Name (ARN) of the resource you want to add tags to.</p>
     #[serde(rename = "ResourceARN")]
@@ -102,7 +102,7 @@ pub struct AddTagsToResourceOutput {
     pub resource_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AddUploadBufferInput {
     #[serde(rename = "DiskIds")]
     pub disk_ids: Vec<String>,
@@ -110,7 +110,7 @@ pub struct AddUploadBufferInput {
     pub gateway_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AddUploadBufferOutput {
     #[serde(rename = "GatewayARN")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -118,7 +118,7 @@ pub struct AddUploadBufferOutput {
 }
 
 /// <p><p>A JSON object containing one or more of the following fields:</p> <ul> <li> <p> <a>AddWorkingStorageInput$DiskIds</a> </p> </li> </ul></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AddWorkingStorageInput {
     /// <p>An array of strings that identify disks that are to be configured as working storage. Each string have a minimum length of 1 and maximum length of 300. You can get the disk IDs from the <a>ListLocalDisks</a> API.</p>
     #[serde(rename = "DiskIds")]
@@ -128,7 +128,7 @@ pub struct AddWorkingStorageInput {
 }
 
 /// <p>A JSON object containing the of the gateway for which working storage was configured.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AddWorkingStorageOutput {
     #[serde(rename = "GatewayARN")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -136,7 +136,7 @@ pub struct AddWorkingStorageOutput {
 }
 
 /// <p>Describes an iSCSI cached volume.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CachediSCSIVolume {
     /// <p>The date the volume was created. Volumes created prior to March 28, 2017 don’t have this time stamp.</p>
     #[serde(rename = "CreatedDate")]
@@ -181,7 +181,7 @@ pub struct CachediSCSIVolume {
 }
 
 /// <p>CancelArchivalInput</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CancelArchivalInput {
     #[serde(rename = "GatewayARN")]
     pub gateway_arn: String,
@@ -191,7 +191,7 @@ pub struct CancelArchivalInput {
 }
 
 /// <p>CancelArchivalOutput</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CancelArchivalOutput {
     /// <p>The Amazon Resource Name (ARN) of the virtual tape for which archiving was canceled.</p>
     #[serde(rename = "TapeARN")]
@@ -200,7 +200,7 @@ pub struct CancelArchivalOutput {
 }
 
 /// <p>CancelRetrievalInput</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CancelRetrievalInput {
     #[serde(rename = "GatewayARN")]
     pub gateway_arn: String,
@@ -210,7 +210,7 @@ pub struct CancelRetrievalInput {
 }
 
 /// <p>CancelRetrievalOutput</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CancelRetrievalOutput {
     /// <p>The Amazon Resource Name (ARN) of the virtual tape for which retrieval was canceled.</p>
     #[serde(rename = "TapeARN")]
@@ -219,7 +219,7 @@ pub struct CancelRetrievalOutput {
 }
 
 /// <p>Describes Challenge-Handshake Authentication Protocol (CHAP) information that supports authentication between your gateway and iSCSI initiators.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ChapInfo {
     /// <p>The iSCSI initiator that connects to the target.</p>
     #[serde(rename = "InitiatorName")]
@@ -239,7 +239,7 @@ pub struct ChapInfo {
     pub target_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateCachediSCSIVolumeInput {
     #[serde(rename = "ClientToken")]
     pub client_token: String,
@@ -260,7 +260,7 @@ pub struct CreateCachediSCSIVolumeInput {
     pub volume_size_in_bytes: i64,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateCachediSCSIVolumeOutput {
     #[serde(rename = "TargetARN")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -271,7 +271,7 @@ pub struct CreateCachediSCSIVolumeOutput {
 }
 
 /// <p>CreateNFSFileShareInput</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateNFSFileShareInput {
     /// <p>The list of clients that are allowed to access the file gateway. The list must contain either valid IP addresses or valid CIDR blocks. </p>
     #[serde(rename = "ClientList")]
@@ -328,7 +328,7 @@ pub struct CreateNFSFileShareInput {
 }
 
 /// <p>CreateNFSFileShareOutput</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateNFSFileShareOutput {
     /// <p>The Amazon Resource Name (ARN) of the newly created file share. </p>
     #[serde(rename = "FileShareARN")]
@@ -336,7 +336,7 @@ pub struct CreateNFSFileShareOutput {
     pub file_share_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateSnapshotFromVolumeRecoveryPointInput {
     #[serde(rename = "SnapshotDescription")]
     pub snapshot_description: String,
@@ -344,7 +344,7 @@ pub struct CreateSnapshotFromVolumeRecoveryPointInput {
     pub volume_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateSnapshotFromVolumeRecoveryPointOutput {
     #[serde(rename = "SnapshotId")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -358,7 +358,7 @@ pub struct CreateSnapshotFromVolumeRecoveryPointOutput {
 }
 
 /// <p><p>A JSON object containing one or more of the following fields:</p> <ul> <li> <p> <a>CreateSnapshotInput$SnapshotDescription</a> </p> </li> <li> <p> <a>CreateSnapshotInput$VolumeARN</a> </p> </li> </ul></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateSnapshotInput {
     /// <p>Textual description of the snapshot that appears in the Amazon EC2 console, Elastic Block Store snapshots panel in the <b>Description</b> field, and in the AWS Storage Gateway snapshot <b>Details</b> pane, <b>Description</b> field</p>
     #[serde(rename = "SnapshotDescription")]
@@ -369,7 +369,7 @@ pub struct CreateSnapshotInput {
 }
 
 /// <p>A JSON object containing the following fields:</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateSnapshotOutput {
     /// <p>The snapshot ID that is used to refer to the snapshot in future operations such as describing snapshots (Amazon Elastic Compute Cloud API <code>DescribeSnapshots</code>) or creating a volume from a snapshot (<a>CreateStorediSCSIVolume</a>).</p>
     #[serde(rename = "SnapshotId")]
@@ -382,7 +382,7 @@ pub struct CreateSnapshotOutput {
 }
 
 /// <p><p>A JSON object containing one or more of the following fields:</p> <ul> <li> <p> <a>CreateStorediSCSIVolumeInput$DiskId</a> </p> </li> <li> <p> <a>CreateStorediSCSIVolumeInput$NetworkInterfaceId</a> </p> </li> <li> <p> <a>CreateStorediSCSIVolumeInput$PreserveExistingData</a> </p> </li> <li> <p> <a>CreateStorediSCSIVolumeInput$SnapshotId</a> </p> </li> <li> <p> <a>CreateStorediSCSIVolumeInput$TargetName</a> </p> </li> </ul></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateStorediSCSIVolumeInput {
     /// <p>The unique identifier for the gateway local disk that is configured as a stored volume. Use <a href="http://docs.aws.amazon.com/storagegateway/latest/userguide/API_ListLocalDisks.html">ListLocalDisks</a> to list disk IDs for a gateway.</p>
     #[serde(rename = "DiskId")]
@@ -405,7 +405,7 @@ pub struct CreateStorediSCSIVolumeInput {
 }
 
 /// <p>A JSON object containing the following fields:</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateStorediSCSIVolumeOutput {
     /// <p>he Amazon Resource Name (ARN) of the volume target that includes the iSCSI name that initiators can use to connect to the target.</p>
     #[serde(rename = "TargetARN")]
@@ -422,7 +422,7 @@ pub struct CreateStorediSCSIVolumeOutput {
 }
 
 /// <p>CreateTapeWithBarcodeInput</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateTapeWithBarcodeInput {
     /// <p>The unique Amazon Resource Name (ARN) that represents the gateway to associate the virtual tape with. Use the <a>ListGateways</a> operation to return a list of gateways for your account and region.</p>
     #[serde(rename = "GatewayARN")]
@@ -436,7 +436,7 @@ pub struct CreateTapeWithBarcodeInput {
 }
 
 /// <p>CreateTapeOutput</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateTapeWithBarcodeOutput {
     /// <p>A unique Amazon Resource Name (ARN) that represents the virtual tape that was created.</p>
     #[serde(rename = "TapeARN")]
@@ -445,7 +445,7 @@ pub struct CreateTapeWithBarcodeOutput {
 }
 
 /// <p>CreateTapesInput</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateTapesInput {
     /// <p><p>A unique identifier that you use to retry a request. If you retry a request, use the same <code>ClientToken</code> you specified in the initial request.</p> <note> <p>Using the same <code>ClientToken</code> prevents creating the tape multiple times.</p> </note></p>
     #[serde(rename = "ClientToken")]
@@ -465,7 +465,7 @@ pub struct CreateTapesInput {
 }
 
 /// <p>CreateTapeOutput</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateTapesOutput {
     /// <p>A list of unique Amazon Resource Names (ARNs) that represents the virtual tapes that were created.</p>
     #[serde(rename = "TapeARNs")]
@@ -474,7 +474,7 @@ pub struct CreateTapesOutput {
 }
 
 /// <p><p>A JSON object containing the following fields:</p> <ul> <li> <p> <a>DeleteBandwidthRateLimitInput$BandwidthType</a> </p> </li> </ul></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteBandwidthRateLimitInput {
     /// <p>One of the BandwidthType values that indicates the gateway bandwidth rate limit to delete.</p> <p>Valid Values: <code>Upload</code>, <code>Download</code>, <code>All</code>.</p>
     #[serde(rename = "BandwidthType")]
@@ -484,7 +484,7 @@ pub struct DeleteBandwidthRateLimitInput {
 }
 
 /// <p>A JSON object containing the of the gateway whose bandwidth rate information was deleted.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteBandwidthRateLimitOutput {
     #[serde(rename = "GatewayARN")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -492,7 +492,7 @@ pub struct DeleteBandwidthRateLimitOutput {
 }
 
 /// <p><p>A JSON object containing one or more of the following fields:</p> <ul> <li> <p> <a>DeleteChapCredentialsInput$InitiatorName</a> </p> </li> <li> <p> <a>DeleteChapCredentialsInput$TargetARN</a> </p> </li> </ul></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteChapCredentialsInput {
     /// <p>The iSCSI initiator that connects to the target.</p>
     #[serde(rename = "InitiatorName")]
@@ -503,7 +503,7 @@ pub struct DeleteChapCredentialsInput {
 }
 
 /// <p>A JSON object containing the following fields:</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteChapCredentialsOutput {
     /// <p>The iSCSI initiator that connects to the target.</p>
     #[serde(rename = "InitiatorName")]
@@ -516,7 +516,7 @@ pub struct DeleteChapCredentialsOutput {
 }
 
 /// <p>DeleteFileShareInput</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteFileShareInput {
     /// <p>The Amazon Resource Name (ARN) of the file share to be deleted. </p>
     #[serde(rename = "FileShareARN")]
@@ -528,7 +528,7 @@ pub struct DeleteFileShareInput {
 }
 
 /// <p>DeleteFileShareOutput</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteFileShareOutput {
     /// <p>The Amazon Resource Name (ARN) of the deleted file share. </p>
     #[serde(rename = "FileShareARN")]
@@ -537,27 +537,27 @@ pub struct DeleteFileShareOutput {
 }
 
 /// <p>A JSON object containing the ID of the gateway to delete.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteGatewayInput {
     #[serde(rename = "GatewayARN")]
     pub gateway_arn: String,
 }
 
 /// <p>A JSON object containing the ID of the deleted gateway.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteGatewayOutput {
     #[serde(rename = "GatewayARN")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub gateway_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteSnapshotScheduleInput {
     #[serde(rename = "VolumeARN")]
     pub volume_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteSnapshotScheduleOutput {
     #[serde(rename = "VolumeARN")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -565,7 +565,7 @@ pub struct DeleteSnapshotScheduleOutput {
 }
 
 /// <p>DeleteTapeArchiveInput</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteTapeArchiveInput {
     /// <p>The Amazon Resource Name (ARN) of the virtual tape to delete from the virtual tape shelf (VTS).</p>
     #[serde(rename = "TapeARN")]
@@ -573,7 +573,7 @@ pub struct DeleteTapeArchiveInput {
 }
 
 /// <p>DeleteTapeArchiveOutput</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteTapeArchiveOutput {
     /// <p>The Amazon Resource Name (ARN) of the virtual tape that was deleted from the virtual tape shelf (VTS).</p>
     #[serde(rename = "TapeARN")]
@@ -582,7 +582,7 @@ pub struct DeleteTapeArchiveOutput {
 }
 
 /// <p>DeleteTapeInput</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteTapeInput {
     /// <p>The unique Amazon Resource Name (ARN) of the gateway that the virtual tape to delete is associated with. Use the <a>ListGateways</a> operation to return a list of gateways for your account and region.</p>
     #[serde(rename = "GatewayARN")]
@@ -593,7 +593,7 @@ pub struct DeleteTapeInput {
 }
 
 /// <p>DeleteTapeOutput</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteTapeOutput {
     /// <p>The Amazon Resource Name (ARN) of the deleted virtual tape.</p>
     #[serde(rename = "TapeARN")]
@@ -602,7 +602,7 @@ pub struct DeleteTapeOutput {
 }
 
 /// <p>A JSON object containing the <a>DeleteVolumeInput$VolumeARN</a> to delete.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteVolumeInput {
     /// <p>The Amazon Resource Name (ARN) of the volume. Use the <a>ListVolumes</a> operation to return a list of gateway volumes.</p>
     #[serde(rename = "VolumeARN")]
@@ -610,7 +610,7 @@ pub struct DeleteVolumeInput {
 }
 
 /// <p>A JSON object containing the of the storage volume that was deleted</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteVolumeOutput {
     /// <p>The Amazon Resource Name (ARN) of the storage volume that was deleted. It is the same ARN you provided in the request.</p>
     #[serde(rename = "VolumeARN")]
@@ -619,14 +619,14 @@ pub struct DeleteVolumeOutput {
 }
 
 /// <p>A JSON object containing the of the gateway.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeBandwidthRateLimitInput {
     #[serde(rename = "GatewayARN")]
     pub gateway_arn: String,
 }
 
 /// <p>A JSON object containing the following fields:</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeBandwidthRateLimitOutput {
     /// <p>The average download bandwidth rate limit in bits per second. This field does not appear in the response if the download rate limit is not set.</p>
     #[serde(rename = "AverageDownloadRateLimitInBitsPerSec")]
@@ -641,13 +641,13 @@ pub struct DescribeBandwidthRateLimitOutput {
     pub gateway_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeCacheInput {
     #[serde(rename = "GatewayARN")]
     pub gateway_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeCacheOutput {
     #[serde(rename = "CacheAllocatedInBytes")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -672,14 +672,14 @@ pub struct DescribeCacheOutput {
     pub gateway_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeCachediSCSIVolumesInput {
     #[serde(rename = "VolumeARNs")]
     pub volume_ar_ns: Vec<String>,
 }
 
 /// <p>A JSON object containing the following fields:</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeCachediSCSIVolumesOutput {
     /// <p>An array of objects where each object contains metadata about one cached volume.</p>
     #[serde(rename = "CachediSCSIVolumes")]
@@ -688,7 +688,7 @@ pub struct DescribeCachediSCSIVolumesOutput {
 }
 
 /// <p>A JSON object containing the Amazon Resource Name (ARN) of the iSCSI volume target.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeChapCredentialsInput {
     /// <p>The Amazon Resource Name (ARN) of the iSCSI volume target. Use the <a>DescribeStorediSCSIVolumes</a> operation to return to retrieve the TargetARN for specified VolumeARN.</p>
     #[serde(rename = "TargetARN")]
@@ -696,7 +696,7 @@ pub struct DescribeChapCredentialsInput {
 }
 
 /// <p>A JSON object containing a .</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeChapCredentialsOutput {
     /// <p><p>An array of <a>ChapInfo</a> objects that represent CHAP credentials. Each object in the array contains CHAP credential information for one target-initiator pair. If no CHAP credentials are set, an empty array is returned. CHAP credential information is provided in a JSON object with the following fields:</p> <ul> <li> <p> <b>InitiatorName</b>: The iSCSI initiator that connects to the target.</p> </li> <li> <p> <b>SecretToAuthenticateInitiator</b>: The secret key that the initiator (for example, the Windows client) must provide to participate in mutual CHAP with the target.</p> </li> <li> <p> <b>SecretToAuthenticateTarget</b>: The secret key that the target must provide to participate in mutual CHAP with the initiator (e.g. Windows client).</p> </li> <li> <p> <b>TargetARN</b>: The Amazon Resource Name (ARN) of the storage volume.</p> </li> </ul></p>
     #[serde(rename = "ChapCredentials")]
@@ -705,14 +705,14 @@ pub struct DescribeChapCredentialsOutput {
 }
 
 /// <p>A JSON object containing the ID of the gateway.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeGatewayInformationInput {
     #[serde(rename = "GatewayARN")]
     pub gateway_arn: String,
 }
 
 /// <p>A JSON object containing the following fields:</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeGatewayInformationOutput {
     #[serde(rename = "GatewayARN")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -752,14 +752,14 @@ pub struct DescribeGatewayInformationOutput {
 }
 
 /// <p>A JSON object containing the of the gateway.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeMaintenanceStartTimeInput {
     #[serde(rename = "GatewayARN")]
     pub gateway_arn: String,
 }
 
 /// <p><p>A JSON object containing the following fields:</p> <ul> <li> <p> <a>DescribeMaintenanceStartTimeOutput$DayOfWeek</a> </p> </li> <li> <p> <a>DescribeMaintenanceStartTimeOutput$HourOfDay</a> </p> </li> <li> <p> <a>DescribeMaintenanceStartTimeOutput$MinuteOfHour</a> </p> </li> <li> <p> <a>DescribeMaintenanceStartTimeOutput$Timezone</a> </p> </li> </ul></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeMaintenanceStartTimeOutput {
     /// <p>An ordinal number between 0 and 6 that represents the day of the week, where 0 represents Sunday and 6 represents Saturday. The day of week is in the time zone of the gateway.</p>
     #[serde(rename = "DayOfWeek")]
@@ -782,7 +782,7 @@ pub struct DescribeMaintenanceStartTimeOutput {
 }
 
 /// <p>DescribeNFSFileSharesInput</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeNFSFileSharesInput {
     /// <p>An array containing the Amazon Resource Name (ARN) of each file share to be described. </p>
     #[serde(rename = "FileShareARNList")]
@@ -790,7 +790,7 @@ pub struct DescribeNFSFileSharesInput {
 }
 
 /// <p>DescribeNFSFileSharesOutput</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeNFSFileSharesOutput {
     /// <p>An array containing a description for each requested file share. </p>
     #[serde(rename = "NFSFileShareInfoList")]
@@ -799,14 +799,14 @@ pub struct DescribeNFSFileSharesOutput {
 }
 
 /// <p>A JSON object containing the <a>DescribeSnapshotScheduleInput$VolumeARN</a> of the volume.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeSnapshotScheduleInput {
     /// <p>The Amazon Resource Name (ARN) of the volume. Use the <a>ListVolumes</a> operation to return a list of gateway volumes.</p>
     #[serde(rename = "VolumeARN")]
     pub volume_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeSnapshotScheduleOutput {
     #[serde(rename = "Description")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -826,14 +826,14 @@ pub struct DescribeSnapshotScheduleOutput {
 }
 
 /// <p>A JSON object containing a list of <a>DescribeStorediSCSIVolumesInput$VolumeARNs</a>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeStorediSCSIVolumesInput {
     /// <p>An array of strings where each string represents the Amazon Resource Name (ARN) of a stored volume. All of the specified stored volumes must from the same gateway. Use <a>ListVolumes</a> to get volume ARNs for a gateway.</p>
     #[serde(rename = "VolumeARNs")]
     pub volume_ar_ns: Vec<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeStorediSCSIVolumesOutput {
     #[serde(rename = "StorediSCSIVolumes")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -841,7 +841,7 @@ pub struct DescribeStorediSCSIVolumesOutput {
 }
 
 /// <p>DescribeTapeArchivesInput</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeTapeArchivesInput {
     /// <p>Specifies that the number of virtual tapes descried be limited to the specified number.</p>
     #[serde(rename = "Limit")]
@@ -858,7 +858,7 @@ pub struct DescribeTapeArchivesInput {
 }
 
 /// <p>DescribeTapeArchivesOutput</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeTapeArchivesOutput {
     /// <p>An opaque string that indicates the position at which the virtual tapes that were fetched for description ended. Use this marker in your next request to fetch the next set of virtual tapes in the virtual tape shelf (VTS). If there are no more virtual tapes to describe, this field does not appear in the response.</p>
     #[serde(rename = "Marker")]
@@ -871,7 +871,7 @@ pub struct DescribeTapeArchivesOutput {
 }
 
 /// <p>DescribeTapeRecoveryPointsInput</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeTapeRecoveryPointsInput {
     #[serde(rename = "GatewayARN")]
     pub gateway_arn: String,
@@ -886,7 +886,7 @@ pub struct DescribeTapeRecoveryPointsInput {
 }
 
 /// <p>DescribeTapeRecoveryPointsOutput</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeTapeRecoveryPointsOutput {
     #[serde(rename = "GatewayARN")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -902,7 +902,7 @@ pub struct DescribeTapeRecoveryPointsOutput {
 }
 
 /// <p>DescribeTapesInput</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeTapesInput {
     #[serde(rename = "GatewayARN")]
     pub gateway_arn: String,
@@ -921,7 +921,7 @@ pub struct DescribeTapesInput {
 }
 
 /// <p>DescribeTapesOutput</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeTapesOutput {
     /// <p>An opaque string which can be used as part of a subsequent DescribeTapes call to retrieve the next page of results.</p> <p>If a response does not contain a marker, then there are no more results to be retrieved.</p>
     #[serde(rename = "Marker")]
@@ -933,13 +933,13 @@ pub struct DescribeTapesOutput {
     pub tapes: Option<Vec<Tape>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeUploadBufferInput {
     #[serde(rename = "GatewayARN")]
     pub gateway_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeUploadBufferOutput {
     #[serde(rename = "DiskIds")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -956,7 +956,7 @@ pub struct DescribeUploadBufferOutput {
 }
 
 /// <p>DescribeVTLDevicesInput</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeVTLDevicesInput {
     #[serde(rename = "GatewayARN")]
     pub gateway_arn: String,
@@ -975,7 +975,7 @@ pub struct DescribeVTLDevicesInput {
 }
 
 /// <p>DescribeVTLDevicesOutput</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeVTLDevicesOutput {
     #[serde(rename = "GatewayARN")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -991,14 +991,14 @@ pub struct DescribeVTLDevicesOutput {
 }
 
 /// <p>A JSON object containing the of the gateway.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeWorkingStorageInput {
     #[serde(rename = "GatewayARN")]
     pub gateway_arn: String,
 }
 
 /// <p>A JSON object containing the following fields:</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeWorkingStorageOutput {
     /// <p>An array of the gateway's local disk IDs that are configured as working storage. Each local disk ID is specified as a string (minimum length of 1 and maximum length of 300). If no local disks are configured as working storage, then the DiskIds array is empty.</p>
     #[serde(rename = "DiskIds")]
@@ -1018,7 +1018,7 @@ pub struct DescribeWorkingStorageOutput {
 }
 
 /// <p>Lists iSCSI information about a VTL device.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeviceiSCSIAttributes {
     /// <p>Indicates whether mutual CHAP is enabled for the iSCSI target.</p>
     #[serde(rename = "ChapEnabled")]
@@ -1039,14 +1039,14 @@ pub struct DeviceiSCSIAttributes {
 }
 
 /// <p>DisableGatewayInput</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DisableGatewayInput {
     #[serde(rename = "GatewayARN")]
     pub gateway_arn: String,
 }
 
 /// <p>DisableGatewayOutput</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DisableGatewayOutput {
     /// <p>The unique Amazon Resource Name of the disabled gateway.</p>
     #[serde(rename = "GatewayARN")]
@@ -1054,7 +1054,7 @@ pub struct DisableGatewayOutput {
     pub gateway_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Disk {
     #[serde(rename = "DiskAllocationResource")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1080,7 +1080,7 @@ pub struct Disk {
 }
 
 /// <p>Describes a file share.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct FileShareInfo {
     #[serde(rename = "FileShareARN")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1097,7 +1097,7 @@ pub struct FileShareInfo {
 }
 
 /// <p>Describes a gateway object.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GatewayInfo {
     /// <p>The Amazon Resource Name (ARN) of the gateway. Use the <a>ListGateways</a> operation to return a list of gateways for your account and region.</p>
     #[serde(rename = "GatewayARN")]
@@ -1122,7 +1122,7 @@ pub struct GatewayInfo {
 }
 
 /// <p>ListFileShareInput</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListFileSharesInput {
     /// <p>The Amazon resource Name (ARN) of the gateway whose file shares you want to list. If this field is not present, all file shares under your account are listed.</p>
     #[serde(rename = "GatewayARN")]
@@ -1139,7 +1139,7 @@ pub struct ListFileSharesInput {
 }
 
 /// <p>ListFileShareOutput</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListFileSharesOutput {
     /// <p>An array of information about the file gateway's file shares. </p>
     #[serde(rename = "FileShareInfoList")]
@@ -1156,7 +1156,7 @@ pub struct ListFileSharesOutput {
 }
 
 /// <p><p>A JSON object containing zero or more of the following fields:</p> <ul> <li> <p> <a>ListGatewaysInput$Limit</a> </p> </li> <li> <p> <a>ListGatewaysInput$Marker</a> </p> </li> </ul></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListGatewaysInput {
     /// <p>Specifies that the list of gateways returned be limited to the specified number of items.</p>
     #[serde(rename = "Limit")]
@@ -1168,7 +1168,7 @@ pub struct ListGatewaysInput {
     pub marker: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListGatewaysOutput {
     #[serde(rename = "Gateways")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1179,13 +1179,13 @@ pub struct ListGatewaysOutput {
 }
 
 /// <p>A JSON object containing the of the gateway.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListLocalDisksInput {
     #[serde(rename = "GatewayARN")]
     pub gateway_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListLocalDisksOutput {
     #[serde(rename = "Disks")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1196,7 +1196,7 @@ pub struct ListLocalDisksOutput {
 }
 
 /// <p>ListTagsForResourceInput</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListTagsForResourceInput {
     /// <p>Specifies that the list of tags returned be limited to the specified number of items.</p>
     #[serde(rename = "Limit")]
@@ -1212,7 +1212,7 @@ pub struct ListTagsForResourceInput {
 }
 
 /// <p>ListTagsForResourceOutput</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListTagsForResourceOutput {
     /// <p>An opaque string that indicates the position at which to stop returning the list of tags.</p>
     #[serde(rename = "Marker")]
@@ -1229,7 +1229,7 @@ pub struct ListTagsForResourceOutput {
 }
 
 /// <p><p>A JSON object that contains one or more of the following fields:</p> <ul> <li> <p> <a>ListTapesInput$Limit</a> </p> </li> <li> <p> <a>ListTapesInput$Marker</a> </p> </li> <li> <p> <a>ListTapesInput$TapeARNs</a> </p> </li> </ul></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListTapesInput {
     /// <p>An optional number limit for the tapes in the list returned by this call.</p>
     #[serde(rename = "Limit")]
@@ -1245,7 +1245,7 @@ pub struct ListTapesInput {
 }
 
 /// <p><p>A JSON object containing the following fields:</p> <ul> <li> <p> <a>ListTapesOutput$Marker</a> </p> </li> <li> <p> <a>ListTapesOutput$VolumeInfos</a> </p> </li> </ul></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListTapesOutput {
     /// <p>A string that indicates the position at which to begin returning the next list of tapes. Use the marker in your next request to continue pagination of tapes. If there are no more tapes to list, this element does not appear in the response body.</p>
     #[serde(rename = "Marker")]
@@ -1257,7 +1257,7 @@ pub struct ListTapesOutput {
 }
 
 /// <p>ListVolumeInitiatorsInput</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListVolumeInitiatorsInput {
     /// <p>The Amazon Resource Name (ARN) of the volume. Use the <a>ListVolumes</a> operation to return a list of gateway volumes for the gateway.</p>
     #[serde(rename = "VolumeARN")]
@@ -1265,7 +1265,7 @@ pub struct ListVolumeInitiatorsInput {
 }
 
 /// <p>ListVolumeInitiatorsOutput</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListVolumeInitiatorsOutput {
     /// <p>The host names and port numbers of all iSCSI initiators that are connected to the gateway.</p>
     #[serde(rename = "Initiators")]
@@ -1273,13 +1273,13 @@ pub struct ListVolumeInitiatorsOutput {
     pub initiators: Option<Vec<String>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListVolumeRecoveryPointsInput {
     #[serde(rename = "GatewayARN")]
     pub gateway_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListVolumeRecoveryPointsOutput {
     #[serde(rename = "GatewayARN")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1290,7 +1290,7 @@ pub struct ListVolumeRecoveryPointsOutput {
 }
 
 /// <p><p>A JSON object that contains one or more of the following fields:</p> <ul> <li> <p> <a>ListVolumesInput$Limit</a> </p> </li> <li> <p> <a>ListVolumesInput$Marker</a> </p> </li> </ul></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListVolumesInput {
     #[serde(rename = "GatewayARN")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1305,7 +1305,7 @@ pub struct ListVolumesInput {
     pub marker: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListVolumesOutput {
     #[serde(rename = "GatewayARN")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1319,7 +1319,7 @@ pub struct ListVolumesOutput {
 }
 
 /// <p>Describes file share default values. Files and folders stored as Amazon S3 objects in S3 buckets don't, by default, have Unix file permissions assigned to them. Upon discovery in an S3 bucket by Storage Gateway, the S3 objects that represent files and folders are assigned these default Unix permissions. This operation is only supported in the file gateway type.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct NFSFileShareDefaults {
     /// <p>The Unix directory mode in the form "nnnn". For example, "0666" represents the default access mode for all directories inside the file share. The default value is 0777.</p>
     #[serde(rename = "DirectoryMode")]
@@ -1340,7 +1340,7 @@ pub struct NFSFileShareDefaults {
 }
 
 /// <p>The Unix file permissions and ownership information assigned, by default, to native S3 objects when file gateway discovers them in S3 buckets. This operation is only supported in file gateways.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct NFSFileShareInfo {
     #[serde(rename = "ClientList")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1401,7 +1401,7 @@ pub struct NFSFileShareInfo {
 }
 
 /// <p>Describes a gateway's network interface.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct NetworkInterface {
     /// <p>The Internet Protocol version 4 (IPv4) address of the interface.</p>
     #[serde(rename = "Ipv4Address")]
@@ -1417,13 +1417,13 @@ pub struct NetworkInterface {
     pub mac_address: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct NotifyWhenUploadedInput {
     #[serde(rename = "FileShareARN")]
     pub file_share_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct NotifyWhenUploadedOutput {
     #[serde(rename = "FileShareARN")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1433,13 +1433,13 @@ pub struct NotifyWhenUploadedOutput {
     pub notification_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RefreshCacheInput {
     #[serde(rename = "FileShareARN")]
     pub file_share_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RefreshCacheOutput {
     #[serde(rename = "FileShareARN")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1447,7 +1447,7 @@ pub struct RefreshCacheOutput {
 }
 
 /// <p>RemoveTagsFromResourceInput</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RemoveTagsFromResourceInput {
     /// <p>The Amazon Resource Name (ARN) of the resource you want to remove the tags from.</p>
     #[serde(rename = "ResourceARN")]
@@ -1458,7 +1458,7 @@ pub struct RemoveTagsFromResourceInput {
 }
 
 /// <p>RemoveTagsFromResourceOutput</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RemoveTagsFromResourceOutput {
     /// <p>The Amazon Resource Name (ARN) of the resource that the tags were removed from.</p>
     #[serde(rename = "ResourceARN")]
@@ -1466,13 +1466,13 @@ pub struct RemoveTagsFromResourceOutput {
     pub resource_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ResetCacheInput {
     #[serde(rename = "GatewayARN")]
     pub gateway_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ResetCacheOutput {
     #[serde(rename = "GatewayARN")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1480,7 +1480,7 @@ pub struct ResetCacheOutput {
 }
 
 /// <p>RetrieveTapeArchiveInput</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RetrieveTapeArchiveInput {
     /// <p>The Amazon Resource Name (ARN) of the gateway you want to retrieve the virtual tape to. Use the <a>ListGateways</a> operation to return a list of gateways for your account and region.</p> <p>You retrieve archived virtual tapes to only one gateway and the gateway must be a tape gateway.</p>
     #[serde(rename = "GatewayARN")]
@@ -1491,7 +1491,7 @@ pub struct RetrieveTapeArchiveInput {
 }
 
 /// <p>RetrieveTapeArchiveOutput</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RetrieveTapeArchiveOutput {
     /// <p>The Amazon Resource Name (ARN) of the retrieved virtual tape.</p>
     #[serde(rename = "TapeARN")]
@@ -1500,7 +1500,7 @@ pub struct RetrieveTapeArchiveOutput {
 }
 
 /// <p>RetrieveTapeRecoveryPointInput</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RetrieveTapeRecoveryPointInput {
     #[serde(rename = "GatewayARN")]
     pub gateway_arn: String,
@@ -1510,7 +1510,7 @@ pub struct RetrieveTapeRecoveryPointInput {
 }
 
 /// <p>RetrieveTapeRecoveryPointOutput</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RetrieveTapeRecoveryPointOutput {
     /// <p>The Amazon Resource Name (ARN) of the virtual tape for which the recovery point was retrieved.</p>
     #[serde(rename = "TapeARN")]
@@ -1519,7 +1519,7 @@ pub struct RetrieveTapeRecoveryPointOutput {
 }
 
 /// <p>SetLocalConsolePasswordInput</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SetLocalConsolePasswordInput {
     #[serde(rename = "GatewayARN")]
     pub gateway_arn: String,
@@ -1528,7 +1528,7 @@ pub struct SetLocalConsolePasswordInput {
     pub local_console_password: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SetLocalConsolePasswordOutput {
     #[serde(rename = "GatewayARN")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1536,14 +1536,14 @@ pub struct SetLocalConsolePasswordOutput {
 }
 
 /// <p>A JSON object containing the of the gateway to shut down.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ShutdownGatewayInput {
     #[serde(rename = "GatewayARN")]
     pub gateway_arn: String,
 }
 
 /// <p>A JSON object containing the of the gateway that was shut down.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ShutdownGatewayOutput {
     #[serde(rename = "GatewayARN")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1551,14 +1551,14 @@ pub struct ShutdownGatewayOutput {
 }
 
 /// <p>A JSON object containing the of the gateway to start.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StartGatewayInput {
     #[serde(rename = "GatewayARN")]
     pub gateway_arn: String,
 }
 
 /// <p>A JSON object containing the of the gateway that was restarted.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StartGatewayOutput {
     #[serde(rename = "GatewayARN")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1566,7 +1566,7 @@ pub struct StartGatewayOutput {
 }
 
 /// <p>Provides additional information about an error that was returned by the service as an or. See the <code>errorCode</code> and <code>errorDetails</code> members for more information about the error.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct StorageGatewayError {
     /// <p>Additional information about the error.</p>
     pub error_code: Option<String>,
@@ -1575,7 +1575,7 @@ pub struct StorageGatewayError {
 }
 
 /// <p>Describes an iSCSI stored volume.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StorediSCSIVolume {
     /// <p>The date the volume was created. Volumes created prior to March 28, 2017 don’t have this time stamp.</p>
     #[serde(rename = "CreatedDate")]
@@ -1627,7 +1627,7 @@ pub struct StorediSCSIVolume {
     pub volumei_scsi_attributes: Option<VolumeiSCSIAttributes>,
 }
 
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Tag {
     #[serde(rename = "Key")]
     pub key: String,
@@ -1636,7 +1636,7 @@ pub struct Tag {
 }
 
 /// <p>Describes a virtual tape object.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Tape {
     /// <p>For archiving virtual tapes, indicates how much data remains to be uploaded before archiving is complete.</p> <p>Range: 0 (not started) to 100 (complete).</p>
     #[serde(rename = "Progress")]
@@ -1673,7 +1673,7 @@ pub struct Tape {
 }
 
 /// <p>Represents a virtual tape that is archived in the virtual tape shelf (VTS).</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct TapeArchive {
     /// <p>The time that the archiving of the virtual tape was completed.</p> <p>The string format of the completion time is in the ISO8601 extended YYYY-MM-DD'T'HH:MM:SS'Z' format.</p>
     #[serde(rename = "CompletionTime")]
@@ -1709,7 +1709,7 @@ pub struct TapeArchive {
 }
 
 /// <p>Describes a virtual tape.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct TapeInfo {
     /// <p>The Amazon Resource Name (ARN) of the gateway. Use the <a>ListGateways</a> operation to return a list of gateways for your account and region.</p>
     #[serde(rename = "GatewayARN")]
@@ -1734,7 +1734,7 @@ pub struct TapeInfo {
 }
 
 /// <p>Describes a recovery point.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct TapeRecoveryPointInfo {
     /// <p>The Amazon Resource Name (ARN) of the virtual tape.</p>
     #[serde(rename = "TapeARN")]
@@ -1754,7 +1754,7 @@ pub struct TapeRecoveryPointInfo {
 }
 
 /// <p><p>A JSON object containing one or more of the following fields:</p> <ul> <li> <p> <a>UpdateBandwidthRateLimitInput$AverageDownloadRateLimitInBitsPerSec</a> </p> </li> <li> <p> <a>UpdateBandwidthRateLimitInput$AverageUploadRateLimitInBitsPerSec</a> </p> </li> </ul></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateBandwidthRateLimitInput {
     /// <p>The average download bandwidth rate limit in bits per second.</p>
     #[serde(rename = "AverageDownloadRateLimitInBitsPerSec")]
@@ -1769,7 +1769,7 @@ pub struct UpdateBandwidthRateLimitInput {
 }
 
 /// <p>A JSON object containing the of the gateway whose throttle information was updated.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateBandwidthRateLimitOutput {
     #[serde(rename = "GatewayARN")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1777,7 +1777,7 @@ pub struct UpdateBandwidthRateLimitOutput {
 }
 
 /// <p><p>A JSON object containing one or more of the following fields:</p> <ul> <li> <p> <a>UpdateChapCredentialsInput$InitiatorName</a> </p> </li> <li> <p> <a>UpdateChapCredentialsInput$SecretToAuthenticateInitiator</a> </p> </li> <li> <p> <a>UpdateChapCredentialsInput$SecretToAuthenticateTarget</a> </p> </li> <li> <p> <a>UpdateChapCredentialsInput$TargetARN</a> </p> </li> </ul></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateChapCredentialsInput {
     /// <p>The iSCSI initiator that connects to the target.</p>
     #[serde(rename = "InitiatorName")]
@@ -1795,7 +1795,7 @@ pub struct UpdateChapCredentialsInput {
 }
 
 /// <p>A JSON object containing the following fields:</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateChapCredentialsOutput {
     /// <p>The iSCSI initiator that connects to the target. This is the same initiator name specified in the request.</p>
     #[serde(rename = "InitiatorName")]
@@ -1807,7 +1807,7 @@ pub struct UpdateChapCredentialsOutput {
     pub target_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateGatewayInformationInput {
     #[serde(rename = "GatewayARN")]
     pub gateway_arn: String,
@@ -1820,7 +1820,7 @@ pub struct UpdateGatewayInformationInput {
 }
 
 /// <p>A JSON object containing the ARN of the gateway that was updated.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateGatewayInformationOutput {
     #[serde(rename = "GatewayARN")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1831,14 +1831,14 @@ pub struct UpdateGatewayInformationOutput {
 }
 
 /// <p>A JSON object containing the of the gateway to update.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateGatewaySoftwareNowInput {
     #[serde(rename = "GatewayARN")]
     pub gateway_arn: String,
 }
 
 /// <p>A JSON object containing the of the gateway that was updated.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateGatewaySoftwareNowOutput {
     #[serde(rename = "GatewayARN")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1846,7 +1846,7 @@ pub struct UpdateGatewaySoftwareNowOutput {
 }
 
 /// <p><p>A JSON object containing the following fields:</p> <ul> <li> <p> <a>UpdateMaintenanceStartTimeInput$DayOfWeek</a> </p> </li> <li> <p> <a>UpdateMaintenanceStartTimeInput$HourOfDay</a> </p> </li> <li> <p> <a>UpdateMaintenanceStartTimeInput$MinuteOfHour</a> </p> </li> </ul></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateMaintenanceStartTimeInput {
     /// <p>The maintenance start time day of the week represented as an ordinal number from 0 to 6, where 0 represents Sunday and 6 Saturday.</p>
     #[serde(rename = "DayOfWeek")]
@@ -1862,7 +1862,7 @@ pub struct UpdateMaintenanceStartTimeInput {
 }
 
 /// <p>A JSON object containing the of the gateway whose maintenance start time is updated.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateMaintenanceStartTimeOutput {
     #[serde(rename = "GatewayARN")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1870,7 +1870,7 @@ pub struct UpdateMaintenanceStartTimeOutput {
 }
 
 /// <p>UpdateNFSFileShareInput</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateNFSFileShareInput {
     /// <p>The list of clients that are allowed to access the file gateway. The list must contain either valid IP addresses or valid CIDR blocks.</p>
     #[serde(rename = "ClientList")]
@@ -1918,7 +1918,7 @@ pub struct UpdateNFSFileShareInput {
 }
 
 /// <p>UpdateNFSFileShareOutput</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateNFSFileShareOutput {
     /// <p>The Amazon Resource Name (ARN) of the updated file share. </p>
     #[serde(rename = "FileShareARN")]
@@ -1927,7 +1927,7 @@ pub struct UpdateNFSFileShareOutput {
 }
 
 /// <p><p>A JSON object containing one or more of the following fields:</p> <ul> <li> <p> <a>UpdateSnapshotScheduleInput$Description</a> </p> </li> <li> <p> <a>UpdateSnapshotScheduleInput$RecurrenceInHours</a> </p> </li> <li> <p> <a>UpdateSnapshotScheduleInput$StartAt</a> </p> </li> <li> <p> <a>UpdateSnapshotScheduleInput$VolumeARN</a> </p> </li> </ul></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateSnapshotScheduleInput {
     /// <p>Optional description of the snapshot that overwrites the existing description.</p>
     #[serde(rename = "Description")]
@@ -1945,7 +1945,7 @@ pub struct UpdateSnapshotScheduleInput {
 }
 
 /// <p>A JSON object containing the of the updated storage volume.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateSnapshotScheduleOutput {
     /// <p><p/></p>
     #[serde(rename = "VolumeARN")]
@@ -1953,7 +1953,7 @@ pub struct UpdateSnapshotScheduleOutput {
     pub volume_arn: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateVTLDeviceTypeInput {
     /// <p>The type of medium changer you want to select.</p> <p> Valid Values: "STK-L700", "AWS-Gateway-VTL"</p>
     #[serde(rename = "DeviceType")]
@@ -1964,7 +1964,7 @@ pub struct UpdateVTLDeviceTypeInput {
 }
 
 /// <p>UpdateVTLDeviceTypeOutput</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateVTLDeviceTypeOutput {
     /// <p>The Amazon Resource Name (ARN) of the medium changer you have selected.</p>
     #[serde(rename = "VTLDeviceARN")]
@@ -1973,7 +1973,7 @@ pub struct UpdateVTLDeviceTypeOutput {
 }
 
 /// <p>Represents a device object associated with a tape gateway.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct VTLDevice {
     /// <p>A list of iSCSI information about a VTL device.</p>
     #[serde(rename = "DeviceiSCSIAttributes")]
@@ -1995,7 +1995,7 @@ pub struct VTLDevice {
 }
 
 /// <p>Describes a storage volume object.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct VolumeInfo {
     #[serde(rename = "GatewayARN")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2021,7 +2021,7 @@ pub struct VolumeInfo {
     pub volume_type: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct VolumeRecoveryPointInfo {
     #[serde(rename = "VolumeARN")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2038,7 +2038,7 @@ pub struct VolumeRecoveryPointInfo {
 }
 
 /// <p>Lists iSCSI information about a volume.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct VolumeiSCSIAttributes {
     /// <p>Indicates whether mutual CHAP is enabled for the iSCSI target.</p>
     #[serde(rename = "ChapEnabled")]

--- a/rusoto/services/sts/src/generated.rs
+++ b/rusoto/services/sts/src/generated.rs
@@ -99,7 +99,7 @@ impl ArnTypeDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AssumeRoleRequest {
     /// <p><p>The duration, in seconds, of the role session. The value can range from 900 seconds (15 minutes) up to the maximum session duration setting for the role. This setting can have a value from 1 hour to 12 hours. If you specify a value higher than this setting, the operation fails. For example, if you specify a session duration of 12 hours, but your administrator set the maximum session duration to 6 hours, your operation fails. To learn how to view the maximum value for your role, see <a href="http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use.html#id_roles_use_view-role-max-session">View the Maximum Session Duration Setting for a Role</a> in the <i>IAM User Guide</i>.</p> <p>By default, the value is set to 3600 seconds. </p> <note> <p>The <code>DurationSeconds</code> parameter is separate from the duration of a console session that you might request using the returned credentials. The request to the federation endpoint for a console sign-in token takes a <code>SessionDuration</code> parameter that specifies the maximum length of the console session. For more information, see <a href="http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_enable-console-custom-url.html">Creating a URL that Enables Federated Users to Access the AWS Management Console</a> in the <i>IAM User Guide</i>.</p> </note></p>
     pub duration_seconds: Option<i64>,
@@ -168,7 +168,7 @@ impl AssumeRoleRequestSerializer {
 }
 
 /// <p>Contains the response to a successful <a>AssumeRole</a> request, including temporary AWS credentials that can be used to make AWS requests. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AssumeRoleResponse {
     /// <p>The Amazon Resource Name (ARN) and the assumed role ID, which are identifiers that you can use to refer to the resulting temporary security credentials. For example, you can reference these credentials as a principal in a resource-based policy by using the ARN or assumed role ID. The ARN and ID include the <code>RoleSessionName</code> that you specified when you called <code>AssumeRole</code>. </p>
     pub assumed_role_user: Option<AssumedRoleUser>,
@@ -232,7 +232,7 @@ impl AssumeRoleResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AssumeRoleWithSAMLRequest {
     /// <p><p>The duration, in seconds, of the role session. Your role session lasts for the duration that you specify for the <code>DurationSeconds</code> parameter, or until the time specified in the SAML authentication response&#39;s <code>SessionNotOnOrAfter</code> value, whichever is shorter. You can provide a <code>DurationSeconds</code> value from 900 seconds (15 minutes) up to the maximum session duration setting for the role. This setting can have a value from 1 hour to 12 hours. If you specify a value higher than this setting, the operation fails. For example, if you specify a session duration of 12 hours, but your administrator set the maximum session duration to 6 hours, your operation fails. To learn how to view the maximum value for your role, see <a href="http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use.html#id_roles_use_view-role-max-session">View the Maximum Session Duration Setting for a Role</a> in the <i>IAM User Guide</i>.</p> <p>By default, the value is set to 3600 seconds. </p> <note> <p>The <code>DurationSeconds</code> parameter is separate from the duration of a console session that you might request using the returned credentials. The request to the federation endpoint for a console sign-in token takes a <code>SessionDuration</code> parameter that specifies the maximum length of the console session. For more information, see <a href="http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_enable-console-custom-url.html">Creating a URL that Enables Federated Users to Access the AWS Management Console</a> in the <i>IAM User Guide</i>.</p> </note></p>
     pub duration_seconds: Option<i64>,
@@ -283,7 +283,7 @@ impl AssumeRoleWithSAMLRequestSerializer {
 }
 
 /// <p>Contains the response to a successful <a>AssumeRoleWithSAML</a> request, including temporary AWS credentials that can be used to make AWS requests. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AssumeRoleWithSAMLResponse {
     /// <p>The identifiers for the temporary security credentials that the operation returns.</p>
     pub assumed_role_user: Option<AssumedRoleUser>,
@@ -380,7 +380,7 @@ impl AssumeRoleWithSAMLResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AssumeRoleWithWebIdentityRequest {
     /// <p><p>The duration, in seconds, of the role session. The value can range from 900 seconds (15 minutes) up to the maximum session duration setting for the role. This setting can have a value from 1 hour to 12 hours. If you specify a value higher than this setting, the operation fails. For example, if you specify a session duration of 12 hours, but your administrator set the maximum session duration to 6 hours, your operation fails. To learn how to view the maximum value for your role, see <a href="http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use.html#id_roles_use_view-role-max-session">View the Maximum Session Duration Setting for a Role</a> in the <i>IAM User Guide</i>.</p> <p>By default, the value is set to 3600 seconds. </p> <note> <p>The <code>DurationSeconds</code> parameter is separate from the duration of a console session that you might request using the returned credentials. The request to the federation endpoint for a console sign-in token takes a <code>SessionDuration</code> parameter that specifies the maximum length of the console session. For more information, see <a href="http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_enable-console-custom-url.html">Creating a URL that Enables Federated Users to Access the AWS Management Console</a> in the <i>IAM User Guide</i>.</p> </note></p>
     pub duration_seconds: Option<i64>,
@@ -439,7 +439,7 @@ impl AssumeRoleWithWebIdentityRequestSerializer {
 }
 
 /// <p>Contains the response to a successful <a>AssumeRoleWithWebIdentity</a> request, including temporary AWS credentials that can be used to make AWS requests. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AssumeRoleWithWebIdentityResponse {
     /// <p>The Amazon Resource Name (ARN) and the assumed role ID, which are identifiers that you can use to refer to the resulting temporary security credentials. For example, you can reference these credentials as a principal in a resource-based policy by using the ARN or assumed role ID. The ARN and ID include the <code>RoleSessionName</code> that you specified when you called <code>AssumeRole</code>. </p>
     pub assumed_role_user: Option<AssumedRoleUser>,
@@ -539,7 +539,7 @@ impl AssumedRoleIdTypeDeserializer {
     }
 }
 /// <p>The identifiers for the temporary security credentials that the operation returns.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct AssumedRoleUser {
     /// <p>The ARN of the temporary security credentials that are returned from the <a>AssumeRole</a> action. For more information about ARNs and how to use them in policies, see <a href="http://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html">IAM Identifiers</a> in <i>Using IAM</i>. </p>
     pub arn: String,
@@ -607,7 +607,7 @@ impl AudienceDeserializer {
     }
 }
 /// <p>AWS credentials for API authentication.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Credentials {
     /// <p>The access key ID that identifies the temporary security credentials.</p>
     pub access_key_id: String,
@@ -689,7 +689,7 @@ impl DateTypeDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DecodeAuthorizationMessageRequest {
     /// <p>The encoded message that was returned with the response.</p>
     pub encoded_message: String,
@@ -712,7 +712,7 @@ impl DecodeAuthorizationMessageRequestSerializer {
 }
 
 /// <p>A document that contains additional information about the authorization status of a request from an encoded message that is returned in response to an AWS request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct DecodeAuthorizationMessageResponse {
     /// <p>An XML document that contains the decoded message.</p>
     pub decoded_message: Option<String>,
@@ -788,7 +788,7 @@ impl FederatedIdTypeDeserializer {
     }
 }
 /// <p>Identifiers for the federated user that is associated with the credentials.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct FederatedUser {
     /// <p>The ARN that specifies the federated user that is associated with the credentials. For more information about ARNs and how to use them in policies, see <a href="http://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html">IAM Identifiers</a> in <i>Using IAM</i>. </p>
     pub arn: String,
@@ -841,7 +841,7 @@ impl FederatedUserDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetCallerIdentityRequest {}
 
 /// Serialize `GetCallerIdentityRequest` contents to a `SignedRequest`.
@@ -856,7 +856,7 @@ impl GetCallerIdentityRequestSerializer {
 }
 
 /// <p>Contains the response to a successful <a>GetCallerIdentity</a> request, including information about the entity making the request.</p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetCallerIdentityResponse {
     /// <p>The AWS account ID number of the account that owns or contains the calling entity.</p>
     pub account: Option<String>,
@@ -913,7 +913,7 @@ impl GetCallerIdentityResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetFederationTokenRequest {
     /// <p>The duration, in seconds, that the session should last. Acceptable durations for federation sessions range from 900 seconds (15 minutes) to 129600 seconds (36 hours), with 43200 seconds (12 hours) as the default. Sessions obtained using AWS account (root) credentials are restricted to a maximum of 3600 seconds (one hour). If the specified duration is longer than one hour, the session obtained by using AWS account (root) credentials defaults to one hour.</p>
     pub duration_seconds: Option<i64>,
@@ -952,7 +952,7 @@ impl GetFederationTokenRequestSerializer {
 }
 
 /// <p>Contains the response to a successful <a>GetFederationToken</a> request, including temporary AWS credentials that can be used to make AWS requests. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetFederationTokenResponse {
     /// <p>The temporary security credentials, which include an access key ID, a secret access key, and a security (or session) token.</p> <p> <b>Note:</b> The size of the security token that STS APIs return is not fixed. We strongly recommend that you make no assumptions about the maximum size. As of this writing, the typical size is less than 4096 bytes, but that can vary. Also, future updates to AWS might require larger sizes.</p>
     pub credentials: Option<Credentials>,
@@ -1017,7 +1017,7 @@ impl GetFederationTokenResponseDeserializer {
         Ok(obj)
     }
 }
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetSessionTokenRequest {
     /// <p>The duration, in seconds, that the credentials should remain valid. Acceptable durations for IAM user sessions range from 900 seconds (15 minutes) to 129600 seconds (36 hours), with 43200 seconds (12 hours) as the default. Sessions for AWS account owners are restricted to a maximum of 3600 seconds (one hour). If the duration is longer than one hour, the session for AWS account owners defaults to one hour.</p>
     pub duration_seconds: Option<i64>,
@@ -1058,7 +1058,7 @@ impl GetSessionTokenRequestSerializer {
 }
 
 /// <p>Contains the response to a successful <a>GetSessionToken</a> request, including temporary AWS credentials that can be used to make AWS requests. </p>
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct GetSessionTokenResponse {
     /// <p>The temporary security credentials, which include an access key ID, a secret access key, and a security (or session) token.</p> <p> <b>Note:</b> The size of the security token that STS APIs return is not fixed. We strongly recommend that you make no assumptions about the maximum size. As of this writing, the typical size is less than 4096 bytes, but that can vary. Also, future updates to AWS might require larger sizes.</p>
     pub credentials: Option<Credentials>,

--- a/rusoto/services/sts/src/generated.rs
+++ b/rusoto/services/sts/src/generated.rs
@@ -29,8 +29,9 @@ use hyper::StatusCode;
 use rusoto_core::param::{Params, ServiceParams};
 use rusoto_core::signature::SignedRequest;
 use rusoto_core::xmlerror::*;
-use rusoto_core::xmlutil::{characters, end_element, find_start_element, peek_at_name, skip_tree,
-                           start_element};
+use rusoto_core::xmlutil::{
+    characters, end_element, find_start_element, peek_at_name, skip_tree, start_element,
+};
 use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
 use std::str::FromStr;
 use xml::reader::ParserConfig;

--- a/rusoto/services/support/src/generated.rs
+++ b/rusoto/services/support/src/generated.rs
@@ -715,7 +715,8 @@ impl AddAttachmentsToSetError {
     pub fn from_body(body: &str) -> AddAttachmentsToSetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -819,7 +820,8 @@ impl AddCommunicationToCaseError {
     pub fn from_body(body: &str) -> AddCommunicationToCaseError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -919,7 +921,8 @@ impl CreateCaseError {
     pub fn from_body(body: &str) -> CreateCaseError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1011,7 +1014,8 @@ impl DescribeAttachmentError {
     pub fn from_body(body: &str) -> DescribeAttachmentError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1103,7 +1107,8 @@ impl DescribeCasesError {
     pub fn from_body(body: &str) -> DescribeCasesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1187,7 +1192,8 @@ impl DescribeCommunicationsError {
     pub fn from_body(body: &str) -> DescribeCommunicationsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1271,7 +1277,8 @@ impl DescribeServicesError {
     pub fn from_body(body: &str) -> DescribeServicesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1349,7 +1356,8 @@ impl DescribeSeverityLevelsError {
     pub fn from_body(body: &str) -> DescribeSeverityLevelsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1429,7 +1437,8 @@ impl DescribeTrustedAdvisorCheckRefreshStatusesError {
     pub fn from_body(body: &str) -> DescribeTrustedAdvisorCheckRefreshStatusesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1519,7 +1528,8 @@ impl DescribeTrustedAdvisorCheckResultError {
     pub fn from_body(body: &str) -> DescribeTrustedAdvisorCheckResultError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1601,7 +1611,8 @@ impl DescribeTrustedAdvisorCheckSummariesError {
     pub fn from_body(body: &str) -> DescribeTrustedAdvisorCheckSummariesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1683,7 +1694,8 @@ impl DescribeTrustedAdvisorChecksError {
     pub fn from_body(body: &str) -> DescribeTrustedAdvisorChecksError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1765,7 +1777,8 @@ impl RefreshTrustedAdvisorCheckError {
     pub fn from_body(body: &str) -> RefreshTrustedAdvisorCheckError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1847,7 +1860,8 @@ impl ResolveCaseError {
     pub fn from_body(body: &str) -> ResolveCaseError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/support/src/generated.rs
+++ b/rusoto/services/support/src/generated.rs
@@ -31,7 +31,7 @@ use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AddAttachmentsToSetRequest {
     /// <p>The ID of the attachment set. If an <code>attachmentSetId</code> is not specified, a new attachment set is created, and the ID of the set is returned in the response. If an <code>attachmentSetId</code> is specified, the attachments are added to the specified set, if it exists.</p>
     #[serde(rename = "attachmentSetId")]
@@ -43,7 +43,7 @@ pub struct AddAttachmentsToSetRequest {
 }
 
 /// <p>The ID and expiry time of the attachment set returned by the <a>AddAttachmentsToSet</a> operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AddAttachmentsToSetResponse {
     /// <p>The ID of the attachment set. If an <code>attachmentSetId</code> was not specified, a new attachment set is created, and the ID of the set is returned in the response. If an <code>attachmentSetId</code> was specified, the attachments are added to the specified set, if it exists.</p>
     #[serde(rename = "attachmentSetId")]
@@ -56,7 +56,7 @@ pub struct AddAttachmentsToSetResponse {
 }
 
 /// <p>To be written.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AddCommunicationToCaseRequest {
     /// <p>The ID of a set of one or more attachments for the communication to add to the case. Create the set by calling <a>AddAttachmentsToSet</a> </p>
     #[serde(rename = "attachmentSetId")]
@@ -76,7 +76,7 @@ pub struct AddCommunicationToCaseRequest {
 }
 
 /// <p>The result of the <a>AddCommunicationToCase</a> operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AddCommunicationToCaseResponse {
     /// <p>True if <a>AddCommunicationToCase</a> succeeds. Otherwise, returns an error.</p>
     #[serde(rename = "result")]
@@ -85,7 +85,7 @@ pub struct AddCommunicationToCaseResponse {
 }
 
 /// <p>An attachment to a case communication. The attachment consists of the file name and the content of the file.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Attachment {
     /// <p>The content of the attachment file.</p>
     #[serde(rename = "data")]
@@ -102,7 +102,7 @@ pub struct Attachment {
 }
 
 /// <p>The file name and ID of an attachment to a case communication. You can use the ID to retrieve the attachment with the <a>DescribeAttachment</a> operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AttachmentDetails {
     /// <p>The ID of the attachment.</p>
     #[serde(rename = "attachmentId")]
@@ -115,7 +115,7 @@ pub struct AttachmentDetails {
 }
 
 /// <p><p>A JSON-formatted object that contains the metadata for a support case. It is contained the response from a <a>DescribeCases</a> request. <b>CaseDetails</b> contains the following fields:</p> <ul> <li> <p> <b>caseId.</b> The AWS Support case ID requested or returned in the call. The case ID is an alphanumeric string formatted as shown in this example: case-<i>12345678910-2013-c4c1d2bf33c5cf47</i>.</p> </li> <li> <p> <b>categoryCode.</b> The category of problem for the AWS Support case. Corresponds to the CategoryCode values returned by a call to <a>DescribeServices</a>.</p> </li> <li> <p> <b>displayId.</b> The identifier for the case on pages in the AWS Support Center.</p> </li> <li> <p> <b>language.</b> The ISO 639-1 code for the language in which AWS provides support. AWS Support currently supports English (&quot;en&quot;) and Japanese (&quot;ja&quot;). Language parameters must be passed explicitly for operations that take them.</p> </li> <li> <p> <b>recentCommunications.</b> One or more <a>Communication</a> objects. Fields of these objects are <code>attachments</code>, <code>body</code>, <code>caseId</code>, <code>submittedBy</code>, and <code>timeCreated</code>.</p> </li> <li> <p> <b>nextToken.</b> A resumption point for pagination.</p> </li> <li> <p> <b>serviceCode.</b> The identifier for the AWS service that corresponds to the service code defined in the call to <a>DescribeServices</a>.</p> </li> <li> <p> <b>severityCode. </b>The severity code assigned to the case. Contains one of the values returned by the call to <a>DescribeSeverityLevels</a>.</p> </li> <li> <p> <b>status.</b> The status of the case in the AWS Support Center.</p> </li> <li> <p> <b>subject.</b> The subject line of the case.</p> </li> <li> <p> <b>submittedBy.</b> The email address of the account that submitted the case.</p> </li> <li> <p> <b>timeCreated.</b> The time the case was created, in ISO-8601 format.</p> </li> </ul></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CaseDetails {
     /// <p>The AWS Support case ID requested or returned in the call. The case ID is an alphanumeric string formatted as shown in this example: case-<i>12345678910-2013-c4c1d2bf33c5cf47</i> </p>
     #[serde(rename = "caseId")]
@@ -168,7 +168,7 @@ pub struct CaseDetails {
 }
 
 /// <p>A JSON-formatted name/value pair that represents the category name and category code of the problem, selected from the <a>DescribeServices</a> response for each AWS service.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Category {
     /// <p>The category code for the support case.</p>
     #[serde(rename = "code")]
@@ -181,7 +181,7 @@ pub struct Category {
 }
 
 /// <p>A communication associated with an AWS Support case. The communication consists of the case ID, the message body, attachment information, the account email address, and the date and time of the communication.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Communication {
     /// <p>Information about the attachments to the case communication.</p>
     #[serde(rename = "attachmentSet")]
@@ -206,7 +206,7 @@ pub struct Communication {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateCaseRequest {
     /// <p>The ID of a set of one or more attachments for the case. Create the set by using <a>AddAttachmentsToSet</a>.</p>
     #[serde(rename = "attachmentSetId")]
@@ -245,7 +245,7 @@ pub struct CreateCaseRequest {
 }
 
 /// <p>The AWS Support case ID returned by a successful completion of the <a>CreateCase</a> operation. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateCaseResponse {
     /// <p>The AWS Support case ID requested or returned in the call. The case ID is an alphanumeric string formatted as shown in this example: case-<i>12345678910-2013-c4c1d2bf33c5cf47</i> </p>
     #[serde(rename = "caseId")]
@@ -253,7 +253,7 @@ pub struct CreateCaseResponse {
     pub case_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeAttachmentRequest {
     /// <p>The ID of the attachment to return. Attachment IDs are returned by the <a>DescribeCommunications</a> operation.</p>
     #[serde(rename = "attachmentId")]
@@ -261,7 +261,7 @@ pub struct DescribeAttachmentRequest {
 }
 
 /// <p>The content and file name of the attachment returned by the <a>DescribeAttachment</a> operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeAttachmentResponse {
     /// <p>The attachment content and file name.</p>
     #[serde(rename = "attachment")]
@@ -270,7 +270,7 @@ pub struct DescribeAttachmentResponse {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeCasesRequest {
     /// <p>The start date for a filtered date search on support case communications. Case communications are available for 12 months after creation.</p>
     #[serde(rename = "afterTime")]
@@ -311,7 +311,7 @@ pub struct DescribeCasesRequest {
 }
 
 /// <p>Returns an array of <a>CaseDetails</a> objects and a <code>nextToken</code> that defines a point for pagination in the result set.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeCasesResponse {
     /// <p>The details for the cases that match the request.</p>
     #[serde(rename = "cases")]
@@ -324,7 +324,7 @@ pub struct DescribeCasesResponse {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeCommunicationsRequest {
     /// <p>The start date for a filtered date search on support case communications. Case communications are available for 12 months after creation.</p>
     #[serde(rename = "afterTime")]
@@ -348,7 +348,7 @@ pub struct DescribeCommunicationsRequest {
 }
 
 /// <p>The communications returned by the <a>DescribeCommunications</a> operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeCommunicationsResponse {
     /// <p>The communications for the case.</p>
     #[serde(rename = "communications")]
@@ -361,7 +361,7 @@ pub struct DescribeCommunicationsResponse {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeServicesRequest {
     /// <p>The ISO 639-1 code for the language in which AWS provides support. AWS Support currently supports English ("en") and Japanese ("ja"). Language parameters must be passed explicitly for operations that take them.</p>
     #[serde(rename = "language")]
@@ -374,7 +374,7 @@ pub struct DescribeServicesRequest {
 }
 
 /// <p>The list of AWS services returned by the <a>DescribeServices</a> operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeServicesResponse {
     /// <p>A JSON-formatted list of AWS services.</p>
     #[serde(rename = "services")]
@@ -383,7 +383,7 @@ pub struct DescribeServicesResponse {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeSeverityLevelsRequest {
     /// <p>The ISO 639-1 code for the language in which AWS provides support. AWS Support currently supports English ("en") and Japanese ("ja"). Language parameters must be passed explicitly for operations that take them.</p>
     #[serde(rename = "language")]
@@ -392,7 +392,7 @@ pub struct DescribeSeverityLevelsRequest {
 }
 
 /// <p>The list of severity levels returned by the <a>DescribeSeverityLevels</a> operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeSeverityLevelsResponse {
     /// <p>The available severity levels for the support case. Available severity levels are defined by your service level agreement with AWS.</p>
     #[serde(rename = "severityLevels")]
@@ -401,7 +401,7 @@ pub struct DescribeSeverityLevelsResponse {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeTrustedAdvisorCheckRefreshStatusesRequest {
     /// <p>The IDs of the Trusted Advisor checks to get the status of. <b>Note:</b> Specifying the check ID of a check that is automatically refreshed causes an <code>InvalidParameterValue</code> error.</p>
     #[serde(rename = "checkIds")]
@@ -409,7 +409,7 @@ pub struct DescribeTrustedAdvisorCheckRefreshStatusesRequest {
 }
 
 /// <p>The statuses of the Trusted Advisor checks returned by the <a>DescribeTrustedAdvisorCheckRefreshStatuses</a> operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeTrustedAdvisorCheckRefreshStatusesResponse {
     /// <p>The refresh status of the specified Trusted Advisor checks.</p>
     #[serde(rename = "statuses")]
@@ -417,7 +417,7 @@ pub struct DescribeTrustedAdvisorCheckRefreshStatusesResponse {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeTrustedAdvisorCheckResultRequest {
     /// <p>The unique identifier for the Trusted Advisor check.</p>
     #[serde(rename = "checkId")]
@@ -429,7 +429,7 @@ pub struct DescribeTrustedAdvisorCheckResultRequest {
 }
 
 /// <p>The result of the Trusted Advisor check returned by the <a>DescribeTrustedAdvisorCheckResult</a> operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeTrustedAdvisorCheckResultResponse {
     /// <p>The detailed results of the Trusted Advisor check.</p>
     #[serde(rename = "result")]
@@ -438,7 +438,7 @@ pub struct DescribeTrustedAdvisorCheckResultResponse {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeTrustedAdvisorCheckSummariesRequest {
     /// <p>The IDs of the Trusted Advisor checks.</p>
     #[serde(rename = "checkIds")]
@@ -446,7 +446,7 @@ pub struct DescribeTrustedAdvisorCheckSummariesRequest {
 }
 
 /// <p>The summaries of the Trusted Advisor checks returned by the <a>DescribeTrustedAdvisorCheckSummaries</a> operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeTrustedAdvisorCheckSummariesResponse {
     /// <p>The summary information for the requested Trusted Advisor checks.</p>
     #[serde(rename = "summaries")]
@@ -454,7 +454,7 @@ pub struct DescribeTrustedAdvisorCheckSummariesResponse {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeTrustedAdvisorChecksRequest {
     /// <p>The ISO 639-1 code for the language in which AWS provides support. AWS Support currently supports English ("en") and Japanese ("ja"). Language parameters must be passed explicitly for operations that take them.</p>
     #[serde(rename = "language")]
@@ -462,7 +462,7 @@ pub struct DescribeTrustedAdvisorChecksRequest {
 }
 
 /// <p>Information about the Trusted Advisor checks returned by the <a>DescribeTrustedAdvisorChecks</a> operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeTrustedAdvisorChecksResponse {
     /// <p>Information about all available Trusted Advisor checks.</p>
     #[serde(rename = "checks")]
@@ -470,7 +470,7 @@ pub struct DescribeTrustedAdvisorChecksResponse {
 }
 
 /// <p>The five most recent communications associated with the case.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RecentCaseCommunications {
     /// <p>The five most recent communications associated with the case.</p>
     #[serde(rename = "communications")]
@@ -483,7 +483,7 @@ pub struct RecentCaseCommunications {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RefreshTrustedAdvisorCheckRequest {
     /// <p>The unique identifier for the Trusted Advisor check to refresh. <b>Note:</b> Specifying the check ID of a check that is automatically refreshed causes an <code>InvalidParameterValue</code> error.</p>
     #[serde(rename = "checkId")]
@@ -491,7 +491,7 @@ pub struct RefreshTrustedAdvisorCheckRequest {
 }
 
 /// <p>The current refresh status of a Trusted Advisor check.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RefreshTrustedAdvisorCheckResponse {
     /// <p>The current refresh status for a check, including the amount of time until the check is eligible for refresh.</p>
     #[serde(rename = "status")]
@@ -499,7 +499,7 @@ pub struct RefreshTrustedAdvisorCheckResponse {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ResolveCaseRequest {
     /// <p>The AWS Support case ID requested or returned in the call. The case ID is an alphanumeric string formatted as shown in this example: case-<i>12345678910-2013-c4c1d2bf33c5cf47</i> </p>
     #[serde(rename = "caseId")]
@@ -508,7 +508,7 @@ pub struct ResolveCaseRequest {
 }
 
 /// <p>The status of the case returned by the <a>ResolveCase</a> operation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ResolveCaseResponse {
     /// <p>The status of the case after the <a>ResolveCase</a> request was processed.</p>
     #[serde(rename = "finalCaseStatus")]
@@ -521,7 +521,7 @@ pub struct ResolveCaseResponse {
 }
 
 /// <p>Information about an AWS service returned by the <a>DescribeServices</a> operation. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Service {
     /// <p>A list of categories that describe the type of support issue a case describes. Categories consist of a category name and a category code. Category names and codes are passed to AWS Support when you call <a>CreateCase</a>.</p>
     #[serde(rename = "categories")]
@@ -538,7 +538,7 @@ pub struct Service {
 }
 
 /// <p>A code and name pair that represent a severity level that can be applied to a support case.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SeverityLevel {
     /// <p>One of four values: "low," "medium," "high," and "urgent". These values correspond to response times returned to the caller in <code>severityLevel.name</code>. </p>
     #[serde(rename = "code")]
@@ -551,7 +551,7 @@ pub struct SeverityLevel {
 }
 
 /// <p>The container for summary information that relates to the category of the Trusted Advisor check.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct TrustedAdvisorCategorySpecificSummary {
     /// <p>The summary information about cost savings for a Trusted Advisor check that is in the Cost Optimizing category.</p>
     #[serde(rename = "costOptimizing")]
@@ -560,7 +560,7 @@ pub struct TrustedAdvisorCategorySpecificSummary {
 }
 
 /// <p>The description and metadata for a Trusted Advisor check.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct TrustedAdvisorCheckDescription {
     /// <p>The category of the Trusted Advisor check.</p>
     #[serde(rename = "category")]
@@ -580,7 +580,7 @@ pub struct TrustedAdvisorCheckDescription {
 }
 
 /// <p>The refresh status of a Trusted Advisor check.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct TrustedAdvisorCheckRefreshStatus {
     /// <p>The unique identifier for the Trusted Advisor check.</p>
     #[serde(rename = "checkId")]
@@ -594,7 +594,7 @@ pub struct TrustedAdvisorCheckRefreshStatus {
 }
 
 /// <p>The results of a Trusted Advisor check returned by <a>DescribeTrustedAdvisorCheckResult</a>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct TrustedAdvisorCheckResult {
     /// <p>Summary information that relates to the category of the check. Cost Optimizing is the only category that is currently supported.</p>
     #[serde(rename = "categorySpecificSummary")]
@@ -616,7 +616,7 @@ pub struct TrustedAdvisorCheckResult {
 }
 
 /// <p>A summary of a Trusted Advisor check result, including the alert status, last refresh, and number of resources examined.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct TrustedAdvisorCheckSummary {
     /// <p>Summary information that relates to the category of the check. Cost Optimizing is the only category that is currently supported.</p>
     #[serde(rename = "categorySpecificSummary")]
@@ -639,7 +639,7 @@ pub struct TrustedAdvisorCheckSummary {
 }
 
 /// <p>The estimated cost savings that might be realized if the recommended actions are taken.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct TrustedAdvisorCostOptimizingSummary {
     /// <p>The estimated monthly savings that might be realized if the recommended actions are taken.</p>
     #[serde(rename = "estimatedMonthlySavings")]
@@ -650,7 +650,7 @@ pub struct TrustedAdvisorCostOptimizingSummary {
 }
 
 /// <p>Contains information about a resource identified by a Trusted Advisor check.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct TrustedAdvisorResourceDetail {
     /// <p>Specifies whether the AWS resource was ignored by Trusted Advisor because it was marked as suppressed by the user.</p>
     #[serde(rename = "isSuppressed")]
@@ -672,7 +672,7 @@ pub struct TrustedAdvisorResourceDetail {
 }
 
 /// <p>Details about AWS resources that were analyzed in a call to Trusted Advisor <a>DescribeTrustedAdvisorCheckSummaries</a>. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct TrustedAdvisorResourcesSummary {
     /// <p>The number of AWS resources that were flagged (listed) by the Trusted Advisor check.</p>
     #[serde(rename = "resourcesFlagged")]

--- a/rusoto/services/swf/src/generated.rs
+++ b/rusoto/services/swf/src/generated.rs
@@ -2763,7 +2763,8 @@ impl CountClosedWorkflowExecutionsError {
     pub fn from_body(body: &str) -> CountClosedWorkflowExecutionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2853,7 +2854,8 @@ impl CountOpenWorkflowExecutionsError {
     pub fn from_body(body: &str) -> CountOpenWorkflowExecutionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2943,7 +2945,8 @@ impl CountPendingActivityTasksError {
     pub fn from_body(body: &str) -> CountPendingActivityTasksError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3031,7 +3034,8 @@ impl CountPendingDecisionTasksError {
     pub fn from_body(body: &str) -> CountPendingDecisionTasksError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3121,7 +3125,8 @@ impl DeprecateActivityTypeError {
     pub fn from_body(body: &str) -> DeprecateActivityTypeError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3215,7 +3220,8 @@ impl DeprecateDomainError {
     pub fn from_body(body: &str) -> DeprecateDomainError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3307,7 +3313,8 @@ impl DeprecateWorkflowTypeError {
     pub fn from_body(body: &str) -> DeprecateWorkflowTypeError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3399,7 +3406,8 @@ impl DescribeActivityTypeError {
     pub fn from_body(body: &str) -> DescribeActivityTypeError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3487,7 +3495,8 @@ impl DescribeDomainError {
     pub fn from_body(body: &str) -> DescribeDomainError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3571,7 +3580,8 @@ impl DescribeWorkflowExecutionError {
     pub fn from_body(body: &str) -> DescribeWorkflowExecutionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3659,7 +3669,8 @@ impl DescribeWorkflowTypeError {
     pub fn from_body(body: &str) -> DescribeWorkflowTypeError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3747,7 +3758,8 @@ impl GetWorkflowExecutionHistoryError {
     pub fn from_body(body: &str) -> GetWorkflowExecutionHistoryError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3837,7 +3849,8 @@ impl ListActivityTypesError {
     pub fn from_body(body: &str) -> ListActivityTypesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3925,7 +3938,8 @@ impl ListClosedWorkflowExecutionsError {
     pub fn from_body(body: &str) -> ListClosedWorkflowExecutionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4013,7 +4027,8 @@ impl ListDomainsError {
     pub fn from_body(body: &str) -> ListDomainsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4093,7 +4108,8 @@ impl ListOpenWorkflowExecutionsError {
     pub fn from_body(body: &str) -> ListOpenWorkflowExecutionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4183,7 +4199,8 @@ impl ListWorkflowTypesError {
     pub fn from_body(body: &str) -> ListWorkflowTypesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4273,7 +4290,8 @@ impl PollForActivityTaskError {
     pub fn from_body(body: &str) -> PollForActivityTaskError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4367,7 +4385,8 @@ impl PollForDecisionTaskError {
     pub fn from_body(body: &str) -> PollForDecisionTaskError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4459,7 +4478,8 @@ impl RecordActivityTaskHeartbeatError {
     pub fn from_body(body: &str) -> RecordActivityTaskHeartbeatError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4553,7 +4573,8 @@ impl RegisterActivityTypeError {
     pub fn from_body(body: &str) -> RegisterActivityTypeError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4651,7 +4672,8 @@ impl RegisterDomainError {
     pub fn from_body(body: &str) -> RegisterDomainError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4743,7 +4765,8 @@ impl RegisterWorkflowTypeError {
     pub fn from_body(body: &str) -> RegisterWorkflowTypeError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4839,7 +4862,8 @@ impl RequestCancelWorkflowExecutionError {
     pub fn from_body(body: &str) -> RequestCancelWorkflowExecutionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4929,7 +4953,8 @@ impl RespondActivityTaskCanceledError {
     pub fn from_body(body: &str) -> RespondActivityTaskCanceledError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5019,7 +5044,8 @@ impl RespondActivityTaskCompletedError {
     pub fn from_body(body: &str) -> RespondActivityTaskCompletedError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5109,7 +5135,8 @@ impl RespondActivityTaskFailedError {
     pub fn from_body(body: &str) -> RespondActivityTaskFailedError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5197,7 +5224,8 @@ impl RespondDecisionTaskCompletedError {
     pub fn from_body(body: &str) -> RespondDecisionTaskCompletedError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5287,7 +5315,8 @@ impl SignalWorkflowExecutionError {
     pub fn from_body(body: &str) -> SignalWorkflowExecutionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5383,7 +5412,8 @@ impl StartWorkflowExecutionError {
     pub fn from_body(body: &str) -> StartWorkflowExecutionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5489,7 +5519,8 @@ impl TerminateWorkflowExecutionError {
     pub fn from_body(body: &str) -> TerminateWorkflowExecutionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/swf/src/generated.rs
+++ b/rusoto/services/swf/src/generated.rs
@@ -31,7 +31,7 @@ use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 /// <p>Unit of work sent to an activity worker.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ActivityTask {
     /// <p>The unique ID of the task.</p>
     #[serde(rename = "activityId")]
@@ -55,7 +55,7 @@ pub struct ActivityTask {
 }
 
 /// <p>Provides the details of the <code>ActivityTaskCancelRequested</code> event.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ActivityTaskCancelRequestedEventAttributes {
     /// <p>The unique ID of the task.</p>
     #[serde(rename = "activityId")]
@@ -66,7 +66,7 @@ pub struct ActivityTaskCancelRequestedEventAttributes {
 }
 
 /// <p>Provides the details of the <code>ActivityTaskCanceled</code> event.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ActivityTaskCanceledEventAttributes {
     /// <p>Details of the cancellation.</p>
     #[serde(rename = "details")]
@@ -85,7 +85,7 @@ pub struct ActivityTaskCanceledEventAttributes {
 }
 
 /// <p>Provides the details of the <code>ActivityTaskCompleted</code> event.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ActivityTaskCompletedEventAttributes {
     /// <p>The results of the activity task.</p>
     #[serde(rename = "result")]
@@ -100,7 +100,7 @@ pub struct ActivityTaskCompletedEventAttributes {
 }
 
 /// <p>Provides the details of the <code>ActivityTaskFailed</code> event.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ActivityTaskFailedEventAttributes {
     /// <p>The details of the failure.</p>
     #[serde(rename = "details")]
@@ -119,7 +119,7 @@ pub struct ActivityTaskFailedEventAttributes {
 }
 
 /// <p>Provides the details of the <code>ActivityTaskScheduled</code> event.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ActivityTaskScheduledEventAttributes {
     /// <p>The unique ID of the activity task.</p>
     #[serde(rename = "activityId")]
@@ -164,7 +164,7 @@ pub struct ActivityTaskScheduledEventAttributes {
 }
 
 /// <p>Provides the details of the <code>ActivityTaskStarted</code> event.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ActivityTaskStartedEventAttributes {
     /// <p>Identity of the worker that was assigned this task. This aids diagnostics when problems arise. The form of this identity is user defined.</p>
     #[serde(rename = "identity")]
@@ -176,7 +176,7 @@ pub struct ActivityTaskStartedEventAttributes {
 }
 
 /// <p>Status information about an activity task.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ActivityTaskStatus {
     /// <p>Set to <code>true</code> if cancellation of the task is requested.</p>
     #[serde(rename = "cancelRequested")]
@@ -184,7 +184,7 @@ pub struct ActivityTaskStatus {
 }
 
 /// <p>Provides the details of the <code>ActivityTaskTimedOut</code> event.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ActivityTaskTimedOutEventAttributes {
     /// <p>Contains the content of the <code>details</code> parameter for the last call made by the activity to <code>RecordActivityTaskHeartbeat</code>.</p>
     #[serde(rename = "details")]
@@ -202,7 +202,7 @@ pub struct ActivityTaskTimedOutEventAttributes {
 }
 
 /// <p>Represents an activity type.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ActivityType {
     /// <p><p>The name of this activity.</p> <note> <p>The combination of activity type name and version must be unique within a domain.</p> </note></p>
     #[serde(rename = "name")]
@@ -213,7 +213,7 @@ pub struct ActivityType {
 }
 
 /// <p>Configuration settings registered with the activity type.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ActivityTypeConfiguration {
     /// <p> The default maximum time, in seconds, before which a worker processing a task must report progress by calling <a>RecordActivityTaskHeartbeat</a>.</p> <p>You can specify this value only when <i>registering</i> an activity type. The registered default value can be overridden when you schedule a task through the <code>ScheduleActivityTask</code> <a>Decision</a>. If the activity worker subsequently attempts to record a heartbeat or returns a result, the activity worker receives an <code>UnknownResource</code> fault. In this case, Amazon SWF no longer considers the activity task to be valid; the activity worker should clean up the activity task.</p> <p>The duration is specified in seconds, an integer greater than or equal to <code>0</code>. You can use <code>NONE</code> to specify unlimited duration.</p>
     #[serde(rename = "defaultTaskHeartbeatTimeout")]
@@ -242,7 +242,7 @@ pub struct ActivityTypeConfiguration {
 }
 
 /// <p>Detailed information about an activity type.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ActivityTypeDetail {
     /// <p>The configuration settings registered with the activity type.</p>
     #[serde(rename = "configuration")]
@@ -253,7 +253,7 @@ pub struct ActivityTypeDetail {
 }
 
 /// <p>Detailed information about an activity type.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ActivityTypeInfo {
     /// <p>The <a>ActivityType</a> type structure representing the activity type.</p>
     #[serde(rename = "activityType")]
@@ -275,7 +275,7 @@ pub struct ActivityTypeInfo {
 }
 
 /// <p>Contains a paginated list of activity type information structures.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ActivityTypeInfos {
     /// <p>If a <code>NextPageToken</code> was returned by a previous call, there are more results available. To retrieve the next page of results, make the call again using the returned token in <code>nextPageToken</code>. Keep all other arguments unchanged.</p> <p>The configured <code>maximumPageSize</code> determines how many results can be returned in a single call.</p>
     #[serde(rename = "nextPageToken")]
@@ -287,7 +287,7 @@ pub struct ActivityTypeInfos {
 }
 
 /// <p>Provides the details of the <code>CancelTimer</code> decision.</p> <p> <b>Access Control</b> </p> <p>You can use IAM policies to control this decision's access to Amazon SWF resources as follows:</p> <ul> <li> <p>Use a <code>Resource</code> element with the domain name to limit the action to only specified domains.</p> </li> <li> <p>Use an <code>Action</code> element to allow or deny permission to call this action.</p> </li> <li> <p>You cannot use an IAM policy to constrain this action's parameters.</p> </li> </ul> <p>If the caller doesn't have sufficient permissions to invoke the action, or the parameter values fall outside the specified constraints, the action fails. The associated event attribute's <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>. For details and example IAM policies, see <a href="http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CancelTimerDecisionAttributes {
     /// <p> The unique ID of the timer to cancel.</p>
     #[serde(rename = "timerId")]
@@ -295,7 +295,7 @@ pub struct CancelTimerDecisionAttributes {
 }
 
 /// <p>Provides the details of the <code>CancelTimerFailed</code> event.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CancelTimerFailedEventAttributes {
     /// <p><p>The cause of the failure. This information is generated by the system and can be useful for diagnostic purposes.</p> <note> <p>If <code>cause</code> is set to <code>OPERATION<em>NOT</em>PERMITTED</code>, the decision failed because it lacked sufficient permissions. For details and example IAM policies, see <a href="http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p> </note></p>
     #[serde(rename = "cause")]
@@ -309,7 +309,7 @@ pub struct CancelTimerFailedEventAttributes {
 }
 
 /// <p>Provides the details of the <code>CancelWorkflowExecution</code> decision.</p> <p> <b>Access Control</b> </p> <p>You can use IAM policies to control this decision's access to Amazon SWF resources as follows:</p> <ul> <li> <p>Use a <code>Resource</code> element with the domain name to limit the action to only specified domains.</p> </li> <li> <p>Use an <code>Action</code> element to allow or deny permission to call this action.</p> </li> <li> <p>You cannot use an IAM policy to constrain this action's parameters.</p> </li> </ul> <p>If the caller doesn't have sufficient permissions to invoke the action, or the parameter values fall outside the specified constraints, the action fails. The associated event attribute's <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>. For details and example IAM policies, see <a href="http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CancelWorkflowExecutionDecisionAttributes {
     /// <p> Details of the cancellation.</p>
     #[serde(rename = "details")]
@@ -318,7 +318,7 @@ pub struct CancelWorkflowExecutionDecisionAttributes {
 }
 
 /// <p>Provides the details of the <code>CancelWorkflowExecutionFailed</code> event.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CancelWorkflowExecutionFailedEventAttributes {
     /// <p><p>The cause of the failure. This information is generated by the system and can be useful for diagnostic purposes.</p> <note> <p>If <code>cause</code> is set to <code>OPERATION<em>NOT</em>PERMITTED</code>, the decision failed because it lacked sufficient permissions. For details and example IAM policies, see <a href="http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p> </note></p>
     #[serde(rename = "cause")]
@@ -329,7 +329,7 @@ pub struct CancelWorkflowExecutionFailedEventAttributes {
 }
 
 /// <p>Provide details of the <code>ChildWorkflowExecutionCanceled</code> event.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ChildWorkflowExecutionCanceledEventAttributes {
     /// <p>Details of the cancellation (if provided).</p>
     #[serde(rename = "details")]
@@ -350,7 +350,7 @@ pub struct ChildWorkflowExecutionCanceledEventAttributes {
 }
 
 /// <p>Provides the details of the <code>ChildWorkflowExecutionCompleted</code> event.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ChildWorkflowExecutionCompletedEventAttributes {
     /// <p>The ID of the <code>StartChildWorkflowExecutionInitiated</code> event corresponding to the <code>StartChildWorkflowExecution</code> <a>Decision</a> to start this child workflow execution. This information can be useful for diagnosing problems by tracing back the chain of events leading up to this event.</p>
     #[serde(rename = "initiatedEventId")]
@@ -371,7 +371,7 @@ pub struct ChildWorkflowExecutionCompletedEventAttributes {
 }
 
 /// <p>Provides the details of the <code>ChildWorkflowExecutionFailed</code> event.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ChildWorkflowExecutionFailedEventAttributes {
     /// <p>The details of the failure (if provided).</p>
     #[serde(rename = "details")]
@@ -396,7 +396,7 @@ pub struct ChildWorkflowExecutionFailedEventAttributes {
 }
 
 /// <p>Provides the details of the <code>ChildWorkflowExecutionStarted</code> event.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ChildWorkflowExecutionStartedEventAttributes {
     /// <p>The ID of the <code>StartChildWorkflowExecutionInitiated</code> event corresponding to the <code>StartChildWorkflowExecution</code> <a>Decision</a> to start this child workflow execution. This information can be useful for diagnosing problems by tracing back the chain of events leading up to this event.</p>
     #[serde(rename = "initiatedEventId")]
@@ -410,7 +410,7 @@ pub struct ChildWorkflowExecutionStartedEventAttributes {
 }
 
 /// <p>Provides the details of the <code>ChildWorkflowExecutionTerminated</code> event.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ChildWorkflowExecutionTerminatedEventAttributes {
     /// <p>The ID of the <code>StartChildWorkflowExecutionInitiated</code> event corresponding to the <code>StartChildWorkflowExecution</code> <a>Decision</a> to start this child workflow execution. This information can be useful for diagnosing problems by tracing back the chain of events leading up to this event.</p>
     #[serde(rename = "initiatedEventId")]
@@ -427,7 +427,7 @@ pub struct ChildWorkflowExecutionTerminatedEventAttributes {
 }
 
 /// <p>Provides the details of the <code>ChildWorkflowExecutionTimedOut</code> event.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ChildWorkflowExecutionTimedOutEventAttributes {
     /// <p>The ID of the <code>StartChildWorkflowExecutionInitiated</code> event corresponding to the <code>StartChildWorkflowExecution</code> <a>Decision</a> to start this child workflow execution. This information can be useful for diagnosing problems by tracing back the chain of events leading up to this event.</p>
     #[serde(rename = "initiatedEventId")]
@@ -447,7 +447,7 @@ pub struct ChildWorkflowExecutionTimedOutEventAttributes {
 }
 
 /// <p>Used to filter the closed workflow executions in visibility APIs by their close status.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CloseStatusFilter {
     /// <p> The close status that must match the close status of an execution for it to meet the criteria of this filter.</p>
     #[serde(rename = "status")]
@@ -455,7 +455,7 @@ pub struct CloseStatusFilter {
 }
 
 /// <p>Provides the details of the <code>CompleteWorkflowExecution</code> decision.</p> <p> <b>Access Control</b> </p> <p>You can use IAM policies to control this decision's access to Amazon SWF resources as follows:</p> <ul> <li> <p>Use a <code>Resource</code> element with the domain name to limit the action to only specified domains.</p> </li> <li> <p>Use an <code>Action</code> element to allow or deny permission to call this action.</p> </li> <li> <p>You cannot use an IAM policy to constrain this action's parameters.</p> </li> </ul> <p>If the caller doesn't have sufficient permissions to invoke the action, or the parameter values fall outside the specified constraints, the action fails. The associated event attribute's <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>. For details and example IAM policies, see <a href="http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CompleteWorkflowExecutionDecisionAttributes {
     /// <p>The result of the workflow execution. The form of the result is implementation defined.</p>
     #[serde(rename = "result")]
@@ -464,7 +464,7 @@ pub struct CompleteWorkflowExecutionDecisionAttributes {
 }
 
 /// <p>Provides the details of the <code>CompleteWorkflowExecutionFailed</code> event.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CompleteWorkflowExecutionFailedEventAttributes {
     /// <p><p>The cause of the failure. This information is generated by the system and can be useful for diagnostic purposes.</p> <note> <p>If <code>cause</code> is set to <code>OPERATION<em>NOT</em>PERMITTED</code>, the decision failed because it lacked sufficient permissions. For details and example IAM policies, see <a href="http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p> </note></p>
     #[serde(rename = "cause")]
@@ -475,7 +475,7 @@ pub struct CompleteWorkflowExecutionFailedEventAttributes {
 }
 
 /// <p>Provides the details of the <code>ContinueAsNewWorkflowExecution</code> decision.</p> <p> <b>Access Control</b> </p> <p>You can use IAM policies to control this decision's access to Amazon SWF resources as follows:</p> <ul> <li> <p>Use a <code>Resource</code> element with the domain name to limit the action to only specified domains.</p> </li> <li> <p>Use an <code>Action</code> element to allow or deny permission to call this action.</p> </li> <li> <p>Constrain the following parameters by using a <code>Condition</code> element with the appropriate keys.</p> <ul> <li> <p> <code>tag</code> – A tag used to identify the workflow execution</p> </li> <li> <p> <code>taskList</code> – String constraint. The key is <code>swf:taskList.name</code>.</p> </li> <li> <p> <code>workflowType.version</code> – String constraint. The key is <code>swf:workflowType.version</code>.</p> </li> </ul> </li> </ul> <p>If the caller doesn't have sufficient permissions to invoke the action, or the parameter values fall outside the specified constraints, the action fails. The associated event attribute's <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>. For details and example IAM policies, see <a href="http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ContinueAsNewWorkflowExecutionDecisionAttributes {
     /// <p><p>If set, specifies the policy to use for the child workflow executions of the new execution if it is terminated by calling the <a>TerminateWorkflowExecution</a> action explicitly or due to an expired timeout. This policy overrides the default child policy specified when registering the workflow type using <a>RegisterWorkflowType</a>.</p> <p>The supported child policies are:</p> <ul> <li> <p> <code>TERMINATE</code> – The child executions are terminated.</p> </li> <li> <p> <code>REQUEST_CANCEL</code> – A request to cancel is attempted for each child execution by recording a <code>WorkflowExecutionCancelRequested</code> event in its history. It is up to the decider to take appropriate actions when it receives an execution history with this event.</p> </li> <li> <p> <code>ABANDON</code> – No action is taken. The child executions continue to run.</p> </li> </ul> <note> <p>A child policy for this workflow execution must be specified either as a default for the workflow type or through this parameter. If neither this parameter is set nor a default child policy was specified at registration time then a fault is returned.</p> </note></p>
     #[serde(rename = "childPolicy")]
@@ -516,7 +516,7 @@ pub struct ContinueAsNewWorkflowExecutionDecisionAttributes {
 }
 
 /// <p>Provides the details of the <code>ContinueAsNewWorkflowExecutionFailed</code> event.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ContinueAsNewWorkflowExecutionFailedEventAttributes {
     /// <p><p>The cause of the failure. This information is generated by the system and can be useful for diagnostic purposes.</p> <note> <p>If <code>cause</code> is set to <code>OPERATION<em>NOT</em>PERMITTED</code>, the decision failed because it lacked sufficient permissions. For details and example IAM policies, see <a href="http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p> </note></p>
     #[serde(rename = "cause")]
@@ -526,7 +526,7 @@ pub struct ContinueAsNewWorkflowExecutionFailedEventAttributes {
     pub decision_task_completed_event_id: i64,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CountClosedWorkflowExecutionsInput {
     /// <p><p>If specified, only workflow executions that match this close status are counted. This filter has an affect only if <code>executionStatus</code> is specified as <code>CLOSED</code>.</p> <note> <p> <code>closeStatusFilter</code>, <code>executionFilter</code>, <code>typeFilter</code> and <code>tagFilter</code> are mutually exclusive. You can specify at most one of these in a request.</p> </note></p>
     #[serde(rename = "closeStatusFilter")]
@@ -557,7 +557,7 @@ pub struct CountClosedWorkflowExecutionsInput {
     pub type_filter: Option<WorkflowTypeFilter>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CountOpenWorkflowExecutionsInput {
     /// <p>The name of the domain containing the workflow executions to count.</p>
     #[serde(rename = "domain")]
@@ -579,7 +579,7 @@ pub struct CountOpenWorkflowExecutionsInput {
     pub type_filter: Option<WorkflowTypeFilter>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CountPendingActivityTasksInput {
     /// <p>The name of the domain that contains the task list.</p>
     #[serde(rename = "domain")]
@@ -589,7 +589,7 @@ pub struct CountPendingActivityTasksInput {
     pub task_list: TaskList,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CountPendingDecisionTasksInput {
     /// <p>The name of the domain that contains the task list.</p>
     #[serde(rename = "domain")]
@@ -600,7 +600,7 @@ pub struct CountPendingDecisionTasksInput {
 }
 
 /// <p><p>Specifies a decision made by the decider. A decision can be one of these types:</p> <ul> <li> <p> <code>CancelTimer</code> – Cancels a previously started timer and records a <code>TimerCanceled</code> event in the history.</p> </li> <li> <p> <code>CancelWorkflowExecution</code> – Closes the workflow execution and records a <code>WorkflowExecutionCanceled</code> event in the history.</p> </li> <li> <p> <code>CompleteWorkflowExecution</code> – Closes the workflow execution and records a <code>WorkflowExecutionCompleted</code> event in the history .</p> </li> <li> <p> <code>ContinueAsNewWorkflowExecution</code> – Closes the workflow execution and starts a new workflow execution of the same type using the same workflow ID and a unique run Id. A <code>WorkflowExecutionContinuedAsNew</code> event is recorded in the history.</p> </li> <li> <p> <code>FailWorkflowExecution</code> – Closes the workflow execution and records a <code>WorkflowExecutionFailed</code> event in the history.</p> </li> <li> <p> <code>RecordMarker</code> – Records a <code>MarkerRecorded</code> event in the history. Markers can be used for adding custom information in the history for instance to let deciders know that they don&#39;t need to look at the history beyond the marker event.</p> </li> <li> <p> <code>RequestCancelActivityTask</code> – Attempts to cancel a previously scheduled activity task. If the activity task was scheduled but has not been assigned to a worker, then it is canceled. If the activity task was already assigned to a worker, then the worker is informed that cancellation has been requested in the response to <a>RecordActivityTaskHeartbeat</a>.</p> </li> <li> <p> <code>RequestCancelExternalWorkflowExecution</code> – Requests that a request be made to cancel the specified external workflow execution and records a <code>RequestCancelExternalWorkflowExecutionInitiated</code> event in the history.</p> </li> <li> <p> <code>ScheduleActivityTask</code> – Schedules an activity task.</p> </li> <li> <p> <code>SignalExternalWorkflowExecution</code> – Requests a signal to be delivered to the specified external workflow execution and records a <code>SignalExternalWorkflowExecutionInitiated</code> event in the history.</p> </li> <li> <p> <code>StartChildWorkflowExecution</code> – Requests that a child workflow execution be started and records a <code>StartChildWorkflowExecutionInitiated</code> event in the history. The child workflow execution is a separate workflow execution with its own history.</p> </li> <li> <p> <code>StartTimer</code> – Starts a timer for this workflow execution and records a <code>TimerStarted</code> event in the history. This timer fires after the specified delay and record a <code>TimerFired</code> event.</p> </li> </ul> <p> <b>Access Control</b> </p> <p>If you grant permission to use <code>RespondDecisionTaskCompleted</code>, you can use IAM policies to express permissions for the list of decisions returned by this action as if they were members of the API. Treating decisions as a pseudo API maintains a uniform conceptual model and helps keep policies readable. For details and example IAM policies, see <a href="http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p> <p> <b>Decision Failure</b> </p> <p>Decisions can fail for several reasons</p> <ul> <li> <p>The ordering of decisions should follow a logical flow. Some decisions might not make sense in the current context of the workflow execution and therefore fails.</p> </li> <li> <p>A limit on your account was reached.</p> </li> <li> <p>The decision lacks sufficient permissions.</p> </li> </ul> <p>One of the following events might be added to the history to indicate an error. The event attribute&#39;s <code>cause</code> parameter indicates the cause. If <code>cause</code> is set to <code>OPERATION<em>NOT</em>PERMITTED</code>, the decision failed because it lacked sufficient permissions. For details and example IAM policies, see <a href="http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p> <ul> <li> <p> <code>ScheduleActivityTaskFailed</code> – A <code>ScheduleActivityTask</code> decision failed. This could happen if the activity type specified in the decision isn&#39;t registered, is in a deprecated state, or the decision isn&#39;t properly configured.</p> </li> <li> <p> <code>RequestCancelActivityTaskFailed</code> – A <code>RequestCancelActivityTask</code> decision failed. This could happen if there is no open activity task with the specified activityId.</p> </li> <li> <p> <code>StartTimerFailed</code> – A <code>StartTimer</code> decision failed. This could happen if there is another open timer with the same timerId.</p> </li> <li> <p> <code>CancelTimerFailed</code> – A <code>CancelTimer</code> decision failed. This could happen if there is no open timer with the specified timerId.</p> </li> <li> <p> <code>StartChildWorkflowExecutionFailed</code> – A <code>StartChildWorkflowExecution</code> decision failed. This could happen if the workflow type specified isn&#39;t registered, is deprecated, or the decision isn&#39;t properly configured.</p> </li> <li> <p> <code>SignalExternalWorkflowExecutionFailed</code> – A <code>SignalExternalWorkflowExecution</code> decision failed. This could happen if the <code>workflowID</code> specified in the decision was incorrect.</p> </li> <li> <p> <code>RequestCancelExternalWorkflowExecutionFailed</code> – A <code>RequestCancelExternalWorkflowExecution</code> decision failed. This could happen if the <code>workflowID</code> specified in the decision was incorrect.</p> </li> <li> <p> <code>CancelWorkflowExecutionFailed</code> – A <code>CancelWorkflowExecution</code> decision failed. This could happen if there is an unhandled decision task pending in the workflow execution.</p> </li> <li> <p> <code>CompleteWorkflowExecutionFailed</code> – A <code>CompleteWorkflowExecution</code> decision failed. This could happen if there is an unhandled decision task pending in the workflow execution.</p> </li> <li> <p> <code>ContinueAsNewWorkflowExecutionFailed</code> – A <code>ContinueAsNewWorkflowExecution</code> decision failed. This could happen if there is an unhandled decision task pending in the workflow execution or the ContinueAsNewWorkflowExecution decision was not configured correctly.</p> </li> <li> <p> <code>FailWorkflowExecutionFailed</code> – A <code>FailWorkflowExecution</code> decision failed. This could happen if there is an unhandled decision task pending in the workflow execution.</p> </li> </ul> <p>The preceding error events might occur due to an error in the decider logic, which might put the workflow execution in an unstable state The cause field in the event structure for the error event indicates the cause of the error.</p> <note> <p>A workflow execution may be closed by the decider by returning one of the following decisions when completing a decision task: <code>CompleteWorkflowExecution</code>, <code>FailWorkflowExecution</code>, <code>CancelWorkflowExecution</code> and <code>ContinueAsNewWorkflowExecution</code>. An <code>UnhandledDecision</code> fault is returned if a workflow closing decision is specified and a signal or activity event had been added to the history while the decision task was being performed by the decider. Unlike the above situations which are logic issues, this fault is always possible because of race conditions in a distributed system. The right action here is to call <a>RespondDecisionTaskCompleted</a> without any decisions. This would result in another decision task with these new events included in the history. The decider should handle the new events and may decide to close the workflow execution.</p> </note> <p> <b>How to Code a Decision</b> </p> <p>You code a decision by first setting the decision type field to one of the above decision values, and then set the corresponding attributes field shown below:</p> <ul> <li> <p> <code> <a>ScheduleActivityTaskDecisionAttributes</a> </code> </p> </li> <li> <p> <code> <a>RequestCancelActivityTaskDecisionAttributes</a> </code> </p> </li> <li> <p> <code> <a>CompleteWorkflowExecutionDecisionAttributes</a> </code> </p> </li> <li> <p> <code> <a>FailWorkflowExecutionDecisionAttributes</a> </code> </p> </li> <li> <p> <code> <a>CancelWorkflowExecutionDecisionAttributes</a> </code> </p> </li> <li> <p> <code> <a>ContinueAsNewWorkflowExecutionDecisionAttributes</a> </code> </p> </li> <li> <p> <code> <a>RecordMarkerDecisionAttributes</a> </code> </p> </li> <li> <p> <code> <a>StartTimerDecisionAttributes</a> </code> </p> </li> <li> <p> <code> <a>CancelTimerDecisionAttributes</a> </code> </p> </li> <li> <p> <code> <a>SignalExternalWorkflowExecutionDecisionAttributes</a> </code> </p> </li> <li> <p> <code> <a>RequestCancelExternalWorkflowExecutionDecisionAttributes</a> </code> </p> </li> <li> <p> <code> <a>StartChildWorkflowExecutionDecisionAttributes</a> </code> </p> </li> </ul></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct Decision {
     /// <p>Provides the details of the <code>CancelTimer</code> decision. It isn't set for other decision types.</p>
     #[serde(rename = "cancelTimerDecisionAttributes")]
@@ -669,7 +669,7 @@ pub struct Decision {
 }
 
 /// <p>A structure that represents a decision task. Decision tasks are sent to deciders in order for them to make decisions.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DecisionTask {
     /// <p>A paginated list of history events of the workflow execution. The decider uses this during the processing of the decision task.</p>
     #[serde(rename = "events")]
@@ -697,7 +697,7 @@ pub struct DecisionTask {
 }
 
 /// <p>Provides the details of the <code>DecisionTaskCompleted</code> event.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DecisionTaskCompletedEventAttributes {
     /// <p>User defined context for the workflow execution.</p>
     #[serde(rename = "executionContext")]
@@ -712,7 +712,7 @@ pub struct DecisionTaskCompletedEventAttributes {
 }
 
 /// <p>Provides details about the <code>DecisionTaskScheduled</code> event.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DecisionTaskScheduledEventAttributes {
     /// <p>The maximum duration for this decision task. The task is considered timed out if it doesn't completed within this duration.</p> <p>The duration is specified in seconds, an integer greater than or equal to <code>0</code>. You can use <code>NONE</code> to specify unlimited duration.</p>
     #[serde(rename = "startToCloseTimeout")]
@@ -728,7 +728,7 @@ pub struct DecisionTaskScheduledEventAttributes {
 }
 
 /// <p>Provides the details of the <code>DecisionTaskStarted</code> event.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DecisionTaskStartedEventAttributes {
     /// <p>Identity of the decider making the request. This enables diagnostic tracing when problems arise. The form of this identity is user defined.</p>
     #[serde(rename = "identity")]
@@ -740,7 +740,7 @@ pub struct DecisionTaskStartedEventAttributes {
 }
 
 /// <p>Provides the details of the <code>DecisionTaskTimedOut</code> event.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DecisionTaskTimedOutEventAttributes {
     /// <p>The ID of the <code>DecisionTaskScheduled</code> event that was recorded when this decision task was scheduled. This information can be useful for diagnosing problems by tracing back the chain of events leading up to this event.</p>
     #[serde(rename = "scheduledEventId")]
@@ -753,7 +753,7 @@ pub struct DecisionTaskTimedOutEventAttributes {
     pub timeout_type: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeprecateActivityTypeInput {
     /// <p>The activity type to deprecate.</p>
     #[serde(rename = "activityType")]
@@ -763,14 +763,14 @@ pub struct DeprecateActivityTypeInput {
     pub domain: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeprecateDomainInput {
     /// <p>The name of the domain to deprecate.</p>
     #[serde(rename = "name")]
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeprecateWorkflowTypeInput {
     /// <p>The name of the domain in which the workflow type is registered.</p>
     #[serde(rename = "domain")]
@@ -780,7 +780,7 @@ pub struct DeprecateWorkflowTypeInput {
     pub workflow_type: WorkflowType,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeActivityTypeInput {
     /// <p>The activity type to get information about. Activity types are identified by the <code>name</code> and <code>version</code> that were supplied when the activity was registered.</p>
     #[serde(rename = "activityType")]
@@ -790,14 +790,14 @@ pub struct DescribeActivityTypeInput {
     pub domain: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeDomainInput {
     /// <p>The name of the domain to describe.</p>
     #[serde(rename = "name")]
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeWorkflowExecutionInput {
     /// <p>The name of the domain containing the workflow execution.</p>
     #[serde(rename = "domain")]
@@ -807,7 +807,7 @@ pub struct DescribeWorkflowExecutionInput {
     pub execution: WorkflowExecution,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeWorkflowTypeInput {
     /// <p>The name of the domain in which this workflow type is registered.</p>
     #[serde(rename = "domain")]
@@ -818,7 +818,7 @@ pub struct DescribeWorkflowTypeInput {
 }
 
 /// <p>Contains the configuration settings of a domain.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DomainConfiguration {
     /// <p>The retention period for workflow executions in this domain.</p>
     #[serde(rename = "workflowExecutionRetentionPeriodInDays")]
@@ -826,7 +826,7 @@ pub struct DomainConfiguration {
 }
 
 /// <p>Contains details of a domain.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DomainDetail {
     /// <p>The domain configuration. Currently, this includes only the domain's retention period.</p>
     #[serde(rename = "configuration")]
@@ -837,7 +837,7 @@ pub struct DomainDetail {
 }
 
 /// <p>Contains general information about a domain.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DomainInfo {
     /// <p>The description of the domain provided through <a>RegisterDomain</a>.</p>
     #[serde(rename = "description")]
@@ -852,7 +852,7 @@ pub struct DomainInfo {
 }
 
 /// <p>Contains a paginated collection of DomainInfo structures.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DomainInfos {
     /// <p>A list of DomainInfo structures.</p>
     #[serde(rename = "domainInfos")]
@@ -864,7 +864,7 @@ pub struct DomainInfos {
 }
 
 /// <p>Used to filter the workflow executions in visibility APIs by various time-based rules. Each parameter, if specified, defines a rule that must be satisfied by each returned query result. The parameter values are in the <a href="https://en.wikipedia.org/wiki/Unix_time">Unix Time format</a>. For example: <code>"oldestDate": 1325376070.</code> </p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ExecutionTimeFilter {
     /// <p>Specifies the latest start or close date and time to return.</p>
     #[serde(rename = "latestDate")]
@@ -876,7 +876,7 @@ pub struct ExecutionTimeFilter {
 }
 
 /// <p>Provides the details of the <code>ExternalWorkflowExecutionCancelRequested</code> event.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ExternalWorkflowExecutionCancelRequestedEventAttributes {
     /// <p>The ID of the <code>RequestCancelExternalWorkflowExecutionInitiated</code> event corresponding to the <code>RequestCancelExternalWorkflowExecution</code> decision to cancel this external workflow execution. This information can be useful for diagnosing problems by tracing back the chain of events leading up to this event.</p>
     #[serde(rename = "initiatedEventId")]
@@ -887,7 +887,7 @@ pub struct ExternalWorkflowExecutionCancelRequestedEventAttributes {
 }
 
 /// <p>Provides the details of the <code>ExternalWorkflowExecutionSignaled</code> event.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ExternalWorkflowExecutionSignaledEventAttributes {
     /// <p>The ID of the <code>SignalExternalWorkflowExecutionInitiated</code> event corresponding to the <code>SignalExternalWorkflowExecution</code> decision to request this signal. This information can be useful for diagnosing problems by tracing back the chain of events leading up to this event.</p>
     #[serde(rename = "initiatedEventId")]
@@ -898,7 +898,7 @@ pub struct ExternalWorkflowExecutionSignaledEventAttributes {
 }
 
 /// <p>Provides the details of the <code>FailWorkflowExecution</code> decision.</p> <p> <b>Access Control</b> </p> <p>You can use IAM policies to control this decision's access to Amazon SWF resources as follows:</p> <ul> <li> <p>Use a <code>Resource</code> element with the domain name to limit the action to only specified domains.</p> </li> <li> <p>Use an <code>Action</code> element to allow or deny permission to call this action.</p> </li> <li> <p>You cannot use an IAM policy to constrain this action's parameters.</p> </li> </ul> <p>If the caller doesn't have sufficient permissions to invoke the action, or the parameter values fall outside the specified constraints, the action fails. The associated event attribute's <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>. For details and example IAM policies, see <a href="http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct FailWorkflowExecutionDecisionAttributes {
     /// <p> Details of the failure.</p>
     #[serde(rename = "details")]
@@ -911,7 +911,7 @@ pub struct FailWorkflowExecutionDecisionAttributes {
 }
 
 /// <p>Provides the details of the <code>FailWorkflowExecutionFailed</code> event.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct FailWorkflowExecutionFailedEventAttributes {
     /// <p><p>The cause of the failure. This information is generated by the system and can be useful for diagnostic purposes.</p> <note> <p>If <code>cause</code> is set to <code>OPERATION<em>NOT</em>PERMITTED</code>, the decision failed because it lacked sufficient permissions. For details and example IAM policies, see <a href="http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p> </note></p>
     #[serde(rename = "cause")]
@@ -921,7 +921,7 @@ pub struct FailWorkflowExecutionFailedEventAttributes {
     pub decision_task_completed_event_id: i64,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetWorkflowExecutionHistoryInput {
     /// <p>The name of the domain containing the workflow execution.</p>
     #[serde(rename = "domain")]
@@ -944,7 +944,7 @@ pub struct GetWorkflowExecutionHistoryInput {
 }
 
 /// <p>Paginated representation of a workflow history for a workflow execution. This is the up to date, complete and authoritative record of the events related to all tasks and events in the life of the workflow execution.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct History {
     /// <p>The list of history events.</p>
     #[serde(rename = "events")]
@@ -956,7 +956,7 @@ pub struct History {
 }
 
 /// <p><p>Event within a workflow execution. A history event can be one of these types:</p> <ul> <li> <p> <code>ActivityTaskCancelRequested</code> – A <code>RequestCancelActivityTask</code> decision was received by the system.</p> </li> <li> <p> <code>ActivityTaskCanceled</code> – The activity task was successfully canceled.</p> </li> <li> <p> <code>ActivityTaskCompleted</code> – An activity worker successfully completed an activity task by calling <a>RespondActivityTaskCompleted</a>.</p> </li> <li> <p> <code>ActivityTaskFailed</code> – An activity worker failed an activity task by calling <a>RespondActivityTaskFailed</a>.</p> </li> <li> <p> <code>ActivityTaskScheduled</code> – An activity task was scheduled for execution.</p> </li> <li> <p> <code>ActivityTaskStarted</code> – The scheduled activity task was dispatched to a worker.</p> </li> <li> <p> <code>ActivityTaskTimedOut</code> – The activity task timed out.</p> </li> <li> <p> <code>CancelTimerFailed</code> – Failed to process CancelTimer decision. This happens when the decision isn&#39;t configured properly, for example no timer exists with the specified timer Id.</p> </li> <li> <p> <code>CancelWorkflowExecutionFailed</code> – A request to cancel a workflow execution failed.</p> </li> <li> <p> <code>ChildWorkflowExecutionCanceled</code> – A child workflow execution, started by this workflow execution, was canceled and closed.</p> </li> <li> <p> <code>ChildWorkflowExecutionCompleted</code> – A child workflow execution, started by this workflow execution, completed successfully and was closed.</p> </li> <li> <p> <code>ChildWorkflowExecutionFailed</code> – A child workflow execution, started by this workflow execution, failed to complete successfully and was closed.</p> </li> <li> <p> <code>ChildWorkflowExecutionStarted</code> – A child workflow execution was successfully started.</p> </li> <li> <p> <code>ChildWorkflowExecutionTerminated</code> – A child workflow execution, started by this workflow execution, was terminated.</p> </li> <li> <p> <code>ChildWorkflowExecutionTimedOut</code> – A child workflow execution, started by this workflow execution, timed out and was closed.</p> </li> <li> <p> <code>CompleteWorkflowExecutionFailed</code> – The workflow execution failed to complete.</p> </li> <li> <p> <code>ContinueAsNewWorkflowExecutionFailed</code> – The workflow execution failed to complete after being continued as a new workflow execution.</p> </li> <li> <p> <code>DecisionTaskCompleted</code> – The decider successfully completed a decision task by calling <a>RespondDecisionTaskCompleted</a>.</p> </li> <li> <p> <code>DecisionTaskScheduled</code> – A decision task was scheduled for the workflow execution.</p> </li> <li> <p> <code>DecisionTaskStarted</code> – The decision task was dispatched to a decider.</p> </li> <li> <p> <code>DecisionTaskTimedOut</code> – The decision task timed out.</p> </li> <li> <p> <code>ExternalWorkflowExecutionCancelRequested</code> – Request to cancel an external workflow execution was successfully delivered to the target execution.</p> </li> <li> <p> <code>ExternalWorkflowExecutionSignaled</code> – A signal, requested by this workflow execution, was successfully delivered to the target external workflow execution.</p> </li> <li> <p> <code>FailWorkflowExecutionFailed</code> – A request to mark a workflow execution as failed, itself failed.</p> </li> <li> <p> <code>MarkerRecorded</code> – A marker was recorded in the workflow history as the result of a <code>RecordMarker</code> decision.</p> </li> <li> <p> <code>RecordMarkerFailed</code> – A <code>RecordMarker</code> decision was returned as failed.</p> </li> <li> <p> <code>RequestCancelActivityTaskFailed</code> – Failed to process RequestCancelActivityTask decision. This happens when the decision isn&#39;t configured properly.</p> </li> <li> <p> <code>RequestCancelExternalWorkflowExecutionFailed</code> – Request to cancel an external workflow execution failed.</p> </li> <li> <p> <code>RequestCancelExternalWorkflowExecutionInitiated</code> – A request was made to request the cancellation of an external workflow execution.</p> </li> <li> <p> <code>ScheduleActivityTaskFailed</code> – Failed to process ScheduleActivityTask decision. This happens when the decision isn&#39;t configured properly, for example the activity type specified isn&#39;t registered.</p> </li> <li> <p> <code>SignalExternalWorkflowExecutionFailed</code> – The request to signal an external workflow execution failed.</p> </li> <li> <p> <code>SignalExternalWorkflowExecutionInitiated</code> – A request to signal an external workflow was made.</p> </li> <li> <p> <code>StartActivityTaskFailed</code> – A scheduled activity task failed to start.</p> </li> <li> <p> <code>StartChildWorkflowExecutionFailed</code> – Failed to process StartChildWorkflowExecution decision. This happens when the decision isn&#39;t configured properly, for example the workflow type specified isn&#39;t registered.</p> </li> <li> <p> <code>StartChildWorkflowExecutionInitiated</code> – A request was made to start a child workflow execution.</p> </li> <li> <p> <code>StartTimerFailed</code> – Failed to process StartTimer decision. This happens when the decision isn&#39;t configured properly, for example a timer already exists with the specified timer Id.</p> </li> <li> <p> <code>TimerCanceled</code> – A timer, previously started for this workflow execution, was successfully canceled.</p> </li> <li> <p> <code>TimerFired</code> – A timer, previously started for this workflow execution, fired.</p> </li> <li> <p> <code>TimerStarted</code> – A timer was started for the workflow execution due to a <code>StartTimer</code> decision.</p> </li> <li> <p> <code>WorkflowExecutionCancelRequested</code> – A request to cancel this workflow execution was made.</p> </li> <li> <p> <code>WorkflowExecutionCanceled</code> – The workflow execution was successfully canceled and closed.</p> </li> <li> <p> <code>WorkflowExecutionCompleted</code> – The workflow execution was closed due to successful completion.</p> </li> <li> <p> <code>WorkflowExecutionContinuedAsNew</code> – The workflow execution was closed and a new execution of the same type was created with the same workflowId.</p> </li> <li> <p> <code>WorkflowExecutionFailed</code> – The workflow execution closed due to a failure.</p> </li> <li> <p> <code>WorkflowExecutionSignaled</code> – An external signal was received for the workflow execution.</p> </li> <li> <p> <code>WorkflowExecutionStarted</code> – The workflow execution was started.</p> </li> <li> <p> <code>WorkflowExecutionTerminated</code> – The workflow execution was terminated.</p> </li> <li> <p> <code>WorkflowExecutionTimedOut</code> – The workflow execution was closed because a time out was exceeded.</p> </li> </ul></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct HistoryEvent {
     /// <p>If the event is of type <code>ActivityTaskcancelRequested</code> then this member is set and provides detailed information about the event. It isn't set for other event types.</p>
     #[serde(rename = "activityTaskCancelRequestedEventAttributes")]
@@ -1217,7 +1217,7 @@ pub struct HistoryEvent {
 }
 
 /// <p>Provides the details of the <code>LambdaFunctionCompleted</code> event. It isn't set for other event types.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct LambdaFunctionCompletedEventAttributes {
     /// <p>The results of the Lambda task.</p>
     #[serde(rename = "result")]
@@ -1232,7 +1232,7 @@ pub struct LambdaFunctionCompletedEventAttributes {
 }
 
 /// <p>Provides the details of the <code>LambdaFunctionFailed</code> event. It isn't set for other event types.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct LambdaFunctionFailedEventAttributes {
     /// <p>The details of the failure.</p>
     #[serde(rename = "details")]
@@ -1251,7 +1251,7 @@ pub struct LambdaFunctionFailedEventAttributes {
 }
 
 /// <p>Provides the details of the <code>LambdaFunctionScheduled</code> event. It isn't set for other event types.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct LambdaFunctionScheduledEventAttributes {
     /// <p>Data attached to the event that the decider can use in subsequent workflow tasks. This data isn't sent to the Lambda task.</p>
     #[serde(rename = "control")]
@@ -1277,7 +1277,7 @@ pub struct LambdaFunctionScheduledEventAttributes {
 }
 
 /// <p>Provides the details of the <code>LambdaFunctionStarted</code> event. It isn't set for other event types.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct LambdaFunctionStartedEventAttributes {
     /// <p>The ID of the <code>LambdaFunctionScheduled</code> event that was recorded when this activity task was scheduled. To help diagnose issues, use this information to trace back the chain of events leading up to this event.</p>
     #[serde(rename = "scheduledEventId")]
@@ -1285,7 +1285,7 @@ pub struct LambdaFunctionStartedEventAttributes {
 }
 
 /// <p>Provides details of the <code>LambdaFunctionTimedOut</code> event.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct LambdaFunctionTimedOutEventAttributes {
     /// <p>The ID of the <code>LambdaFunctionScheduled</code> event that was recorded when this activity task was scheduled. To help diagnose issues, use this information to trace back the chain of events leading up to this event.</p>
     #[serde(rename = "scheduledEventId")]
@@ -1299,7 +1299,7 @@ pub struct LambdaFunctionTimedOutEventAttributes {
     pub timeout_type: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListActivityTypesInput {
     /// <p>The name of the domain in which the activity types have been registered.</p>
     #[serde(rename = "domain")]
@@ -1325,7 +1325,7 @@ pub struct ListActivityTypesInput {
     pub reverse_order: Option<bool>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListClosedWorkflowExecutionsInput {
     /// <p><p>If specified, only workflow executions that match this <i>close status</i> are listed. For example, if TERMINATED is specified, then only TERMINATED workflow executions are listed.</p> <note> <p> <code>closeStatusFilter</code>, <code>executionFilter</code>, <code>typeFilter</code> and <code>tagFilter</code> are mutually exclusive. You can specify at most one of these in a request.</p> </note></p>
     #[serde(rename = "closeStatusFilter")]
@@ -1368,7 +1368,7 @@ pub struct ListClosedWorkflowExecutionsInput {
     pub type_filter: Option<WorkflowTypeFilter>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListDomainsInput {
     /// <p>The maximum number of results that are returned per call. <code>nextPageToken</code> can be used to obtain futher pages of results. The default is 1000, which is the maximum allowed page size. You can, however, specify a page size <i>smaller</i> than the maximum.</p> <p>This is an upper limit only; the actual number of results returned per call may be fewer than the specified maximum.</p>
     #[serde(rename = "maximumPageSize")]
@@ -1387,7 +1387,7 @@ pub struct ListDomainsInput {
     pub reverse_order: Option<bool>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListOpenWorkflowExecutionsInput {
     /// <p>The name of the domain that contains the workflow executions to list.</p>
     #[serde(rename = "domain")]
@@ -1421,7 +1421,7 @@ pub struct ListOpenWorkflowExecutionsInput {
     pub type_filter: Option<WorkflowTypeFilter>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListWorkflowTypesInput {
     /// <p>The name of the domain in which the workflow types have been registered.</p>
     #[serde(rename = "domain")]
@@ -1448,7 +1448,7 @@ pub struct ListWorkflowTypesInput {
 }
 
 /// <p>Provides the details of the <code>MarkerRecorded</code> event.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct MarkerRecordedEventAttributes {
     /// <p>The ID of the <code>DecisionTaskCompleted</code> event corresponding to the decision task that resulted in the <code>RecordMarker</code> decision that requested this marker. This information can be useful for diagnosing problems by tracing back the chain of events leading up to this event.</p>
     #[serde(rename = "decisionTaskCompletedEventId")]
@@ -1463,7 +1463,7 @@ pub struct MarkerRecordedEventAttributes {
 }
 
 /// <p>Contains the count of tasks in a task list.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PendingTaskCount {
     /// <p>The number of tasks in the task list.</p>
     #[serde(rename = "count")]
@@ -1474,7 +1474,7 @@ pub struct PendingTaskCount {
     pub truncated: Option<bool>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PollForActivityTaskInput {
     /// <p>The name of the domain that contains the task lists being polled.</p>
     #[serde(rename = "domain")]
@@ -1488,7 +1488,7 @@ pub struct PollForActivityTaskInput {
     pub task_list: TaskList,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PollForDecisionTaskInput {
     /// <p>The name of the domain containing the task lists to poll.</p>
     #[serde(rename = "domain")]
@@ -1514,7 +1514,7 @@ pub struct PollForDecisionTaskInput {
     pub task_list: TaskList,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RecordActivityTaskHeartbeatInput {
     /// <p>If specified, contains details about the progress of the task.</p>
     #[serde(rename = "details")]
@@ -1526,7 +1526,7 @@ pub struct RecordActivityTaskHeartbeatInput {
 }
 
 /// <p>Provides the details of the <code>RecordMarker</code> decision.</p> <p> <b>Access Control</b> </p> <p>You can use IAM policies to control this decision's access to Amazon SWF resources as follows:</p> <ul> <li> <p>Use a <code>Resource</code> element with the domain name to limit the action to only specified domains.</p> </li> <li> <p>Use an <code>Action</code> element to allow or deny permission to call this action.</p> </li> <li> <p>You cannot use an IAM policy to constrain this action's parameters.</p> </li> </ul> <p>If the caller doesn't have sufficient permissions to invoke the action, or the parameter values fall outside the specified constraints, the action fails. The associated event attribute's <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>. For details and example IAM policies, see <a href="http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RecordMarkerDecisionAttributes {
     /// <p> The details of the marker.</p>
     #[serde(rename = "details")]
@@ -1538,7 +1538,7 @@ pub struct RecordMarkerDecisionAttributes {
 }
 
 /// <p>Provides the details of the <code>RecordMarkerFailed</code> event.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RecordMarkerFailedEventAttributes {
     /// <p><p>The cause of the failure. This information is generated by the system and can be useful for diagnostic purposes.</p> <note> <p>If <code>cause</code> is set to <code>OPERATION<em>NOT</em>PERMITTED</code>, the decision failed because it lacked sufficient permissions. For details and example IAM policies, see <a href="http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p> </note></p>
     #[serde(rename = "cause")]
@@ -1551,7 +1551,7 @@ pub struct RecordMarkerFailedEventAttributes {
     pub marker_name: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RegisterActivityTypeInput {
     /// <p>If set, specifies the default maximum time before which a worker processing a task of this type must report progress by calling <a>RecordActivityTaskHeartbeat</a>. If the timeout is exceeded, the activity task is automatically timed out. This default can be overridden when scheduling an activity task using the <code>ScheduleActivityTask</code> <a>Decision</a>. If the activity worker subsequently attempts to record a heartbeat or returns a result, the activity worker receives an <code>UnknownResource</code> fault. In this case, Amazon SWF no longer considers the activity task to be valid; the activity worker should clean up the activity task.</p> <p>The duration is specified in seconds, an integer greater than or equal to <code>0</code>. You can use <code>NONE</code> to specify unlimited duration.</p>
     #[serde(rename = "defaultTaskHeartbeatTimeout")]
@@ -1592,7 +1592,7 @@ pub struct RegisterActivityTypeInput {
     pub version: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RegisterDomainInput {
     /// <p>A text description of the domain.</p>
     #[serde(rename = "description")]
@@ -1606,7 +1606,7 @@ pub struct RegisterDomainInput {
     pub workflow_execution_retention_period_in_days: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RegisterWorkflowTypeInput {
     /// <p><p>If set, specifies the default policy to use for the child workflow executions when a workflow execution of this type is terminated, by calling the <a>TerminateWorkflowExecution</a> action explicitly or due to an expired timeout. This default can be overridden when starting a workflow execution using the <a>StartWorkflowExecution</a> action or the <code>StartChildWorkflowExecution</code> <a>Decision</a>.</p> <p>The supported child policies are:</p> <ul> <li> <p> <code>TERMINATE</code> – The child executions are terminated.</p> </li> <li> <p> <code>REQUEST_CANCEL</code> – A request to cancel is attempted for each child execution by recording a <code>WorkflowExecutionCancelRequested</code> event in its history. It is up to the decider to take appropriate actions when it receives an execution history with this event.</p> </li> <li> <p> <code>ABANDON</code> – No action is taken. The child executions continue to run.</p> </li> </ul></p>
     #[serde(rename = "defaultChildPolicy")]
@@ -1648,7 +1648,7 @@ pub struct RegisterWorkflowTypeInput {
 }
 
 /// <p>Provides the details of the <code>RequestCancelActivityTask</code> decision.</p> <p> <b>Access Control</b> </p> <p>You can use IAM policies to control this decision's access to Amazon SWF resources as follows:</p> <ul> <li> <p>Use a <code>Resource</code> element with the domain name to limit the action to only specified domains.</p> </li> <li> <p>Use an <code>Action</code> element to allow or deny permission to call this action.</p> </li> <li> <p>You cannot use an IAM policy to constrain this action's parameters.</p> </li> </ul> <p>If the caller doesn't have sufficient permissions to invoke the action, or the parameter values fall outside the specified constraints, the action fails. The associated event attribute's <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>. For details and example IAM policies, see <a href="http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RequestCancelActivityTaskDecisionAttributes {
     /// <p>The <code>activityId</code> of the activity task to be canceled.</p>
     #[serde(rename = "activityId")]
@@ -1656,7 +1656,7 @@ pub struct RequestCancelActivityTaskDecisionAttributes {
 }
 
 /// <p>Provides the details of the <code>RequestCancelActivityTaskFailed</code> event.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RequestCancelActivityTaskFailedEventAttributes {
     /// <p>The activityId provided in the <code>RequestCancelActivityTask</code> decision that failed.</p>
     #[serde(rename = "activityId")]
@@ -1670,7 +1670,7 @@ pub struct RequestCancelActivityTaskFailedEventAttributes {
 }
 
 /// <p>Provides the details of the <code>RequestCancelExternalWorkflowExecution</code> decision.</p> <p> <b>Access Control</b> </p> <p>You can use IAM policies to control this decision's access to Amazon SWF resources as follows:</p> <ul> <li> <p>Use a <code>Resource</code> element with the domain name to limit the action to only specified domains.</p> </li> <li> <p>Use an <code>Action</code> element to allow or deny permission to call this action.</p> </li> <li> <p>You cannot use an IAM policy to constrain this action's parameters.</p> </li> </ul> <p>If the caller doesn't have sufficient permissions to invoke the action, or the parameter values fall outside the specified constraints, the action fails. The associated event attribute's <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>. For details and example IAM policies, see <a href="http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RequestCancelExternalWorkflowExecutionDecisionAttributes {
     /// <p>The data attached to the event that can be used by the decider in subsequent workflow tasks.</p>
     #[serde(rename = "control")]
@@ -1686,7 +1686,7 @@ pub struct RequestCancelExternalWorkflowExecutionDecisionAttributes {
 }
 
 /// <p>Provides the details of the <code>RequestCancelExternalWorkflowExecutionFailed</code> event.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RequestCancelExternalWorkflowExecutionFailedEventAttributes {
     /// <p><p>The cause of the failure. This information is generated by the system and can be useful for diagnostic purposes.</p> <note> <p>If <code>cause</code> is set to <code>OPERATION<em>NOT</em>PERMITTED</code>, the decision failed because it lacked sufficient permissions. For details and example IAM policies, see <a href="http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p> </note></p>
     #[serde(rename = "cause")]
@@ -1711,7 +1711,7 @@ pub struct RequestCancelExternalWorkflowExecutionFailedEventAttributes {
 }
 
 /// <p>Provides the details of the <code>RequestCancelExternalWorkflowExecutionInitiated</code> event.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RequestCancelExternalWorkflowExecutionInitiatedEventAttributes {
     /// <p>Data attached to the event that can be used by the decider in subsequent workflow tasks.</p>
     #[serde(rename = "control")]
@@ -1729,7 +1729,7 @@ pub struct RequestCancelExternalWorkflowExecutionInitiatedEventAttributes {
     pub workflow_id: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RequestCancelWorkflowExecutionInput {
     /// <p>The name of the domain containing the workflow execution to cancel.</p>
     #[serde(rename = "domain")]
@@ -1743,7 +1743,7 @@ pub struct RequestCancelWorkflowExecutionInput {
     pub workflow_id: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RespondActivityTaskCanceledInput {
     /// <p> Information about the cancellation.</p>
     #[serde(rename = "details")]
@@ -1754,7 +1754,7 @@ pub struct RespondActivityTaskCanceledInput {
     pub task_token: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RespondActivityTaskCompletedInput {
     /// <p>The result of the activity task. It is a free form string that is implementation specific.</p>
     #[serde(rename = "result")]
@@ -1765,7 +1765,7 @@ pub struct RespondActivityTaskCompletedInput {
     pub task_token: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RespondActivityTaskFailedInput {
     /// <p> Detailed information about the failure.</p>
     #[serde(rename = "details")]
@@ -1781,7 +1781,7 @@ pub struct RespondActivityTaskFailedInput {
 }
 
 /// <p>Input data for a TaskCompleted response to a decision task.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RespondDecisionTaskCompletedInput {
     /// <p>The list of decisions (possibly empty) made by the decider while processing this decision task. See the docs for the <a>Decision</a> structure for details.</p>
     #[serde(rename = "decisions")]
@@ -1797,7 +1797,7 @@ pub struct RespondDecisionTaskCompletedInput {
 }
 
 /// <p>Specifies the <code>runId</code> of a workflow execution.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Run {
     /// <p>The <code>runId</code> of a workflow execution. This ID is generated by the service and can be used to uniquely identify the workflow execution within a domain.</p>
     #[serde(rename = "runId")]
@@ -1806,7 +1806,7 @@ pub struct Run {
 }
 
 /// <p>Provides the details of the <code>ScheduleActivityTask</code> decision.</p> <p> <b>Access Control</b> </p> <p>You can use IAM policies to control this decision's access to Amazon SWF resources as follows:</p> <ul> <li> <p>Use a <code>Resource</code> element with the domain name to limit the action to only specified domains.</p> </li> <li> <p>Use an <code>Action</code> element to allow or deny permission to call this action.</p> </li> <li> <p>Constrain the following parameters by using a <code>Condition</code> element with the appropriate keys.</p> <ul> <li> <p> <code>activityType.name</code> – String constraint. The key is <code>swf:activityType.name</code>.</p> </li> <li> <p> <code>activityType.version</code> – String constraint. The key is <code>swf:activityType.version</code>.</p> </li> <li> <p> <code>taskList</code> – String constraint. The key is <code>swf:taskList.name</code>.</p> </li> </ul> </li> </ul> <p>If the caller doesn't have sufficient permissions to invoke the action, or the parameter values fall outside the specified constraints, the action fails. The associated event attribute's <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>. For details and example IAM policies, see <a href="http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ScheduleActivityTaskDecisionAttributes {
     /// <p> The <code>activityId</code> of the activity task.</p> <p>The specified string must not start or end with whitespace. It must not contain a <code>:</code> (colon), <code>/</code> (slash), <code>|</code> (vertical bar), or any control characters (<code>\u0000-\u001f</code> | <code>\u007f-\u009f</code>). Also, it must not contain the literal string <code>arn</code>.</p>
     #[serde(rename = "activityId")]
@@ -1849,7 +1849,7 @@ pub struct ScheduleActivityTaskDecisionAttributes {
 }
 
 /// <p>Provides the details of the <code>ScheduleActivityTaskFailed</code> event.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ScheduleActivityTaskFailedEventAttributes {
     /// <p>The activityId provided in the <code>ScheduleActivityTask</code> decision that failed.</p>
     #[serde(rename = "activityId")]
@@ -1866,7 +1866,7 @@ pub struct ScheduleActivityTaskFailedEventAttributes {
 }
 
 /// <p>Decision attributes specified in <code>scheduleLambdaFunctionDecisionAttributes</code> within the list of decisions <code>decisions</code> passed to <a>RespondDecisionTaskCompleted</a>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ScheduleLambdaFunctionDecisionAttributes {
     /// <p>The data attached to the event that the decider can use in subsequent workflow tasks. This data isn't sent to the Lambda task.</p>
     #[serde(rename = "control")]
@@ -1889,7 +1889,7 @@ pub struct ScheduleLambdaFunctionDecisionAttributes {
 }
 
 /// <p>Provides the details of the <code>ScheduleLambdaFunctionFailed</code> event. It isn't set for other event types.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ScheduleLambdaFunctionFailedEventAttributes {
     /// <p><p>The cause of the failure. To help diagnose issues, use this information to trace back the chain of events leading up to this event.</p> <note> <p>If <code>cause</code> is set to <code>OPERATION<em>NOT</em>PERMITTED</code>, the decision failed because it lacked sufficient permissions. For details and example IAM policies, see <a href="http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p> </note></p>
     #[serde(rename = "cause")]
@@ -1906,7 +1906,7 @@ pub struct ScheduleLambdaFunctionFailedEventAttributes {
 }
 
 /// <p>Provides the details of the <code>SignalExternalWorkflowExecution</code> decision.</p> <p> <b>Access Control</b> </p> <p>You can use IAM policies to control this decision's access to Amazon SWF resources as follows:</p> <ul> <li> <p>Use a <code>Resource</code> element with the domain name to limit the action to only specified domains.</p> </li> <li> <p>Use an <code>Action</code> element to allow or deny permission to call this action.</p> </li> <li> <p>You cannot use an IAM policy to constrain this action's parameters.</p> </li> </ul> <p>If the caller doesn't have sufficient permissions to invoke the action, or the parameter values fall outside the specified constraints, the action fails. The associated event attribute's <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>. For details and example IAM policies, see <a href="http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SignalExternalWorkflowExecutionDecisionAttributes {
     /// <p>The data attached to the event that can be used by the decider in subsequent decision tasks.</p>
     #[serde(rename = "control")]
@@ -1929,7 +1929,7 @@ pub struct SignalExternalWorkflowExecutionDecisionAttributes {
 }
 
 /// <p>Provides the details of the <code>SignalExternalWorkflowExecutionFailed</code> event.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SignalExternalWorkflowExecutionFailedEventAttributes {
     /// <p><p>The cause of the failure. This information is generated by the system and can be useful for diagnostic purposes.</p> <note> <p>If <code>cause</code> is set to <code>OPERATION<em>NOT</em>PERMITTED</code>, the decision failed because it lacked sufficient permissions. For details and example IAM policies, see <a href="http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p> </note></p>
     #[serde(rename = "cause")]
@@ -1954,7 +1954,7 @@ pub struct SignalExternalWorkflowExecutionFailedEventAttributes {
 }
 
 /// <p>Provides the details of the <code>SignalExternalWorkflowExecutionInitiated</code> event.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SignalExternalWorkflowExecutionInitiatedEventAttributes {
     /// <p>Data attached to the event that can be used by the decider in subsequent decision tasks.</p>
     #[serde(rename = "control")]
@@ -1979,7 +1979,7 @@ pub struct SignalExternalWorkflowExecutionInitiatedEventAttributes {
     pub workflow_id: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SignalWorkflowExecutionInput {
     /// <p>The name of the domain containing the workflow execution to signal.</p>
     #[serde(rename = "domain")]
@@ -2001,7 +2001,7 @@ pub struct SignalWorkflowExecutionInput {
 }
 
 /// <p>Provides the details of the <code>StartChildWorkflowExecution</code> decision.</p> <p> <b>Access Control</b> </p> <p>You can use IAM policies to control this decision's access to Amazon SWF resources as follows:</p> <ul> <li> <p>Use a <code>Resource</code> element with the domain name to limit the action to only specified domains.</p> </li> <li> <p>Use an <code>Action</code> element to allow or deny permission to call this action.</p> </li> <li> <p>Constrain the following parameters by using a <code>Condition</code> element with the appropriate keys.</p> <ul> <li> <p> <code>tagList.member.N</code> – The key is "swf:tagList.N" where N is the tag number from 0 to 4, inclusive.</p> </li> <li> <p> <code>taskList</code> – String constraint. The key is <code>swf:taskList.name</code>.</p> </li> <li> <p> <code>workflowType.name</code> – String constraint. The key is <code>swf:workflowType.name</code>.</p> </li> <li> <p> <code>workflowType.version</code> – String constraint. The key is <code>swf:workflowType.version</code>.</p> </li> </ul> </li> </ul> <p>If the caller doesn't have sufficient permissions to invoke the action, or the parameter values fall outside the specified constraints, the action fails. The associated event attribute's <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>. For details and example IAM policies, see <a href="http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StartChildWorkflowExecutionDecisionAttributes {
     /// <p><p> If set, specifies the policy to use for the child workflow executions if the workflow execution being started is terminated by calling the <a>TerminateWorkflowExecution</a> action explicitly or due to an expired timeout. This policy overrides the default child policy specified when registering the workflow type using <a>RegisterWorkflowType</a>.</p> <p>The supported child policies are:</p> <ul> <li> <p> <code>TERMINATE</code> – The child executions are terminated.</p> </li> <li> <p> <code>REQUEST_CANCEL</code> – A request to cancel is attempted for each child execution by recording a <code>WorkflowExecutionCancelRequested</code> event in its history. It is up to the decider to take appropriate actions when it receives an execution history with this event.</p> </li> <li> <p> <code>ABANDON</code> – No action is taken. The child executions continue to run.</p> </li> </ul> <note> <p>A child policy for this workflow execution must be specified either as a default for the workflow type or through this parameter. If neither this parameter is set nor a default child policy was specified at registration time then a fault is returned.</p> </note></p>
     #[serde(rename = "childPolicy")]
@@ -2048,7 +2048,7 @@ pub struct StartChildWorkflowExecutionDecisionAttributes {
 }
 
 /// <p>Provides the details of the <code>StartChildWorkflowExecutionFailed</code> event.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StartChildWorkflowExecutionFailedEventAttributes {
     /// <p><p>The cause of the failure. This information is generated by the system and can be useful for diagnostic purposes.</p> <note> <p>When <code>cause</code> is set to <code>OPERATION<em>NOT</em>PERMITTED</code>, the decision fails because it lacks sufficient permissions. For details and example IAM policies, see <a href="http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html"> Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p> </note></p>
     #[serde(rename = "cause")]
@@ -2072,7 +2072,7 @@ pub struct StartChildWorkflowExecutionFailedEventAttributes {
 }
 
 /// <p>Provides the details of the <code>StartChildWorkflowExecutionInitiated</code> event.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StartChildWorkflowExecutionInitiatedEventAttributes {
     /// <p><p>The policy to use for the child workflow executions if this execution gets terminated by explicitly calling the <a>TerminateWorkflowExecution</a> action or due to an expired timeout.</p> <p>The supported child policies are:</p> <ul> <li> <p> <code>TERMINATE</code> – The child executions are terminated.</p> </li> <li> <p> <code>REQUEST_CANCEL</code> – A request to cancel is attempted for each child execution by recording a <code>WorkflowExecutionCancelRequested</code> event in its history. It is up to the decider to take appropriate actions when it receives an execution history with this event.</p> </li> <li> <p> <code>ABANDON</code> – No action is taken. The child executions continue to run.</p> </li> </ul></p>
     #[serde(rename = "childPolicy")]
@@ -2120,7 +2120,7 @@ pub struct StartChildWorkflowExecutionInitiatedEventAttributes {
 }
 
 /// <p>Provides the details of the <code>StartLambdaFunctionFailed</code> event. It isn't set for other event types.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StartLambdaFunctionFailedEventAttributes {
     /// <p><p>The cause of the failure. To help diagnose issues, use this information to trace back the chain of events leading up to this event.</p> <note> <p>If <code>cause</code> is set to <code>OPERATION<em>NOT</em>PERMITTED</code>, the decision failed because the IAM role attached to the execution lacked sufficient permissions. For details and example IAM policies, see <a href="http://docs.aws.amazon.com/amazonswf/latest/developerguide/lambda-task.html">Lambda Tasks</a> in the <i>Amazon SWF Developer Guide</i>.</p> </note></p>
     #[serde(rename = "cause")]
@@ -2137,7 +2137,7 @@ pub struct StartLambdaFunctionFailedEventAttributes {
 }
 
 /// <p>Provides the details of the <code>StartTimer</code> decision.</p> <p> <b>Access Control</b> </p> <p>You can use IAM policies to control this decision's access to Amazon SWF resources as follows:</p> <ul> <li> <p>Use a <code>Resource</code> element with the domain name to limit the action to only specified domains.</p> </li> <li> <p>Use an <code>Action</code> element to allow or deny permission to call this action.</p> </li> <li> <p>You cannot use an IAM policy to constrain this action's parameters.</p> </li> </ul> <p>If the caller doesn't have sufficient permissions to invoke the action, or the parameter values fall outside the specified constraints, the action fails. The associated event attribute's <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>. For details and example IAM policies, see <a href="http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StartTimerDecisionAttributes {
     /// <p>The data attached to the event that can be used by the decider in subsequent workflow tasks.</p>
     #[serde(rename = "control")]
@@ -2152,7 +2152,7 @@ pub struct StartTimerDecisionAttributes {
 }
 
 /// <p>Provides the details of the <code>StartTimerFailed</code> event.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StartTimerFailedEventAttributes {
     /// <p><p>The cause of the failure. This information is generated by the system and can be useful for diagnostic purposes.</p> <note> <p>If <code>cause</code> is set to <code>OPERATION<em>NOT</em>PERMITTED</code>, the decision failed because it lacked sufficient permissions. For details and example IAM policies, see <a href="http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p> </note></p>
     #[serde(rename = "cause")]
@@ -2165,7 +2165,7 @@ pub struct StartTimerFailedEventAttributes {
     pub timer_id: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StartWorkflowExecutionInput {
     /// <p><p>If set, specifies the policy to use for the child workflow executions of this workflow execution if it is terminated, by calling the <a>TerminateWorkflowExecution</a> action explicitly or due to an expired timeout. This policy overrides the default child policy specified when registering the workflow type using <a>RegisterWorkflowType</a>.</p> <p>The supported child policies are:</p> <ul> <li> <p> <code>TERMINATE</code> – The child executions are terminated.</p> </li> <li> <p> <code>REQUEST_CANCEL</code> – A request to cancel is attempted for each child execution by recording a <code>WorkflowExecutionCancelRequested</code> event in its history. It is up to the decider to take appropriate actions when it receives an execution history with this event.</p> </li> <li> <p> <code>ABANDON</code> – No action is taken. The child executions continue to run.</p> </li> </ul> <note> <p>A child policy for this workflow execution must be specified either as a default for the workflow type or through this parameter. If neither this parameter is set nor a default child policy was specified at registration time then a fault is returned.</p> </note></p>
     #[serde(rename = "childPolicy")]
@@ -2211,7 +2211,7 @@ pub struct StartWorkflowExecutionInput {
 }
 
 /// <p>Used to filter the workflow executions in visibility APIs based on a tag.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct TagFilter {
     /// <p> Specifies the tag that must be associated with the execution for it to meet the filter criteria.</p>
     #[serde(rename = "tag")]
@@ -2219,14 +2219,14 @@ pub struct TagFilter {
 }
 
 /// <p>Represents a task list.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TaskList {
     /// <p>The name of the task list.</p>
     #[serde(rename = "name")]
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct TerminateWorkflowExecutionInput {
     /// <p><p>If set, specifies the policy to use for the child workflow executions of the workflow execution being terminated. This policy overrides the child policy specified for the workflow execution at registration time or when starting the execution.</p> <p>The supported child policies are:</p> <ul> <li> <p> <code>TERMINATE</code> – The child executions are terminated.</p> </li> <li> <p> <code>REQUEST_CANCEL</code> – A request to cancel is attempted for each child execution by recording a <code>WorkflowExecutionCancelRequested</code> event in its history. It is up to the decider to take appropriate actions when it receives an execution history with this event.</p> </li> <li> <p> <code>ABANDON</code> – No action is taken. The child executions continue to run.</p> </li> </ul> <note> <p>A child policy for this workflow execution must be specified either as a default for the workflow type or through this parameter. If neither this parameter is set nor a default child policy was specified at registration time then a fault is returned.</p> </note></p>
     #[serde(rename = "childPolicy")]
@@ -2253,7 +2253,7 @@ pub struct TerminateWorkflowExecutionInput {
 }
 
 /// <p> Provides the details of the <code>TimerCanceled</code> event. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct TimerCanceledEventAttributes {
     /// <p>The ID of the <code>DecisionTaskCompleted</code> event corresponding to the decision task that resulted in the <code>CancelTimer</code> decision to cancel this timer. This information can be useful for diagnosing problems by tracing back the chain of events leading up to this event.</p>
     #[serde(rename = "decisionTaskCompletedEventId")]
@@ -2267,7 +2267,7 @@ pub struct TimerCanceledEventAttributes {
 }
 
 /// <p>Provides the details of the <code>TimerFired</code> event.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct TimerFiredEventAttributes {
     /// <p>The ID of the <code>TimerStarted</code> event that was recorded when this timer was started. This information can be useful for diagnosing problems by tracing back the chain of events leading up to this event.</p>
     #[serde(rename = "startedEventId")]
@@ -2278,7 +2278,7 @@ pub struct TimerFiredEventAttributes {
 }
 
 /// <p>Provides the details of the <code>TimerStarted</code> event.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct TimerStartedEventAttributes {
     /// <p>Data attached to the event that can be used by the decider in subsequent workflow tasks.</p>
     #[serde(rename = "control")]
@@ -2296,7 +2296,7 @@ pub struct TimerStartedEventAttributes {
 }
 
 /// <p>Represents a workflow execution.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct WorkflowExecution {
     /// <p>A system-generated unique identifier for the workflow execution.</p>
     #[serde(rename = "runId")]
@@ -2307,7 +2307,7 @@ pub struct WorkflowExecution {
 }
 
 /// <p>Provides the details of the <code>WorkflowExecutionCancelRequested</code> event.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct WorkflowExecutionCancelRequestedEventAttributes {
     /// <p>If set, indicates that the request to cancel the workflow execution was automatically generated, and specifies the cause. This happens if the parent workflow execution times out or is terminated, and the child policy is set to cancel child executions.</p>
     #[serde(rename = "cause")]
@@ -2324,7 +2324,7 @@ pub struct WorkflowExecutionCancelRequestedEventAttributes {
 }
 
 /// <p>Provides the details of the <code>WorkflowExecutionCanceled</code> event.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct WorkflowExecutionCanceledEventAttributes {
     /// <p>The ID of the <code>DecisionTaskCompleted</code> event corresponding to the decision task that resulted in the <code>CancelWorkflowExecution</code> decision for this cancellation request. This information can be useful for diagnosing problems by tracing back the chain of events leading up to this event.</p>
     #[serde(rename = "decisionTaskCompletedEventId")]
@@ -2336,7 +2336,7 @@ pub struct WorkflowExecutionCanceledEventAttributes {
 }
 
 /// <p>Provides the details of the <code>WorkflowExecutionCompleted</code> event.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct WorkflowExecutionCompletedEventAttributes {
     /// <p>The ID of the <code>DecisionTaskCompleted</code> event corresponding to the decision task that resulted in the <code>CompleteWorkflowExecution</code> decision to complete this execution. This information can be useful for diagnosing problems by tracing back the chain of events leading up to this event.</p>
     #[serde(rename = "decisionTaskCompletedEventId")]
@@ -2348,7 +2348,7 @@ pub struct WorkflowExecutionCompletedEventAttributes {
 }
 
 /// <p>The configuration settings for a workflow execution including timeout values, tasklist etc. These configuration settings are determined from the defaults specified when registering the workflow type and those specified when starting the workflow execution.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct WorkflowExecutionConfiguration {
     /// <p><p>The policy to use for the child workflow executions if this workflow execution is terminated, by calling the <a>TerminateWorkflowExecution</a> action explicitly or due to an expired timeout.</p> <p>The supported child policies are:</p> <ul> <li> <p> <code>TERMINATE</code> – The child executions are terminated.</p> </li> <li> <p> <code>REQUEST_CANCEL</code> – A request to cancel is attempted for each child execution by recording a <code>WorkflowExecutionCancelRequested</code> event in its history. It is up to the decider to take appropriate actions when it receives an execution history with this event.</p> </li> <li> <p> <code>ABANDON</code> – No action is taken. The child executions continue to run.</p> </li> </ul></p>
     #[serde(rename = "childPolicy")]
@@ -2373,7 +2373,7 @@ pub struct WorkflowExecutionConfiguration {
 }
 
 /// <p>Provides the details of the <code>WorkflowExecutionContinuedAsNew</code> event.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct WorkflowExecutionContinuedAsNewEventAttributes {
     /// <p><p>The policy to use for the child workflow executions of the new execution if it is terminated by calling the <a>TerminateWorkflowExecution</a> action explicitly or due to an expired timeout.</p> <p>The supported child policies are:</p> <ul> <li> <p> <code>TERMINATE</code> – The child executions are terminated.</p> </li> <li> <p> <code>REQUEST_CANCEL</code> – A request to cancel is attempted for each child execution by recording a <code>WorkflowExecutionCancelRequested</code> event in its history. It is up to the decider to take appropriate actions when it receives an execution history with this event.</p> </li> <li> <p> <code>ABANDON</code> – No action is taken. The child executions continue to run.</p> </li> </ul></p>
     #[serde(rename = "childPolicy")]
@@ -2417,7 +2417,7 @@ pub struct WorkflowExecutionContinuedAsNewEventAttributes {
 }
 
 /// <p>Contains the count of workflow executions returned from <a>CountOpenWorkflowExecutions</a> or <a>CountClosedWorkflowExecutions</a> </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct WorkflowExecutionCount {
     /// <p>The number of workflow executions.</p>
     #[serde(rename = "count")]
@@ -2429,7 +2429,7 @@ pub struct WorkflowExecutionCount {
 }
 
 /// <p>Contains details about a workflow execution.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct WorkflowExecutionDetail {
     /// <p>The configuration settings for this workflow execution including timeout values, tasklist etc.</p>
     #[serde(rename = "executionConfiguration")]
@@ -2451,7 +2451,7 @@ pub struct WorkflowExecutionDetail {
 }
 
 /// <p>Provides the details of the <code>WorkflowExecutionFailed</code> event.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct WorkflowExecutionFailedEventAttributes {
     /// <p>The ID of the <code>DecisionTaskCompleted</code> event corresponding to the decision task that resulted in the <code>FailWorkflowExecution</code> decision to fail this execution. This information can be useful for diagnosing problems by tracing back the chain of events leading up to this event.</p>
     #[serde(rename = "decisionTaskCompletedEventId")]
@@ -2467,7 +2467,7 @@ pub struct WorkflowExecutionFailedEventAttributes {
 }
 
 /// <p>Used to filter the workflow executions in visibility APIs by their <code>workflowId</code>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct WorkflowExecutionFilter {
     /// <p>The workflowId to pass of match the criteria of this filter.</p>
     #[serde(rename = "workflowId")]
@@ -2475,7 +2475,7 @@ pub struct WorkflowExecutionFilter {
 }
 
 /// <p>Contains information about a workflow execution.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct WorkflowExecutionInfo {
     /// <p>Set to true if a cancellation is requested for this workflow execution.</p>
     #[serde(rename = "cancelRequested")]
@@ -2512,7 +2512,7 @@ pub struct WorkflowExecutionInfo {
 }
 
 /// <p>Contains a paginated list of information about workflow executions.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct WorkflowExecutionInfos {
     /// <p>The list of workflow information structures.</p>
     #[serde(rename = "executionInfos")]
@@ -2524,7 +2524,7 @@ pub struct WorkflowExecutionInfos {
 }
 
 /// <p>Contains the counts of open tasks, child workflow executions and timers for a workflow execution.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct WorkflowExecutionOpenCounts {
     /// <p>The count of activity tasks whose status is <code>OPEN</code>.</p>
     #[serde(rename = "openActivityTasks")]
@@ -2545,7 +2545,7 @@ pub struct WorkflowExecutionOpenCounts {
 }
 
 /// <p>Provides the details of the <code>WorkflowExecutionSignaled</code> event.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct WorkflowExecutionSignaledEventAttributes {
     /// <p>The ID of the <code>SignalExternalWorkflowExecutionInitiated</code> event corresponding to the <code>SignalExternalWorkflow</code> decision to signal this workflow execution.The source event with this ID can be found in the history of the source workflow execution. This information can be useful for diagnosing problems by tracing back the chain of events leading up to this event. This field is set only if the signal was initiated by another workflow execution.</p>
     #[serde(rename = "externalInitiatedEventId")]
@@ -2565,7 +2565,7 @@ pub struct WorkflowExecutionSignaledEventAttributes {
 }
 
 /// <p>Provides details of <code>WorkflowExecutionStarted</code> event.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct WorkflowExecutionStartedEventAttributes {
     /// <p><p>The policy to use for the child workflow executions if this workflow execution is terminated, by calling the <a>TerminateWorkflowExecution</a> action explicitly or due to an expired timeout.</p> <p>The supported child policies are:</p> <ul> <li> <p> <code>TERMINATE</code> – The child executions are terminated.</p> </li> <li> <p> <code>REQUEST_CANCEL</code> – A request to cancel is attempted for each child execution by recording a <code>WorkflowExecutionCancelRequested</code> event in its history. It is up to the decider to take appropriate actions when it receives an execution history with this event.</p> </li> <li> <p> <code>ABANDON</code> – No action is taken. The child executions continue to run.</p> </li> </ul></p>
     #[serde(rename = "childPolicy")]
@@ -2615,7 +2615,7 @@ pub struct WorkflowExecutionStartedEventAttributes {
 }
 
 /// <p>Provides the details of the <code>WorkflowExecutionTerminated</code> event.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct WorkflowExecutionTerminatedEventAttributes {
     /// <p>If set, indicates that the workflow execution was automatically terminated, and specifies the cause. This happens if the parent workflow execution times out or is terminated and the child policy is set to terminate child executions.</p>
     #[serde(rename = "cause")]
@@ -2635,7 +2635,7 @@ pub struct WorkflowExecutionTerminatedEventAttributes {
 }
 
 /// <p>Provides the details of the <code>WorkflowExecutionTimedOut</code> event.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct WorkflowExecutionTimedOutEventAttributes {
     /// <p><p>The policy used for the child workflow executions of this workflow execution.</p> <p>The supported child policies are:</p> <ul> <li> <p> <code>TERMINATE</code> – The child executions are terminated.</p> </li> <li> <p> <code>REQUEST_CANCEL</code> – A request to cancel is attempted for each child execution by recording a <code>WorkflowExecutionCancelRequested</code> event in its history. It is up to the decider to take appropriate actions when it receives an execution history with this event.</p> </li> <li> <p> <code>ABANDON</code> – No action is taken. The child executions continue to run.</p> </li> </ul></p>
     #[serde(rename = "childPolicy")]
@@ -2646,7 +2646,7 @@ pub struct WorkflowExecutionTimedOutEventAttributes {
 }
 
 /// <p>Represents a workflow type.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct WorkflowType {
     /// <p><p> The name of the workflow type.</p> <note> <p>The combination of workflow type name and version must be unique with in a domain.</p> </note></p>
     #[serde(rename = "name")]
@@ -2657,7 +2657,7 @@ pub struct WorkflowType {
 }
 
 /// <p>The configuration settings of a workflow type.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct WorkflowTypeConfiguration {
     /// <p><p> The default policy to use for the child workflow executions when a workflow execution of this type is terminated, by calling the <a>TerminateWorkflowExecution</a> action explicitly or due to an expired timeout. This default can be overridden when starting a workflow execution using the <a>StartWorkflowExecution</a> action or the <code>StartChildWorkflowExecution</code> <a>Decision</a>.</p> <p>The supported child policies are:</p> <ul> <li> <p> <code>TERMINATE</code> – The child executions are terminated.</p> </li> <li> <p> <code>REQUEST_CANCEL</code> – A request to cancel is attempted for each child execution by recording a <code>WorkflowExecutionCancelRequested</code> event in its history. It is up to the decider to take appropriate actions when it receives an execution history with this event.</p> </li> <li> <p> <code>ABANDON</code> – No action is taken. The child executions continue to run.</p> </li> </ul></p>
     #[serde(rename = "defaultChildPolicy")]
@@ -2686,7 +2686,7 @@ pub struct WorkflowTypeConfiguration {
 }
 
 /// <p>Contains details about a workflow type.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct WorkflowTypeDetail {
     /// <p>Configuration settings of the workflow type registered through <a>RegisterWorkflowType</a> </p>
     #[serde(rename = "configuration")]
@@ -2697,7 +2697,7 @@ pub struct WorkflowTypeDetail {
 }
 
 /// <p>Used to filter workflow execution query results by type. Each parameter, if specified, defines a rule that must be satisfied by each returned result.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct WorkflowTypeFilter {
     /// <p> Name of the workflow type.</p>
     #[serde(rename = "name")]
@@ -2709,7 +2709,7 @@ pub struct WorkflowTypeFilter {
 }
 
 /// <p>Contains information about a workflow type.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct WorkflowTypeInfo {
     /// <p>The date when this type was registered.</p>
     #[serde(rename = "creationDate")]
@@ -2731,7 +2731,7 @@ pub struct WorkflowTypeInfo {
 }
 
 /// <p>Contains a paginated list of information structures about workflow types.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct WorkflowTypeInfos {
     /// <p>If a <code>NextPageToken</code> was returned by a previous call, there are more results available. To retrieve the next page of results, make the call again using the returned token in <code>nextPageToken</code>. Keep all other arguments unchanged.</p> <p>The configured <code>maximumPageSize</code> determines how many results can be returned in a single call.</p>
     #[serde(rename = "nextPageToken")]

--- a/rusoto/services/waf-regional/src/generated.rs
+++ b/rusoto/services/waf-regional/src/generated.rs
@@ -31,7 +31,7 @@ use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 /// <p>The <code>ActivatedRule</code> object in an <a>UpdateWebACL</a> request specifies a <code>Rule</code> that you want to insert or delete, the priority of the <code>Rule</code> in the <code>WebACL</code>, and the action that you want AWS WAF to take when a web request matches the <code>Rule</code> (<code>ALLOW</code>, <code>BLOCK</code>, or <code>COUNT</code>).</p> <p>To specify whether to insert or delete a <code>Rule</code>, use the <code>Action</code> parameter in the <a>WebACLUpdate</a> data type.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ActivatedRule {
     /// <p>Specifies the action that CloudFront or AWS WAF takes when a web request matches the conditions in the <code>Rule</code>. Valid values for <code>Action</code> include the following:</p> <ul> <li> <p> <code>ALLOW</code>: CloudFront responds with the requested object.</p> </li> <li> <p> <code>BLOCK</code>: CloudFront responds with an HTTP 403 (Forbidden) status code.</p> </li> <li> <p> <code>COUNT</code>: AWS WAF increments a counter of requests that match the conditions in the rule and then continues to inspect the web request based on the remaining rules in the web ACL. </p> </li> </ul> <p> <code>ActivatedRule|OverrideAction</code> applies only when updating or adding a <code>RuleGroup</code> to a <code>WebACL</code>. In this case you do not use <code>ActivatedRule|Action</code>. For all other update requests, <code>ActivatedRule|Action</code> is used instead of <code>ActivatedRule|OverrideAction</code>.</p>
     #[serde(rename = "Action")]
@@ -53,7 +53,7 @@ pub struct ActivatedRule {
     pub type_: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AssociateWebACLRequest {
     /// <p>The ARN (Amazon Resource Name) of the resource to be protected.</p>
     #[serde(rename = "ResourceArn")]
@@ -63,11 +63,11 @@ pub struct AssociateWebACLRequest {
     pub web_acl_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AssociateWebACLResponse {}
 
 /// <p>In a <a>GetByteMatchSet</a> request, <code>ByteMatchSet</code> is a complex type that contains the <code>ByteMatchSetId</code> and <code>Name</code> of a <code>ByteMatchSet</code>, and the values that you specified when you updated the <code>ByteMatchSet</code>. </p> <p>A complex type that contains <code>ByteMatchTuple</code> objects, which specify the parts of web requests that you want AWS WAF to inspect and the values that you want AWS WAF to search for. If a <code>ByteMatchSet</code> contains more than one <code>ByteMatchTuple</code> object, a request needs to match the settings in only one <code>ByteMatchTuple</code> to be considered a match.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ByteMatchSet {
     /// <p>The <code>ByteMatchSetId</code> for a <code>ByteMatchSet</code>. You use <code>ByteMatchSetId</code> to get information about a <code>ByteMatchSet</code> (see <a>GetByteMatchSet</a>), update a <code>ByteMatchSet</code> (see <a>UpdateByteMatchSet</a>), insert a <code>ByteMatchSet</code> into a <code>Rule</code> or delete one from a <code>Rule</code> (see <a>UpdateRule</a>), and delete a <code>ByteMatchSet</code> from AWS WAF (see <a>DeleteByteMatchSet</a>).</p> <p> <code>ByteMatchSetId</code> is returned by <a>CreateByteMatchSet</a> and by <a>ListByteMatchSets</a>.</p>
     #[serde(rename = "ByteMatchSetId")]
@@ -82,7 +82,7 @@ pub struct ByteMatchSet {
 }
 
 /// <p>Returned by <a>ListByteMatchSets</a>. Each <code>ByteMatchSetSummary</code> object includes the <code>Name</code> and <code>ByteMatchSetId</code> for one <a>ByteMatchSet</a>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ByteMatchSetSummary {
     /// <p>The <code>ByteMatchSetId</code> for a <code>ByteMatchSet</code>. You use <code>ByteMatchSetId</code> to get information about a <code>ByteMatchSet</code>, update a <code>ByteMatchSet</code>, remove a <code>ByteMatchSet</code> from a <code>Rule</code>, and delete a <code>ByteMatchSet</code> from AWS WAF.</p> <p> <code>ByteMatchSetId</code> is returned by <a>CreateByteMatchSet</a> and by <a>ListByteMatchSets</a>.</p>
     #[serde(rename = "ByteMatchSetId")]
@@ -93,7 +93,7 @@ pub struct ByteMatchSetSummary {
 }
 
 /// <p>In an <a>UpdateByteMatchSet</a> request, <code>ByteMatchSetUpdate</code> specifies whether to insert or delete a <a>ByteMatchTuple</a> and includes the settings for the <code>ByteMatchTuple</code>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ByteMatchSetUpdate {
     /// <p>Specifies whether to insert or delete a <a>ByteMatchTuple</a>.</p>
     #[serde(rename = "Action")]
@@ -104,7 +104,7 @@ pub struct ByteMatchSetUpdate {
 }
 
 /// <p>The bytes (typically a string that corresponds with ASCII characters) that you want AWS WAF to search for in web requests, the location in requests that you want AWS WAF to search, and other settings.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ByteMatchTuple {
     /// <p>The part of a web request that you want AWS WAF to search, such as a specified header or a query string. For more information, see <a>FieldToMatch</a>.</p>
     #[serde(rename = "FieldToMatch")]
@@ -125,7 +125,7 @@ pub struct ByteMatchTuple {
     pub text_transformation: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateByteMatchSetRequest {
     /// <p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -135,7 +135,7 @@ pub struct CreateByteMatchSetRequest {
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateByteMatchSetResponse {
     /// <p>A <a>ByteMatchSet</a> that contains no <code>ByteMatchTuple</code> objects.</p>
     #[serde(rename = "ByteMatchSet")]
@@ -147,7 +147,7 @@ pub struct CreateByteMatchSetResponse {
     pub change_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateGeoMatchSetRequest {
     /// <p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -157,7 +157,7 @@ pub struct CreateGeoMatchSetRequest {
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateGeoMatchSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>CreateGeoMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -169,7 +169,7 @@ pub struct CreateGeoMatchSetResponse {
     pub geo_match_set: Option<GeoMatchSet>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateIPSetRequest {
     /// <p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -179,7 +179,7 @@ pub struct CreateIPSetRequest {
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateIPSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>CreateIPSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -191,7 +191,7 @@ pub struct CreateIPSetResponse {
     pub ip_set: Option<IPSet>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateRateBasedRuleRequest {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>CreateRateBasedRule</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -210,7 +210,7 @@ pub struct CreateRateBasedRuleRequest {
     pub rate_limit: i64,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateRateBasedRuleResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>CreateRateBasedRule</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -222,7 +222,7 @@ pub struct CreateRateBasedRuleResponse {
     pub rule: Option<RateBasedRule>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateRegexMatchSetRequest {
     /// <p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -232,7 +232,7 @@ pub struct CreateRegexMatchSetRequest {
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateRegexMatchSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>CreateRegexMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -244,7 +244,7 @@ pub struct CreateRegexMatchSetResponse {
     pub regex_match_set: Option<RegexMatchSet>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateRegexPatternSetRequest {
     /// <p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -254,7 +254,7 @@ pub struct CreateRegexPatternSetRequest {
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateRegexPatternSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>CreateRegexPatternSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -266,7 +266,7 @@ pub struct CreateRegexPatternSetResponse {
     pub regex_pattern_set: Option<RegexPatternSet>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateRuleGroupRequest {
     /// <p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -279,7 +279,7 @@ pub struct CreateRuleGroupRequest {
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateRuleGroupResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>CreateRuleGroup</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -291,7 +291,7 @@ pub struct CreateRuleGroupResponse {
     pub rule_group: Option<RuleGroup>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateRuleRequest {
     /// <p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -304,7 +304,7 @@ pub struct CreateRuleRequest {
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateRuleResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>CreateRule</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -316,7 +316,7 @@ pub struct CreateRuleResponse {
     pub rule: Option<Rule>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateSizeConstraintSetRequest {
     /// <p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -326,7 +326,7 @@ pub struct CreateSizeConstraintSetRequest {
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateSizeConstraintSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>CreateSizeConstraintSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -339,7 +339,7 @@ pub struct CreateSizeConstraintSetResponse {
 }
 
 /// <p>A request to create a <a>SqlInjectionMatchSet</a>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateSqlInjectionMatchSetRequest {
     /// <p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -350,7 +350,7 @@ pub struct CreateSqlInjectionMatchSetRequest {
 }
 
 /// <p>The response to a <code>CreateSqlInjectionMatchSet</code> request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateSqlInjectionMatchSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>CreateSqlInjectionMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -362,7 +362,7 @@ pub struct CreateSqlInjectionMatchSetResponse {
     pub sql_injection_match_set: Option<SqlInjectionMatchSet>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateWebACLRequest {
     /// <p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -378,7 +378,7 @@ pub struct CreateWebACLRequest {
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateWebACLResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>CreateWebACL</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -391,7 +391,7 @@ pub struct CreateWebACLResponse {
 }
 
 /// <p>A request to create an <a>XssMatchSet</a>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateXssMatchSetRequest {
     /// <p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -402,7 +402,7 @@ pub struct CreateXssMatchSetRequest {
 }
 
 /// <p>The response to a <code>CreateXssMatchSet</code> request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateXssMatchSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>CreateXssMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -414,7 +414,7 @@ pub struct CreateXssMatchSetResponse {
     pub xss_match_set: Option<XssMatchSet>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteByteMatchSetRequest {
     /// <p>The <code>ByteMatchSetId</code> of the <a>ByteMatchSet</a> that you want to delete. <code>ByteMatchSetId</code> is returned by <a>CreateByteMatchSet</a> and by <a>ListByteMatchSets</a>.</p>
     #[serde(rename = "ByteMatchSetId")]
@@ -424,7 +424,7 @@ pub struct DeleteByteMatchSetRequest {
     pub change_token: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteByteMatchSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>DeleteByteMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -432,7 +432,7 @@ pub struct DeleteByteMatchSetResponse {
     pub change_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteGeoMatchSetRequest {
     /// <p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -442,7 +442,7 @@ pub struct DeleteGeoMatchSetRequest {
     pub geo_match_set_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteGeoMatchSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>DeleteGeoMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -450,7 +450,7 @@ pub struct DeleteGeoMatchSetResponse {
     pub change_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteIPSetRequest {
     /// <p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -460,7 +460,7 @@ pub struct DeleteIPSetRequest {
     pub ip_set_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteIPSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>DeleteIPSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -468,17 +468,17 @@ pub struct DeleteIPSetResponse {
     pub change_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeletePermissionPolicyRequest {
     /// <p>The Amazon Resource Name (ARN) of the RuleGroup from which you want to delete the policy.</p> <p>The user making the request must be the owner of the RuleGroup.</p>
     #[serde(rename = "ResourceArn")]
     pub resource_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeletePermissionPolicyResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteRateBasedRuleRequest {
     /// <p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -488,7 +488,7 @@ pub struct DeleteRateBasedRuleRequest {
     pub rule_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteRateBasedRuleResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>DeleteRateBasedRule</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -496,7 +496,7 @@ pub struct DeleteRateBasedRuleResponse {
     pub change_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteRegexMatchSetRequest {
     /// <p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -506,7 +506,7 @@ pub struct DeleteRegexMatchSetRequest {
     pub regex_match_set_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteRegexMatchSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>DeleteRegexMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -514,7 +514,7 @@ pub struct DeleteRegexMatchSetResponse {
     pub change_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteRegexPatternSetRequest {
     /// <p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -524,7 +524,7 @@ pub struct DeleteRegexPatternSetRequest {
     pub regex_pattern_set_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteRegexPatternSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>DeleteRegexPatternSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -532,7 +532,7 @@ pub struct DeleteRegexPatternSetResponse {
     pub change_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteRuleGroupRequest {
     /// <p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -542,7 +542,7 @@ pub struct DeleteRuleGroupRequest {
     pub rule_group_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteRuleGroupResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>DeleteRuleGroup</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -550,7 +550,7 @@ pub struct DeleteRuleGroupResponse {
     pub change_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteRuleRequest {
     /// <p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -560,7 +560,7 @@ pub struct DeleteRuleRequest {
     pub rule_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteRuleResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>DeleteRule</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -568,7 +568,7 @@ pub struct DeleteRuleResponse {
     pub change_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteSizeConstraintSetRequest {
     /// <p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -578,7 +578,7 @@ pub struct DeleteSizeConstraintSetRequest {
     pub size_constraint_set_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteSizeConstraintSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>DeleteSizeConstraintSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -587,7 +587,7 @@ pub struct DeleteSizeConstraintSetResponse {
 }
 
 /// <p>A request to delete a <a>SqlInjectionMatchSet</a> from AWS WAF.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteSqlInjectionMatchSetRequest {
     /// <p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -598,7 +598,7 @@ pub struct DeleteSqlInjectionMatchSetRequest {
 }
 
 /// <p>The response to a request to delete a <a>SqlInjectionMatchSet</a> from AWS WAF.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteSqlInjectionMatchSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>DeleteSqlInjectionMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -606,7 +606,7 @@ pub struct DeleteSqlInjectionMatchSetResponse {
     pub change_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteWebACLRequest {
     /// <p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -616,7 +616,7 @@ pub struct DeleteWebACLRequest {
     pub web_acl_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteWebACLResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>DeleteWebACL</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -625,7 +625,7 @@ pub struct DeleteWebACLResponse {
 }
 
 /// <p>A request to delete an <a>XssMatchSet</a> from AWS WAF.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteXssMatchSetRequest {
     /// <p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -636,7 +636,7 @@ pub struct DeleteXssMatchSetRequest {
 }
 
 /// <p>The response to a request to delete an <a>XssMatchSet</a> from AWS WAF.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteXssMatchSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>DeleteXssMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -644,18 +644,18 @@ pub struct DeleteXssMatchSetResponse {
     pub change_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DisassociateWebACLRequest {
     /// <p>The ARN (Amazon Resource Name) of the resource from which the web ACL is being removed.</p>
     #[serde(rename = "ResourceArn")]
     pub resource_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DisassociateWebACLResponse {}
 
 /// <p>Specifies where in a web request to look for <code>TargetString</code>.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct FieldToMatch {
     /// <p>When the value of <code>Type</code> is <code>HEADER</code>, enter the name of the header that you want AWS WAF to search, for example, <code>User-Agent</code> or <code>Referer</code>. If the value of <code>Type</code> is any other value, omit <code>Data</code>.</p> <p>The name of the header is not case sensitive.</p>
     #[serde(rename = "Data")]
@@ -667,7 +667,7 @@ pub struct FieldToMatch {
 }
 
 /// <p>The country from which web requests originate that you want AWS WAF to search for.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct GeoMatchConstraint {
     /// <p>The type of geographical area you want AWS WAF to search for. Currently <code>Country</code> is the only valid value.</p>
     #[serde(rename = "Type")]
@@ -678,7 +678,7 @@ pub struct GeoMatchConstraint {
 }
 
 /// <p>Contains one or more countries that AWS WAF will search for.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GeoMatchSet {
     /// <p>An array of <a>GeoMatchConstraint</a> objects, which contain the country that you want AWS WAF to search for.</p>
     #[serde(rename = "GeoMatchConstraints")]
@@ -693,7 +693,7 @@ pub struct GeoMatchSet {
 }
 
 /// <p>Contains the identifier and the name of the <code>GeoMatchSet</code>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GeoMatchSetSummary {
     /// <p>The <code>GeoMatchSetId</code> for an <a>GeoMatchSet</a>. You can use <code>GeoMatchSetId</code> in a <a>GetGeoMatchSet</a> request to get detailed information about an <a>GeoMatchSet</a>.</p>
     #[serde(rename = "GeoMatchSetId")]
@@ -704,7 +704,7 @@ pub struct GeoMatchSetSummary {
 }
 
 /// <p>Specifies the type of update to perform to an <a>GeoMatchSet</a> with <a>UpdateGeoMatchSet</a>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GeoMatchSetUpdate {
     /// <p>Specifies whether to insert or delete a country with <a>UpdateGeoMatchSet</a>.</p>
     #[serde(rename = "Action")]
@@ -714,14 +714,14 @@ pub struct GeoMatchSetUpdate {
     pub geo_match_constraint: GeoMatchConstraint,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetByteMatchSetRequest {
     /// <p>The <code>ByteMatchSetId</code> of the <a>ByteMatchSet</a> that you want to get. <code>ByteMatchSetId</code> is returned by <a>CreateByteMatchSet</a> and by <a>ListByteMatchSets</a>.</p>
     #[serde(rename = "ByteMatchSetId")]
     pub byte_match_set_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetByteMatchSetResponse {
     /// <p><p>Information about the <a>ByteMatchSet</a> that you specified in the <code>GetByteMatchSet</code> request. For more information, see the following topics:</p> <ul> <li> <p> <a>ByteMatchSet</a>: Contains <code>ByteMatchSetId</code>, <code>ByteMatchTuples</code>, and <code>Name</code> </p> </li> <li> <p> <code>ByteMatchTuples</code>: Contains an array of <a>ByteMatchTuple</a> objects. Each <code>ByteMatchTuple</code> object contains <a>FieldToMatch</a>, <code>PositionalConstraint</code>, <code>TargetString</code>, and <code>TextTransformation</code> </p> </li> <li> <p> <a>FieldToMatch</a>: Contains <code>Data</code> and <code>Type</code> </p> </li> </ul></p>
     #[serde(rename = "ByteMatchSet")]
@@ -729,10 +729,10 @@ pub struct GetByteMatchSetResponse {
     pub byte_match_set: Option<ByteMatchSet>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetChangeTokenRequest {}
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetChangeTokenResponse {
     /// <p>The <code>ChangeToken</code> that you used in the request. Use this value in a <code>GetChangeTokenStatus</code> request to get the current status of the request. </p>
     #[serde(rename = "ChangeToken")]
@@ -740,14 +740,14 @@ pub struct GetChangeTokenResponse {
     pub change_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetChangeTokenStatusRequest {
     /// <p>The change token for which you want to get the status. This change token was previously returned in the <code>GetChangeToken</code> response.</p>
     #[serde(rename = "ChangeToken")]
     pub change_token: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetChangeTokenStatusResponse {
     /// <p>The status of the change token.</p>
     #[serde(rename = "ChangeTokenStatus")]
@@ -755,14 +755,14 @@ pub struct GetChangeTokenStatusResponse {
     pub change_token_status: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetGeoMatchSetRequest {
     /// <p>The <code>GeoMatchSetId</code> of the <a>GeoMatchSet</a> that you want to get. <code>GeoMatchSetId</code> is returned by <a>CreateGeoMatchSet</a> and by <a>ListGeoMatchSets</a>.</p>
     #[serde(rename = "GeoMatchSetId")]
     pub geo_match_set_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetGeoMatchSetResponse {
     /// <p>Information about the <a>GeoMatchSet</a> that you specified in the <code>GetGeoMatchSet</code> request. This includes the <code>Type</code>, which for a <code>GeoMatchContraint</code> is always <code>Country</code>, as well as the <code>Value</code>, which is the identifier for a specific country.</p>
     #[serde(rename = "GeoMatchSet")]
@@ -770,14 +770,14 @@ pub struct GetGeoMatchSetResponse {
     pub geo_match_set: Option<GeoMatchSet>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetIPSetRequest {
     /// <p>The <code>IPSetId</code> of the <a>IPSet</a> that you want to get. <code>IPSetId</code> is returned by <a>CreateIPSet</a> and by <a>ListIPSets</a>.</p>
     #[serde(rename = "IPSetId")]
     pub ip_set_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetIPSetResponse {
     /// <p><p>Information about the <a>IPSet</a> that you specified in the <code>GetIPSet</code> request. For more information, see the following topics:</p> <ul> <li> <p> <a>IPSet</a>: Contains <code>IPSetDescriptors</code>, <code>IPSetId</code>, and <code>Name</code> </p> </li> <li> <p> <code>IPSetDescriptors</code>: Contains an array of <a>IPSetDescriptor</a> objects. Each <code>IPSetDescriptor</code> object contains <code>Type</code> and <code>Value</code> </p> </li> </ul></p>
     #[serde(rename = "IPSet")]
@@ -785,14 +785,14 @@ pub struct GetIPSetResponse {
     pub ip_set: Option<IPSet>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetPermissionPolicyRequest {
     /// <p>The Amazon Resource Name (ARN) of the RuleGroup for which you want to get the policy.</p>
     #[serde(rename = "ResourceArn")]
     pub resource_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetPermissionPolicyResponse {
     /// <p>The IAM policy attached to the specified RuleGroup.</p>
     #[serde(rename = "Policy")]
@@ -800,7 +800,7 @@ pub struct GetPermissionPolicyResponse {
     pub policy: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetRateBasedRuleManagedKeysRequest {
     /// <p>A null value and not currently used. Do not include this in your request.</p>
     #[serde(rename = "NextMarker")]
@@ -811,7 +811,7 @@ pub struct GetRateBasedRuleManagedKeysRequest {
     pub rule_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetRateBasedRuleManagedKeysResponse {
     /// <p>An array of IP addresses that currently are blocked by the specified <a>RateBasedRule</a>. </p>
     #[serde(rename = "ManagedKeys")]
@@ -823,14 +823,14 @@ pub struct GetRateBasedRuleManagedKeysResponse {
     pub next_marker: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetRateBasedRuleRequest {
     /// <p>The <code>RuleId</code> of the <a>RateBasedRule</a> that you want to get. <code>RuleId</code> is returned by <a>CreateRateBasedRule</a> and by <a>ListRateBasedRules</a>.</p>
     #[serde(rename = "RuleId")]
     pub rule_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetRateBasedRuleResponse {
     /// <p>Information about the <a>RateBasedRule</a> that you specified in the <code>GetRateBasedRule</code> request.</p>
     #[serde(rename = "Rule")]
@@ -838,14 +838,14 @@ pub struct GetRateBasedRuleResponse {
     pub rule: Option<RateBasedRule>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetRegexMatchSetRequest {
     /// <p>The <code>RegexMatchSetId</code> of the <a>RegexMatchSet</a> that you want to get. <code>RegexMatchSetId</code> is returned by <a>CreateRegexMatchSet</a> and by <a>ListRegexMatchSets</a>.</p>
     #[serde(rename = "RegexMatchSetId")]
     pub regex_match_set_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetRegexMatchSetResponse {
     /// <p>Information about the <a>RegexMatchSet</a> that you specified in the <code>GetRegexMatchSet</code> request. For more information, see <a>RegexMatchTuple</a>.</p>
     #[serde(rename = "RegexMatchSet")]
@@ -853,14 +853,14 @@ pub struct GetRegexMatchSetResponse {
     pub regex_match_set: Option<RegexMatchSet>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetRegexPatternSetRequest {
     /// <p>The <code>RegexPatternSetId</code> of the <a>RegexPatternSet</a> that you want to get. <code>RegexPatternSetId</code> is returned by <a>CreateRegexPatternSet</a> and by <a>ListRegexPatternSets</a>.</p>
     #[serde(rename = "RegexPatternSetId")]
     pub regex_pattern_set_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetRegexPatternSetResponse {
     /// <p>Information about the <a>RegexPatternSet</a> that you specified in the <code>GetRegexPatternSet</code> request, including the identifier of the pattern set and the regular expression patterns you want AWS WAF to search for. </p>
     #[serde(rename = "RegexPatternSet")]
@@ -868,14 +868,14 @@ pub struct GetRegexPatternSetResponse {
     pub regex_pattern_set: Option<RegexPatternSet>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetRuleGroupRequest {
     /// <p>The <code>RuleGroupId</code> of the <a>RuleGroup</a> that you want to get. <code>RuleGroupId</code> is returned by <a>CreateRuleGroup</a> and by <a>ListRuleGroups</a>.</p>
     #[serde(rename = "RuleGroupId")]
     pub rule_group_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetRuleGroupResponse {
     /// <p>Information about the <a>RuleGroup</a> that you specified in the <code>GetRuleGroup</code> request. </p>
     #[serde(rename = "RuleGroup")]
@@ -883,14 +883,14 @@ pub struct GetRuleGroupResponse {
     pub rule_group: Option<RuleGroup>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetRuleRequest {
     /// <p>The <code>RuleId</code> of the <a>Rule</a> that you want to get. <code>RuleId</code> is returned by <a>CreateRule</a> and by <a>ListRules</a>.</p>
     #[serde(rename = "RuleId")]
     pub rule_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetRuleResponse {
     /// <p><p>Information about the <a>Rule</a> that you specified in the <code>GetRule</code> request. For more information, see the following topics:</p> <ul> <li> <p> <a>Rule</a>: Contains <code>MetricName</code>, <code>Name</code>, an array of <code>Predicate</code> objects, and <code>RuleId</code> </p> </li> <li> <p> <a>Predicate</a>: Each <code>Predicate</code> object contains <code>DataId</code>, <code>Negated</code>, and <code>Type</code> </p> </li> </ul></p>
     #[serde(rename = "Rule")]
@@ -898,7 +898,7 @@ pub struct GetRuleResponse {
     pub rule: Option<Rule>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetSampledRequestsRequest {
     /// <p>The number of requests that you want AWS WAF to return from among the first 5,000 requests that your AWS resource received during the time range. If your resource received fewer requests than the value of <code>MaxItems</code>, <code>GetSampledRequests</code> returns information about all of them. </p>
     #[serde(rename = "MaxItems")]
@@ -914,7 +914,7 @@ pub struct GetSampledRequestsRequest {
     pub web_acl_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetSampledRequestsResponse {
     /// <p>The total number of requests from which <code>GetSampledRequests</code> got a sample of <code>MaxItems</code> requests. If <code>PopulationSize</code> is less than <code>MaxItems</code>, the sample includes every request that your AWS resource received during the specified time range.</p>
     #[serde(rename = "PopulationSize")]
@@ -930,14 +930,14 @@ pub struct GetSampledRequestsResponse {
     pub time_window: Option<TimeWindow>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetSizeConstraintSetRequest {
     /// <p>The <code>SizeConstraintSetId</code> of the <a>SizeConstraintSet</a> that you want to get. <code>SizeConstraintSetId</code> is returned by <a>CreateSizeConstraintSet</a> and by <a>ListSizeConstraintSets</a>.</p>
     #[serde(rename = "SizeConstraintSetId")]
     pub size_constraint_set_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetSizeConstraintSetResponse {
     /// <p><p>Information about the <a>SizeConstraintSet</a> that you specified in the <code>GetSizeConstraintSet</code> request. For more information, see the following topics:</p> <ul> <li> <p> <a>SizeConstraintSet</a>: Contains <code>SizeConstraintSetId</code>, <code>SizeConstraints</code>, and <code>Name</code> </p> </li> <li> <p> <code>SizeConstraints</code>: Contains an array of <a>SizeConstraint</a> objects. Each <code>SizeConstraint</code> object contains <a>FieldToMatch</a>, <code>TextTransformation</code>, <code>ComparisonOperator</code>, and <code>Size</code> </p> </li> <li> <p> <a>FieldToMatch</a>: Contains <code>Data</code> and <code>Type</code> </p> </li> </ul></p>
     #[serde(rename = "SizeConstraintSet")]
@@ -946,7 +946,7 @@ pub struct GetSizeConstraintSetResponse {
 }
 
 /// <p>A request to get a <a>SqlInjectionMatchSet</a>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetSqlInjectionMatchSetRequest {
     /// <p>The <code>SqlInjectionMatchSetId</code> of the <a>SqlInjectionMatchSet</a> that you want to get. <code>SqlInjectionMatchSetId</code> is returned by <a>CreateSqlInjectionMatchSet</a> and by <a>ListSqlInjectionMatchSets</a>.</p>
     #[serde(rename = "SqlInjectionMatchSetId")]
@@ -954,7 +954,7 @@ pub struct GetSqlInjectionMatchSetRequest {
 }
 
 /// <p>The response to a <a>GetSqlInjectionMatchSet</a> request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetSqlInjectionMatchSetResponse {
     /// <p><p>Information about the <a>SqlInjectionMatchSet</a> that you specified in the <code>GetSqlInjectionMatchSet</code> request. For more information, see the following topics:</p> <ul> <li> <p> <a>SqlInjectionMatchSet</a>: Contains <code>Name</code>, <code>SqlInjectionMatchSetId</code>, and an array of <code>SqlInjectionMatchTuple</code> objects</p> </li> <li> <p> <a>SqlInjectionMatchTuple</a>: Each <code>SqlInjectionMatchTuple</code> object contains <code>FieldToMatch</code> and <code>TextTransformation</code> </p> </li> <li> <p> <a>FieldToMatch</a>: Contains <code>Data</code> and <code>Type</code> </p> </li> </ul></p>
     #[serde(rename = "SqlInjectionMatchSet")]
@@ -962,14 +962,14 @@ pub struct GetSqlInjectionMatchSetResponse {
     pub sql_injection_match_set: Option<SqlInjectionMatchSet>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetWebACLForResourceRequest {
     /// <p>The ARN (Amazon Resource Name) of the resource for which to get the web ACL.</p>
     #[serde(rename = "ResourceArn")]
     pub resource_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetWebACLForResourceResponse {
     /// <p>Information about the web ACL that you specified in the <code>GetWebACLForResource</code> request. If there is no associated resource, a null WebACLSummary is returned.</p>
     #[serde(rename = "WebACLSummary")]
@@ -977,14 +977,14 @@ pub struct GetWebACLForResourceResponse {
     pub web_acl_summary: Option<WebACLSummary>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetWebACLRequest {
     /// <p>The <code>WebACLId</code> of the <a>WebACL</a> that you want to get. <code>WebACLId</code> is returned by <a>CreateWebACL</a> and by <a>ListWebACLs</a>.</p>
     #[serde(rename = "WebACLId")]
     pub web_acl_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetWebACLResponse {
     /// <p><p>Information about the <a>WebACL</a> that you specified in the <code>GetWebACL</code> request. For more information, see the following topics:</p> <ul> <li> <p> <a>WebACL</a>: Contains <code>DefaultAction</code>, <code>MetricName</code>, <code>Name</code>, an array of <code>Rule</code> objects, and <code>WebACLId</code> </p> </li> <li> <p> <code>DefaultAction</code> (Data type is <a>WafAction</a>): Contains <code>Type</code> </p> </li> <li> <p> <code>Rules</code>: Contains an array of <code>ActivatedRule</code> objects, which contain <code>Action</code>, <code>Priority</code>, and <code>RuleId</code> </p> </li> <li> <p> <code>Action</code>: Contains <code>Type</code> </p> </li> </ul></p>
     #[serde(rename = "WebACL")]
@@ -993,7 +993,7 @@ pub struct GetWebACLResponse {
 }
 
 /// <p>A request to get an <a>XssMatchSet</a>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetXssMatchSetRequest {
     /// <p>The <code>XssMatchSetId</code> of the <a>XssMatchSet</a> that you want to get. <code>XssMatchSetId</code> is returned by <a>CreateXssMatchSet</a> and by <a>ListXssMatchSets</a>.</p>
     #[serde(rename = "XssMatchSetId")]
@@ -1001,7 +1001,7 @@ pub struct GetXssMatchSetRequest {
 }
 
 /// <p>The response to a <a>GetXssMatchSet</a> request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetXssMatchSetResponse {
     /// <p><p>Information about the <a>XssMatchSet</a> that you specified in the <code>GetXssMatchSet</code> request. For more information, see the following topics:</p> <ul> <li> <p> <a>XssMatchSet</a>: Contains <code>Name</code>, <code>XssMatchSetId</code>, and an array of <code>XssMatchTuple</code> objects</p> </li> <li> <p> <a>XssMatchTuple</a>: Each <code>XssMatchTuple</code> object contains <code>FieldToMatch</code> and <code>TextTransformation</code> </p> </li> <li> <p> <a>FieldToMatch</a>: Contains <code>Data</code> and <code>Type</code> </p> </li> </ul></p>
     #[serde(rename = "XssMatchSet")]
@@ -1010,7 +1010,7 @@ pub struct GetXssMatchSetResponse {
 }
 
 /// <p>The response from a <a>GetSampledRequests</a> request includes an <code>HTTPHeader</code> complex type that appears as <code>Headers</code> in the response syntax. <code>HTTPHeader</code> contains the names and values of all of the headers that appear in one of the web requests that were returned by <code>GetSampledRequests</code>. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct HTTPHeader {
     /// <p>The name of one of the headers in the sampled web request.</p>
     #[serde(rename = "Name")]
@@ -1023,7 +1023,7 @@ pub struct HTTPHeader {
 }
 
 /// <p>The response from a <a>GetSampledRequests</a> request includes an <code>HTTPRequest</code> complex type that appears as <code>Request</code> in the response syntax. <code>HTTPRequest</code> contains information about one of the web requests that were returned by <code>GetSampledRequests</code>. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct HTTPRequest {
     /// <p><p>The IP address that the request originated from. If the <code>WebACL</code> is associated with a CloudFront distribution, this is the value of one of the following fields in CloudFront access logs:</p> <ul> <li> <p> <code>c-ip</code>, if the viewer did not use an HTTP proxy or a load balancer to send the request</p> </li> <li> <p> <code>x-forwarded-for</code>, if the viewer did use an HTTP proxy or a load balancer to send the request</p> </li> </ul></p>
     #[serde(rename = "ClientIP")]
@@ -1052,7 +1052,7 @@ pub struct HTTPRequest {
 }
 
 /// <p>Contains one or more IP addresses or blocks of IP addresses specified in Classless Inter-Domain Routing (CIDR) notation. AWS WAF supports /8, /16, /24, and /32 IP address ranges for IPv4, and /24, /32, /48, /56, /64 and /128 for IPv6.</p> <p>To specify an individual IP address, you specify the four-part IP address followed by a <code>/32</code>, for example, 192.0.2.0/31. To block a range of IP addresses, you can specify a <code>/128</code>, <code>/64</code>, <code>/56</code>, <code>/48</code>, <code>/32</code>, <code>/24</code>, <code>/16</code>, or <code>/8</code> CIDR. For more information about CIDR notation, see the Wikipedia entry <a href="https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing">Classless Inter-Domain Routing</a>. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct IPSet {
     /// <p>The IP address type (<code>IPV4</code> or <code>IPV6</code>) and the IP address range (in CIDR notation) that web requests originate from. If the <code>WebACL</code> is associated with a CloudFront distribution and the viewer did not use an HTTP proxy or a load balancer to send the request, this is the value of the c-ip field in the CloudFront access logs.</p>
     #[serde(rename = "IPSetDescriptors")]
@@ -1067,7 +1067,7 @@ pub struct IPSet {
 }
 
 /// <p>Specifies the IP address type (<code>IPV4</code> or <code>IPV6</code>) and the IP address range (in CIDR format) that web requests originate from.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct IPSetDescriptor {
     /// <p>Specify <code>IPV4</code> or <code>IPV6</code>.</p>
     #[serde(rename = "Type")]
@@ -1078,7 +1078,7 @@ pub struct IPSetDescriptor {
 }
 
 /// <p>Contains the identifier and the name of the <code>IPSet</code>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct IPSetSummary {
     /// <p>The <code>IPSetId</code> for an <a>IPSet</a>. You can use <code>IPSetId</code> in a <a>GetIPSet</a> request to get detailed information about an <a>IPSet</a>.</p>
     #[serde(rename = "IPSetId")]
@@ -1089,7 +1089,7 @@ pub struct IPSetSummary {
 }
 
 /// <p>Specifies the type of update to perform to an <a>IPSet</a> with <a>UpdateIPSet</a>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct IPSetUpdate {
     /// <p>Specifies whether to insert or delete an IP address with <a>UpdateIPSet</a>.</p>
     #[serde(rename = "Action")]
@@ -1099,7 +1099,7 @@ pub struct IPSetUpdate {
     pub ip_set_descriptor: IPSetDescriptor,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListActivatedRulesInRuleGroupRequest {
     /// <p>Specifies the number of <code>ActivatedRules</code> that you want AWS WAF to return for this request. If you have more <code>ActivatedRules</code> than the number that you specify for <code>Limit</code>, the response includes a <code>NextMarker</code> value that you can use to get another batch of <code>ActivatedRules</code>.</p>
     #[serde(rename = "Limit")]
@@ -1115,7 +1115,7 @@ pub struct ListActivatedRulesInRuleGroupRequest {
     pub rule_group_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListActivatedRulesInRuleGroupResponse {
     /// <p>An array of <code>ActivatedRules</code> objects.</p>
     #[serde(rename = "ActivatedRules")]
@@ -1127,7 +1127,7 @@ pub struct ListActivatedRulesInRuleGroupResponse {
     pub next_marker: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListByteMatchSetsRequest {
     /// <p>Specifies the number of <code>ByteMatchSet</code> objects that you want AWS WAF to return for this request. If you have more <code>ByteMatchSets</code> objects than the number you specify for <code>Limit</code>, the response includes a <code>NextMarker</code> value that you can use to get another batch of <code>ByteMatchSet</code> objects.</p>
     #[serde(rename = "Limit")]
@@ -1139,7 +1139,7 @@ pub struct ListByteMatchSetsRequest {
     pub next_marker: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListByteMatchSetsResponse {
     /// <p>An array of <a>ByteMatchSetSummary</a> objects.</p>
     #[serde(rename = "ByteMatchSets")]
@@ -1151,7 +1151,7 @@ pub struct ListByteMatchSetsResponse {
     pub next_marker: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListGeoMatchSetsRequest {
     /// <p>Specifies the number of <code>GeoMatchSet</code> objects that you want AWS WAF to return for this request. If you have more <code>GeoMatchSet</code> objects than the number you specify for <code>Limit</code>, the response includes a <code>NextMarker</code> value that you can use to get another batch of <code>GeoMatchSet</code> objects.</p>
     #[serde(rename = "Limit")]
@@ -1163,7 +1163,7 @@ pub struct ListGeoMatchSetsRequest {
     pub next_marker: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListGeoMatchSetsResponse {
     /// <p>An array of <a>GeoMatchSetSummary</a> objects.</p>
     #[serde(rename = "GeoMatchSets")]
@@ -1175,7 +1175,7 @@ pub struct ListGeoMatchSetsResponse {
     pub next_marker: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListIPSetsRequest {
     /// <p>Specifies the number of <code>IPSet</code> objects that you want AWS WAF to return for this request. If you have more <code>IPSet</code> objects than the number you specify for <code>Limit</code>, the response includes a <code>NextMarker</code> value that you can use to get another batch of <code>IPSet</code> objects.</p>
     #[serde(rename = "Limit")]
@@ -1187,7 +1187,7 @@ pub struct ListIPSetsRequest {
     pub next_marker: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListIPSetsResponse {
     /// <p>An array of <a>IPSetSummary</a> objects.</p>
     #[serde(rename = "IPSets")]
@@ -1199,7 +1199,7 @@ pub struct ListIPSetsResponse {
     pub next_marker: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListRateBasedRulesRequest {
     /// <p>Specifies the number of <code>Rules</code> that you want AWS WAF to return for this request. If you have more <code>Rules</code> than the number that you specify for <code>Limit</code>, the response includes a <code>NextMarker</code> value that you can use to get another batch of <code>Rules</code>.</p>
     #[serde(rename = "Limit")]
@@ -1211,7 +1211,7 @@ pub struct ListRateBasedRulesRequest {
     pub next_marker: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListRateBasedRulesResponse {
     /// <p>If you have more <code>Rules</code> than the number that you specified for <code>Limit</code> in the request, the response includes a <code>NextMarker</code> value. To list more <code>Rules</code>, submit another <code>ListRateBasedRules</code> request, and specify the <code>NextMarker</code> value from the response in the <code>NextMarker</code> value in the next request.</p>
     #[serde(rename = "NextMarker")]
@@ -1223,7 +1223,7 @@ pub struct ListRateBasedRulesResponse {
     pub rules: Option<Vec<RuleSummary>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListRegexMatchSetsRequest {
     /// <p>Specifies the number of <code>RegexMatchSet</code> objects that you want AWS WAF to return for this request. If you have more <code>RegexMatchSet</code> objects than the number you specify for <code>Limit</code>, the response includes a <code>NextMarker</code> value that you can use to get another batch of <code>RegexMatchSet</code> objects.</p>
     #[serde(rename = "Limit")]
@@ -1235,7 +1235,7 @@ pub struct ListRegexMatchSetsRequest {
     pub next_marker: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListRegexMatchSetsResponse {
     /// <p>If you have more <code>RegexMatchSet</code> objects than the number that you specified for <code>Limit</code> in the request, the response includes a <code>NextMarker</code> value. To list more <code>RegexMatchSet</code> objects, submit another <code>ListRegexMatchSets</code> request, and specify the <code>NextMarker</code> value from the response in the <code>NextMarker</code> value in the next request.</p>
     #[serde(rename = "NextMarker")]
@@ -1247,7 +1247,7 @@ pub struct ListRegexMatchSetsResponse {
     pub regex_match_sets: Option<Vec<RegexMatchSetSummary>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListRegexPatternSetsRequest {
     /// <p>Specifies the number of <code>RegexPatternSet</code> objects that you want AWS WAF to return for this request. If you have more <code>RegexPatternSet</code> objects than the number you specify for <code>Limit</code>, the response includes a <code>NextMarker</code> value that you can use to get another batch of <code>RegexPatternSet</code> objects.</p>
     #[serde(rename = "Limit")]
@@ -1259,7 +1259,7 @@ pub struct ListRegexPatternSetsRequest {
     pub next_marker: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListRegexPatternSetsResponse {
     /// <p>If you have more <code>RegexPatternSet</code> objects than the number that you specified for <code>Limit</code> in the request, the response includes a <code>NextMarker</code> value. To list more <code>RegexPatternSet</code> objects, submit another <code>ListRegexPatternSets</code> request, and specify the <code>NextMarker</code> value from the response in the <code>NextMarker</code> value in the next request.</p>
     #[serde(rename = "NextMarker")]
@@ -1271,14 +1271,14 @@ pub struct ListRegexPatternSetsResponse {
     pub regex_pattern_sets: Option<Vec<RegexPatternSetSummary>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListResourcesForWebACLRequest {
     /// <p>The unique identifier (ID) of the web ACL for which to list the associated resources.</p>
     #[serde(rename = "WebACLId")]
     pub web_acl_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListResourcesForWebACLResponse {
     /// <p>An array of ARNs (Amazon Resource Names) of the resources associated with the specified web ACL. An array with zero elements is returned if there are no resources associated with the web ACL.</p>
     #[serde(rename = "ResourceArns")]
@@ -1286,7 +1286,7 @@ pub struct ListResourcesForWebACLResponse {
     pub resource_arns: Option<Vec<String>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListRuleGroupsRequest {
     /// <p>Specifies the number of <code>RuleGroups</code> that you want AWS WAF to return for this request. If you have more <code>RuleGroups</code> than the number that you specify for <code>Limit</code>, the response includes a <code>NextMarker</code> value that you can use to get another batch of <code>RuleGroups</code>.</p>
     #[serde(rename = "Limit")]
@@ -1298,7 +1298,7 @@ pub struct ListRuleGroupsRequest {
     pub next_marker: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListRuleGroupsResponse {
     /// <p>If you have more <code>RuleGroups</code> than the number that you specified for <code>Limit</code> in the request, the response includes a <code>NextMarker</code> value. To list more <code>RuleGroups</code>, submit another <code>ListRuleGroups</code> request, and specify the <code>NextMarker</code> value from the response in the <code>NextMarker</code> value in the next request.</p>
     #[serde(rename = "NextMarker")]
@@ -1310,7 +1310,7 @@ pub struct ListRuleGroupsResponse {
     pub rule_groups: Option<Vec<RuleGroupSummary>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListRulesRequest {
     /// <p>Specifies the number of <code>Rules</code> that you want AWS WAF to return for this request. If you have more <code>Rules</code> than the number that you specify for <code>Limit</code>, the response includes a <code>NextMarker</code> value that you can use to get another batch of <code>Rules</code>.</p>
     #[serde(rename = "Limit")]
@@ -1322,7 +1322,7 @@ pub struct ListRulesRequest {
     pub next_marker: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListRulesResponse {
     /// <p>If you have more <code>Rules</code> than the number that you specified for <code>Limit</code> in the request, the response includes a <code>NextMarker</code> value. To list more <code>Rules</code>, submit another <code>ListRules</code> request, and specify the <code>NextMarker</code> value from the response in the <code>NextMarker</code> value in the next request.</p>
     #[serde(rename = "NextMarker")]
@@ -1334,7 +1334,7 @@ pub struct ListRulesResponse {
     pub rules: Option<Vec<RuleSummary>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListSizeConstraintSetsRequest {
     /// <p>Specifies the number of <code>SizeConstraintSet</code> objects that you want AWS WAF to return for this request. If you have more <code>SizeConstraintSets</code> objects than the number you specify for <code>Limit</code>, the response includes a <code>NextMarker</code> value that you can use to get another batch of <code>SizeConstraintSet</code> objects.</p>
     #[serde(rename = "Limit")]
@@ -1346,7 +1346,7 @@ pub struct ListSizeConstraintSetsRequest {
     pub next_marker: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListSizeConstraintSetsResponse {
     /// <p>If you have more <code>SizeConstraintSet</code> objects than the number that you specified for <code>Limit</code> in the request, the response includes a <code>NextMarker</code> value. To list more <code>SizeConstraintSet</code> objects, submit another <code>ListSizeConstraintSets</code> request, and specify the <code>NextMarker</code> value from the response in the <code>NextMarker</code> value in the next request.</p>
     #[serde(rename = "NextMarker")]
@@ -1359,7 +1359,7 @@ pub struct ListSizeConstraintSetsResponse {
 }
 
 /// <p>A request to list the <a>SqlInjectionMatchSet</a> objects created by the current AWS account.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListSqlInjectionMatchSetsRequest {
     /// <p>Specifies the number of <a>SqlInjectionMatchSet</a> objects that you want AWS WAF to return for this request. If you have more <code>SqlInjectionMatchSet</code> objects than the number you specify for <code>Limit</code>, the response includes a <code>NextMarker</code> value that you can use to get another batch of <code>Rules</code>.</p>
     #[serde(rename = "Limit")]
@@ -1372,7 +1372,7 @@ pub struct ListSqlInjectionMatchSetsRequest {
 }
 
 /// <p>The response to a <a>ListSqlInjectionMatchSets</a> request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListSqlInjectionMatchSetsResponse {
     /// <p>If you have more <a>SqlInjectionMatchSet</a> objects than the number that you specified for <code>Limit</code> in the request, the response includes a <code>NextMarker</code> value. To list more <code>SqlInjectionMatchSet</code> objects, submit another <code>ListSqlInjectionMatchSets</code> request, and specify the <code>NextMarker</code> value from the response in the <code>NextMarker</code> value in the next request.</p>
     #[serde(rename = "NextMarker")]
@@ -1384,7 +1384,7 @@ pub struct ListSqlInjectionMatchSetsResponse {
     pub sql_injection_match_sets: Option<Vec<SqlInjectionMatchSetSummary>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListSubscribedRuleGroupsRequest {
     /// <p>Specifies the number of subscribed rule groups that you want AWS WAF to return for this request. If you have more objects than the number you specify for <code>Limit</code>, the response includes a <code>NextMarker</code> value that you can use to get another batch of objects.</p>
     #[serde(rename = "Limit")]
@@ -1396,7 +1396,7 @@ pub struct ListSubscribedRuleGroupsRequest {
     pub next_marker: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListSubscribedRuleGroupsResponse {
     /// <p>If you have more objects than the number that you specified for <code>Limit</code> in the request, the response includes a <code>NextMarker</code> value. To list more objects, submit another <code>ListSubscribedRuleGroups</code> request, and specify the <code>NextMarker</code> value from the response in the <code>NextMarker</code> value in the next request.</p>
     #[serde(rename = "NextMarker")]
@@ -1408,7 +1408,7 @@ pub struct ListSubscribedRuleGroupsResponse {
     pub rule_groups: Option<Vec<SubscribedRuleGroupSummary>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListWebACLsRequest {
     /// <p>Specifies the number of <code>WebACL</code> objects that you want AWS WAF to return for this request. If you have more <code>WebACL</code> objects than the number that you specify for <code>Limit</code>, the response includes a <code>NextMarker</code> value that you can use to get another batch of <code>WebACL</code> objects.</p>
     #[serde(rename = "Limit")]
@@ -1420,7 +1420,7 @@ pub struct ListWebACLsRequest {
     pub next_marker: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListWebACLsResponse {
     /// <p>If you have more <code>WebACL</code> objects than the number that you specified for <code>Limit</code> in the request, the response includes a <code>NextMarker</code> value. To list more <code>WebACL</code> objects, submit another <code>ListWebACLs</code> request, and specify the <code>NextMarker</code> value from the response in the <code>NextMarker</code> value in the next request.</p>
     #[serde(rename = "NextMarker")]
@@ -1433,7 +1433,7 @@ pub struct ListWebACLsResponse {
 }
 
 /// <p>A request to list the <a>XssMatchSet</a> objects created by the current AWS account.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListXssMatchSetsRequest {
     /// <p>Specifies the number of <a>XssMatchSet</a> objects that you want AWS WAF to return for this request. If you have more <code>XssMatchSet</code> objects than the number you specify for <code>Limit</code>, the response includes a <code>NextMarker</code> value that you can use to get another batch of <code>Rules</code>.</p>
     #[serde(rename = "Limit")]
@@ -1446,7 +1446,7 @@ pub struct ListXssMatchSetsRequest {
 }
 
 /// <p>The response to a <a>ListXssMatchSets</a> request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListXssMatchSetsResponse {
     /// <p>If you have more <a>XssMatchSet</a> objects than the number that you specified for <code>Limit</code> in the request, the response includes a <code>NextMarker</code> value. To list more <code>XssMatchSet</code> objects, submit another <code>ListXssMatchSets</code> request, and specify the <code>NextMarker</code> value from the response in the <code>NextMarker</code> value in the next request.</p>
     #[serde(rename = "NextMarker")]
@@ -1459,7 +1459,7 @@ pub struct ListXssMatchSetsResponse {
 }
 
 /// <p>Specifies the <a>ByteMatchSet</a>, <a>IPSet</a>, <a>SqlInjectionMatchSet</a>, <a>XssMatchSet</a>, <a>RegexMatchSet</a>, <a>GeoMatchSet</a>, and <a>SizeConstraintSet</a> objects that you want to add to a <code>Rule</code> and, for each object, indicates whether you want to negate the settings, for example, requests that do NOT originate from the IP address 192.0.2.44. </p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Predicate {
     /// <p>A unique identifier for a predicate in a <code>Rule</code>, such as <code>ByteMatchSetId</code> or <code>IPSetId</code>. The ID is returned by the corresponding <code>Create</code> or <code>List</code> command.</p>
     #[serde(rename = "DataId")]
@@ -1472,7 +1472,7 @@ pub struct Predicate {
     pub type_: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PutPermissionPolicyRequest {
     /// <p>The policy to attach to the specified RuleGroup.</p>
     #[serde(rename = "Policy")]
@@ -1482,11 +1482,11 @@ pub struct PutPermissionPolicyRequest {
     pub resource_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PutPermissionPolicyResponse {}
 
 /// <p>A <code>RateBasedRule</code> is identical to a regular <a>Rule</a>, with one addition: a <code>RateBasedRule</code> counts the number of requests that arrive from a specified IP address every five minutes. For example, based on recent requests that you've seen from an attacker, you might create a <code>RateBasedRule</code> that includes the following conditions: </p> <ul> <li> <p>The requests come from 192.0.2.44.</p> </li> <li> <p>They contain the value <code>BadBot</code> in the <code>User-Agent</code> header.</p> </li> </ul> <p>In the rule, you also define the rate limit as 15,000.</p> <p>Requests that meet both of these conditions and exceed 15,000 requests every five minutes trigger the rule's action (block or count), which is defined in the web ACL.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RateBasedRule {
     /// <p>The <code>Predicates</code> object contains one <code>Predicate</code> element for each <a>ByteMatchSet</a>, <a>IPSet</a>, or <a>SqlInjectionMatchSet</a> object that you want to include in a <code>RateBasedRule</code>.</p>
     #[serde(rename = "MatchPredicates")]
@@ -1511,7 +1511,7 @@ pub struct RateBasedRule {
 }
 
 /// <p>In a <a>GetRegexMatchSet</a> request, <code>RegexMatchSet</code> is a complex type that contains the <code>RegexMatchSetId</code> and <code>Name</code> of a <code>RegexMatchSet</code>, and the values that you specified when you updated the <code>RegexMatchSet</code>.</p> <p> The values are contained in a <code>RegexMatchTuple</code> object, which specify the parts of web requests that you want AWS WAF to inspect and the values that you want AWS WAF to search for. If a <code>RegexMatchSet</code> contains more than one <code>RegexMatchTuple</code> object, a request needs to match the settings in only one <code>ByteMatchTuple</code> to be considered a match.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RegexMatchSet {
     /// <p>A friendly name or description of the <a>RegexMatchSet</a>. You can't change <code>Name</code> after you create a <code>RegexMatchSet</code>.</p>
     #[serde(rename = "Name")]
@@ -1528,7 +1528,7 @@ pub struct RegexMatchSet {
 }
 
 /// <p>Returned by <a>ListRegexMatchSets</a>. Each <code>RegexMatchSetSummary</code> object includes the <code>Name</code> and <code>RegexMatchSetId</code> for one <a>RegexMatchSet</a>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RegexMatchSetSummary {
     /// <p>A friendly name or description of the <a>RegexMatchSet</a>. You can't change <code>Name</code> after you create a <code>RegexMatchSet</code>.</p>
     #[serde(rename = "Name")]
@@ -1539,7 +1539,7 @@ pub struct RegexMatchSetSummary {
 }
 
 /// <p>In an <a>UpdateRegexMatchSet</a> request, <code>RegexMatchSetUpdate</code> specifies whether to insert or delete a <a>RegexMatchTuple</a> and includes the settings for the <code>RegexMatchTuple</code>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RegexMatchSetUpdate {
     /// <p>Specifies whether to insert or delete a <a>RegexMatchTuple</a>.</p>
     #[serde(rename = "Action")]
@@ -1550,7 +1550,7 @@ pub struct RegexMatchSetUpdate {
 }
 
 /// <p><p>The regular expression pattern that you want AWS WAF to search for in web requests, the location in requests that you want AWS WAF to search, and other settings. Each <code>RegexMatchTuple</code> object contains: </p> <ul> <li> <p>The part of a web request that you want AWS WAF to inspect, such as a query string or the value of the <code>User-Agent</code> header. </p> </li> <li> <p>The identifier of the pattern (a regular expression) that you want AWS WAF to look for. For more information, see <a>RegexPatternSet</a>. </p> </li> <li> <p>Whether to perform any conversions on the request, such as converting it to lowercase, before inspecting it for the specified string.</p> </li> </ul></p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RegexMatchTuple {
     /// <p>Specifies where in a web request to look for the <code>RegexPatternSet</code>.</p>
     #[serde(rename = "FieldToMatch")]
@@ -1564,7 +1564,7 @@ pub struct RegexMatchTuple {
 }
 
 /// <p>The <code>RegexPatternSet</code> specifies the regular expression (regex) pattern that you want AWS WAF to search for, such as <code>B[a@]dB[o0]t</code>. You can then configure AWS WAF to reject those requests.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RegexPatternSet {
     /// <p>A friendly name or description of the <a>RegexPatternSet</a>. You can't change <code>Name</code> after you create a <code>RegexPatternSet</code>.</p>
     #[serde(rename = "Name")]
@@ -1579,7 +1579,7 @@ pub struct RegexPatternSet {
 }
 
 /// <p>Returned by <a>ListRegexPatternSets</a>. Each <code>RegexPatternSetSummary</code> object includes the <code>Name</code> and <code>RegexPatternSetId</code> for one <a>RegexPatternSet</a>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RegexPatternSetSummary {
     /// <p>A friendly name or description of the <a>RegexPatternSet</a>. You can't change <code>Name</code> after you create a <code>RegexPatternSet</code>.</p>
     #[serde(rename = "Name")]
@@ -1590,7 +1590,7 @@ pub struct RegexPatternSetSummary {
 }
 
 /// <p>In an <a>UpdateRegexPatternSet</a> request, <code>RegexPatternSetUpdate</code> specifies whether to insert or delete a <code>RegexPatternString</code> and includes the settings for the <code>RegexPatternString</code>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RegexPatternSetUpdate {
     /// <p>Specifies whether to insert or delete a <code>RegexPatternString</code>.</p>
     #[serde(rename = "Action")]
@@ -1601,7 +1601,7 @@ pub struct RegexPatternSetUpdate {
 }
 
 /// <p>A combination of <a>ByteMatchSet</a>, <a>IPSet</a>, and/or <a>SqlInjectionMatchSet</a> objects that identify the web requests that you want to allow, block, or count. For example, you might create a <code>Rule</code> that includes the following predicates:</p> <ul> <li> <p>An <code>IPSet</code> that causes AWS WAF to search for web requests that originate from the IP address <code>192.0.2.44</code> </p> </li> <li> <p>A <code>ByteMatchSet</code> that causes AWS WAF to search for web requests for which the value of the <code>User-Agent</code> header is <code>BadBot</code>.</p> </li> </ul> <p>To match the settings in this <code>Rule</code>, a request must originate from <code>192.0.2.44</code> AND include a <code>User-Agent</code> header for which the value is <code>BadBot</code>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Rule {
     /// <p>A friendly name or description for the metrics for this <code>Rule</code>. The name can contain only alphanumeric characters (A-Z, a-z, 0-9); the name can't contain whitespace. You can't change <code>MetricName</code> after you create the <code>Rule</code>.</p>
     #[serde(rename = "MetricName")]
@@ -1620,7 +1620,7 @@ pub struct Rule {
 }
 
 /// <p><p>A collection of predefined rules that you can add to a web ACL.</p> <p>Rule groups are subject to the following limits:</p> <ul> <li> <p>Three rule groups per account. You can request an increase to this limit by contacting customer support.</p> </li> <li> <p>One rule group per web ACL.</p> </li> <li> <p>Ten rules per rule group.</p> </li> </ul></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RuleGroup {
     /// <p>A friendly name or description for the metrics for this <code>RuleGroup</code>. The name can contain only alphanumeric characters (A-Z, a-z, 0-9); the name can't contain whitespace. You can't change the name of the metric after you create the <code>RuleGroup</code>.</p>
     #[serde(rename = "MetricName")]
@@ -1636,7 +1636,7 @@ pub struct RuleGroup {
 }
 
 /// <p>Contains the identifier and the friendly name or description of the <code>RuleGroup</code>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RuleGroupSummary {
     /// <p>A friendly name or description of the <a>RuleGroup</a>. You can't change the name of a <code>RuleGroup</code> after you create it.</p>
     #[serde(rename = "Name")]
@@ -1647,7 +1647,7 @@ pub struct RuleGroupSummary {
 }
 
 /// <p>Specifies an <code>ActivatedRule</code> and indicates whether you want to add it to a <code>RuleGroup</code> or delete it from a <code>RuleGroup</code>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RuleGroupUpdate {
     /// <p>Specify <code>INSERT</code> to add an <code>ActivatedRule</code> to a <code>RuleGroup</code>. Use <code>DELETE</code> to remove an <code>ActivatedRule</code> from a <code>RuleGroup</code>.</p>
     #[serde(rename = "Action")]
@@ -1658,7 +1658,7 @@ pub struct RuleGroupUpdate {
 }
 
 /// <p>Contains the identifier and the friendly name or description of the <code>Rule</code>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RuleSummary {
     /// <p>A friendly name or description of the <a>Rule</a>. You can't change the name of a <code>Rule</code> after you create it.</p>
     #[serde(rename = "Name")]
@@ -1669,7 +1669,7 @@ pub struct RuleSummary {
 }
 
 /// <p>Specifies a <code>Predicate</code> (such as an <code>IPSet</code>) and indicates whether you want to add it to a <code>Rule</code> or delete it from a <code>Rule</code>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RuleUpdate {
     /// <p>Specify <code>INSERT</code> to add a <code>Predicate</code> to a <code>Rule</code>. Use <code>DELETE</code> to remove a <code>Predicate</code> from a <code>Rule</code>.</p>
     #[serde(rename = "Action")]
@@ -1680,7 +1680,7 @@ pub struct RuleUpdate {
 }
 
 /// <p>The response from a <a>GetSampledRequests</a> request includes a <code>SampledHTTPRequests</code> complex type that appears as <code>SampledRequests</code> in the response syntax. <code>SampledHTTPRequests</code> contains one <code>SampledHTTPRequest</code> object for each web request that is returned by <code>GetSampledRequests</code>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SampledHTTPRequest {
     /// <p>The action for the <code>Rule</code> that the request matched: <code>ALLOW</code>, <code>BLOCK</code>, or <code>COUNT</code>.</p>
     #[serde(rename = "Action")]
@@ -1703,7 +1703,7 @@ pub struct SampledHTTPRequest {
 }
 
 /// <p>Specifies a constraint on the size of a part of the web request. AWS WAF uses the <code>Size</code>, <code>ComparisonOperator</code>, and <code>FieldToMatch</code> to build an expression in the form of "<code>Size</code> <code>ComparisonOperator</code> size in bytes of <code>FieldToMatch</code>". If that expression is true, the <code>SizeConstraint</code> is considered to match.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SizeConstraint {
     /// <p>The type of comparison you want AWS WAF to perform. AWS WAF uses this in combination with the provided <code>Size</code> and <code>FieldToMatch</code> to build an expression in the form of "<code>Size</code> <code>ComparisonOperator</code> size in bytes of <code>FieldToMatch</code>". If that expression is true, the <code>SizeConstraint</code> is considered to match.</p> <p> <b>EQ</b>: Used to test if the <code>Size</code> is equal to the size of the <code>FieldToMatch</code> </p> <p> <b>NE</b>: Used to test if the <code>Size</code> is not equal to the size of the <code>FieldToMatch</code> </p> <p> <b>LE</b>: Used to test if the <code>Size</code> is less than or equal to the size of the <code>FieldToMatch</code> </p> <p> <b>LT</b>: Used to test if the <code>Size</code> is strictly less than the size of the <code>FieldToMatch</code> </p> <p> <b>GE</b>: Used to test if the <code>Size</code> is greater than or equal to the size of the <code>FieldToMatch</code> </p> <p> <b>GT</b>: Used to test if the <code>Size</code> is strictly greater than the size of the <code>FieldToMatch</code> </p>
     #[serde(rename = "ComparisonOperator")]
@@ -1720,7 +1720,7 @@ pub struct SizeConstraint {
 }
 
 /// <p>A complex type that contains <code>SizeConstraint</code> objects, which specify the parts of web requests that you want AWS WAF to inspect the size of. If a <code>SizeConstraintSet</code> contains more than one <code>SizeConstraint</code> object, a request only needs to match one constraint to be considered a match.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SizeConstraintSet {
     /// <p>The name, if any, of the <code>SizeConstraintSet</code>.</p>
     #[serde(rename = "Name")]
@@ -1735,7 +1735,7 @@ pub struct SizeConstraintSet {
 }
 
 /// <p>The <code>Id</code> and <code>Name</code> of a <code>SizeConstraintSet</code>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SizeConstraintSetSummary {
     /// <p>The name of the <code>SizeConstraintSet</code>, if any.</p>
     #[serde(rename = "Name")]
@@ -1746,7 +1746,7 @@ pub struct SizeConstraintSetSummary {
 }
 
 /// <p>Specifies the part of a web request that you want to inspect the size of and indicates whether you want to add the specification to a <a>SizeConstraintSet</a> or delete it from a <code>SizeConstraintSet</code>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SizeConstraintSetUpdate {
     /// <p>Specify <code>INSERT</code> to add a <a>SizeConstraintSetUpdate</a> to a <a>SizeConstraintSet</a>. Use <code>DELETE</code> to remove a <code>SizeConstraintSetUpdate</code> from a <code>SizeConstraintSet</code>.</p>
     #[serde(rename = "Action")]
@@ -1757,7 +1757,7 @@ pub struct SizeConstraintSetUpdate {
 }
 
 /// <p>A complex type that contains <code>SqlInjectionMatchTuple</code> objects, which specify the parts of web requests that you want AWS WAF to inspect for snippets of malicious SQL code and, if you want AWS WAF to inspect a header, the name of the header. If a <code>SqlInjectionMatchSet</code> contains more than one <code>SqlInjectionMatchTuple</code> object, a request needs to include snippets of SQL code in only one of the specified parts of the request to be considered a match.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SqlInjectionMatchSet {
     /// <p>The name, if any, of the <code>SqlInjectionMatchSet</code>.</p>
     #[serde(rename = "Name")]
@@ -1772,7 +1772,7 @@ pub struct SqlInjectionMatchSet {
 }
 
 /// <p>The <code>Id</code> and <code>Name</code> of a <code>SqlInjectionMatchSet</code>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SqlInjectionMatchSetSummary {
     /// <p>The name of the <code>SqlInjectionMatchSet</code>, if any, specified by <code>Id</code>.</p>
     #[serde(rename = "Name")]
@@ -1783,7 +1783,7 @@ pub struct SqlInjectionMatchSetSummary {
 }
 
 /// <p>Specifies the part of a web request that you want to inspect for snippets of malicious SQL code and indicates whether you want to add the specification to a <a>SqlInjectionMatchSet</a> or delete it from a <code>SqlInjectionMatchSet</code>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SqlInjectionMatchSetUpdate {
     /// <p>Specify <code>INSERT</code> to add a <a>SqlInjectionMatchSetUpdate</a> to a <a>SqlInjectionMatchSet</a>. Use <code>DELETE</code> to remove a <code>SqlInjectionMatchSetUpdate</code> from a <code>SqlInjectionMatchSet</code>.</p>
     #[serde(rename = "Action")]
@@ -1794,7 +1794,7 @@ pub struct SqlInjectionMatchSetUpdate {
 }
 
 /// <p>Specifies the part of a web request that you want AWS WAF to inspect for snippets of malicious SQL code and, if you want AWS WAF to inspect a header, the name of the header.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SqlInjectionMatchTuple {
     /// <p>Specifies where in a web request to look for snippets of malicious SQL code.</p>
     #[serde(rename = "FieldToMatch")]
@@ -1805,7 +1805,7 @@ pub struct SqlInjectionMatchTuple {
 }
 
 /// <p>A summary of the rule groups you are subscribed to.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SubscribedRuleGroupSummary {
     /// <p>A friendly name or description for the metrics for this <code>RuleGroup</code>. The name can contain only alphanumeric characters (A-Z, a-z, 0-9); the name can't contain whitespace. You can't change the name of the metric after you create the <code>RuleGroup</code>.</p>
     #[serde(rename = "MetricName")]
@@ -1819,7 +1819,7 @@ pub struct SubscribedRuleGroupSummary {
 }
 
 /// <p>In a <a>GetSampledRequests</a> request, the <code>StartTime</code> and <code>EndTime</code> objects specify the time range for which you want AWS WAF to return a sample of web requests.</p> <p>In a <a>GetSampledRequests</a> response, the <code>StartTime</code> and <code>EndTime</code> objects specify the time range for which AWS WAF actually returned a sample of web requests. AWS WAF gets the specified number of requests from among the first 5,000 requests that your AWS resource receives during the specified time period. If your resource receives more than 5,000 requests during that period, AWS WAF stops sampling after the 5,000th request. In that case, <code>EndTime</code> is the time that AWS WAF received the 5,000th request. </p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TimeWindow {
     /// <p>The end of the time range from which you want <code>GetSampledRequests</code> to return a sample of the requests that your AWS resource received. Specify the date and time in the following format: <code>"2016-09-27T14:50Z"</code>. You can specify any time range in the previous three hours.</p>
     #[serde(rename = "EndTime")]
@@ -1829,7 +1829,7 @@ pub struct TimeWindow {
     pub start_time: f64,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateByteMatchSetRequest {
     /// <p>The <code>ByteMatchSetId</code> of the <a>ByteMatchSet</a> that you want to update. <code>ByteMatchSetId</code> is returned by <a>CreateByteMatchSet</a> and by <a>ListByteMatchSets</a>.</p>
     #[serde(rename = "ByteMatchSetId")]
@@ -1842,7 +1842,7 @@ pub struct UpdateByteMatchSetRequest {
     pub updates: Vec<ByteMatchSetUpdate>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateByteMatchSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>UpdateByteMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -1850,7 +1850,7 @@ pub struct UpdateByteMatchSetResponse {
     pub change_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateGeoMatchSetRequest {
     /// <p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -1863,7 +1863,7 @@ pub struct UpdateGeoMatchSetRequest {
     pub updates: Vec<GeoMatchSetUpdate>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateGeoMatchSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>UpdateGeoMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -1871,7 +1871,7 @@ pub struct UpdateGeoMatchSetResponse {
     pub change_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateIPSetRequest {
     /// <p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -1884,7 +1884,7 @@ pub struct UpdateIPSetRequest {
     pub updates: Vec<IPSetUpdate>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateIPSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>UpdateIPSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -1892,7 +1892,7 @@ pub struct UpdateIPSetResponse {
     pub change_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateRateBasedRuleRequest {
     /// <p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -1908,7 +1908,7 @@ pub struct UpdateRateBasedRuleRequest {
     pub updates: Vec<RuleUpdate>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateRateBasedRuleResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>UpdateRateBasedRule</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -1916,7 +1916,7 @@ pub struct UpdateRateBasedRuleResponse {
     pub change_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateRegexMatchSetRequest {
     /// <p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -1929,7 +1929,7 @@ pub struct UpdateRegexMatchSetRequest {
     pub updates: Vec<RegexMatchSetUpdate>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateRegexMatchSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>UpdateRegexMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -1937,7 +1937,7 @@ pub struct UpdateRegexMatchSetResponse {
     pub change_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateRegexPatternSetRequest {
     /// <p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -1950,7 +1950,7 @@ pub struct UpdateRegexPatternSetRequest {
     pub updates: Vec<RegexPatternSetUpdate>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateRegexPatternSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>UpdateRegexPatternSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -1958,7 +1958,7 @@ pub struct UpdateRegexPatternSetResponse {
     pub change_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateRuleGroupRequest {
     /// <p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -1971,7 +1971,7 @@ pub struct UpdateRuleGroupRequest {
     pub updates: Vec<RuleGroupUpdate>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateRuleGroupResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>UpdateRuleGroup</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -1979,7 +1979,7 @@ pub struct UpdateRuleGroupResponse {
     pub change_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateRuleRequest {
     /// <p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -1992,7 +1992,7 @@ pub struct UpdateRuleRequest {
     pub updates: Vec<RuleUpdate>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateRuleResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>UpdateRule</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -2000,7 +2000,7 @@ pub struct UpdateRuleResponse {
     pub change_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateSizeConstraintSetRequest {
     /// <p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -2013,7 +2013,7 @@ pub struct UpdateSizeConstraintSetRequest {
     pub updates: Vec<SizeConstraintSetUpdate>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateSizeConstraintSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>UpdateSizeConstraintSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -2022,7 +2022,7 @@ pub struct UpdateSizeConstraintSetResponse {
 }
 
 /// <p>A request to update a <a>SqlInjectionMatchSet</a>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateSqlInjectionMatchSetRequest {
     /// <p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -2036,7 +2036,7 @@ pub struct UpdateSqlInjectionMatchSetRequest {
 }
 
 /// <p>The response to an <a>UpdateSqlInjectionMatchSets</a> request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateSqlInjectionMatchSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>UpdateSqlInjectionMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -2044,7 +2044,7 @@ pub struct UpdateSqlInjectionMatchSetResponse {
     pub change_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateWebACLRequest {
     /// <p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -2062,7 +2062,7 @@ pub struct UpdateWebACLRequest {
     pub web_acl_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateWebACLResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>UpdateWebACL</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -2071,7 +2071,7 @@ pub struct UpdateWebACLResponse {
 }
 
 /// <p>A request to update an <a>XssMatchSet</a>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateXssMatchSetRequest {
     /// <p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -2085,7 +2085,7 @@ pub struct UpdateXssMatchSetRequest {
 }
 
 /// <p>The response to an <a>UpdateXssMatchSets</a> request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateXssMatchSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>UpdateXssMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -2094,7 +2094,7 @@ pub struct UpdateXssMatchSetResponse {
 }
 
 /// <p>For the action that is associated with a rule in a <code>WebACL</code>, specifies the action that you want AWS WAF to perform when a web request matches all of the conditions in a rule. For the default action in a <code>WebACL</code>, specifies the action that you want AWS WAF to take when a web request doesn't match all of the conditions in any of the rules in a <code>WebACL</code>. </p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct WafAction {
     /// <p><p>Specifies how you want AWS WAF to respond to requests that match the settings in a <code>Rule</code>. Valid settings include the following:</p> <ul> <li> <p> <code>ALLOW</code>: AWS WAF allows requests</p> </li> <li> <p> <code>BLOCK</code>: AWS WAF blocks requests</p> </li> <li> <p> <code>COUNT</code>: AWS WAF increments a counter of the requests that match all of the conditions in the rule. AWS WAF then continues to inspect the web request based on the remaining rules in the web ACL. You can&#39;t specify <code>COUNT</code> for the default action for a <code>WebACL</code>.</p> </li> </ul></p>
     #[serde(rename = "Type")]
@@ -2102,7 +2102,7 @@ pub struct WafAction {
 }
 
 /// <p>The action to take if any rule within the <code>RuleGroup</code> matches a request. </p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct WafOverrideAction {
     /// <p> <code>COUNT</code> overrides the action specified by the individual rule within a <code>RuleGroup</code> . If set to <code>NONE</code>, the rule's action will take place.</p>
     #[serde(rename = "Type")]
@@ -2110,7 +2110,7 @@ pub struct WafOverrideAction {
 }
 
 /// <p>Contains the <code>Rules</code> that identify the requests that you want to allow, block, or count. In a <code>WebACL</code>, you also specify a default action (<code>ALLOW</code> or <code>BLOCK</code>), and the action for each <code>Rule</code> that you add to a <code>WebACL</code>, for example, block requests from specified IP addresses or block requests from specified referrers. You also associate the <code>WebACL</code> with a CloudFront distribution to identify the requests that you want AWS WAF to filter. If you add more than one <code>Rule</code> to a <code>WebACL</code>, a request needs to match only one of the specifications to be allowed, blocked, or counted. For more information, see <a>UpdateWebACL</a>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct WebACL {
     /// <p>The action to perform if none of the <code>Rules</code> contained in the <code>WebACL</code> match. The action is specified by the <a>WafAction</a> object.</p>
     #[serde(rename = "DefaultAction")]
@@ -2132,7 +2132,7 @@ pub struct WebACL {
 }
 
 /// <p>Contains the identifier and the name or description of the <a>WebACL</a>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct WebACLSummary {
     /// <p>A friendly name or description of the <a>WebACL</a>. You can't change the name of a <code>WebACL</code> after you create it.</p>
     #[serde(rename = "Name")]
@@ -2143,7 +2143,7 @@ pub struct WebACLSummary {
 }
 
 /// <p>Specifies whether to insert a <code>Rule</code> into or delete a <code>Rule</code> from a <code>WebACL</code>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct WebACLUpdate {
     /// <p>Specifies whether to insert a <code>Rule</code> into or delete a <code>Rule</code> from a <code>WebACL</code>.</p>
     #[serde(rename = "Action")]
@@ -2154,7 +2154,7 @@ pub struct WebACLUpdate {
 }
 
 /// <p>A complex type that contains <code>XssMatchTuple</code> objects, which specify the parts of web requests that you want AWS WAF to inspect for cross-site scripting attacks and, if you want AWS WAF to inspect a header, the name of the header. If a <code>XssMatchSet</code> contains more than one <code>XssMatchTuple</code> object, a request needs to include cross-site scripting attacks in only one of the specified parts of the request to be considered a match.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct XssMatchSet {
     /// <p>The name, if any, of the <code>XssMatchSet</code>.</p>
     #[serde(rename = "Name")]
@@ -2169,7 +2169,7 @@ pub struct XssMatchSet {
 }
 
 /// <p>The <code>Id</code> and <code>Name</code> of an <code>XssMatchSet</code>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct XssMatchSetSummary {
     /// <p>The name of the <code>XssMatchSet</code>, if any, specified by <code>Id</code>.</p>
     #[serde(rename = "Name")]
@@ -2180,7 +2180,7 @@ pub struct XssMatchSetSummary {
 }
 
 /// <p>Specifies the part of a web request that you want to inspect for cross-site scripting attacks and indicates whether you want to add the specification to an <a>XssMatchSet</a> or delete it from an <code>XssMatchSet</code>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct XssMatchSetUpdate {
     /// <p>Specify <code>INSERT</code> to add a <a>XssMatchSetUpdate</a> to an <a>XssMatchSet</a>. Use <code>DELETE</code> to remove a <code>XssMatchSetUpdate</code> from an <code>XssMatchSet</code>.</p>
     #[serde(rename = "Action")]
@@ -2191,7 +2191,7 @@ pub struct XssMatchSetUpdate {
 }
 
 /// <p>Specifies the part of a web request that you want AWS WAF to inspect for cross-site scripting attacks and, if you want AWS WAF to inspect a header, the name of the header.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct XssMatchTuple {
     /// <p>Specifies where in a web request to look for cross-site scripting attacks.</p>
     #[serde(rename = "FieldToMatch")]

--- a/rusoto/services/waf-regional/src/generated.rs
+++ b/rusoto/services/waf-regional/src/generated.rs
@@ -2228,7 +2228,8 @@ impl AssociateWebACLError {
     pub fn from_body(body: &str) -> AssociateWebACLError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2332,7 +2333,8 @@ impl CreateByteMatchSetError {
     pub fn from_body(body: &str) -> CreateByteMatchSetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2442,7 +2444,8 @@ impl CreateGeoMatchSetError {
     pub fn from_body(body: &str) -> CreateGeoMatchSetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2552,7 +2555,8 @@ impl CreateIPSetError {
     pub fn from_body(body: &str) -> CreateIPSetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2658,7 +2662,8 @@ impl CreateRateBasedRuleError {
     pub fn from_body(body: &str) -> CreateRateBasedRuleError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2760,7 +2765,8 @@ impl CreateRegexMatchSetError {
     pub fn from_body(body: &str) -> CreateRegexMatchSetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2858,7 +2864,8 @@ impl CreateRegexPatternSetError {
     pub fn from_body(body: &str) -> CreateRegexPatternSetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2958,7 +2965,8 @@ impl CreateRuleError {
     pub fn from_body(body: &str) -> CreateRuleError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3056,7 +3064,8 @@ impl CreateRuleGroupError {
     pub fn from_body(body: &str) -> CreateRuleGroupError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3156,7 +3165,8 @@ impl CreateSizeConstraintSetError {
     pub fn from_body(body: &str) -> CreateSizeConstraintSetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3268,7 +3278,8 @@ impl CreateSqlInjectionMatchSetError {
     pub fn from_body(body: &str) -> CreateSqlInjectionMatchSetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3388,7 +3399,8 @@ impl CreateWebACLError {
     pub fn from_body(body: &str) -> CreateWebACLError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3496,7 +3508,8 @@ impl CreateXssMatchSetError {
     pub fn from_body(body: &str) -> CreateXssMatchSetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3606,7 +3619,8 @@ impl DeleteByteMatchSetError {
     pub fn from_body(body: &str) -> DeleteByteMatchSetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3716,7 +3730,8 @@ impl DeleteGeoMatchSetError {
     pub fn from_body(body: &str) -> DeleteGeoMatchSetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3826,7 +3841,8 @@ impl DeleteIPSetError {
     pub fn from_body(body: &str) -> DeleteIPSetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3928,7 +3944,8 @@ impl DeletePermissionPolicyError {
     pub fn from_body(body: &str) -> DeletePermissionPolicyError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4026,7 +4043,8 @@ impl DeleteRateBasedRuleError {
     pub fn from_body(body: &str) -> DeleteRateBasedRuleError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4136,7 +4154,8 @@ impl DeleteRegexMatchSetError {
     pub fn from_body(body: &str) -> DeleteRegexMatchSetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4246,7 +4265,8 @@ impl DeleteRegexPatternSetError {
     pub fn from_body(body: &str) -> DeleteRegexPatternSetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4356,7 +4376,8 @@ impl DeleteRuleError {
     pub fn from_body(body: &str) -> DeleteRuleError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4460,7 +4481,8 @@ impl DeleteRuleGroupError {
     pub fn from_body(body: &str) -> DeleteRuleGroupError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4564,7 +4586,8 @@ impl DeleteSizeConstraintSetError {
     pub fn from_body(body: &str) -> DeleteSizeConstraintSetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4676,7 +4699,8 @@ impl DeleteSqlInjectionMatchSetError {
     pub fn from_body(body: &str) -> DeleteSqlInjectionMatchSetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4796,7 +4820,8 @@ impl DeleteWebACLError {
     pub fn from_body(body: &str) -> DeleteWebACLError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4904,7 +4929,8 @@ impl DeleteXssMatchSetError {
     pub fn from_body(body: &str) -> DeleteXssMatchSetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5010,7 +5036,8 @@ impl DisassociateWebACLError {
     pub fn from_body(body: &str) -> DisassociateWebACLError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5106,7 +5133,8 @@ impl GetByteMatchSetError {
     pub fn from_body(body: &str) -> GetByteMatchSetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5192,7 +5220,8 @@ impl GetChangeTokenError {
     pub fn from_body(body: &str) -> GetChangeTokenError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5272,7 +5301,8 @@ impl GetChangeTokenStatusError {
     pub fn from_body(body: &str) -> GetChangeTokenStatusError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5360,7 +5390,8 @@ impl GetGeoMatchSetError {
     pub fn from_body(body: &str) -> GetGeoMatchSetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5450,7 +5481,8 @@ impl GetIPSetError {
     pub fn from_body(body: &str) -> GetIPSetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5536,7 +5568,8 @@ impl GetPermissionPolicyError {
     pub fn from_body(body: &str) -> GetPermissionPolicyError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5624,7 +5657,8 @@ impl GetRateBasedRuleError {
     pub fn from_body(body: &str) -> GetRateBasedRuleError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5716,7 +5750,8 @@ impl GetRateBasedRuleManagedKeysError {
     pub fn from_body(body: &str) -> GetRateBasedRuleManagedKeysError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5820,7 +5855,8 @@ impl GetRegexMatchSetError {
     pub fn from_body(body: &str) -> GetRegexMatchSetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5910,7 +5946,8 @@ impl GetRegexPatternSetError {
     pub fn from_body(body: &str) -> GetRegexPatternSetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6002,7 +6039,8 @@ impl GetRuleError {
     pub fn from_body(body: &str) -> GetRuleError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6088,7 +6126,8 @@ impl GetRuleGroupError {
     pub fn from_body(body: &str) -> GetRuleGroupError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6172,7 +6211,8 @@ impl GetSampledRequestsError {
     pub fn from_body(body: &str) -> GetSampledRequestsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6260,7 +6300,8 @@ impl GetSizeConstraintSetError {
     pub fn from_body(body: &str) -> GetSizeConstraintSetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6352,7 +6393,8 @@ impl GetSqlInjectionMatchSetError {
     pub fn from_body(body: &str) -> GetSqlInjectionMatchSetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6446,7 +6488,8 @@ impl GetWebACLError {
     pub fn from_body(body: &str) -> GetWebACLError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6538,7 +6581,8 @@ impl GetWebACLForResourceError {
     pub fn from_body(body: &str) -> GetWebACLForResourceError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6638,7 +6682,8 @@ impl GetXssMatchSetError {
     pub fn from_body(body: &str) -> GetXssMatchSetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6728,7 +6773,8 @@ impl ListActivatedRulesInRuleGroupError {
     pub fn from_body(body: &str) -> ListActivatedRulesInRuleGroupError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6824,7 +6870,8 @@ impl ListByteMatchSetsError {
     pub fn from_body(body: &str) -> ListByteMatchSetsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6910,7 +6957,8 @@ impl ListGeoMatchSetsError {
     pub fn from_body(body: &str) -> ListGeoMatchSetsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6994,7 +7042,8 @@ impl ListIPSetsError {
     pub fn from_body(body: &str) -> ListIPSetsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7076,7 +7125,8 @@ impl ListRateBasedRulesError {
     pub fn from_body(body: &str) -> ListRateBasedRulesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7162,7 +7212,8 @@ impl ListRegexMatchSetsError {
     pub fn from_body(body: &str) -> ListRegexMatchSetsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7248,7 +7299,8 @@ impl ListRegexPatternSetsError {
     pub fn from_body(body: &str) -> ListRegexPatternSetsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7336,7 +7388,8 @@ impl ListResourcesForWebACLError {
     pub fn from_body(body: &str) -> ListResourcesForWebACLError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7424,7 +7477,8 @@ impl ListRuleGroupsError {
     pub fn from_body(body: &str) -> ListRuleGroupsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7504,7 +7558,8 @@ impl ListRulesError {
     pub fn from_body(body: &str) -> ListRulesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7586,7 +7641,8 @@ impl ListSizeConstraintSetsError {
     pub fn from_body(body: &str) -> ListSizeConstraintSetsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7672,7 +7728,8 @@ impl ListSqlInjectionMatchSetsError {
     pub fn from_body(body: &str) -> ListSqlInjectionMatchSetsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7762,7 +7819,8 @@ impl ListSubscribedRuleGroupsError {
     pub fn from_body(body: &str) -> ListSubscribedRuleGroupsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7850,7 +7908,8 @@ impl ListWebACLsError {
     pub fn from_body(body: &str) -> ListWebACLsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7934,7 +7993,8 @@ impl ListXssMatchSetsError {
     pub fn from_body(body: &str) -> ListXssMatchSetsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8022,7 +8082,8 @@ impl PutPermissionPolicyError {
     pub fn from_body(body: &str) -> PutPermissionPolicyError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8130,7 +8191,8 @@ impl UpdateByteMatchSetError {
     pub fn from_body(body: &str) -> UpdateByteMatchSetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8256,7 +8318,8 @@ impl UpdateGeoMatchSetError {
     pub fn from_body(body: &str) -> UpdateGeoMatchSetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8384,7 +8447,8 @@ impl UpdateIPSetError {
     pub fn from_body(body: &str) -> UpdateIPSetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8510,7 +8574,8 @@ impl UpdateRateBasedRuleError {
     pub fn from_body(body: &str) -> UpdateRateBasedRuleError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8638,7 +8703,8 @@ impl UpdateRegexMatchSetError {
     pub fn from_body(body: &str) -> UpdateRegexMatchSetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8762,7 +8828,8 @@ impl UpdateRegexPatternSetError {
     pub fn from_body(body: &str) -> UpdateRegexPatternSetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8890,7 +8957,8 @@ impl UpdateRuleError {
     pub fn from_body(body: &str) -> UpdateRuleError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9010,7 +9078,8 @@ impl UpdateRuleGroupError {
     pub fn from_body(body: &str) -> UpdateRuleGroupError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9128,7 +9197,8 @@ impl UpdateSizeConstraintSetError {
     pub fn from_body(body: &str) -> UpdateSizeConstraintSetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9262,7 +9332,8 @@ impl UpdateSqlInjectionMatchSetError {
     pub fn from_body(body: &str) -> UpdateSqlInjectionMatchSetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9402,7 +9473,8 @@ impl UpdateWebACLError {
     pub fn from_body(body: &str) -> UpdateWebACLError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9530,7 +9602,8 @@ impl UpdateXssMatchSetError {
     pub fn from_body(body: &str) -> UpdateXssMatchSetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/waf/src/generated.rs
+++ b/rusoto/services/waf/src/generated.rs
@@ -2177,7 +2177,8 @@ impl CreateByteMatchSetError {
     pub fn from_body(body: &str) -> CreateByteMatchSetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2287,7 +2288,8 @@ impl CreateGeoMatchSetError {
     pub fn from_body(body: &str) -> CreateGeoMatchSetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2397,7 +2399,8 @@ impl CreateIPSetError {
     pub fn from_body(body: &str) -> CreateIPSetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2503,7 +2506,8 @@ impl CreateRateBasedRuleError {
     pub fn from_body(body: &str) -> CreateRateBasedRuleError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2605,7 +2609,8 @@ impl CreateRegexMatchSetError {
     pub fn from_body(body: &str) -> CreateRegexMatchSetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2703,7 +2708,8 @@ impl CreateRegexPatternSetError {
     pub fn from_body(body: &str) -> CreateRegexPatternSetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2803,7 +2809,8 @@ impl CreateRuleError {
     pub fn from_body(body: &str) -> CreateRuleError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2901,7 +2908,8 @@ impl CreateRuleGroupError {
     pub fn from_body(body: &str) -> CreateRuleGroupError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3001,7 +3009,8 @@ impl CreateSizeConstraintSetError {
     pub fn from_body(body: &str) -> CreateSizeConstraintSetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3113,7 +3122,8 @@ impl CreateSqlInjectionMatchSetError {
     pub fn from_body(body: &str) -> CreateSqlInjectionMatchSetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3233,7 +3243,8 @@ impl CreateWebACLError {
     pub fn from_body(body: &str) -> CreateWebACLError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3341,7 +3352,8 @@ impl CreateXssMatchSetError {
     pub fn from_body(body: &str) -> CreateXssMatchSetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3451,7 +3463,8 @@ impl DeleteByteMatchSetError {
     pub fn from_body(body: &str) -> DeleteByteMatchSetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3561,7 +3574,8 @@ impl DeleteGeoMatchSetError {
     pub fn from_body(body: &str) -> DeleteGeoMatchSetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3671,7 +3685,8 @@ impl DeleteIPSetError {
     pub fn from_body(body: &str) -> DeleteIPSetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3773,7 +3788,8 @@ impl DeletePermissionPolicyError {
     pub fn from_body(body: &str) -> DeletePermissionPolicyError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3871,7 +3887,8 @@ impl DeleteRateBasedRuleError {
     pub fn from_body(body: &str) -> DeleteRateBasedRuleError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3981,7 +3998,8 @@ impl DeleteRegexMatchSetError {
     pub fn from_body(body: &str) -> DeleteRegexMatchSetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4091,7 +4109,8 @@ impl DeleteRegexPatternSetError {
     pub fn from_body(body: &str) -> DeleteRegexPatternSetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4201,7 +4220,8 @@ impl DeleteRuleError {
     pub fn from_body(body: &str) -> DeleteRuleError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4305,7 +4325,8 @@ impl DeleteRuleGroupError {
     pub fn from_body(body: &str) -> DeleteRuleGroupError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4409,7 +4430,8 @@ impl DeleteSizeConstraintSetError {
     pub fn from_body(body: &str) -> DeleteSizeConstraintSetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4521,7 +4543,8 @@ impl DeleteSqlInjectionMatchSetError {
     pub fn from_body(body: &str) -> DeleteSqlInjectionMatchSetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4641,7 +4664,8 @@ impl DeleteWebACLError {
     pub fn from_body(body: &str) -> DeleteWebACLError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4749,7 +4773,8 @@ impl DeleteXssMatchSetError {
     pub fn from_body(body: &str) -> DeleteXssMatchSetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4853,7 +4878,8 @@ impl GetByteMatchSetError {
     pub fn from_body(body: &str) -> GetByteMatchSetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4939,7 +4965,8 @@ impl GetChangeTokenError {
     pub fn from_body(body: &str) -> GetChangeTokenError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5019,7 +5046,8 @@ impl GetChangeTokenStatusError {
     pub fn from_body(body: &str) -> GetChangeTokenStatusError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5107,7 +5135,8 @@ impl GetGeoMatchSetError {
     pub fn from_body(body: &str) -> GetGeoMatchSetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5197,7 +5226,8 @@ impl GetIPSetError {
     pub fn from_body(body: &str) -> GetIPSetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5283,7 +5313,8 @@ impl GetPermissionPolicyError {
     pub fn from_body(body: &str) -> GetPermissionPolicyError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5371,7 +5402,8 @@ impl GetRateBasedRuleError {
     pub fn from_body(body: &str) -> GetRateBasedRuleError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5463,7 +5495,8 @@ impl GetRateBasedRuleManagedKeysError {
     pub fn from_body(body: &str) -> GetRateBasedRuleManagedKeysError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5567,7 +5600,8 @@ impl GetRegexMatchSetError {
     pub fn from_body(body: &str) -> GetRegexMatchSetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5657,7 +5691,8 @@ impl GetRegexPatternSetError {
     pub fn from_body(body: &str) -> GetRegexPatternSetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5749,7 +5784,8 @@ impl GetRuleError {
     pub fn from_body(body: &str) -> GetRuleError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5835,7 +5871,8 @@ impl GetRuleGroupError {
     pub fn from_body(body: &str) -> GetRuleGroupError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5919,7 +5956,8 @@ impl GetSampledRequestsError {
     pub fn from_body(body: &str) -> GetSampledRequestsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6007,7 +6045,8 @@ impl GetSizeConstraintSetError {
     pub fn from_body(body: &str) -> GetSizeConstraintSetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6099,7 +6138,8 @@ impl GetSqlInjectionMatchSetError {
     pub fn from_body(body: &str) -> GetSqlInjectionMatchSetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6193,7 +6233,8 @@ impl GetWebACLError {
     pub fn from_body(body: &str) -> GetWebACLError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6281,7 +6322,8 @@ impl GetXssMatchSetError {
     pub fn from_body(body: &str) -> GetXssMatchSetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6371,7 +6413,8 @@ impl ListActivatedRulesInRuleGroupError {
     pub fn from_body(body: &str) -> ListActivatedRulesInRuleGroupError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6467,7 +6510,8 @@ impl ListByteMatchSetsError {
     pub fn from_body(body: &str) -> ListByteMatchSetsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6553,7 +6597,8 @@ impl ListGeoMatchSetsError {
     pub fn from_body(body: &str) -> ListGeoMatchSetsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6637,7 +6682,8 @@ impl ListIPSetsError {
     pub fn from_body(body: &str) -> ListIPSetsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6719,7 +6765,8 @@ impl ListRateBasedRulesError {
     pub fn from_body(body: &str) -> ListRateBasedRulesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6805,7 +6852,8 @@ impl ListRegexMatchSetsError {
     pub fn from_body(body: &str) -> ListRegexMatchSetsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6891,7 +6939,8 @@ impl ListRegexPatternSetsError {
     pub fn from_body(body: &str) -> ListRegexPatternSetsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -6975,7 +7024,8 @@ impl ListRuleGroupsError {
     pub fn from_body(body: &str) -> ListRuleGroupsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7055,7 +7105,8 @@ impl ListRulesError {
     pub fn from_body(body: &str) -> ListRulesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7137,7 +7188,8 @@ impl ListSizeConstraintSetsError {
     pub fn from_body(body: &str) -> ListSizeConstraintSetsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7223,7 +7275,8 @@ impl ListSqlInjectionMatchSetsError {
     pub fn from_body(body: &str) -> ListSqlInjectionMatchSetsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7313,7 +7366,8 @@ impl ListSubscribedRuleGroupsError {
     pub fn from_body(body: &str) -> ListSubscribedRuleGroupsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7401,7 +7455,8 @@ impl ListWebACLsError {
     pub fn from_body(body: &str) -> ListWebACLsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7485,7 +7540,8 @@ impl ListXssMatchSetsError {
     pub fn from_body(body: &str) -> ListXssMatchSetsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7573,7 +7629,8 @@ impl PutPermissionPolicyError {
     pub fn from_body(body: &str) -> PutPermissionPolicyError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7681,7 +7738,8 @@ impl UpdateByteMatchSetError {
     pub fn from_body(body: &str) -> UpdateByteMatchSetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7807,7 +7865,8 @@ impl UpdateGeoMatchSetError {
     pub fn from_body(body: &str) -> UpdateGeoMatchSetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -7935,7 +7994,8 @@ impl UpdateIPSetError {
     pub fn from_body(body: &str) -> UpdateIPSetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8061,7 +8121,8 @@ impl UpdateRateBasedRuleError {
     pub fn from_body(body: &str) -> UpdateRateBasedRuleError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8189,7 +8250,8 @@ impl UpdateRegexMatchSetError {
     pub fn from_body(body: &str) -> UpdateRegexMatchSetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8313,7 +8375,8 @@ impl UpdateRegexPatternSetError {
     pub fn from_body(body: &str) -> UpdateRegexPatternSetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8441,7 +8504,8 @@ impl UpdateRuleError {
     pub fn from_body(body: &str) -> UpdateRuleError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8561,7 +8625,8 @@ impl UpdateRuleGroupError {
     pub fn from_body(body: &str) -> UpdateRuleGroupError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8679,7 +8744,8 @@ impl UpdateSizeConstraintSetError {
     pub fn from_body(body: &str) -> UpdateSizeConstraintSetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8813,7 +8879,8 @@ impl UpdateSqlInjectionMatchSetError {
     pub fn from_body(body: &str) -> UpdateSqlInjectionMatchSetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -8953,7 +9020,8 @@ impl UpdateWebACLError {
     pub fn from_body(body: &str) -> UpdateWebACLError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -9081,7 +9149,8 @@ impl UpdateXssMatchSetError {
     pub fn from_body(body: &str) -> UpdateXssMatchSetError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/waf/src/generated.rs
+++ b/rusoto/services/waf/src/generated.rs
@@ -31,7 +31,7 @@ use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 /// <p>The <code>ActivatedRule</code> object in an <a>UpdateWebACL</a> request specifies a <code>Rule</code> that you want to insert or delete, the priority of the <code>Rule</code> in the <code>WebACL</code>, and the action that you want AWS WAF to take when a web request matches the <code>Rule</code> (<code>ALLOW</code>, <code>BLOCK</code>, or <code>COUNT</code>).</p> <p>To specify whether to insert or delete a <code>Rule</code>, use the <code>Action</code> parameter in the <a>WebACLUpdate</a> data type.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ActivatedRule {
     /// <p>Specifies the action that CloudFront or AWS WAF takes when a web request matches the conditions in the <code>Rule</code>. Valid values for <code>Action</code> include the following:</p> <ul> <li> <p> <code>ALLOW</code>: CloudFront responds with the requested object.</p> </li> <li> <p> <code>BLOCK</code>: CloudFront responds with an HTTP 403 (Forbidden) status code.</p> </li> <li> <p> <code>COUNT</code>: AWS WAF increments a counter of requests that match the conditions in the rule and then continues to inspect the web request based on the remaining rules in the web ACL. </p> </li> </ul> <p> <code>ActivatedRule|OverrideAction</code> applies only when updating or adding a <code>RuleGroup</code> to a <code>WebACL</code>. In this case you do not use <code>ActivatedRule|Action</code>. For all other update requests, <code>ActivatedRule|Action</code> is used instead of <code>ActivatedRule|OverrideAction</code>.</p>
     #[serde(rename = "Action")]
@@ -54,7 +54,7 @@ pub struct ActivatedRule {
 }
 
 /// <p>In a <a>GetByteMatchSet</a> request, <code>ByteMatchSet</code> is a complex type that contains the <code>ByteMatchSetId</code> and <code>Name</code> of a <code>ByteMatchSet</code>, and the values that you specified when you updated the <code>ByteMatchSet</code>. </p> <p>A complex type that contains <code>ByteMatchTuple</code> objects, which specify the parts of web requests that you want AWS WAF to inspect and the values that you want AWS WAF to search for. If a <code>ByteMatchSet</code> contains more than one <code>ByteMatchTuple</code> object, a request needs to match the settings in only one <code>ByteMatchTuple</code> to be considered a match.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ByteMatchSet {
     /// <p>The <code>ByteMatchSetId</code> for a <code>ByteMatchSet</code>. You use <code>ByteMatchSetId</code> to get information about a <code>ByteMatchSet</code> (see <a>GetByteMatchSet</a>), update a <code>ByteMatchSet</code> (see <a>UpdateByteMatchSet</a>), insert a <code>ByteMatchSet</code> into a <code>Rule</code> or delete one from a <code>Rule</code> (see <a>UpdateRule</a>), and delete a <code>ByteMatchSet</code> from AWS WAF (see <a>DeleteByteMatchSet</a>).</p> <p> <code>ByteMatchSetId</code> is returned by <a>CreateByteMatchSet</a> and by <a>ListByteMatchSets</a>.</p>
     #[serde(rename = "ByteMatchSetId")]
@@ -69,7 +69,7 @@ pub struct ByteMatchSet {
 }
 
 /// <p>Returned by <a>ListByteMatchSets</a>. Each <code>ByteMatchSetSummary</code> object includes the <code>Name</code> and <code>ByteMatchSetId</code> for one <a>ByteMatchSet</a>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ByteMatchSetSummary {
     /// <p>The <code>ByteMatchSetId</code> for a <code>ByteMatchSet</code>. You use <code>ByteMatchSetId</code> to get information about a <code>ByteMatchSet</code>, update a <code>ByteMatchSet</code>, remove a <code>ByteMatchSet</code> from a <code>Rule</code>, and delete a <code>ByteMatchSet</code> from AWS WAF.</p> <p> <code>ByteMatchSetId</code> is returned by <a>CreateByteMatchSet</a> and by <a>ListByteMatchSets</a>.</p>
     #[serde(rename = "ByteMatchSetId")]
@@ -80,7 +80,7 @@ pub struct ByteMatchSetSummary {
 }
 
 /// <p>In an <a>UpdateByteMatchSet</a> request, <code>ByteMatchSetUpdate</code> specifies whether to insert or delete a <a>ByteMatchTuple</a> and includes the settings for the <code>ByteMatchTuple</code>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ByteMatchSetUpdate {
     /// <p>Specifies whether to insert or delete a <a>ByteMatchTuple</a>.</p>
     #[serde(rename = "Action")]
@@ -91,7 +91,7 @@ pub struct ByteMatchSetUpdate {
 }
 
 /// <p>The bytes (typically a string that corresponds with ASCII characters) that you want AWS WAF to search for in web requests, the location in requests that you want AWS WAF to search, and other settings.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ByteMatchTuple {
     /// <p>The part of a web request that you want AWS WAF to search, such as a specified header or a query string. For more information, see <a>FieldToMatch</a>.</p>
     #[serde(rename = "FieldToMatch")]
@@ -112,7 +112,7 @@ pub struct ByteMatchTuple {
     pub text_transformation: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateByteMatchSetRequest {
     /// <p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -122,7 +122,7 @@ pub struct CreateByteMatchSetRequest {
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateByteMatchSetResponse {
     /// <p>A <a>ByteMatchSet</a> that contains no <code>ByteMatchTuple</code> objects.</p>
     #[serde(rename = "ByteMatchSet")]
@@ -134,7 +134,7 @@ pub struct CreateByteMatchSetResponse {
     pub change_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateGeoMatchSetRequest {
     /// <p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -144,7 +144,7 @@ pub struct CreateGeoMatchSetRequest {
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateGeoMatchSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>CreateGeoMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -156,7 +156,7 @@ pub struct CreateGeoMatchSetResponse {
     pub geo_match_set: Option<GeoMatchSet>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateIPSetRequest {
     /// <p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -166,7 +166,7 @@ pub struct CreateIPSetRequest {
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateIPSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>CreateIPSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -178,7 +178,7 @@ pub struct CreateIPSetResponse {
     pub ip_set: Option<IPSet>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateRateBasedRuleRequest {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>CreateRateBasedRule</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -197,7 +197,7 @@ pub struct CreateRateBasedRuleRequest {
     pub rate_limit: i64,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateRateBasedRuleResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>CreateRateBasedRule</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -209,7 +209,7 @@ pub struct CreateRateBasedRuleResponse {
     pub rule: Option<RateBasedRule>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateRegexMatchSetRequest {
     /// <p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -219,7 +219,7 @@ pub struct CreateRegexMatchSetRequest {
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateRegexMatchSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>CreateRegexMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -231,7 +231,7 @@ pub struct CreateRegexMatchSetResponse {
     pub regex_match_set: Option<RegexMatchSet>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateRegexPatternSetRequest {
     /// <p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -241,7 +241,7 @@ pub struct CreateRegexPatternSetRequest {
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateRegexPatternSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>CreateRegexPatternSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -253,7 +253,7 @@ pub struct CreateRegexPatternSetResponse {
     pub regex_pattern_set: Option<RegexPatternSet>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateRuleGroupRequest {
     /// <p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -266,7 +266,7 @@ pub struct CreateRuleGroupRequest {
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateRuleGroupResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>CreateRuleGroup</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -278,7 +278,7 @@ pub struct CreateRuleGroupResponse {
     pub rule_group: Option<RuleGroup>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateRuleRequest {
     /// <p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -291,7 +291,7 @@ pub struct CreateRuleRequest {
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateRuleResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>CreateRule</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -303,7 +303,7 @@ pub struct CreateRuleResponse {
     pub rule: Option<Rule>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateSizeConstraintSetRequest {
     /// <p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -313,7 +313,7 @@ pub struct CreateSizeConstraintSetRequest {
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateSizeConstraintSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>CreateSizeConstraintSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -326,7 +326,7 @@ pub struct CreateSizeConstraintSetResponse {
 }
 
 /// <p>A request to create a <a>SqlInjectionMatchSet</a>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateSqlInjectionMatchSetRequest {
     /// <p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -337,7 +337,7 @@ pub struct CreateSqlInjectionMatchSetRequest {
 }
 
 /// <p>The response to a <code>CreateSqlInjectionMatchSet</code> request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateSqlInjectionMatchSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>CreateSqlInjectionMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -349,7 +349,7 @@ pub struct CreateSqlInjectionMatchSetResponse {
     pub sql_injection_match_set: Option<SqlInjectionMatchSet>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateWebACLRequest {
     /// <p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -365,7 +365,7 @@ pub struct CreateWebACLRequest {
     pub name: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateWebACLResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>CreateWebACL</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -378,7 +378,7 @@ pub struct CreateWebACLResponse {
 }
 
 /// <p>A request to create an <a>XssMatchSet</a>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateXssMatchSetRequest {
     /// <p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -389,7 +389,7 @@ pub struct CreateXssMatchSetRequest {
 }
 
 /// <p>The response to a <code>CreateXssMatchSet</code> request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateXssMatchSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>CreateXssMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -401,7 +401,7 @@ pub struct CreateXssMatchSetResponse {
     pub xss_match_set: Option<XssMatchSet>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteByteMatchSetRequest {
     /// <p>The <code>ByteMatchSetId</code> of the <a>ByteMatchSet</a> that you want to delete. <code>ByteMatchSetId</code> is returned by <a>CreateByteMatchSet</a> and by <a>ListByteMatchSets</a>.</p>
     #[serde(rename = "ByteMatchSetId")]
@@ -411,7 +411,7 @@ pub struct DeleteByteMatchSetRequest {
     pub change_token: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteByteMatchSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>DeleteByteMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -419,7 +419,7 @@ pub struct DeleteByteMatchSetResponse {
     pub change_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteGeoMatchSetRequest {
     /// <p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -429,7 +429,7 @@ pub struct DeleteGeoMatchSetRequest {
     pub geo_match_set_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteGeoMatchSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>DeleteGeoMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -437,7 +437,7 @@ pub struct DeleteGeoMatchSetResponse {
     pub change_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteIPSetRequest {
     /// <p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -447,7 +447,7 @@ pub struct DeleteIPSetRequest {
     pub ip_set_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteIPSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>DeleteIPSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -455,17 +455,17 @@ pub struct DeleteIPSetResponse {
     pub change_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeletePermissionPolicyRequest {
     /// <p>The Amazon Resource Name (ARN) of the RuleGroup from which you want to delete the policy.</p> <p>The user making the request must be the owner of the RuleGroup.</p>
     #[serde(rename = "ResourceArn")]
     pub resource_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeletePermissionPolicyResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteRateBasedRuleRequest {
     /// <p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -475,7 +475,7 @@ pub struct DeleteRateBasedRuleRequest {
     pub rule_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteRateBasedRuleResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>DeleteRateBasedRule</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -483,7 +483,7 @@ pub struct DeleteRateBasedRuleResponse {
     pub change_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteRegexMatchSetRequest {
     /// <p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -493,7 +493,7 @@ pub struct DeleteRegexMatchSetRequest {
     pub regex_match_set_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteRegexMatchSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>DeleteRegexMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -501,7 +501,7 @@ pub struct DeleteRegexMatchSetResponse {
     pub change_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteRegexPatternSetRequest {
     /// <p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -511,7 +511,7 @@ pub struct DeleteRegexPatternSetRequest {
     pub regex_pattern_set_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteRegexPatternSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>DeleteRegexPatternSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -519,7 +519,7 @@ pub struct DeleteRegexPatternSetResponse {
     pub change_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteRuleGroupRequest {
     /// <p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -529,7 +529,7 @@ pub struct DeleteRuleGroupRequest {
     pub rule_group_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteRuleGroupResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>DeleteRuleGroup</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -537,7 +537,7 @@ pub struct DeleteRuleGroupResponse {
     pub change_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteRuleRequest {
     /// <p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -547,7 +547,7 @@ pub struct DeleteRuleRequest {
     pub rule_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteRuleResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>DeleteRule</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -555,7 +555,7 @@ pub struct DeleteRuleResponse {
     pub change_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteSizeConstraintSetRequest {
     /// <p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -565,7 +565,7 @@ pub struct DeleteSizeConstraintSetRequest {
     pub size_constraint_set_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteSizeConstraintSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>DeleteSizeConstraintSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -574,7 +574,7 @@ pub struct DeleteSizeConstraintSetResponse {
 }
 
 /// <p>A request to delete a <a>SqlInjectionMatchSet</a> from AWS WAF.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteSqlInjectionMatchSetRequest {
     /// <p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -585,7 +585,7 @@ pub struct DeleteSqlInjectionMatchSetRequest {
 }
 
 /// <p>The response to a request to delete a <a>SqlInjectionMatchSet</a> from AWS WAF.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteSqlInjectionMatchSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>DeleteSqlInjectionMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -593,7 +593,7 @@ pub struct DeleteSqlInjectionMatchSetResponse {
     pub change_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteWebACLRequest {
     /// <p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -603,7 +603,7 @@ pub struct DeleteWebACLRequest {
     pub web_acl_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteWebACLResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>DeleteWebACL</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -612,7 +612,7 @@ pub struct DeleteWebACLResponse {
 }
 
 /// <p>A request to delete an <a>XssMatchSet</a> from AWS WAF.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteXssMatchSetRequest {
     /// <p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -623,7 +623,7 @@ pub struct DeleteXssMatchSetRequest {
 }
 
 /// <p>The response to a request to delete an <a>XssMatchSet</a> from AWS WAF.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteXssMatchSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>DeleteXssMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -632,7 +632,7 @@ pub struct DeleteXssMatchSetResponse {
 }
 
 /// <p>Specifies where in a web request to look for <code>TargetString</code>.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct FieldToMatch {
     /// <p>When the value of <code>Type</code> is <code>HEADER</code>, enter the name of the header that you want AWS WAF to search, for example, <code>User-Agent</code> or <code>Referer</code>. If the value of <code>Type</code> is any other value, omit <code>Data</code>.</p> <p>The name of the header is not case sensitive.</p>
     #[serde(rename = "Data")]
@@ -644,7 +644,7 @@ pub struct FieldToMatch {
 }
 
 /// <p>The country from which web requests originate that you want AWS WAF to search for.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct GeoMatchConstraint {
     /// <p>The type of geographical area you want AWS WAF to search for. Currently <code>Country</code> is the only valid value.</p>
     #[serde(rename = "Type")]
@@ -655,7 +655,7 @@ pub struct GeoMatchConstraint {
 }
 
 /// <p>Contains one or more countries that AWS WAF will search for.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GeoMatchSet {
     /// <p>An array of <a>GeoMatchConstraint</a> objects, which contain the country that you want AWS WAF to search for.</p>
     #[serde(rename = "GeoMatchConstraints")]
@@ -670,7 +670,7 @@ pub struct GeoMatchSet {
 }
 
 /// <p>Contains the identifier and the name of the <code>GeoMatchSet</code>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GeoMatchSetSummary {
     /// <p>The <code>GeoMatchSetId</code> for an <a>GeoMatchSet</a>. You can use <code>GeoMatchSetId</code> in a <a>GetGeoMatchSet</a> request to get detailed information about an <a>GeoMatchSet</a>.</p>
     #[serde(rename = "GeoMatchSetId")]
@@ -681,7 +681,7 @@ pub struct GeoMatchSetSummary {
 }
 
 /// <p>Specifies the type of update to perform to an <a>GeoMatchSet</a> with <a>UpdateGeoMatchSet</a>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GeoMatchSetUpdate {
     /// <p>Specifies whether to insert or delete a country with <a>UpdateGeoMatchSet</a>.</p>
     #[serde(rename = "Action")]
@@ -691,14 +691,14 @@ pub struct GeoMatchSetUpdate {
     pub geo_match_constraint: GeoMatchConstraint,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetByteMatchSetRequest {
     /// <p>The <code>ByteMatchSetId</code> of the <a>ByteMatchSet</a> that you want to get. <code>ByteMatchSetId</code> is returned by <a>CreateByteMatchSet</a> and by <a>ListByteMatchSets</a>.</p>
     #[serde(rename = "ByteMatchSetId")]
     pub byte_match_set_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetByteMatchSetResponse {
     /// <p><p>Information about the <a>ByteMatchSet</a> that you specified in the <code>GetByteMatchSet</code> request. For more information, see the following topics:</p> <ul> <li> <p> <a>ByteMatchSet</a>: Contains <code>ByteMatchSetId</code>, <code>ByteMatchTuples</code>, and <code>Name</code> </p> </li> <li> <p> <code>ByteMatchTuples</code>: Contains an array of <a>ByteMatchTuple</a> objects. Each <code>ByteMatchTuple</code> object contains <a>FieldToMatch</a>, <code>PositionalConstraint</code>, <code>TargetString</code>, and <code>TextTransformation</code> </p> </li> <li> <p> <a>FieldToMatch</a>: Contains <code>Data</code> and <code>Type</code> </p> </li> </ul></p>
     #[serde(rename = "ByteMatchSet")]
@@ -706,10 +706,10 @@ pub struct GetByteMatchSetResponse {
     pub byte_match_set: Option<ByteMatchSet>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetChangeTokenRequest {}
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetChangeTokenResponse {
     /// <p>The <code>ChangeToken</code> that you used in the request. Use this value in a <code>GetChangeTokenStatus</code> request to get the current status of the request. </p>
     #[serde(rename = "ChangeToken")]
@@ -717,14 +717,14 @@ pub struct GetChangeTokenResponse {
     pub change_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetChangeTokenStatusRequest {
     /// <p>The change token for which you want to get the status. This change token was previously returned in the <code>GetChangeToken</code> response.</p>
     #[serde(rename = "ChangeToken")]
     pub change_token: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetChangeTokenStatusResponse {
     /// <p>The status of the change token.</p>
     #[serde(rename = "ChangeTokenStatus")]
@@ -732,14 +732,14 @@ pub struct GetChangeTokenStatusResponse {
     pub change_token_status: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetGeoMatchSetRequest {
     /// <p>The <code>GeoMatchSetId</code> of the <a>GeoMatchSet</a> that you want to get. <code>GeoMatchSetId</code> is returned by <a>CreateGeoMatchSet</a> and by <a>ListGeoMatchSets</a>.</p>
     #[serde(rename = "GeoMatchSetId")]
     pub geo_match_set_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetGeoMatchSetResponse {
     /// <p>Information about the <a>GeoMatchSet</a> that you specified in the <code>GetGeoMatchSet</code> request. This includes the <code>Type</code>, which for a <code>GeoMatchContraint</code> is always <code>Country</code>, as well as the <code>Value</code>, which is the identifier for a specific country.</p>
     #[serde(rename = "GeoMatchSet")]
@@ -747,14 +747,14 @@ pub struct GetGeoMatchSetResponse {
     pub geo_match_set: Option<GeoMatchSet>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetIPSetRequest {
     /// <p>The <code>IPSetId</code> of the <a>IPSet</a> that you want to get. <code>IPSetId</code> is returned by <a>CreateIPSet</a> and by <a>ListIPSets</a>.</p>
     #[serde(rename = "IPSetId")]
     pub ip_set_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetIPSetResponse {
     /// <p><p>Information about the <a>IPSet</a> that you specified in the <code>GetIPSet</code> request. For more information, see the following topics:</p> <ul> <li> <p> <a>IPSet</a>: Contains <code>IPSetDescriptors</code>, <code>IPSetId</code>, and <code>Name</code> </p> </li> <li> <p> <code>IPSetDescriptors</code>: Contains an array of <a>IPSetDescriptor</a> objects. Each <code>IPSetDescriptor</code> object contains <code>Type</code> and <code>Value</code> </p> </li> </ul></p>
     #[serde(rename = "IPSet")]
@@ -762,14 +762,14 @@ pub struct GetIPSetResponse {
     pub ip_set: Option<IPSet>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetPermissionPolicyRequest {
     /// <p>The Amazon Resource Name (ARN) of the RuleGroup for which you want to get the policy.</p>
     #[serde(rename = "ResourceArn")]
     pub resource_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetPermissionPolicyResponse {
     /// <p>The IAM policy attached to the specified RuleGroup.</p>
     #[serde(rename = "Policy")]
@@ -777,7 +777,7 @@ pub struct GetPermissionPolicyResponse {
     pub policy: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetRateBasedRuleManagedKeysRequest {
     /// <p>A null value and not currently used. Do not include this in your request.</p>
     #[serde(rename = "NextMarker")]
@@ -788,7 +788,7 @@ pub struct GetRateBasedRuleManagedKeysRequest {
     pub rule_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetRateBasedRuleManagedKeysResponse {
     /// <p>An array of IP addresses that currently are blocked by the specified <a>RateBasedRule</a>. </p>
     #[serde(rename = "ManagedKeys")]
@@ -800,14 +800,14 @@ pub struct GetRateBasedRuleManagedKeysResponse {
     pub next_marker: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetRateBasedRuleRequest {
     /// <p>The <code>RuleId</code> of the <a>RateBasedRule</a> that you want to get. <code>RuleId</code> is returned by <a>CreateRateBasedRule</a> and by <a>ListRateBasedRules</a>.</p>
     #[serde(rename = "RuleId")]
     pub rule_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetRateBasedRuleResponse {
     /// <p>Information about the <a>RateBasedRule</a> that you specified in the <code>GetRateBasedRule</code> request.</p>
     #[serde(rename = "Rule")]
@@ -815,14 +815,14 @@ pub struct GetRateBasedRuleResponse {
     pub rule: Option<RateBasedRule>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetRegexMatchSetRequest {
     /// <p>The <code>RegexMatchSetId</code> of the <a>RegexMatchSet</a> that you want to get. <code>RegexMatchSetId</code> is returned by <a>CreateRegexMatchSet</a> and by <a>ListRegexMatchSets</a>.</p>
     #[serde(rename = "RegexMatchSetId")]
     pub regex_match_set_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetRegexMatchSetResponse {
     /// <p>Information about the <a>RegexMatchSet</a> that you specified in the <code>GetRegexMatchSet</code> request. For more information, see <a>RegexMatchTuple</a>.</p>
     #[serde(rename = "RegexMatchSet")]
@@ -830,14 +830,14 @@ pub struct GetRegexMatchSetResponse {
     pub regex_match_set: Option<RegexMatchSet>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetRegexPatternSetRequest {
     /// <p>The <code>RegexPatternSetId</code> of the <a>RegexPatternSet</a> that you want to get. <code>RegexPatternSetId</code> is returned by <a>CreateRegexPatternSet</a> and by <a>ListRegexPatternSets</a>.</p>
     #[serde(rename = "RegexPatternSetId")]
     pub regex_pattern_set_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetRegexPatternSetResponse {
     /// <p>Information about the <a>RegexPatternSet</a> that you specified in the <code>GetRegexPatternSet</code> request, including the identifier of the pattern set and the regular expression patterns you want AWS WAF to search for. </p>
     #[serde(rename = "RegexPatternSet")]
@@ -845,14 +845,14 @@ pub struct GetRegexPatternSetResponse {
     pub regex_pattern_set: Option<RegexPatternSet>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetRuleGroupRequest {
     /// <p>The <code>RuleGroupId</code> of the <a>RuleGroup</a> that you want to get. <code>RuleGroupId</code> is returned by <a>CreateRuleGroup</a> and by <a>ListRuleGroups</a>.</p>
     #[serde(rename = "RuleGroupId")]
     pub rule_group_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetRuleGroupResponse {
     /// <p>Information about the <a>RuleGroup</a> that you specified in the <code>GetRuleGroup</code> request. </p>
     #[serde(rename = "RuleGroup")]
@@ -860,14 +860,14 @@ pub struct GetRuleGroupResponse {
     pub rule_group: Option<RuleGroup>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetRuleRequest {
     /// <p>The <code>RuleId</code> of the <a>Rule</a> that you want to get. <code>RuleId</code> is returned by <a>CreateRule</a> and by <a>ListRules</a>.</p>
     #[serde(rename = "RuleId")]
     pub rule_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetRuleResponse {
     /// <p><p>Information about the <a>Rule</a> that you specified in the <code>GetRule</code> request. For more information, see the following topics:</p> <ul> <li> <p> <a>Rule</a>: Contains <code>MetricName</code>, <code>Name</code>, an array of <code>Predicate</code> objects, and <code>RuleId</code> </p> </li> <li> <p> <a>Predicate</a>: Each <code>Predicate</code> object contains <code>DataId</code>, <code>Negated</code>, and <code>Type</code> </p> </li> </ul></p>
     #[serde(rename = "Rule")]
@@ -875,7 +875,7 @@ pub struct GetRuleResponse {
     pub rule: Option<Rule>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetSampledRequestsRequest {
     /// <p>The number of requests that you want AWS WAF to return from among the first 5,000 requests that your AWS resource received during the time range. If your resource received fewer requests than the value of <code>MaxItems</code>, <code>GetSampledRequests</code> returns information about all of them. </p>
     #[serde(rename = "MaxItems")]
@@ -891,7 +891,7 @@ pub struct GetSampledRequestsRequest {
     pub web_acl_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetSampledRequestsResponse {
     /// <p>The total number of requests from which <code>GetSampledRequests</code> got a sample of <code>MaxItems</code> requests. If <code>PopulationSize</code> is less than <code>MaxItems</code>, the sample includes every request that your AWS resource received during the specified time range.</p>
     #[serde(rename = "PopulationSize")]
@@ -907,14 +907,14 @@ pub struct GetSampledRequestsResponse {
     pub time_window: Option<TimeWindow>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetSizeConstraintSetRequest {
     /// <p>The <code>SizeConstraintSetId</code> of the <a>SizeConstraintSet</a> that you want to get. <code>SizeConstraintSetId</code> is returned by <a>CreateSizeConstraintSet</a> and by <a>ListSizeConstraintSets</a>.</p>
     #[serde(rename = "SizeConstraintSetId")]
     pub size_constraint_set_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetSizeConstraintSetResponse {
     /// <p><p>Information about the <a>SizeConstraintSet</a> that you specified in the <code>GetSizeConstraintSet</code> request. For more information, see the following topics:</p> <ul> <li> <p> <a>SizeConstraintSet</a>: Contains <code>SizeConstraintSetId</code>, <code>SizeConstraints</code>, and <code>Name</code> </p> </li> <li> <p> <code>SizeConstraints</code>: Contains an array of <a>SizeConstraint</a> objects. Each <code>SizeConstraint</code> object contains <a>FieldToMatch</a>, <code>TextTransformation</code>, <code>ComparisonOperator</code>, and <code>Size</code> </p> </li> <li> <p> <a>FieldToMatch</a>: Contains <code>Data</code> and <code>Type</code> </p> </li> </ul></p>
     #[serde(rename = "SizeConstraintSet")]
@@ -923,7 +923,7 @@ pub struct GetSizeConstraintSetResponse {
 }
 
 /// <p>A request to get a <a>SqlInjectionMatchSet</a>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetSqlInjectionMatchSetRequest {
     /// <p>The <code>SqlInjectionMatchSetId</code> of the <a>SqlInjectionMatchSet</a> that you want to get. <code>SqlInjectionMatchSetId</code> is returned by <a>CreateSqlInjectionMatchSet</a> and by <a>ListSqlInjectionMatchSets</a>.</p>
     #[serde(rename = "SqlInjectionMatchSetId")]
@@ -931,7 +931,7 @@ pub struct GetSqlInjectionMatchSetRequest {
 }
 
 /// <p>The response to a <a>GetSqlInjectionMatchSet</a> request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetSqlInjectionMatchSetResponse {
     /// <p><p>Information about the <a>SqlInjectionMatchSet</a> that you specified in the <code>GetSqlInjectionMatchSet</code> request. For more information, see the following topics:</p> <ul> <li> <p> <a>SqlInjectionMatchSet</a>: Contains <code>Name</code>, <code>SqlInjectionMatchSetId</code>, and an array of <code>SqlInjectionMatchTuple</code> objects</p> </li> <li> <p> <a>SqlInjectionMatchTuple</a>: Each <code>SqlInjectionMatchTuple</code> object contains <code>FieldToMatch</code> and <code>TextTransformation</code> </p> </li> <li> <p> <a>FieldToMatch</a>: Contains <code>Data</code> and <code>Type</code> </p> </li> </ul></p>
     #[serde(rename = "SqlInjectionMatchSet")]
@@ -939,14 +939,14 @@ pub struct GetSqlInjectionMatchSetResponse {
     pub sql_injection_match_set: Option<SqlInjectionMatchSet>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetWebACLRequest {
     /// <p>The <code>WebACLId</code> of the <a>WebACL</a> that you want to get. <code>WebACLId</code> is returned by <a>CreateWebACL</a> and by <a>ListWebACLs</a>.</p>
     #[serde(rename = "WebACLId")]
     pub web_acl_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetWebACLResponse {
     /// <p><p>Information about the <a>WebACL</a> that you specified in the <code>GetWebACL</code> request. For more information, see the following topics:</p> <ul> <li> <p> <a>WebACL</a>: Contains <code>DefaultAction</code>, <code>MetricName</code>, <code>Name</code>, an array of <code>Rule</code> objects, and <code>WebACLId</code> </p> </li> <li> <p> <code>DefaultAction</code> (Data type is <a>WafAction</a>): Contains <code>Type</code> </p> </li> <li> <p> <code>Rules</code>: Contains an array of <code>ActivatedRule</code> objects, which contain <code>Action</code>, <code>Priority</code>, and <code>RuleId</code> </p> </li> <li> <p> <code>Action</code>: Contains <code>Type</code> </p> </li> </ul></p>
     #[serde(rename = "WebACL")]
@@ -955,7 +955,7 @@ pub struct GetWebACLResponse {
 }
 
 /// <p>A request to get an <a>XssMatchSet</a>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetXssMatchSetRequest {
     /// <p>The <code>XssMatchSetId</code> of the <a>XssMatchSet</a> that you want to get. <code>XssMatchSetId</code> is returned by <a>CreateXssMatchSet</a> and by <a>ListXssMatchSets</a>.</p>
     #[serde(rename = "XssMatchSetId")]
@@ -963,7 +963,7 @@ pub struct GetXssMatchSetRequest {
 }
 
 /// <p>The response to a <a>GetXssMatchSet</a> request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetXssMatchSetResponse {
     /// <p><p>Information about the <a>XssMatchSet</a> that you specified in the <code>GetXssMatchSet</code> request. For more information, see the following topics:</p> <ul> <li> <p> <a>XssMatchSet</a>: Contains <code>Name</code>, <code>XssMatchSetId</code>, and an array of <code>XssMatchTuple</code> objects</p> </li> <li> <p> <a>XssMatchTuple</a>: Each <code>XssMatchTuple</code> object contains <code>FieldToMatch</code> and <code>TextTransformation</code> </p> </li> <li> <p> <a>FieldToMatch</a>: Contains <code>Data</code> and <code>Type</code> </p> </li> </ul></p>
     #[serde(rename = "XssMatchSet")]
@@ -972,7 +972,7 @@ pub struct GetXssMatchSetResponse {
 }
 
 /// <p>The response from a <a>GetSampledRequests</a> request includes an <code>HTTPHeader</code> complex type that appears as <code>Headers</code> in the response syntax. <code>HTTPHeader</code> contains the names and values of all of the headers that appear in one of the web requests that were returned by <code>GetSampledRequests</code>. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct HTTPHeader {
     /// <p>The name of one of the headers in the sampled web request.</p>
     #[serde(rename = "Name")]
@@ -985,7 +985,7 @@ pub struct HTTPHeader {
 }
 
 /// <p>The response from a <a>GetSampledRequests</a> request includes an <code>HTTPRequest</code> complex type that appears as <code>Request</code> in the response syntax. <code>HTTPRequest</code> contains information about one of the web requests that were returned by <code>GetSampledRequests</code>. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct HTTPRequest {
     /// <p><p>The IP address that the request originated from. If the <code>WebACL</code> is associated with a CloudFront distribution, this is the value of one of the following fields in CloudFront access logs:</p> <ul> <li> <p> <code>c-ip</code>, if the viewer did not use an HTTP proxy or a load balancer to send the request</p> </li> <li> <p> <code>x-forwarded-for</code>, if the viewer did use an HTTP proxy or a load balancer to send the request</p> </li> </ul></p>
     #[serde(rename = "ClientIP")]
@@ -1014,7 +1014,7 @@ pub struct HTTPRequest {
 }
 
 /// <p>Contains one or more IP addresses or blocks of IP addresses specified in Classless Inter-Domain Routing (CIDR) notation. AWS WAF supports /8, /16, /24, and /32 IP address ranges for IPv4, and /24, /32, /48, /56, /64 and /128 for IPv6.</p> <p>To specify an individual IP address, you specify the four-part IP address followed by a <code>/32</code>, for example, 192.0.2.0/31. To block a range of IP addresses, you can specify a <code>/128</code>, <code>/64</code>, <code>/56</code>, <code>/48</code>, <code>/32</code>, <code>/24</code>, <code>/16</code>, or <code>/8</code> CIDR. For more information about CIDR notation, see the Wikipedia entry <a href="https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing">Classless Inter-Domain Routing</a>. </p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct IPSet {
     /// <p>The IP address type (<code>IPV4</code> or <code>IPV6</code>) and the IP address range (in CIDR notation) that web requests originate from. If the <code>WebACL</code> is associated with a CloudFront distribution and the viewer did not use an HTTP proxy or a load balancer to send the request, this is the value of the c-ip field in the CloudFront access logs.</p>
     #[serde(rename = "IPSetDescriptors")]
@@ -1029,7 +1029,7 @@ pub struct IPSet {
 }
 
 /// <p>Specifies the IP address type (<code>IPV4</code> or <code>IPV6</code>) and the IP address range (in CIDR format) that web requests originate from.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct IPSetDescriptor {
     /// <p>Specify <code>IPV4</code> or <code>IPV6</code>.</p>
     #[serde(rename = "Type")]
@@ -1040,7 +1040,7 @@ pub struct IPSetDescriptor {
 }
 
 /// <p>Contains the identifier and the name of the <code>IPSet</code>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct IPSetSummary {
     /// <p>The <code>IPSetId</code> for an <a>IPSet</a>. You can use <code>IPSetId</code> in a <a>GetIPSet</a> request to get detailed information about an <a>IPSet</a>.</p>
     #[serde(rename = "IPSetId")]
@@ -1051,7 +1051,7 @@ pub struct IPSetSummary {
 }
 
 /// <p>Specifies the type of update to perform to an <a>IPSet</a> with <a>UpdateIPSet</a>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct IPSetUpdate {
     /// <p>Specifies whether to insert or delete an IP address with <a>UpdateIPSet</a>.</p>
     #[serde(rename = "Action")]
@@ -1061,7 +1061,7 @@ pub struct IPSetUpdate {
     pub ip_set_descriptor: IPSetDescriptor,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListActivatedRulesInRuleGroupRequest {
     /// <p>Specifies the number of <code>ActivatedRules</code> that you want AWS WAF to return for this request. If you have more <code>ActivatedRules</code> than the number that you specify for <code>Limit</code>, the response includes a <code>NextMarker</code> value that you can use to get another batch of <code>ActivatedRules</code>.</p>
     #[serde(rename = "Limit")]
@@ -1077,7 +1077,7 @@ pub struct ListActivatedRulesInRuleGroupRequest {
     pub rule_group_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListActivatedRulesInRuleGroupResponse {
     /// <p>An array of <code>ActivatedRules</code> objects.</p>
     #[serde(rename = "ActivatedRules")]
@@ -1089,7 +1089,7 @@ pub struct ListActivatedRulesInRuleGroupResponse {
     pub next_marker: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListByteMatchSetsRequest {
     /// <p>Specifies the number of <code>ByteMatchSet</code> objects that you want AWS WAF to return for this request. If you have more <code>ByteMatchSets</code> objects than the number you specify for <code>Limit</code>, the response includes a <code>NextMarker</code> value that you can use to get another batch of <code>ByteMatchSet</code> objects.</p>
     #[serde(rename = "Limit")]
@@ -1101,7 +1101,7 @@ pub struct ListByteMatchSetsRequest {
     pub next_marker: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListByteMatchSetsResponse {
     /// <p>An array of <a>ByteMatchSetSummary</a> objects.</p>
     #[serde(rename = "ByteMatchSets")]
@@ -1113,7 +1113,7 @@ pub struct ListByteMatchSetsResponse {
     pub next_marker: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListGeoMatchSetsRequest {
     /// <p>Specifies the number of <code>GeoMatchSet</code> objects that you want AWS WAF to return for this request. If you have more <code>GeoMatchSet</code> objects than the number you specify for <code>Limit</code>, the response includes a <code>NextMarker</code> value that you can use to get another batch of <code>GeoMatchSet</code> objects.</p>
     #[serde(rename = "Limit")]
@@ -1125,7 +1125,7 @@ pub struct ListGeoMatchSetsRequest {
     pub next_marker: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListGeoMatchSetsResponse {
     /// <p>An array of <a>GeoMatchSetSummary</a> objects.</p>
     #[serde(rename = "GeoMatchSets")]
@@ -1137,7 +1137,7 @@ pub struct ListGeoMatchSetsResponse {
     pub next_marker: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListIPSetsRequest {
     /// <p>Specifies the number of <code>IPSet</code> objects that you want AWS WAF to return for this request. If you have more <code>IPSet</code> objects than the number you specify for <code>Limit</code>, the response includes a <code>NextMarker</code> value that you can use to get another batch of <code>IPSet</code> objects.</p>
     #[serde(rename = "Limit")]
@@ -1149,7 +1149,7 @@ pub struct ListIPSetsRequest {
     pub next_marker: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListIPSetsResponse {
     /// <p>An array of <a>IPSetSummary</a> objects.</p>
     #[serde(rename = "IPSets")]
@@ -1161,7 +1161,7 @@ pub struct ListIPSetsResponse {
     pub next_marker: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListRateBasedRulesRequest {
     /// <p>Specifies the number of <code>Rules</code> that you want AWS WAF to return for this request. If you have more <code>Rules</code> than the number that you specify for <code>Limit</code>, the response includes a <code>NextMarker</code> value that you can use to get another batch of <code>Rules</code>.</p>
     #[serde(rename = "Limit")]
@@ -1173,7 +1173,7 @@ pub struct ListRateBasedRulesRequest {
     pub next_marker: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListRateBasedRulesResponse {
     /// <p>If you have more <code>Rules</code> than the number that you specified for <code>Limit</code> in the request, the response includes a <code>NextMarker</code> value. To list more <code>Rules</code>, submit another <code>ListRateBasedRules</code> request, and specify the <code>NextMarker</code> value from the response in the <code>NextMarker</code> value in the next request.</p>
     #[serde(rename = "NextMarker")]
@@ -1185,7 +1185,7 @@ pub struct ListRateBasedRulesResponse {
     pub rules: Option<Vec<RuleSummary>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListRegexMatchSetsRequest {
     /// <p>Specifies the number of <code>RegexMatchSet</code> objects that you want AWS WAF to return for this request. If you have more <code>RegexMatchSet</code> objects than the number you specify for <code>Limit</code>, the response includes a <code>NextMarker</code> value that you can use to get another batch of <code>RegexMatchSet</code> objects.</p>
     #[serde(rename = "Limit")]
@@ -1197,7 +1197,7 @@ pub struct ListRegexMatchSetsRequest {
     pub next_marker: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListRegexMatchSetsResponse {
     /// <p>If you have more <code>RegexMatchSet</code> objects than the number that you specified for <code>Limit</code> in the request, the response includes a <code>NextMarker</code> value. To list more <code>RegexMatchSet</code> objects, submit another <code>ListRegexMatchSets</code> request, and specify the <code>NextMarker</code> value from the response in the <code>NextMarker</code> value in the next request.</p>
     #[serde(rename = "NextMarker")]
@@ -1209,7 +1209,7 @@ pub struct ListRegexMatchSetsResponse {
     pub regex_match_sets: Option<Vec<RegexMatchSetSummary>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListRegexPatternSetsRequest {
     /// <p>Specifies the number of <code>RegexPatternSet</code> objects that you want AWS WAF to return for this request. If you have more <code>RegexPatternSet</code> objects than the number you specify for <code>Limit</code>, the response includes a <code>NextMarker</code> value that you can use to get another batch of <code>RegexPatternSet</code> objects.</p>
     #[serde(rename = "Limit")]
@@ -1221,7 +1221,7 @@ pub struct ListRegexPatternSetsRequest {
     pub next_marker: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListRegexPatternSetsResponse {
     /// <p>If you have more <code>RegexPatternSet</code> objects than the number that you specified for <code>Limit</code> in the request, the response includes a <code>NextMarker</code> value. To list more <code>RegexPatternSet</code> objects, submit another <code>ListRegexPatternSets</code> request, and specify the <code>NextMarker</code> value from the response in the <code>NextMarker</code> value in the next request.</p>
     #[serde(rename = "NextMarker")]
@@ -1233,7 +1233,7 @@ pub struct ListRegexPatternSetsResponse {
     pub regex_pattern_sets: Option<Vec<RegexPatternSetSummary>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListRuleGroupsRequest {
     /// <p>Specifies the number of <code>RuleGroups</code> that you want AWS WAF to return for this request. If you have more <code>RuleGroups</code> than the number that you specify for <code>Limit</code>, the response includes a <code>NextMarker</code> value that you can use to get another batch of <code>RuleGroups</code>.</p>
     #[serde(rename = "Limit")]
@@ -1245,7 +1245,7 @@ pub struct ListRuleGroupsRequest {
     pub next_marker: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListRuleGroupsResponse {
     /// <p>If you have more <code>RuleGroups</code> than the number that you specified for <code>Limit</code> in the request, the response includes a <code>NextMarker</code> value. To list more <code>RuleGroups</code>, submit another <code>ListRuleGroups</code> request, and specify the <code>NextMarker</code> value from the response in the <code>NextMarker</code> value in the next request.</p>
     #[serde(rename = "NextMarker")]
@@ -1257,7 +1257,7 @@ pub struct ListRuleGroupsResponse {
     pub rule_groups: Option<Vec<RuleGroupSummary>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListRulesRequest {
     /// <p>Specifies the number of <code>Rules</code> that you want AWS WAF to return for this request. If you have more <code>Rules</code> than the number that you specify for <code>Limit</code>, the response includes a <code>NextMarker</code> value that you can use to get another batch of <code>Rules</code>.</p>
     #[serde(rename = "Limit")]
@@ -1269,7 +1269,7 @@ pub struct ListRulesRequest {
     pub next_marker: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListRulesResponse {
     /// <p>If you have more <code>Rules</code> than the number that you specified for <code>Limit</code> in the request, the response includes a <code>NextMarker</code> value. To list more <code>Rules</code>, submit another <code>ListRules</code> request, and specify the <code>NextMarker</code> value from the response in the <code>NextMarker</code> value in the next request.</p>
     #[serde(rename = "NextMarker")]
@@ -1281,7 +1281,7 @@ pub struct ListRulesResponse {
     pub rules: Option<Vec<RuleSummary>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListSizeConstraintSetsRequest {
     /// <p>Specifies the number of <code>SizeConstraintSet</code> objects that you want AWS WAF to return for this request. If you have more <code>SizeConstraintSets</code> objects than the number you specify for <code>Limit</code>, the response includes a <code>NextMarker</code> value that you can use to get another batch of <code>SizeConstraintSet</code> objects.</p>
     #[serde(rename = "Limit")]
@@ -1293,7 +1293,7 @@ pub struct ListSizeConstraintSetsRequest {
     pub next_marker: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListSizeConstraintSetsResponse {
     /// <p>If you have more <code>SizeConstraintSet</code> objects than the number that you specified for <code>Limit</code> in the request, the response includes a <code>NextMarker</code> value. To list more <code>SizeConstraintSet</code> objects, submit another <code>ListSizeConstraintSets</code> request, and specify the <code>NextMarker</code> value from the response in the <code>NextMarker</code> value in the next request.</p>
     #[serde(rename = "NextMarker")]
@@ -1306,7 +1306,7 @@ pub struct ListSizeConstraintSetsResponse {
 }
 
 /// <p>A request to list the <a>SqlInjectionMatchSet</a> objects created by the current AWS account.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListSqlInjectionMatchSetsRequest {
     /// <p>Specifies the number of <a>SqlInjectionMatchSet</a> objects that you want AWS WAF to return for this request. If you have more <code>SqlInjectionMatchSet</code> objects than the number you specify for <code>Limit</code>, the response includes a <code>NextMarker</code> value that you can use to get another batch of <code>Rules</code>.</p>
     #[serde(rename = "Limit")]
@@ -1319,7 +1319,7 @@ pub struct ListSqlInjectionMatchSetsRequest {
 }
 
 /// <p>The response to a <a>ListSqlInjectionMatchSets</a> request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListSqlInjectionMatchSetsResponse {
     /// <p>If you have more <a>SqlInjectionMatchSet</a> objects than the number that you specified for <code>Limit</code> in the request, the response includes a <code>NextMarker</code> value. To list more <code>SqlInjectionMatchSet</code> objects, submit another <code>ListSqlInjectionMatchSets</code> request, and specify the <code>NextMarker</code> value from the response in the <code>NextMarker</code> value in the next request.</p>
     #[serde(rename = "NextMarker")]
@@ -1331,7 +1331,7 @@ pub struct ListSqlInjectionMatchSetsResponse {
     pub sql_injection_match_sets: Option<Vec<SqlInjectionMatchSetSummary>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListSubscribedRuleGroupsRequest {
     /// <p>Specifies the number of subscribed rule groups that you want AWS WAF to return for this request. If you have more objects than the number you specify for <code>Limit</code>, the response includes a <code>NextMarker</code> value that you can use to get another batch of objects.</p>
     #[serde(rename = "Limit")]
@@ -1343,7 +1343,7 @@ pub struct ListSubscribedRuleGroupsRequest {
     pub next_marker: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListSubscribedRuleGroupsResponse {
     /// <p>If you have more objects than the number that you specified for <code>Limit</code> in the request, the response includes a <code>NextMarker</code> value. To list more objects, submit another <code>ListSubscribedRuleGroups</code> request, and specify the <code>NextMarker</code> value from the response in the <code>NextMarker</code> value in the next request.</p>
     #[serde(rename = "NextMarker")]
@@ -1355,7 +1355,7 @@ pub struct ListSubscribedRuleGroupsResponse {
     pub rule_groups: Option<Vec<SubscribedRuleGroupSummary>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListWebACLsRequest {
     /// <p>Specifies the number of <code>WebACL</code> objects that you want AWS WAF to return for this request. If you have more <code>WebACL</code> objects than the number that you specify for <code>Limit</code>, the response includes a <code>NextMarker</code> value that you can use to get another batch of <code>WebACL</code> objects.</p>
     #[serde(rename = "Limit")]
@@ -1367,7 +1367,7 @@ pub struct ListWebACLsRequest {
     pub next_marker: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListWebACLsResponse {
     /// <p>If you have more <code>WebACL</code> objects than the number that you specified for <code>Limit</code> in the request, the response includes a <code>NextMarker</code> value. To list more <code>WebACL</code> objects, submit another <code>ListWebACLs</code> request, and specify the <code>NextMarker</code> value from the response in the <code>NextMarker</code> value in the next request.</p>
     #[serde(rename = "NextMarker")]
@@ -1380,7 +1380,7 @@ pub struct ListWebACLsResponse {
 }
 
 /// <p>A request to list the <a>XssMatchSet</a> objects created by the current AWS account.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListXssMatchSetsRequest {
     /// <p>Specifies the number of <a>XssMatchSet</a> objects that you want AWS WAF to return for this request. If you have more <code>XssMatchSet</code> objects than the number you specify for <code>Limit</code>, the response includes a <code>NextMarker</code> value that you can use to get another batch of <code>Rules</code>.</p>
     #[serde(rename = "Limit")]
@@ -1393,7 +1393,7 @@ pub struct ListXssMatchSetsRequest {
 }
 
 /// <p>The response to a <a>ListXssMatchSets</a> request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ListXssMatchSetsResponse {
     /// <p>If you have more <a>XssMatchSet</a> objects than the number that you specified for <code>Limit</code> in the request, the response includes a <code>NextMarker</code> value. To list more <code>XssMatchSet</code> objects, submit another <code>ListXssMatchSets</code> request, and specify the <code>NextMarker</code> value from the response in the <code>NextMarker</code> value in the next request.</p>
     #[serde(rename = "NextMarker")]
@@ -1406,7 +1406,7 @@ pub struct ListXssMatchSetsResponse {
 }
 
 /// <p>Specifies the <a>ByteMatchSet</a>, <a>IPSet</a>, <a>SqlInjectionMatchSet</a>, <a>XssMatchSet</a>, <a>RegexMatchSet</a>, <a>GeoMatchSet</a>, and <a>SizeConstraintSet</a> objects that you want to add to a <code>Rule</code> and, for each object, indicates whether you want to negate the settings, for example, requests that do NOT originate from the IP address 192.0.2.44. </p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Predicate {
     /// <p>A unique identifier for a predicate in a <code>Rule</code>, such as <code>ByteMatchSetId</code> or <code>IPSetId</code>. The ID is returned by the corresponding <code>Create</code> or <code>List</code> command.</p>
     #[serde(rename = "DataId")]
@@ -1419,7 +1419,7 @@ pub struct Predicate {
     pub type_: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PutPermissionPolicyRequest {
     /// <p>The policy to attach to the specified RuleGroup.</p>
     #[serde(rename = "Policy")]
@@ -1429,11 +1429,11 @@ pub struct PutPermissionPolicyRequest {
     pub resource_arn: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PutPermissionPolicyResponse {}
 
 /// <p>A <code>RateBasedRule</code> is identical to a regular <a>Rule</a>, with one addition: a <code>RateBasedRule</code> counts the number of requests that arrive from a specified IP address every five minutes. For example, based on recent requests that you've seen from an attacker, you might create a <code>RateBasedRule</code> that includes the following conditions: </p> <ul> <li> <p>The requests come from 192.0.2.44.</p> </li> <li> <p>They contain the value <code>BadBot</code> in the <code>User-Agent</code> header.</p> </li> </ul> <p>In the rule, you also define the rate limit as 15,000.</p> <p>Requests that meet both of these conditions and exceed 15,000 requests every five minutes trigger the rule's action (block or count), which is defined in the web ACL.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RateBasedRule {
     /// <p>The <code>Predicates</code> object contains one <code>Predicate</code> element for each <a>ByteMatchSet</a>, <a>IPSet</a>, or <a>SqlInjectionMatchSet</a> object that you want to include in a <code>RateBasedRule</code>.</p>
     #[serde(rename = "MatchPredicates")]
@@ -1458,7 +1458,7 @@ pub struct RateBasedRule {
 }
 
 /// <p>In a <a>GetRegexMatchSet</a> request, <code>RegexMatchSet</code> is a complex type that contains the <code>RegexMatchSetId</code> and <code>Name</code> of a <code>RegexMatchSet</code>, and the values that you specified when you updated the <code>RegexMatchSet</code>.</p> <p> The values are contained in a <code>RegexMatchTuple</code> object, which specify the parts of web requests that you want AWS WAF to inspect and the values that you want AWS WAF to search for. If a <code>RegexMatchSet</code> contains more than one <code>RegexMatchTuple</code> object, a request needs to match the settings in only one <code>ByteMatchTuple</code> to be considered a match.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RegexMatchSet {
     /// <p>A friendly name or description of the <a>RegexMatchSet</a>. You can't change <code>Name</code> after you create a <code>RegexMatchSet</code>.</p>
     #[serde(rename = "Name")]
@@ -1475,7 +1475,7 @@ pub struct RegexMatchSet {
 }
 
 /// <p>Returned by <a>ListRegexMatchSets</a>. Each <code>RegexMatchSetSummary</code> object includes the <code>Name</code> and <code>RegexMatchSetId</code> for one <a>RegexMatchSet</a>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RegexMatchSetSummary {
     /// <p>A friendly name or description of the <a>RegexMatchSet</a>. You can't change <code>Name</code> after you create a <code>RegexMatchSet</code>.</p>
     #[serde(rename = "Name")]
@@ -1486,7 +1486,7 @@ pub struct RegexMatchSetSummary {
 }
 
 /// <p>In an <a>UpdateRegexMatchSet</a> request, <code>RegexMatchSetUpdate</code> specifies whether to insert or delete a <a>RegexMatchTuple</a> and includes the settings for the <code>RegexMatchTuple</code>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RegexMatchSetUpdate {
     /// <p>Specifies whether to insert or delete a <a>RegexMatchTuple</a>.</p>
     #[serde(rename = "Action")]
@@ -1497,7 +1497,7 @@ pub struct RegexMatchSetUpdate {
 }
 
 /// <p><p>The regular expression pattern that you want AWS WAF to search for in web requests, the location in requests that you want AWS WAF to search, and other settings. Each <code>RegexMatchTuple</code> object contains: </p> <ul> <li> <p>The part of a web request that you want AWS WAF to inspect, such as a query string or the value of the <code>User-Agent</code> header. </p> </li> <li> <p>The identifier of the pattern (a regular expression) that you want AWS WAF to look for. For more information, see <a>RegexPatternSet</a>. </p> </li> <li> <p>Whether to perform any conversions on the request, such as converting it to lowercase, before inspecting it for the specified string.</p> </li> </ul></p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RegexMatchTuple {
     /// <p>Specifies where in a web request to look for the <code>RegexPatternSet</code>.</p>
     #[serde(rename = "FieldToMatch")]
@@ -1511,7 +1511,7 @@ pub struct RegexMatchTuple {
 }
 
 /// <p>The <code>RegexPatternSet</code> specifies the regular expression (regex) pattern that you want AWS WAF to search for, such as <code>B[a@]dB[o0]t</code>. You can then configure AWS WAF to reject those requests.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RegexPatternSet {
     /// <p>A friendly name or description of the <a>RegexPatternSet</a>. You can't change <code>Name</code> after you create a <code>RegexPatternSet</code>.</p>
     #[serde(rename = "Name")]
@@ -1526,7 +1526,7 @@ pub struct RegexPatternSet {
 }
 
 /// <p>Returned by <a>ListRegexPatternSets</a>. Each <code>RegexPatternSetSummary</code> object includes the <code>Name</code> and <code>RegexPatternSetId</code> for one <a>RegexPatternSet</a>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RegexPatternSetSummary {
     /// <p>A friendly name or description of the <a>RegexPatternSet</a>. You can't change <code>Name</code> after you create a <code>RegexPatternSet</code>.</p>
     #[serde(rename = "Name")]
@@ -1537,7 +1537,7 @@ pub struct RegexPatternSetSummary {
 }
 
 /// <p>In an <a>UpdateRegexPatternSet</a> request, <code>RegexPatternSetUpdate</code> specifies whether to insert or delete a <code>RegexPatternString</code> and includes the settings for the <code>RegexPatternString</code>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RegexPatternSetUpdate {
     /// <p>Specifies whether to insert or delete a <code>RegexPatternString</code>.</p>
     #[serde(rename = "Action")]
@@ -1548,7 +1548,7 @@ pub struct RegexPatternSetUpdate {
 }
 
 /// <p>A combination of <a>ByteMatchSet</a>, <a>IPSet</a>, and/or <a>SqlInjectionMatchSet</a> objects that identify the web requests that you want to allow, block, or count. For example, you might create a <code>Rule</code> that includes the following predicates:</p> <ul> <li> <p>An <code>IPSet</code> that causes AWS WAF to search for web requests that originate from the IP address <code>192.0.2.44</code> </p> </li> <li> <p>A <code>ByteMatchSet</code> that causes AWS WAF to search for web requests for which the value of the <code>User-Agent</code> header is <code>BadBot</code>.</p> </li> </ul> <p>To match the settings in this <code>Rule</code>, a request must originate from <code>192.0.2.44</code> AND include a <code>User-Agent</code> header for which the value is <code>BadBot</code>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Rule {
     /// <p>A friendly name or description for the metrics for this <code>Rule</code>. The name can contain only alphanumeric characters (A-Z, a-z, 0-9); the name can't contain whitespace. You can't change <code>MetricName</code> after you create the <code>Rule</code>.</p>
     #[serde(rename = "MetricName")]
@@ -1567,7 +1567,7 @@ pub struct Rule {
 }
 
 /// <p><p>A collection of predefined rules that you can add to a web ACL.</p> <p>Rule groups are subject to the following limits:</p> <ul> <li> <p>Three rule groups per account. You can request an increase to this limit by contacting customer support.</p> </li> <li> <p>One rule group per web ACL.</p> </li> <li> <p>Ten rules per rule group.</p> </li> </ul></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RuleGroup {
     /// <p>A friendly name or description for the metrics for this <code>RuleGroup</code>. The name can contain only alphanumeric characters (A-Z, a-z, 0-9); the name can't contain whitespace. You can't change the name of the metric after you create the <code>RuleGroup</code>.</p>
     #[serde(rename = "MetricName")]
@@ -1583,7 +1583,7 @@ pub struct RuleGroup {
 }
 
 /// <p>Contains the identifier and the friendly name or description of the <code>RuleGroup</code>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RuleGroupSummary {
     /// <p>A friendly name or description of the <a>RuleGroup</a>. You can't change the name of a <code>RuleGroup</code> after you create it.</p>
     #[serde(rename = "Name")]
@@ -1594,7 +1594,7 @@ pub struct RuleGroupSummary {
 }
 
 /// <p>Specifies an <code>ActivatedRule</code> and indicates whether you want to add it to a <code>RuleGroup</code> or delete it from a <code>RuleGroup</code>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RuleGroupUpdate {
     /// <p>Specify <code>INSERT</code> to add an <code>ActivatedRule</code> to a <code>RuleGroup</code>. Use <code>DELETE</code> to remove an <code>ActivatedRule</code> from a <code>RuleGroup</code>.</p>
     #[serde(rename = "Action")]
@@ -1605,7 +1605,7 @@ pub struct RuleGroupUpdate {
 }
 
 /// <p>Contains the identifier and the friendly name or description of the <code>Rule</code>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RuleSummary {
     /// <p>A friendly name or description of the <a>Rule</a>. You can't change the name of a <code>Rule</code> after you create it.</p>
     #[serde(rename = "Name")]
@@ -1616,7 +1616,7 @@ pub struct RuleSummary {
 }
 
 /// <p>Specifies a <code>Predicate</code> (such as an <code>IPSet</code>) and indicates whether you want to add it to a <code>Rule</code> or delete it from a <code>Rule</code>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RuleUpdate {
     /// <p>Specify <code>INSERT</code> to add a <code>Predicate</code> to a <code>Rule</code>. Use <code>DELETE</code> to remove a <code>Predicate</code> from a <code>Rule</code>.</p>
     #[serde(rename = "Action")]
@@ -1627,7 +1627,7 @@ pub struct RuleUpdate {
 }
 
 /// <p>The response from a <a>GetSampledRequests</a> request includes a <code>SampledHTTPRequests</code> complex type that appears as <code>SampledRequests</code> in the response syntax. <code>SampledHTTPRequests</code> contains one <code>SampledHTTPRequest</code> object for each web request that is returned by <code>GetSampledRequests</code>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SampledHTTPRequest {
     /// <p>The action for the <code>Rule</code> that the request matched: <code>ALLOW</code>, <code>BLOCK</code>, or <code>COUNT</code>.</p>
     #[serde(rename = "Action")]
@@ -1650,7 +1650,7 @@ pub struct SampledHTTPRequest {
 }
 
 /// <p>Specifies a constraint on the size of a part of the web request. AWS WAF uses the <code>Size</code>, <code>ComparisonOperator</code>, and <code>FieldToMatch</code> to build an expression in the form of "<code>Size</code> <code>ComparisonOperator</code> size in bytes of <code>FieldToMatch</code>". If that expression is true, the <code>SizeConstraint</code> is considered to match.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SizeConstraint {
     /// <p>The type of comparison you want AWS WAF to perform. AWS WAF uses this in combination with the provided <code>Size</code> and <code>FieldToMatch</code> to build an expression in the form of "<code>Size</code> <code>ComparisonOperator</code> size in bytes of <code>FieldToMatch</code>". If that expression is true, the <code>SizeConstraint</code> is considered to match.</p> <p> <b>EQ</b>: Used to test if the <code>Size</code> is equal to the size of the <code>FieldToMatch</code> </p> <p> <b>NE</b>: Used to test if the <code>Size</code> is not equal to the size of the <code>FieldToMatch</code> </p> <p> <b>LE</b>: Used to test if the <code>Size</code> is less than or equal to the size of the <code>FieldToMatch</code> </p> <p> <b>LT</b>: Used to test if the <code>Size</code> is strictly less than the size of the <code>FieldToMatch</code> </p> <p> <b>GE</b>: Used to test if the <code>Size</code> is greater than or equal to the size of the <code>FieldToMatch</code> </p> <p> <b>GT</b>: Used to test if the <code>Size</code> is strictly greater than the size of the <code>FieldToMatch</code> </p>
     #[serde(rename = "ComparisonOperator")]
@@ -1667,7 +1667,7 @@ pub struct SizeConstraint {
 }
 
 /// <p>A complex type that contains <code>SizeConstraint</code> objects, which specify the parts of web requests that you want AWS WAF to inspect the size of. If a <code>SizeConstraintSet</code> contains more than one <code>SizeConstraint</code> object, a request only needs to match one constraint to be considered a match.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SizeConstraintSet {
     /// <p>The name, if any, of the <code>SizeConstraintSet</code>.</p>
     #[serde(rename = "Name")]
@@ -1682,7 +1682,7 @@ pub struct SizeConstraintSet {
 }
 
 /// <p>The <code>Id</code> and <code>Name</code> of a <code>SizeConstraintSet</code>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SizeConstraintSetSummary {
     /// <p>The name of the <code>SizeConstraintSet</code>, if any.</p>
     #[serde(rename = "Name")]
@@ -1693,7 +1693,7 @@ pub struct SizeConstraintSetSummary {
 }
 
 /// <p>Specifies the part of a web request that you want to inspect the size of and indicates whether you want to add the specification to a <a>SizeConstraintSet</a> or delete it from a <code>SizeConstraintSet</code>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SizeConstraintSetUpdate {
     /// <p>Specify <code>INSERT</code> to add a <a>SizeConstraintSetUpdate</a> to a <a>SizeConstraintSet</a>. Use <code>DELETE</code> to remove a <code>SizeConstraintSetUpdate</code> from a <code>SizeConstraintSet</code>.</p>
     #[serde(rename = "Action")]
@@ -1704,7 +1704,7 @@ pub struct SizeConstraintSetUpdate {
 }
 
 /// <p>A complex type that contains <code>SqlInjectionMatchTuple</code> objects, which specify the parts of web requests that you want AWS WAF to inspect for snippets of malicious SQL code and, if you want AWS WAF to inspect a header, the name of the header. If a <code>SqlInjectionMatchSet</code> contains more than one <code>SqlInjectionMatchTuple</code> object, a request needs to include snippets of SQL code in only one of the specified parts of the request to be considered a match.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SqlInjectionMatchSet {
     /// <p>The name, if any, of the <code>SqlInjectionMatchSet</code>.</p>
     #[serde(rename = "Name")]
@@ -1719,7 +1719,7 @@ pub struct SqlInjectionMatchSet {
 }
 
 /// <p>The <code>Id</code> and <code>Name</code> of a <code>SqlInjectionMatchSet</code>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SqlInjectionMatchSetSummary {
     /// <p>The name of the <code>SqlInjectionMatchSet</code>, if any, specified by <code>Id</code>.</p>
     #[serde(rename = "Name")]
@@ -1730,7 +1730,7 @@ pub struct SqlInjectionMatchSetSummary {
 }
 
 /// <p>Specifies the part of a web request that you want to inspect for snippets of malicious SQL code and indicates whether you want to add the specification to a <a>SqlInjectionMatchSet</a> or delete it from a <code>SqlInjectionMatchSet</code>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SqlInjectionMatchSetUpdate {
     /// <p>Specify <code>INSERT</code> to add a <a>SqlInjectionMatchSetUpdate</a> to a <a>SqlInjectionMatchSet</a>. Use <code>DELETE</code> to remove a <code>SqlInjectionMatchSetUpdate</code> from a <code>SqlInjectionMatchSet</code>.</p>
     #[serde(rename = "Action")]
@@ -1741,7 +1741,7 @@ pub struct SqlInjectionMatchSetUpdate {
 }
 
 /// <p>Specifies the part of a web request that you want AWS WAF to inspect for snippets of malicious SQL code and, if you want AWS WAF to inspect a header, the name of the header.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SqlInjectionMatchTuple {
     /// <p>Specifies where in a web request to look for snippets of malicious SQL code.</p>
     #[serde(rename = "FieldToMatch")]
@@ -1752,7 +1752,7 @@ pub struct SqlInjectionMatchTuple {
 }
 
 /// <p>A summary of the rule groups you are subscribed to.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct SubscribedRuleGroupSummary {
     /// <p>A friendly name or description for the metrics for this <code>RuleGroup</code>. The name can contain only alphanumeric characters (A-Z, a-z, 0-9); the name can't contain whitespace. You can't change the name of the metric after you create the <code>RuleGroup</code>.</p>
     #[serde(rename = "MetricName")]
@@ -1766,7 +1766,7 @@ pub struct SubscribedRuleGroupSummary {
 }
 
 /// <p>In a <a>GetSampledRequests</a> request, the <code>StartTime</code> and <code>EndTime</code> objects specify the time range for which you want AWS WAF to return a sample of web requests.</p> <p>In a <a>GetSampledRequests</a> response, the <code>StartTime</code> and <code>EndTime</code> objects specify the time range for which AWS WAF actually returned a sample of web requests. AWS WAF gets the specified number of requests from among the first 5,000 requests that your AWS resource receives during the specified time period. If your resource receives more than 5,000 requests during that period, AWS WAF stops sampling after the 5,000th request. In that case, <code>EndTime</code> is the time that AWS WAF received the 5,000th request. </p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TimeWindow {
     /// <p>The end of the time range from which you want <code>GetSampledRequests</code> to return a sample of the requests that your AWS resource received. Specify the date and time in the following format: <code>"2016-09-27T14:50Z"</code>. You can specify any time range in the previous three hours.</p>
     #[serde(rename = "EndTime")]
@@ -1776,7 +1776,7 @@ pub struct TimeWindow {
     pub start_time: f64,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateByteMatchSetRequest {
     /// <p>The <code>ByteMatchSetId</code> of the <a>ByteMatchSet</a> that you want to update. <code>ByteMatchSetId</code> is returned by <a>CreateByteMatchSet</a> and by <a>ListByteMatchSets</a>.</p>
     #[serde(rename = "ByteMatchSetId")]
@@ -1789,7 +1789,7 @@ pub struct UpdateByteMatchSetRequest {
     pub updates: Vec<ByteMatchSetUpdate>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateByteMatchSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>UpdateByteMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -1797,7 +1797,7 @@ pub struct UpdateByteMatchSetResponse {
     pub change_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateGeoMatchSetRequest {
     /// <p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -1810,7 +1810,7 @@ pub struct UpdateGeoMatchSetRequest {
     pub updates: Vec<GeoMatchSetUpdate>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateGeoMatchSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>UpdateGeoMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -1818,7 +1818,7 @@ pub struct UpdateGeoMatchSetResponse {
     pub change_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateIPSetRequest {
     /// <p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -1831,7 +1831,7 @@ pub struct UpdateIPSetRequest {
     pub updates: Vec<IPSetUpdate>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateIPSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>UpdateIPSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -1839,7 +1839,7 @@ pub struct UpdateIPSetResponse {
     pub change_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateRateBasedRuleRequest {
     /// <p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -1855,7 +1855,7 @@ pub struct UpdateRateBasedRuleRequest {
     pub updates: Vec<RuleUpdate>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateRateBasedRuleResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>UpdateRateBasedRule</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -1863,7 +1863,7 @@ pub struct UpdateRateBasedRuleResponse {
     pub change_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateRegexMatchSetRequest {
     /// <p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -1876,7 +1876,7 @@ pub struct UpdateRegexMatchSetRequest {
     pub updates: Vec<RegexMatchSetUpdate>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateRegexMatchSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>UpdateRegexMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -1884,7 +1884,7 @@ pub struct UpdateRegexMatchSetResponse {
     pub change_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateRegexPatternSetRequest {
     /// <p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -1897,7 +1897,7 @@ pub struct UpdateRegexPatternSetRequest {
     pub updates: Vec<RegexPatternSetUpdate>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateRegexPatternSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>UpdateRegexPatternSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -1905,7 +1905,7 @@ pub struct UpdateRegexPatternSetResponse {
     pub change_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateRuleGroupRequest {
     /// <p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -1918,7 +1918,7 @@ pub struct UpdateRuleGroupRequest {
     pub updates: Vec<RuleGroupUpdate>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateRuleGroupResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>UpdateRuleGroup</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -1926,7 +1926,7 @@ pub struct UpdateRuleGroupResponse {
     pub change_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateRuleRequest {
     /// <p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -1939,7 +1939,7 @@ pub struct UpdateRuleRequest {
     pub updates: Vec<RuleUpdate>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateRuleResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>UpdateRule</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -1947,7 +1947,7 @@ pub struct UpdateRuleResponse {
     pub change_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateSizeConstraintSetRequest {
     /// <p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -1960,7 +1960,7 @@ pub struct UpdateSizeConstraintSetRequest {
     pub updates: Vec<SizeConstraintSetUpdate>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateSizeConstraintSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>UpdateSizeConstraintSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -1969,7 +1969,7 @@ pub struct UpdateSizeConstraintSetResponse {
 }
 
 /// <p>A request to update a <a>SqlInjectionMatchSet</a>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateSqlInjectionMatchSetRequest {
     /// <p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -1983,7 +1983,7 @@ pub struct UpdateSqlInjectionMatchSetRequest {
 }
 
 /// <p>The response to an <a>UpdateSqlInjectionMatchSets</a> request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateSqlInjectionMatchSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>UpdateSqlInjectionMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -1991,7 +1991,7 @@ pub struct UpdateSqlInjectionMatchSetResponse {
     pub change_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateWebACLRequest {
     /// <p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -2009,7 +2009,7 @@ pub struct UpdateWebACLRequest {
     pub web_acl_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateWebACLResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>UpdateWebACL</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -2018,7 +2018,7 @@ pub struct UpdateWebACLResponse {
 }
 
 /// <p>A request to update an <a>XssMatchSet</a>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateXssMatchSetRequest {
     /// <p>The value returned by the most recent call to <a>GetChangeToken</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -2032,7 +2032,7 @@ pub struct UpdateXssMatchSetRequest {
 }
 
 /// <p>The response to an <a>UpdateXssMatchSets</a> request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateXssMatchSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>UpdateXssMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -2041,7 +2041,7 @@ pub struct UpdateXssMatchSetResponse {
 }
 
 /// <p>For the action that is associated with a rule in a <code>WebACL</code>, specifies the action that you want AWS WAF to perform when a web request matches all of the conditions in a rule. For the default action in a <code>WebACL</code>, specifies the action that you want AWS WAF to take when a web request doesn't match all of the conditions in any of the rules in a <code>WebACL</code>. </p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct WafAction {
     /// <p><p>Specifies how you want AWS WAF to respond to requests that match the settings in a <code>Rule</code>. Valid settings include the following:</p> <ul> <li> <p> <code>ALLOW</code>: AWS WAF allows requests</p> </li> <li> <p> <code>BLOCK</code>: AWS WAF blocks requests</p> </li> <li> <p> <code>COUNT</code>: AWS WAF increments a counter of the requests that match all of the conditions in the rule. AWS WAF then continues to inspect the web request based on the remaining rules in the web ACL. You can&#39;t specify <code>COUNT</code> for the default action for a <code>WebACL</code>.</p> </li> </ul></p>
     #[serde(rename = "Type")]
@@ -2049,7 +2049,7 @@ pub struct WafAction {
 }
 
 /// <p>The action to take if any rule within the <code>RuleGroup</code> matches a request. </p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct WafOverrideAction {
     /// <p> <code>COUNT</code> overrides the action specified by the individual rule within a <code>RuleGroup</code> . If set to <code>NONE</code>, the rule's action will take place.</p>
     #[serde(rename = "Type")]
@@ -2057,7 +2057,7 @@ pub struct WafOverrideAction {
 }
 
 /// <p>Contains the <code>Rules</code> that identify the requests that you want to allow, block, or count. In a <code>WebACL</code>, you also specify a default action (<code>ALLOW</code> or <code>BLOCK</code>), and the action for each <code>Rule</code> that you add to a <code>WebACL</code>, for example, block requests from specified IP addresses or block requests from specified referrers. You also associate the <code>WebACL</code> with a CloudFront distribution to identify the requests that you want AWS WAF to filter. If you add more than one <code>Rule</code> to a <code>WebACL</code>, a request needs to match only one of the specifications to be allowed, blocked, or counted. For more information, see <a>UpdateWebACL</a>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct WebACL {
     /// <p>The action to perform if none of the <code>Rules</code> contained in the <code>WebACL</code> match. The action is specified by the <a>WafAction</a> object.</p>
     #[serde(rename = "DefaultAction")]
@@ -2079,7 +2079,7 @@ pub struct WebACL {
 }
 
 /// <p>Contains the identifier and the name or description of the <a>WebACL</a>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct WebACLSummary {
     /// <p>A friendly name or description of the <a>WebACL</a>. You can't change the name of a <code>WebACL</code> after you create it.</p>
     #[serde(rename = "Name")]
@@ -2090,7 +2090,7 @@ pub struct WebACLSummary {
 }
 
 /// <p>Specifies whether to insert a <code>Rule</code> into or delete a <code>Rule</code> from a <code>WebACL</code>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct WebACLUpdate {
     /// <p>Specifies whether to insert a <code>Rule</code> into or delete a <code>Rule</code> from a <code>WebACL</code>.</p>
     #[serde(rename = "Action")]
@@ -2101,7 +2101,7 @@ pub struct WebACLUpdate {
 }
 
 /// <p>A complex type that contains <code>XssMatchTuple</code> objects, which specify the parts of web requests that you want AWS WAF to inspect for cross-site scripting attacks and, if you want AWS WAF to inspect a header, the name of the header. If a <code>XssMatchSet</code> contains more than one <code>XssMatchTuple</code> object, a request needs to include cross-site scripting attacks in only one of the specified parts of the request to be considered a match.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct XssMatchSet {
     /// <p>The name, if any, of the <code>XssMatchSet</code>.</p>
     #[serde(rename = "Name")]
@@ -2116,7 +2116,7 @@ pub struct XssMatchSet {
 }
 
 /// <p>The <code>Id</code> and <code>Name</code> of an <code>XssMatchSet</code>.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct XssMatchSetSummary {
     /// <p>The name of the <code>XssMatchSet</code>, if any, specified by <code>Id</code>.</p>
     #[serde(rename = "Name")]
@@ -2127,7 +2127,7 @@ pub struct XssMatchSetSummary {
 }
 
 /// <p>Specifies the part of a web request that you want to inspect for cross-site scripting attacks and indicates whether you want to add the specification to an <a>XssMatchSet</a> or delete it from an <code>XssMatchSet</code>.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct XssMatchSetUpdate {
     /// <p>Specify <code>INSERT</code> to add a <a>XssMatchSetUpdate</a> to an <a>XssMatchSet</a>. Use <code>DELETE</code> to remove a <code>XssMatchSetUpdate</code> from an <code>XssMatchSet</code>.</p>
     #[serde(rename = "Action")]
@@ -2138,7 +2138,7 @@ pub struct XssMatchSetUpdate {
 }
 
 /// <p>Specifies the part of a web request that you want AWS WAF to inspect for cross-site scripting attacks and, if you want AWS WAF to inspect a header, the name of the header.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct XssMatchTuple {
     /// <p>Specifies where in a web request to look for cross-site scripting attacks.</p>
     #[serde(rename = "FieldToMatch")]

--- a/rusoto/services/workdocs/src/generated.rs
+++ b/rusoto/services/workdocs/src/generated.rs
@@ -30,7 +30,7 @@ use rusoto_core::signature::SignedRequest;
 use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AbortDocumentVersionUploadRequest {
     /// <p>Amazon WorkDocs authentication token. Do not set this field when using administrative API actions, as in accessing the API using AWS credentials.</p>
     #[serde(rename = "AuthenticationToken")]
@@ -44,7 +44,7 @@ pub struct AbortDocumentVersionUploadRequest {
     pub version_id: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ActivateUserRequest {
     /// <p>Amazon WorkDocs authentication token. Do not set this field when using administrative API actions, as in accessing the API using AWS credentials.</p>
     #[serde(rename = "AuthenticationToken")]
@@ -55,7 +55,7 @@ pub struct ActivateUserRequest {
     pub user_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ActivateUserResponse {
     /// <p>The user information.</p>
     #[serde(rename = "User")]
@@ -64,7 +64,7 @@ pub struct ActivateUserResponse {
 }
 
 /// <p>Describes the activity information.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Activity {
     /// <p>Metadata of the commenting activity. This is an optional field and is filled for commenting activities.</p>
     #[serde(rename = "CommentMetadata")]
@@ -100,7 +100,7 @@ pub struct Activity {
     pub type_: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct AddResourcePermissionsRequest {
     /// <p>Amazon WorkDocs authentication token. Do not set this field when using administrative API actions, as in accessing the API using AWS credentials.</p>
     #[serde(rename = "AuthenticationToken")]
@@ -118,7 +118,7 @@ pub struct AddResourcePermissionsRequest {
     pub resource_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AddResourcePermissionsResponse {
     /// <p>The share results.</p>
     #[serde(rename = "ShareResults")]
@@ -127,7 +127,7 @@ pub struct AddResourcePermissionsResponse {
 }
 
 /// <p>Describes a comment.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Comment {
     /// <p>The ID of the comment.</p>
     #[serde(rename = "CommentId")]
@@ -167,7 +167,7 @@ pub struct Comment {
 }
 
 /// <p>Describes the metadata of a comment.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CommentMetadata {
     /// <p>The ID of the comment.</p>
     #[serde(rename = "CommentId")]
@@ -191,7 +191,7 @@ pub struct CommentMetadata {
     pub recipient_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateCommentRequest {
     /// <p>Amazon WorkDocs authentication token. Do not set this field when using administrative API actions, as in accessing the API using AWS credentials.</p>
     #[serde(rename = "AuthenticationToken")]
@@ -224,7 +224,7 @@ pub struct CreateCommentRequest {
     pub visibility: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateCommentResponse {
     /// <p>The comment that has been created.</p>
     #[serde(rename = "Comment")]
@@ -232,7 +232,7 @@ pub struct CreateCommentResponse {
     pub comment: Option<Comment>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateCustomMetadataRequest {
     /// <p>Amazon WorkDocs authentication token. Do not set this field when using administrative API actions, as in accessing the API using AWS credentials.</p>
     #[serde(rename = "AuthenticationToken")]
@@ -250,10 +250,10 @@ pub struct CreateCustomMetadataRequest {
     pub version_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateCustomMetadataResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateFolderRequest {
     /// <p>Amazon WorkDocs authentication token. Do not set this field when using administrative API actions, as in accessing the API using AWS credentials.</p>
     #[serde(rename = "AuthenticationToken")]
@@ -268,7 +268,7 @@ pub struct CreateFolderRequest {
     pub parent_folder_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateFolderResponse {
     /// <p>The metadata of the folder.</p>
     #[serde(rename = "Metadata")]
@@ -276,7 +276,7 @@ pub struct CreateFolderResponse {
     pub metadata: Option<FolderMetadata>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateLabelsRequest {
     /// <p>Amazon WorkDocs authentication token. Do not set this field when using administrative API actions, as in accessing the API using AWS credentials.</p>
     #[serde(rename = "AuthenticationToken")]
@@ -290,10 +290,10 @@ pub struct CreateLabelsRequest {
     pub resource_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateLabelsResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateNotificationSubscriptionRequest {
     /// <p>The endpoint to receive the notifications. If the protocol is HTTPS, the endpoint is a URL that begins with "https://".</p>
     #[serde(rename = "Endpoint")]
@@ -309,7 +309,7 @@ pub struct CreateNotificationSubscriptionRequest {
     pub subscription_type: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateNotificationSubscriptionResponse {
     /// <p>The subscription.</p>
     #[serde(rename = "Subscription")]
@@ -317,7 +317,7 @@ pub struct CreateNotificationSubscriptionResponse {
     pub subscription: Option<Subscription>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateUserRequest {
     /// <p>Amazon WorkDocs authentication token. Do not set this field when using administrative API actions, as in accessing the API using AWS credentials.</p>
     #[serde(rename = "AuthenticationToken")]
@@ -353,7 +353,7 @@ pub struct CreateUserRequest {
     pub username: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateUserResponse {
     /// <p>The user information.</p>
     #[serde(rename = "User")]
@@ -361,7 +361,7 @@ pub struct CreateUserResponse {
     pub user: Option<User>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeactivateUserRequest {
     /// <p>Amazon WorkDocs authentication token. Do not set this field when using administrative API actions, as in accessing the API using AWS credentials.</p>
     #[serde(rename = "AuthenticationToken")]
@@ -372,7 +372,7 @@ pub struct DeactivateUserRequest {
     pub user_id: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteCommentRequest {
     /// <p>Amazon WorkDocs authentication token. Do not set this field when using administrative API actions, as in accessing the API using AWS credentials.</p>
     #[serde(rename = "AuthenticationToken")]
@@ -389,7 +389,7 @@ pub struct DeleteCommentRequest {
     pub version_id: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteCustomMetadataRequest {
     /// <p>Amazon WorkDocs authentication token. Do not set this field when using administrative API actions, as in accessing the API using AWS credentials.</p>
     #[serde(rename = "AuthenticationToken")]
@@ -412,10 +412,10 @@ pub struct DeleteCustomMetadataRequest {
     pub version_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteCustomMetadataResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteDocumentRequest {
     /// <p>Amazon WorkDocs authentication token. Do not set this field when using administrative API actions, as in accessing the API using AWS credentials.</p>
     #[serde(rename = "AuthenticationToken")]
@@ -426,7 +426,7 @@ pub struct DeleteDocumentRequest {
     pub document_id: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteFolderContentsRequest {
     /// <p>Amazon WorkDocs authentication token. Do not set this field when using administrative API actions, as in accessing the API using AWS credentials.</p>
     #[serde(rename = "AuthenticationToken")]
@@ -437,7 +437,7 @@ pub struct DeleteFolderContentsRequest {
     pub folder_id: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteFolderRequest {
     /// <p>Amazon WorkDocs authentication token. Do not set this field when using administrative API actions, as in accessing the API using AWS credentials.</p>
     #[serde(rename = "AuthenticationToken")]
@@ -448,7 +448,7 @@ pub struct DeleteFolderRequest {
     pub folder_id: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteLabelsRequest {
     /// <p>Amazon WorkDocs authentication token. Do not set this field when using administrative API actions, as in accessing the API using AWS credentials.</p>
     #[serde(rename = "AuthenticationToken")]
@@ -467,10 +467,10 @@ pub struct DeleteLabelsRequest {
     pub resource_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteLabelsResponse {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteNotificationSubscriptionRequest {
     /// <p>The ID of the organization.</p>
     #[serde(rename = "OrganizationId")]
@@ -480,7 +480,7 @@ pub struct DeleteNotificationSubscriptionRequest {
     pub subscription_id: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteUserRequest {
     /// <p>Amazon WorkDocs authentication token. Do not set this field when using administrative API actions, as in accessing the API using AWS credentials.</p>
     #[serde(rename = "AuthenticationToken")]
@@ -491,7 +491,7 @@ pub struct DeleteUserRequest {
     pub user_id: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeActivitiesRequest {
     /// <p>Amazon WorkDocs authentication token. Do not set this field when using administrative API actions, as in accessing the API using AWS credentials.</p>
     #[serde(rename = "AuthenticationToken")]
@@ -523,7 +523,7 @@ pub struct DescribeActivitiesRequest {
     pub user_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeActivitiesResponse {
     /// <p>The marker for the next set of results.</p>
     #[serde(rename = "Marker")]
@@ -535,7 +535,7 @@ pub struct DescribeActivitiesResponse {
     pub user_activities: Option<Vec<Activity>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeCommentsRequest {
     /// <p>Amazon WorkDocs authentication token. Do not set this field when using administrative API actions, as in accessing the API using AWS credentials.</p>
     #[serde(rename = "AuthenticationToken")]
@@ -557,7 +557,7 @@ pub struct DescribeCommentsRequest {
     pub version_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeCommentsResponse {
     /// <p>The list of comments for the specified document version.</p>
     #[serde(rename = "Comments")]
@@ -569,7 +569,7 @@ pub struct DescribeCommentsResponse {
     pub marker: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeDocumentVersionsRequest {
     /// <p>Amazon WorkDocs authentication token. Do not set this field when using administrative API actions, as in accessing the API using AWS credentials.</p>
     #[serde(rename = "AuthenticationToken")]
@@ -596,7 +596,7 @@ pub struct DescribeDocumentVersionsRequest {
     pub marker: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeDocumentVersionsResponse {
     /// <p>The document versions.</p>
     #[serde(rename = "DocumentVersions")]
@@ -608,7 +608,7 @@ pub struct DescribeDocumentVersionsResponse {
     pub marker: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeFolderContentsRequest {
     /// <p>Amazon WorkDocs authentication token. Do not set this field when using administrative API actions, as in accessing the API using AWS credentials.</p>
     #[serde(rename = "AuthenticationToken")]
@@ -643,7 +643,7 @@ pub struct DescribeFolderContentsRequest {
     pub type_: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeFolderContentsResponse {
     /// <p>The documents in the specified folder.</p>
     #[serde(rename = "Documents")]
@@ -659,7 +659,7 @@ pub struct DescribeFolderContentsResponse {
     pub marker: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeGroupsRequest {
     /// <p>Amazon WorkDocs authentication token. Do not set this field when using administrative API actions, as in accessing the API using AWS credentials.</p>
     #[serde(rename = "AuthenticationToken")]
@@ -682,7 +682,7 @@ pub struct DescribeGroupsRequest {
     pub search_query: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeGroupsResponse {
     /// <p>The list of groups.</p>
     #[serde(rename = "Groups")]
@@ -694,7 +694,7 @@ pub struct DescribeGroupsResponse {
     pub marker: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeNotificationSubscriptionsRequest {
     /// <p>The maximum number of items to return with this call.</p>
     #[serde(rename = "Limit")]
@@ -709,7 +709,7 @@ pub struct DescribeNotificationSubscriptionsRequest {
     pub organization_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeNotificationSubscriptionsResponse {
     /// <p>The marker to use when requesting the next set of results. If there are no additional results, the string is empty.</p>
     #[serde(rename = "Marker")]
@@ -721,7 +721,7 @@ pub struct DescribeNotificationSubscriptionsResponse {
     pub subscriptions: Option<Vec<Subscription>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeResourcePermissionsRequest {
     /// <p>Amazon WorkDocs authentication token. Do not set this field when using administrative API actions, as in accessing the API using AWS credentials.</p>
     #[serde(rename = "AuthenticationToken")]
@@ -744,7 +744,7 @@ pub struct DescribeResourcePermissionsRequest {
     pub resource_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeResourcePermissionsResponse {
     /// <p>The marker to use when requesting the next set of results. If there are no additional results, the string is empty.</p>
     #[serde(rename = "Marker")]
@@ -756,7 +756,7 @@ pub struct DescribeResourcePermissionsResponse {
     pub principals: Option<Vec<Principal>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeRootFoldersRequest {
     /// <p>Amazon WorkDocs authentication token. Do not set this field when using administrative API actions, as in accessing the API using AWS credentials.</p>
     #[serde(rename = "AuthenticationToken")]
@@ -771,7 +771,7 @@ pub struct DescribeRootFoldersRequest {
     pub marker: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeRootFoldersResponse {
     /// <p>The user's special folders.</p>
     #[serde(rename = "Folders")]
@@ -783,7 +783,7 @@ pub struct DescribeRootFoldersResponse {
     pub marker: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeUsersRequest {
     /// <p>Amazon WorkDocs authentication token. Do not set this field when using administrative API actions, as in accessing the API using AWS credentials.</p>
     #[serde(rename = "AuthenticationToken")]
@@ -827,7 +827,7 @@ pub struct DescribeUsersRequest {
     pub user_ids: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeUsersResponse {
     /// <p>The marker to use when requesting the next set of results. If there are no additional results, the string is empty.</p>
     #[serde(rename = "Marker")]
@@ -840,7 +840,7 @@ pub struct DescribeUsersResponse {
 }
 
 /// <p>Describes the document.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DocumentMetadata {
     /// <p>The time when the document was created.</p>
     #[serde(rename = "CreatedTimestamp")]
@@ -877,7 +877,7 @@ pub struct DocumentMetadata {
 }
 
 /// <p>Describes a version of a document.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DocumentVersionMetadata {
     /// <p>The timestamp when the content of the document was originally created.</p>
     #[serde(rename = "ContentCreatedTimestamp")]
@@ -934,7 +934,7 @@ pub struct DocumentVersionMetadata {
 }
 
 /// <p>Describes a folder.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct FolderMetadata {
     /// <p>The time when the folder was created.</p>
     #[serde(rename = "CreatedTimestamp")]
@@ -982,14 +982,14 @@ pub struct FolderMetadata {
     pub size: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetCurrentUserRequest {
     /// <p>Amazon WorkDocs authentication token. Do not set this field when using administrative API actions, as in accessing the API using AWS credentials.</p>
     #[serde(rename = "AuthenticationToken")]
     pub authentication_token: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetCurrentUserResponse {
     /// <p>Metadata of the user.</p>
     #[serde(rename = "User")]
@@ -997,7 +997,7 @@ pub struct GetCurrentUserResponse {
     pub user: Option<User>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetDocumentPathRequest {
     /// <p>Amazon WorkDocs authentication token. Do not set this field when using administrative API actions, as in accessing the API using AWS credentials.</p>
     #[serde(rename = "AuthenticationToken")]
@@ -1020,7 +1020,7 @@ pub struct GetDocumentPathRequest {
     pub marker: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetDocumentPathResponse {
     /// <p>The path information.</p>
     #[serde(rename = "Path")]
@@ -1028,7 +1028,7 @@ pub struct GetDocumentPathResponse {
     pub path: Option<ResourcePath>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetDocumentRequest {
     /// <p>Amazon WorkDocs authentication token. Do not set this field when using administrative API actions, as in accessing the API using AWS credentials.</p>
     #[serde(rename = "AuthenticationToken")]
@@ -1043,7 +1043,7 @@ pub struct GetDocumentRequest {
     pub include_custom_metadata: Option<bool>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetDocumentResponse {
     /// <p>The custom metadata on the document.</p>
     #[serde(rename = "CustomMetadata")]
@@ -1055,7 +1055,7 @@ pub struct GetDocumentResponse {
     pub metadata: Option<DocumentMetadata>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetDocumentVersionRequest {
     /// <p>Amazon WorkDocs authentication token. Do not set this field when using administrative API actions, as in accessing the API using AWS credentials.</p>
     #[serde(rename = "AuthenticationToken")]
@@ -1077,7 +1077,7 @@ pub struct GetDocumentVersionRequest {
     pub version_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetDocumentVersionResponse {
     /// <p>The custom metadata on the document version.</p>
     #[serde(rename = "CustomMetadata")]
@@ -1089,7 +1089,7 @@ pub struct GetDocumentVersionResponse {
     pub metadata: Option<DocumentVersionMetadata>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetFolderPathRequest {
     /// <p>Amazon WorkDocs authentication token. Do not set this field when using administrative API actions, as in accessing the API using AWS credentials.</p>
     #[serde(rename = "AuthenticationToken")]
@@ -1112,7 +1112,7 @@ pub struct GetFolderPathRequest {
     pub marker: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetFolderPathResponse {
     /// <p>The path information.</p>
     #[serde(rename = "Path")]
@@ -1120,7 +1120,7 @@ pub struct GetFolderPathResponse {
     pub path: Option<ResourcePath>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetFolderRequest {
     /// <p>Amazon WorkDocs authentication token. Do not set this field when using administrative API actions, as in accessing the API using AWS credentials.</p>
     #[serde(rename = "AuthenticationToken")]
@@ -1135,7 +1135,7 @@ pub struct GetFolderRequest {
     pub include_custom_metadata: Option<bool>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetFolderResponse {
     /// <p>The custom metadata on the folder.</p>
     #[serde(rename = "CustomMetadata")]
@@ -1148,7 +1148,7 @@ pub struct GetFolderResponse {
 }
 
 /// <p>Describes the metadata of a user group.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GroupMetadata {
     /// <p>The ID of the user group.</p>
     #[serde(rename = "Id")]
@@ -1160,7 +1160,7 @@ pub struct GroupMetadata {
     pub name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct InitiateDocumentVersionUploadRequest {
     /// <p>Amazon WorkDocs authentication token. Do not set this field when using administrative API actions, as in accessing the API using AWS credentials.</p>
     #[serde(rename = "AuthenticationToken")]
@@ -1195,7 +1195,7 @@ pub struct InitiateDocumentVersionUploadRequest {
     pub parent_folder_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct InitiateDocumentVersionUploadResponse {
     /// <p>The document metadata.</p>
     #[serde(rename = "Metadata")]
@@ -1208,7 +1208,7 @@ pub struct InitiateDocumentVersionUploadResponse {
 }
 
 /// <p>Set of options which defines notification preferences of given action.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct NotificationOptions {
     /// <p>Text value to be included in the email body.</p>
     #[serde(rename = "EmailMessage")]
@@ -1221,7 +1221,7 @@ pub struct NotificationOptions {
 }
 
 /// <p>Describes the users or user groups.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Participants {
     /// <p>The list of user groups.</p>
     #[serde(rename = "Groups")]
@@ -1234,7 +1234,7 @@ pub struct Participants {
 }
 
 /// <p>Describes the permissions.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PermissionInfo {
     /// <p>The role of the user.</p>
     #[serde(rename = "Role")]
@@ -1247,7 +1247,7 @@ pub struct PermissionInfo {
 }
 
 /// <p>Describes a resource.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Principal {
     /// <p>The ID of the resource.</p>
     #[serde(rename = "Id")]
@@ -1263,7 +1263,7 @@ pub struct Principal {
     pub type_: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RemoveAllResourcePermissionsRequest {
     /// <p>Amazon WorkDocs authentication token. Do not set this field when using administrative API actions, as in accessing the API using AWS credentials.</p>
     #[serde(rename = "AuthenticationToken")]
@@ -1274,7 +1274,7 @@ pub struct RemoveAllResourcePermissionsRequest {
     pub resource_id: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RemoveResourcePermissionRequest {
     /// <p>Amazon WorkDocs authentication token. Do not set this field when using administrative API actions, as in accessing the API using AWS credentials.</p>
     #[serde(rename = "AuthenticationToken")]
@@ -1293,7 +1293,7 @@ pub struct RemoveResourcePermissionRequest {
 }
 
 /// <p>Describes the metadata of a resource.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ResourceMetadata {
     /// <p>The ID of the resource.</p>
     #[serde(rename = "Id")]
@@ -1326,7 +1326,7 @@ pub struct ResourceMetadata {
 }
 
 /// <p>Describes the path information of a resource.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ResourcePath {
     /// <p>The components of the resource path.</p>
     #[serde(rename = "Components")]
@@ -1335,7 +1335,7 @@ pub struct ResourcePath {
 }
 
 /// <p>Describes the resource path.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ResourcePathComponent {
     /// <p>The ID of the resource path.</p>
     #[serde(rename = "Id")]
@@ -1348,7 +1348,7 @@ pub struct ResourcePathComponent {
 }
 
 /// <p>Describes the recipient type and ID, if available.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct SharePrincipal {
     /// <p>The ID of the recipient.</p>
     #[serde(rename = "Id")]
@@ -1362,7 +1362,7 @@ pub struct SharePrincipal {
 }
 
 /// <p>Describes the share results of a resource.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ShareResult {
     /// <p>The ID of the principal.</p>
     #[serde(rename = "PrincipalId")]
@@ -1387,7 +1387,7 @@ pub struct ShareResult {
 }
 
 /// <p>Describes the storage for a user.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct StorageRuleType {
     /// <p>The amount of storage allocated, in bytes.</p>
     #[serde(rename = "StorageAllocatedInBytes")]
@@ -1400,7 +1400,7 @@ pub struct StorageRuleType {
 }
 
 /// <p>Describes a subscription.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Subscription {
     /// <p>The endpoint of the subscription.</p>
     #[serde(rename = "EndPoint")]
@@ -1416,7 +1416,7 @@ pub struct Subscription {
     pub subscription_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateDocumentRequest {
     /// <p>Amazon WorkDocs authentication token. Do not set this field when using administrative API actions, as in accessing the API using AWS credentials.</p>
     #[serde(rename = "AuthenticationToken")]
@@ -1439,7 +1439,7 @@ pub struct UpdateDocumentRequest {
     pub resource_state: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateDocumentVersionRequest {
     /// <p>Amazon WorkDocs authentication token. Do not set this field when using administrative API actions, as in accessing the API using AWS credentials.</p>
     #[serde(rename = "AuthenticationToken")]
@@ -1457,7 +1457,7 @@ pub struct UpdateDocumentVersionRequest {
     pub version_status: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateFolderRequest {
     /// <p>Amazon WorkDocs authentication token. Do not set this field when using administrative API actions, as in accessing the API using AWS credentials.</p>
     #[serde(rename = "AuthenticationToken")]
@@ -1480,7 +1480,7 @@ pub struct UpdateFolderRequest {
     pub resource_state: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateUserRequest {
     /// <p>Amazon WorkDocs authentication token. Do not set this field when using administrative API actions, as in accessing the API using AWS credentials.</p>
     #[serde(rename = "AuthenticationToken")]
@@ -1519,7 +1519,7 @@ pub struct UpdateUserRequest {
     pub user_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UpdateUserResponse {
     /// <p>The user information.</p>
     #[serde(rename = "User")]
@@ -1528,7 +1528,7 @@ pub struct UpdateUserResponse {
 }
 
 /// <p>Describes the upload.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UploadMetadata {
     /// <p>The signed headers.</p>
     #[serde(rename = "SignedHeaders")]
@@ -1541,7 +1541,7 @@ pub struct UploadMetadata {
 }
 
 /// <p>Describes a user.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct User {
     /// <p>The time when the user was created.</p>
     #[serde(rename = "CreatedTimestamp")]
@@ -1606,7 +1606,7 @@ pub struct User {
 }
 
 /// <p>Describes the metadata of the user.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UserMetadata {
     /// <p>The email address of the user.</p>
     #[serde(rename = "EmailAddress")]
@@ -1631,7 +1631,7 @@ pub struct UserMetadata {
 }
 
 /// <p>Describes the storage for a user.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UserStorageMetadata {
     /// <p>The storage for a user.</p>
     #[serde(rename = "StorageRule")]

--- a/rusoto/services/workdocs/src/generated.rs
+++ b/rusoto/services/workdocs/src/generated.rs
@@ -1672,7 +1672,8 @@ impl AbortDocumentVersionUploadError {
     pub fn from_body(body: &str) -> AbortDocumentVersionUploadError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1788,7 +1789,8 @@ impl ActivateUserError {
     pub fn from_body(body: &str) -> ActivateUserError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1888,7 +1890,8 @@ impl AddResourcePermissionsError {
     pub fn from_body(body: &str) -> AddResourcePermissionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1996,7 +1999,8 @@ impl CreateCommentError {
     pub fn from_body(body: &str) -> CreateCommentError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2110,7 +2114,8 @@ impl CreateCustomMetadataError {
     pub fn from_body(body: &str) -> CreateCustomMetadataError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2234,7 +2239,8 @@ impl CreateFolderError {
     pub fn from_body(body: &str) -> CreateFolderError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2350,7 +2356,8 @@ impl CreateLabelsError {
     pub fn from_body(body: &str) -> CreateLabelsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2452,7 +2459,8 @@ impl CreateNotificationSubscriptionError {
     pub fn from_body(body: &str) -> CreateNotificationSubscriptionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2554,7 +2562,8 @@ impl CreateUserError {
     pub fn from_body(body: &str) -> CreateUserError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2654,7 +2663,8 @@ impl DeactivateUserError {
     pub fn from_body(body: &str) -> DeactivateUserError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2760,7 +2770,8 @@ impl DeleteCommentError {
     pub fn from_body(body: &str) -> DeleteCommentError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2872,7 +2883,8 @@ impl DeleteCustomMetadataError {
     pub fn from_body(body: &str) -> DeleteCustomMetadataError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -2988,7 +3000,8 @@ impl DeleteDocumentError {
     pub fn from_body(body: &str) -> DeleteDocumentError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3102,7 +3115,8 @@ impl DeleteFolderError {
     pub fn from_body(body: &str) -> DeleteFolderError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3212,7 +3226,8 @@ impl DeleteFolderContentsError {
     pub fn from_body(body: &str) -> DeleteFolderContentsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3320,7 +3335,8 @@ impl DeleteLabelsError {
     pub fn from_body(body: &str) -> DeleteLabelsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3420,7 +3436,8 @@ impl DeleteNotificationSubscriptionError {
     pub fn from_body(body: &str) -> DeleteNotificationSubscriptionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3528,7 +3545,8 @@ impl DeleteUserError {
     pub fn from_body(body: &str) -> DeleteUserError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3628,7 +3646,8 @@ impl DescribeActivitiesError {
     pub fn from_body(body: &str) -> DescribeActivitiesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3736,7 +3755,8 @@ impl DescribeCommentsError {
     pub fn from_body(body: &str) -> DescribeCommentsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3848,7 +3868,8 @@ impl DescribeDocumentVersionsError {
     pub fn from_body(body: &str) -> DescribeDocumentVersionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -3968,7 +3989,8 @@ impl DescribeFolderContentsError {
     pub fn from_body(body: &str) -> DescribeFolderContentsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4076,7 +4098,8 @@ impl DescribeGroupsError {
     pub fn from_body(body: &str) -> DescribeGroupsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4170,7 +4193,8 @@ impl DescribeNotificationSubscriptionsError {
     pub fn from_body(body: &str) -> DescribeNotificationSubscriptionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4270,7 +4294,8 @@ impl DescribeResourcePermissionsError {
     pub fn from_body(body: &str) -> DescribeResourcePermissionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4378,7 +4403,8 @@ impl DescribeRootFoldersError {
     pub fn from_body(body: &str) -> DescribeRootFoldersError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4484,7 +4510,8 @@ impl DescribeUsersError {
     pub fn from_body(body: &str) -> DescribeUsersError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4586,7 +4613,8 @@ impl GetCurrentUserError {
     pub fn from_body(body: &str) -> GetCurrentUserError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4692,7 +4720,8 @@ impl GetDocumentError {
     pub fn from_body(body: &str) -> GetDocumentError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4802,7 +4831,8 @@ impl GetDocumentPathError {
     pub fn from_body(body: &str) -> GetDocumentPathError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -4910,7 +4940,8 @@ impl GetDocumentVersionError {
     pub fn from_body(body: &str) -> GetDocumentVersionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5028,7 +5059,8 @@ impl GetFolderError {
     pub fn from_body(body: &str) -> GetFolderError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5136,7 +5168,8 @@ impl GetFolderPathError {
     pub fn from_body(body: &str) -> GetFolderPathError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5250,7 +5283,8 @@ impl InitiateDocumentVersionUploadError {
     pub fn from_body(body: &str) -> InitiateDocumentVersionUploadError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5398,7 +5432,8 @@ impl RemoveAllResourcePermissionsError {
     pub fn from_body(body: &str) -> RemoveAllResourcePermissionsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5504,7 +5539,8 @@ impl RemoveResourcePermissionError {
     pub fn from_body(body: &str) -> RemoveResourcePermissionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5618,7 +5654,8 @@ impl UpdateDocumentError {
     pub fn from_body(body: &str) -> UpdateDocumentError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5742,7 +5779,8 @@ impl UpdateDocumentVersionError {
     pub fn from_body(body: &str) -> UpdateDocumentVersionError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5872,7 +5910,8 @@ impl UpdateFolderError {
     pub fn from_body(body: &str) -> UpdateFolderError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -5996,7 +6035,8 @@ impl UpdateUserError {
     pub fn from_body(body: &str) -> UpdateUserError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/workspaces/src/generated.rs
+++ b/rusoto/services/workspaces/src/generated.rs
@@ -701,7 +701,8 @@ impl CreateTagsError {
     pub fn from_body(body: &str) -> CreateTagsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -787,7 +788,8 @@ impl CreateWorkspacesError {
     pub fn from_body(body: &str) -> CreateWorkspacesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -871,7 +873,8 @@ impl DeleteTagsError {
     pub fn from_body(body: &str) -> DeleteTagsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -951,7 +954,8 @@ impl DescribeTagsError {
     pub fn from_body(body: &str) -> DescribeTagsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1029,7 +1033,8 @@ impl DescribeWorkspaceBundlesError {
     pub fn from_body(body: &str) -> DescribeWorkspaceBundlesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1111,7 +1116,8 @@ impl DescribeWorkspaceDirectoriesError {
     pub fn from_body(body: &str) -> DescribeWorkspaceDirectoriesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1195,7 +1201,8 @@ impl DescribeWorkspacesError {
     pub fn from_body(body: &str) -> DescribeWorkspacesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1279,7 +1286,8 @@ impl DescribeWorkspacesConnectionStatusError {
     pub fn from_body(body: &str) -> DescribeWorkspacesConnectionStatusError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1373,7 +1381,8 @@ impl ModifyWorkspacePropertiesError {
     pub fn from_body(body: &str) -> ModifyWorkspacePropertiesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1487,7 +1496,8 @@ impl RebootWorkspacesError {
     pub fn from_body(body: &str) -> RebootWorkspacesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1559,7 +1569,8 @@ impl RebuildWorkspacesError {
     pub fn from_body(body: &str) -> RebuildWorkspacesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1633,7 +1644,8 @@ impl StartWorkspacesError {
     pub fn from_body(body: &str) -> StartWorkspacesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1705,7 +1717,8 @@ impl StopWorkspacesError {
     pub fn from_body(body: &str) -> StopWorkspacesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1777,7 +1790,8 @@ impl TerminateWorkspacesError {
     pub fn from_body(body: &str) -> TerminateWorkspacesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/workspaces/src/generated.rs
+++ b/rusoto/services/workspaces/src/generated.rs
@@ -31,7 +31,7 @@ use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 /// <p>Information about the compute type.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ComputeType {
     /// <p>The compute type.</p>
     #[serde(rename = "Name")]
@@ -39,7 +39,7 @@ pub struct ComputeType {
     pub name: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateTagsRequest {
     /// <p>The ID of the resource.</p>
     #[serde(rename = "ResourceId")]
@@ -49,17 +49,17 @@ pub struct CreateTagsRequest {
     pub tags: Vec<Tag>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateTagsResult {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateWorkspacesRequest {
     /// <p>Information about the WorkSpaces to create.</p>
     #[serde(rename = "Workspaces")]
     pub workspaces: Vec<WorkspaceRequest>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct CreateWorkspacesResult {
     /// <p>Information about the WorkSpaces that could not be created.</p>
     #[serde(rename = "FailedRequests")]
@@ -72,7 +72,7 @@ pub struct CreateWorkspacesResult {
 }
 
 /// <p>Information about defaults used to create a WorkSpace.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DefaultWorkspaceCreationProperties {
     /// <p>The identifier of any security groups to apply to WorkSpaces when they are created.</p>
     #[serde(rename = "CustomSecurityGroupId")]
@@ -96,7 +96,7 @@ pub struct DefaultWorkspaceCreationProperties {
     pub user_enabled_as_local_administrator: Option<bool>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteTagsRequest {
     /// <p>The ID of the resource.</p>
     #[serde(rename = "ResourceId")]
@@ -106,17 +106,17 @@ pub struct DeleteTagsRequest {
     pub tag_keys: Vec<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DeleteTagsResult {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeTagsRequest {
     /// <p>The ID of the resource.</p>
     #[serde(rename = "ResourceId")]
     pub resource_id: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeTagsResult {
     /// <p>The tags.</p>
     #[serde(rename = "TagList")]
@@ -124,7 +124,7 @@ pub struct DescribeTagsResult {
     pub tag_list: Option<Vec<Tag>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeWorkspaceBundlesRequest {
     /// <p>The IDs of the bundles. This parameter cannot be combined with any other filter.</p>
     #[serde(rename = "BundleIds")]
@@ -140,7 +140,7 @@ pub struct DescribeWorkspaceBundlesRequest {
     pub owner: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeWorkspaceBundlesResult {
     /// <p>Information about the bundles.</p>
     #[serde(rename = "Bundles")]
@@ -152,7 +152,7 @@ pub struct DescribeWorkspaceBundlesResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeWorkspaceDirectoriesRequest {
     /// <p>The identifiers of the directories. If the value is null, all directories are retrieved.</p>
     #[serde(rename = "DirectoryIds")]
@@ -164,7 +164,7 @@ pub struct DescribeWorkspaceDirectoriesRequest {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeWorkspaceDirectoriesResult {
     /// <p>Information about the directories.</p>
     #[serde(rename = "Directories")]
@@ -176,7 +176,7 @@ pub struct DescribeWorkspaceDirectoriesResult {
     pub next_token: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeWorkspacesConnectionStatusRequest {
     /// <p>The token for the next set of results. (You received this token from a previous call.)</p>
     #[serde(rename = "NextToken")]
@@ -188,7 +188,7 @@ pub struct DescribeWorkspacesConnectionStatusRequest {
     pub workspace_ids: Option<Vec<String>>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeWorkspacesConnectionStatusResult {
     /// <p>The token to use to retrieve the next set of results, or null if there are no more results available.</p>
     #[serde(rename = "NextToken")]
@@ -200,7 +200,7 @@ pub struct DescribeWorkspacesConnectionStatusResult {
     pub workspaces_connection_status: Option<Vec<WorkspaceConnectionStatus>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeWorkspacesRequest {
     /// <p>The ID of the bundle. All WorkSpaces that are created from this bundle are retrieved. This parameter cannot be combined with any other filter.</p>
     #[serde(rename = "BundleId")]
@@ -228,7 +228,7 @@ pub struct DescribeWorkspacesRequest {
     pub workspace_ids: Option<Vec<String>>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct DescribeWorkspacesResult {
     /// <p>The token to use to retrieve the next set of results, or null if there are no more results available. This token is valid for one day and must be used within that time frame.</p>
     #[serde(rename = "NextToken")]
@@ -241,7 +241,7 @@ pub struct DescribeWorkspacesResult {
 }
 
 /// <p>Information about a WorkSpace that could not be created.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct FailedCreateWorkspaceRequest {
     /// <p>The error code.</p>
     #[serde(rename = "ErrorCode")]
@@ -258,7 +258,7 @@ pub struct FailedCreateWorkspaceRequest {
 }
 
 /// <p>Information about a WorkSpace that could not be rebooted (<a>RebootWorkspaces</a>), rebuilt (<a>RebuildWorkspaces</a>), terminated (<a>TerminateWorkspaces</a>), started (<a>StartWorkspaces</a>), or stopped (<a>StopWorkspaces</a>).</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct FailedWorkspaceChangeRequest {
     /// <p>The error code.</p>
     #[serde(rename = "ErrorCode")]
@@ -275,7 +275,7 @@ pub struct FailedWorkspaceChangeRequest {
 }
 
 /// <p>Information about a WorkSpace modification.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ModificationState {
     /// <p>The resource.</p>
     #[serde(rename = "Resource")]
@@ -287,7 +287,7 @@ pub struct ModificationState {
     pub state: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ModifyWorkspacePropertiesRequest {
     /// <p>The ID of the WorkSpace.</p>
     #[serde(rename = "WorkspaceId")]
@@ -297,25 +297,25 @@ pub struct ModifyWorkspacePropertiesRequest {
     pub workspace_properties: WorkspaceProperties,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ModifyWorkspacePropertiesResult {}
 
 /// <p>Information used to reboot a WorkSpace.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RebootRequest {
     /// <p>The identifier of the WorkSpace.</p>
     #[serde(rename = "WorkspaceId")]
     pub workspace_id: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RebootWorkspacesRequest {
     /// <p>The WorkSpaces to reboot.</p>
     #[serde(rename = "RebootWorkspaceRequests")]
     pub reboot_workspace_requests: Vec<RebootRequest>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RebootWorkspacesResult {
     /// <p>Information about the WorkSpaces that could not be rebooted.</p>
     #[serde(rename = "FailedRequests")]
@@ -324,21 +324,21 @@ pub struct RebootWorkspacesResult {
 }
 
 /// <p>Information used to rebuild a WorkSpace.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RebuildRequest {
     /// <p>The identifier of the WorkSpace.</p>
     #[serde(rename = "WorkspaceId")]
     pub workspace_id: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RebuildWorkspacesRequest {
     /// <p>The WorkSpaces to rebuild.</p>
     #[serde(rename = "RebuildWorkspaceRequests")]
     pub rebuild_workspace_requests: Vec<RebuildRequest>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RebuildWorkspacesResult {
     /// <p>Information about the WorkSpaces that could not be rebuilt.</p>
     #[serde(rename = "FailedRequests")]
@@ -347,7 +347,7 @@ pub struct RebuildWorkspacesResult {
 }
 
 /// <p>Information about the root volume for a WorkSpace bundle.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct RootStorage {
     /// <p>The size of the root volume.</p>
     #[serde(rename = "Capacity")]
@@ -356,7 +356,7 @@ pub struct RootStorage {
 }
 
 /// <p>Information used to start a WorkSpace.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StartRequest {
     /// <p>The ID of the WorkSpace.</p>
     #[serde(rename = "WorkspaceId")]
@@ -364,14 +364,14 @@ pub struct StartRequest {
     pub workspace_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StartWorkspacesRequest {
     /// <p>The WorkSpaces to start.</p>
     #[serde(rename = "StartWorkspaceRequests")]
     pub start_workspace_requests: Vec<StartRequest>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StartWorkspacesResult {
     /// <p>Information about the WorkSpaces that could not be started.</p>
     #[serde(rename = "FailedRequests")]
@@ -380,7 +380,7 @@ pub struct StartWorkspacesResult {
 }
 
 /// <p>Information used to stop a WorkSpace.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StopRequest {
     /// <p>The ID of the WorkSpace.</p>
     #[serde(rename = "WorkspaceId")]
@@ -388,14 +388,14 @@ pub struct StopRequest {
     pub workspace_id: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct StopWorkspacesRequest {
     /// <p>The WorkSpaces to stop.</p>
     #[serde(rename = "StopWorkspaceRequests")]
     pub stop_workspace_requests: Vec<StopRequest>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct StopWorkspacesResult {
     /// <p>Information about the WorkSpaces that could not be stopped.</p>
     #[serde(rename = "FailedRequests")]
@@ -404,7 +404,7 @@ pub struct StopWorkspacesResult {
 }
 
 /// <p>Information about a tag.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Tag {
     /// <p>The key of the tag.</p>
     #[serde(rename = "Key")]
@@ -416,21 +416,21 @@ pub struct Tag {
 }
 
 /// <p>Information used to terminate a WorkSpace.</p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct TerminateRequest {
     /// <p>The identifier of the WorkSpace.</p>
     #[serde(rename = "WorkspaceId")]
     pub workspace_id: String,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct TerminateWorkspacesRequest {
     /// <p>The WorkSpaces to terminate.</p>
     #[serde(rename = "TerminateWorkspaceRequests")]
     pub terminate_workspace_requests: Vec<TerminateRequest>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct TerminateWorkspacesResult {
     /// <p>Information about the WorkSpaces that could not be terminated.</p>
     #[serde(rename = "FailedRequests")]
@@ -439,7 +439,7 @@ pub struct TerminateWorkspacesResult {
 }
 
 /// <p>Information about the user storage for a WorkSpace bundle.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UserStorage {
     /// <p>The size of the user storage.</p>
     #[serde(rename = "Capacity")]
@@ -448,7 +448,7 @@ pub struct UserStorage {
 }
 
 /// <p>Information about a WorkSpace.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Workspace {
     /// <p>The identifier of the bundle used to create the WorkSpace.</p>
     #[serde(rename = "BundleId")]
@@ -513,7 +513,7 @@ pub struct Workspace {
 }
 
 /// <p>Information about a WorkSpace bundle.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct WorkspaceBundle {
     /// <p>The bundle identifier.</p>
     #[serde(rename = "BundleId")]
@@ -546,7 +546,7 @@ pub struct WorkspaceBundle {
 }
 
 /// <p>Describes the connection status of a WorkSpace.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct WorkspaceConnectionStatus {
     /// <p>The connection state of the WorkSpace. The connection state is unknown if the WorkSpace is stopped.</p>
     #[serde(rename = "ConnectionState")]
@@ -567,7 +567,7 @@ pub struct WorkspaceConnectionStatus {
 }
 
 /// <p>Contains information about an AWS Directory Service directory for use with Amazon WorkSpaces.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct WorkspaceDirectory {
     /// <p>The directory alias.</p>
     #[serde(rename = "Alias")]
@@ -620,7 +620,7 @@ pub struct WorkspaceDirectory {
 }
 
 /// <p>Information about a WorkSpace.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct WorkspaceProperties {
     /// <p>The compute type. For more information, see <a href="http://aws.amazon.com/workspaces/details/#Amazon_WorkSpaces_Bundles">Amazon WorkSpaces Bundles</a>.</p>
     #[serde(rename = "ComputeTypeName")]
@@ -645,7 +645,7 @@ pub struct WorkspaceProperties {
 }
 
 /// <p>Information used to create a WorkSpace.</p>
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct WorkspaceRequest {
     /// <p>The identifier of the bundle for the WorkSpace. You can use <a>DescribeWorkspaceBundles</a> to list the available bundles.</p>
     #[serde(rename = "BundleId")]

--- a/rusoto/services/xray/src/generated.rs
+++ b/rusoto/services/xray/src/generated.rs
@@ -651,7 +651,8 @@ impl BatchGetTracesError {
     pub fn from_body(body: &str) -> BatchGetTracesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -735,7 +736,8 @@ impl GetServiceGraphError {
     pub fn from_body(body: &str) -> GetServiceGraphError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -819,7 +821,8 @@ impl GetTraceGraphError {
     pub fn from_body(body: &str) -> GetTraceGraphError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -903,7 +906,8 @@ impl GetTraceSummariesError {
     pub fn from_body(body: &str) -> GetTraceSummariesError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -989,7 +993,8 @@ impl PutTelemetryRecordsError {
     pub fn from_body(body: &str) -> PutTelemetryRecordsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);
@@ -1075,7 +1080,8 @@ impl PutTraceSegmentsError {
     pub fn from_body(body: &str) -> PutTraceSegmentsError {
         match from_str::<SerdeJsonValue>(body) {
             Ok(json) => {
-                let raw_error_type = json.get("__type")
+                let raw_error_type = json
+                    .get("__type")
                     .and_then(|e| e.as_str())
                     .unwrap_or("Unknown");
                 let error_message = json.get("message").and_then(|m| m.as_str()).unwrap_or(body);

--- a/rusoto/services/xray/src/generated.rs
+++ b/rusoto/services/xray/src/generated.rs
@@ -30,7 +30,7 @@ use serde_json;
 use serde_json::from_str;
 use serde_json::Value as SerdeJsonValue;
 /// <p>An alias for an edge.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Alias {
     /// <p>The canonical name of the alias.</p>
     #[serde(rename = "Name")]
@@ -47,7 +47,7 @@ pub struct Alias {
 }
 
 /// <p>Value of a segment annotation. Has one of three value types: Number, Boolean or String.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct AnnotationValue {
     /// <p>Value for a Boolean annotation.</p>
     #[serde(rename = "BooleanValue")]
@@ -64,7 +64,7 @@ pub struct AnnotationValue {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct BackendConnectionErrors {
     /// <p><p/></p>
     #[serde(rename = "ConnectionRefusedCount")]
@@ -92,7 +92,7 @@ pub struct BackendConnectionErrors {
     pub unknown_host_count: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct BatchGetTracesRequest {
     /// <p>Pagination token. Not used.</p>
     #[serde(rename = "NextToken")]
@@ -103,7 +103,7 @@ pub struct BatchGetTracesRequest {
     pub trace_ids: Vec<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct BatchGetTracesResult {
     /// <p>Pagination token. Not used.</p>
     #[serde(rename = "NextToken")]
@@ -120,7 +120,7 @@ pub struct BatchGetTracesResult {
 }
 
 /// <p>Information about a connection between two services.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Edge {
     /// <p>Aliases for the edge.</p>
     #[serde(rename = "Aliases")]
@@ -149,7 +149,7 @@ pub struct Edge {
 }
 
 /// <p>Response statistics for an edge.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct EdgeStatistics {
     /// <p>Information about requests that failed with a 4xx Client Error status code.</p>
     #[serde(rename = "ErrorStatistics")]
@@ -174,7 +174,7 @@ pub struct EdgeStatistics {
 }
 
 /// <p>Information about requests that failed with a 4xx Client Error status code.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ErrorStatistics {
     /// <p>The number of requests that failed with untracked 4xx Client Error status codes.</p>
     #[serde(rename = "OtherCount")]
@@ -191,7 +191,7 @@ pub struct ErrorStatistics {
 }
 
 /// <p>Information about requests that failed with a 5xx Server Error status code.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct FaultStatistics {
     /// <p>The number of requests that failed with untracked 5xx Server Error status codes.</p>
     #[serde(rename = "OtherCount")]
@@ -203,7 +203,7 @@ pub struct FaultStatistics {
     pub total_count: Option<i64>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetServiceGraphRequest {
     /// <p>The end of the time frame for which to generate a graph.</p>
     #[serde(rename = "EndTime")]
@@ -217,7 +217,7 @@ pub struct GetServiceGraphRequest {
     pub start_time: f64,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetServiceGraphResult {
     /// <p>The end of the time frame for which the graph was generated.</p>
     #[serde(rename = "EndTime")]
@@ -237,7 +237,7 @@ pub struct GetServiceGraphResult {
     pub start_time: Option<f64>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetTraceGraphRequest {
     /// <p>Pagination token. Not used.</p>
     #[serde(rename = "NextToken")]
@@ -248,7 +248,7 @@ pub struct GetTraceGraphRequest {
     pub trace_ids: Vec<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetTraceGraphResult {
     /// <p>Pagination token. Not used.</p>
     #[serde(rename = "NextToken")]
@@ -260,7 +260,7 @@ pub struct GetTraceGraphResult {
     pub services: Option<Vec<Service>>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetTraceSummariesRequest {
     /// <p>The end of the time frame for which to retrieve traces.</p>
     #[serde(rename = "EndTime")]
@@ -282,7 +282,7 @@ pub struct GetTraceSummariesRequest {
     pub start_time: f64,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct GetTraceSummariesResult {
     /// <p>The start time of this page of results.</p>
     #[serde(rename = "ApproximateTime")]
@@ -303,7 +303,7 @@ pub struct GetTraceSummariesResult {
 }
 
 /// <p>An entry in a histogram for a statistic. A histogram maps the range of observed values on the X axis, and the prevalence of each value on the Y axis.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct HistogramEntry {
     /// <p>The prevalence of the entry.</p>
     #[serde(rename = "Count")]
@@ -316,7 +316,7 @@ pub struct HistogramEntry {
 }
 
 /// <p>Information about an HTTP request.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Http {
     /// <p>The IP address of the requestor.</p>
     #[serde(rename = "ClientIp")]
@@ -340,7 +340,7 @@ pub struct Http {
     pub user_agent: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PutTelemetryRecordsRequest {
     /// <p><p/></p>
     #[serde(rename = "EC2InstanceId")]
@@ -359,17 +359,17 @@ pub struct PutTelemetryRecordsRequest {
     pub telemetry_records: Vec<TelemetryRecord>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PutTelemetryRecordsResult {}
 
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PutTraceSegmentsRequest {
     /// <p>A string containing a JSON document defining one or more segments or subsegments.</p>
     #[serde(rename = "TraceSegmentDocuments")]
     pub trace_segment_documents: Vec<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct PutTraceSegmentsResult {
     /// <p>Segments that failed processing.</p>
     #[serde(rename = "UnprocessedTraceSegments")]
@@ -378,7 +378,7 @@ pub struct PutTraceSegmentsResult {
 }
 
 /// <p>A segment from a trace that has been ingested by the X-Ray service. The segment can be compiled from documents uploaded with <a>PutTraceSegments</a>, or an <code>inferred</code> segment for a downstream service, generated from a subsegment sent by the service that called it.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Segment {
     /// <p>The segment document</p>
     #[serde(rename = "Document")]
@@ -391,7 +391,7 @@ pub struct Segment {
 }
 
 /// <p>Information about an application that processed requests, users that made requests, or downstream services, resources and applications that an application used.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Service {
     /// <p>Identifier of the AWS account in which the service runs.</p>
     #[serde(rename = "AccountId")]
@@ -448,7 +448,7 @@ pub struct Service {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ServiceId {
     /// <p><p/></p>
     #[serde(rename = "AccountId")]
@@ -469,7 +469,7 @@ pub struct ServiceId {
 }
 
 /// <p>Response statistics for a service.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ServiceStatistics {
     /// <p>Information about requests that failed with a 4xx Client Error status code.</p>
     #[serde(rename = "ErrorStatistics")]
@@ -494,7 +494,7 @@ pub struct ServiceStatistics {
 }
 
 /// <p><p/></p>
-#[derive(Default, Debug, Clone, Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct TelemetryRecord {
     /// <p><p/></p>
     #[serde(rename = "BackendConnectionErrors")]
@@ -522,7 +522,7 @@ pub struct TelemetryRecord {
 }
 
 /// <p>A collection of segment documents with matching trace IDs.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct Trace {
     /// <p>The length of time in seconds between the start time of the root segment and the end time of the last segment that completed.</p>
     #[serde(rename = "Duration")]
@@ -539,7 +539,7 @@ pub struct Trace {
 }
 
 /// <p>Metadata generated from the segment documents in a trace.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct TraceSummary {
     /// <p>Annotations from the trace's segment documents.</p>
     #[serde(rename = "Annotations")]
@@ -588,7 +588,7 @@ pub struct TraceSummary {
 }
 
 /// <p>Information about a user recorded in segment documents.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct TraceUser {
     /// <p>Services that the user's request hit.</p>
     #[serde(rename = "ServiceIds")]
@@ -601,7 +601,7 @@ pub struct TraceUser {
 }
 
 /// <p>Information about a segment that failed processing.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct UnprocessedTraceSegment {
     /// <p>The error that caused processing to fail.</p>
     #[serde(rename = "ErrorCode")]
@@ -618,7 +618,7 @@ pub struct UnprocessedTraceSegment {
 }
 
 /// <p>Information about a segment annotation.</p>
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ValueWithServiceIds {
     /// <p>Values of the annotation.</p>
     #[serde(rename = "AnnotationValue")]

--- a/service_crategen/src/commands/generate/codegen/mod.rs
+++ b/service_crategen/src/commands/generate/codegen/mod.rs
@@ -405,10 +405,11 @@ fn generate_struct<P>(service: &Service,
 {
     let mut derived = vec!["Default", "Debug"];
 
-    // Streaming is implemented with Box<Stream<...>>, so we can't derive Clone.
+    // Streaming is implemented with Box<Stream<...>>, so we can't derive Clone nor PartialEq.
     // This affects both the streaming struct itself, and structs which contain it.
     if !streaming && streaming_members(shape).next().is_none() {
         derived.push("Clone");
+        derived.push("PartialEq");
     }
 
     if serialized {

--- a/service_crategen/src/commands/generate/mod.rs
+++ b/service_crategen/src/commands/generate/mod.rs
@@ -288,7 +288,7 @@ pub use custom::*;
             let gen_file_path = src_dir.join("generated.rs");
 
             let status = Command::new("rustfmt")
-                .args(&["--write-mode", "overwrite"])
+                .args(&["--emit", "files"])
                 .args(&["--config-path", "rustfmt.toml"])
                 .arg(gen_file_path)
                 .status()


### PR DESCRIPTION
I'd like to add PartialEq support to request/response structs for exactly the same reason with #932 .

(This changeset is based on #1059's re-format)
