### PR TITLE
Stop using to be deprecated std::env::home_dir()

### DIFF
--- a/rusoto/credential/Cargo.toml
+++ b/rusoto/credential/Cargo.toml
@@ -14,6 +14,7 @@ version = "0.11.0"
 
 [dependencies]
 chrono = "0.4.0"
+dirs = "1.0.2"
 futures = "0.1.16"
 hyper = "0.12"
 hyper-tls = "0.2"

--- a/rusoto/credential/src/lib.rs
+++ b/rusoto/credential/src/lib.rs
@@ -7,6 +7,7 @@
 //! Types for loading and managing AWS access credentials for API requests.
 
 extern crate chrono;
+extern crate dirs;
 #[macro_use]
 extern crate futures;
 extern crate hyper;

--- a/rusoto/credential/src/profile.rs
+++ b/rusoto/credential/src/profile.rs
@@ -1,12 +1,12 @@
 //! The Credentials Provider for Credentials stored in a profile inside of a Credentials file.
 
 use std::collections::HashMap;
-use std::env::{home_dir};
 use std::fs;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 
+use dirs::home_dir;
 use futures::{Future, Poll};
 use futures::future::{FutureResult, result};
 use regex::Regex;
@@ -76,7 +76,7 @@ impl ProfileProvider {
                 Ok(home_path)
             }
             None => Err(CredentialsError::new(
-                "The environment variable HOME must be set.",
+                "Failed to determine home directory.",
             )),
         }
     }


### PR DESCRIPTION
Error on Nightly:

```
error: use of deprecated item 'std::env::home_dir': This function's behavior is unexpected and probably not what you want. Consider using the home_dir function from crates.io/crates/dirs instead.
 --> rusoto/credential/src/profile.rs:4:16
  |
4 | use std::env::{home_dir};
  |                ^^^^^^^^
  |
note: lint level defined here
 --> rusoto/credential/src/lib.rs:4:45
  |
4 | #![cfg_attr(not(feature = "unstable"), deny(warnings))]
  |                                             ^^^^^^^^
  = note: #[deny(deprecated)] implied by #[deny(warnings)]

error: use of deprecated item 'std::env::home_dir': This function's behavior is unexpected and probably not what you want. Consider using the home_dir function from crates.io/crates/dirs instead.
  --> rusoto/credential/src/profile.rs:72:15
   |
72 |         match home_dir() {
   |               ^^^^^^^^
```