### PR TITLE
Travis: split unit tests into multiple jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
-sudo: required
-dist: trusty
 language: rust
 # cache dependencies: https://docs.travis-ci.com/user/caching/#Rust-Cargo-cache
+osx_image: xcode9.4
 cache:
   directories:
     - ~/.cargo
@@ -18,8 +17,18 @@ before_install:
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then ulimit -n 1024; fi
 script:
   - |
-      if [ "$JOB" = "unit_tests" ]; then
-        echo "Running Rusoto tests" && cargo update && cargo test --all -v
+      if [ "$JOB" = "unit_tests_A" ]; then
+        echo "Running Rusoto tests (phase A)" \
+         && pip install --user toml \
+         && .travis/split_workspace 1 2 \
+         && cargo test --all -v
+      fi
+  - |
+      if [ "$JOB" = "unit_tests_B" ]; then
+        echo "Running Rusoto tests (phase B)" \
+         && pip install --user toml \
+         && .travis/split_workspace 2 2 \
+         && cargo test --all -v
       fi
   - |
       if [ "$JOB" = "integration_tests_and_docs" ]; then
@@ -47,7 +56,8 @@ env:
     - RUST_BACKTRACE=1
     - CARGO_INCREMENTAL=0
   matrix:
-    - JOB=unit_tests
+    - JOB=unit_tests_A
+    - JOB=unit_tests_B
     - JOB=integration_tests_and_docs
 branches:
   only:

--- a/.travis/split_workspace
+++ b/.travis/split_workspace
@@ -1,0 +1,43 @@
+#!/usr/bin/python
+"""Split members of workspace into evenly sized chunks for testing
+
+Example splitting members into three chunks:
+
+# Test first of three chunks
+$ ./split_workspace 1 3  # rewrites Cargo.toml
+$ cargo test
+
+# Reset Cargo.toml and test second of three chunks
+$ git checkout Cargo.toml
+$ ./split_workspace 2 3
+$ cargo test
+
+# Reset Cargo.toml and test third of three chunks
+$ git checkout Cargo.toml
+$ ./split_workspace 3 3
+$ cargo test
+"""
+
+import sys
+import toml
+
+
+def get_chunk(members, part, total_parts):
+   chunk_size = int(len(members) / total_parts)
+   end = None if part == total_parts - 1 else chunk_size*(part+1)
+   return members[chunk_size*part:end]
+
+
+def main():
+    if len(sys.argv) != 3:
+        raise AssertionError('Expected exactly two arguments')
+    part, total_parts = int(sys.argv[1]) - 1, int(sys.argv[2])
+    content = toml.load('Cargo.toml')
+    members_of_part = get_chunk(content['workspace']['members'], part, total_parts)
+    content['workspace']['members'] = members_of_part
+    with open('Cargo.toml', 'w') as f:
+        toml.dump(content, f)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This isn't exactly an ideal solution since splitting the tests leads to some dependencies being built twice but it gets the build time down enough to allow for some more tests.

I'm not sure what the long-term solution is here, I've been using GitLab CI lately. While I'm using it in combination with GitLab, it's also available for [free for any public projects on GitHub](https://about.gitlab.com/features/github/). I generally prefer it over Travis, it has a far more modern and flexible design and it also allows for longer execution times. The only thing I'm not sure about is Mac OS support. Linux support is all I needed for my projects.