### PR TITLE
Replace deprecated tokio_timer::Deadline

### DIFF
--- a/rusoto/core/Cargo.toml
+++ b/rusoto/core/Cargo.toml
@@ -38,7 +38,7 @@ sha2 = "0.7.0"
 time = "0.1.35"
 url = "1.6.0"
 tokio = "0.1.7"
-tokio-timer = "0.2.1"
+tokio-timer = "0.2.6"
 xml-rs = "0.7"
 
 [dependencies.rusoto_credential]

--- a/rusoto/credential/Cargo.toml
+++ b/rusoto/credential/Cargo.toml
@@ -19,7 +19,7 @@ futures = "0.1.16"
 hyper = "0.12"
 regex = "0.2.1"
 serde_json = "1.0.2"
-tokio-timer = "0.2.1"
+tokio-timer = "0.2.6"
 
 [dev-dependencies]
 lazy_static = "1.0"


### PR DESCRIPTION
tokio-rs/tokio#558 replaced `Deadline` with `Timeout`, and deprecated the former. Since it was released in the minor release [0.2.6](https://github.com/tokio-rs/tokio/blob/master/tokio-timer/CHANGELOG.md#026-august-23-2018), and rusoto doesn't check in `Cargo.lock`, but treats warnings as errors, this prevents compilation when compiling in newer checkouts. We should probably change this to avoid more breakage in the future, but for now, this patch replaces all uses of `Deadline` with `Timeout`.