### PR TITLE
Bump required version of Rust to 1.26.1.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache:
     - ~/.cargo
 # run builds for all the trains (and more)
 rust:
-  - 1.25.0 # test against minimum Rust version supported
+  - 1.26.1 # test against minimum Rust version supported
   - stable
   - beta
   - nightly

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ You may be looking for:
 
 ## Requirements
 
-Rust 1.25.0 or later is required.
+Rust 1.26.1 or later is required.
 
 On Linux, OpenSSL is required.
 

--- a/rusoto/core/README.md
+++ b/rusoto/core/README.md
@@ -31,7 +31,7 @@ You may be looking for:
 
 ## Requirements
 
-Rust 1.25.0 or later is required.
+Rust 1.26.1 or later is required.
 
 On Linux, OpenSSL is required.
 


### PR DESCRIPTION
Bumping min version to 1.26.1 as required by `parking_lot_core` 0.3.0.