### PR TITLE
Reenable S3 integration tests against Ceph

### DIFF
--- a/.semaphoreci/test_10_ceph.sh
+++ b/.semaphoreci/test_10_ceph.sh
@@ -8,16 +8,20 @@ export S3_ENDPOINT='http://localhost:9000'
 GIT_ROOT=$(git rev-parse --show-toplevel)
 cd "$GIT_ROOT/integration_tests"
 
-# temporarily deactivated: ceph/demo image is no longer available
-# ./docker_test_run.py \
-#     --docker-image "ceph/demo" \
-#     --port=9000 \
-#     --run-opt=-p=9000:80 \
-#     --run-opt=--env=CEPH_DEMO_ACCESS_KEY=$AWS_ACCESS_KEY_ID \
-#     --run-opt=--env=CEPH_DEMO_SECRET_KEY=$AWS_SECRET_ACCESS_KEY \
-#     --run-opt=--env=CEPH_DEMO_UID=demo_uid \
-#     --run-opt=--env=MON_IP=127.0.0.1 \
-#     --run-opt=--env=CEPH_PUBLIC_NETWORK=0.0.0.0/0 \
-#     --run-opt=--hostname=localhost \
-#     "--run-opt=-v=$GIT_ROOT/.semaphoreci/ceph.conf:/etc/ceph.conf:ro" \
-#     -- cargo test --features s3,disable_ceph_unsupported
+# Ceph releases supported by upstream:
+# http://docs.ceph.com/docs/master/releases/schedule/
+
+./docker_test_run.py \
+    --docker-image "ceph/daemon:latest-luminous" \
+    --docker-image "ceph/daemon" \
+    --port=9000 \
+    --run-opt=-p=9000:8080 \
+    --run-opt=--env=CEPH_DEMO_ACCESS_KEY=$AWS_ACCESS_KEY_ID \
+    --run-opt=--env=CEPH_DEMO_SECRET_KEY=$AWS_SECRET_ACCESS_KEY \
+    --run-opt=--env=CEPH_DEMO_UID=demo_uid \
+    --run-opt=--env=MON_IP=127.0.0.1 \
+    --run-opt=--env=CEPH_PUBLIC_NETWORK=0.0.0.0/0 \
+    --run-arg=DEMO \
+    --run-opt=--hostname=localhost \
+    "--run-opt=-v=$GIT_ROOT/.semaphoreci/ceph.conf:/etc/ceph.conf:ro" \
+    -- cargo test --features s3,disable_ceph_unsupported

--- a/integration_tests/docker_test_run.py
+++ b/integration_tests/docker_test_run.py
@@ -46,7 +46,8 @@ class Docker:
     def _kill(self):
         if self.container is not None:
             print("terminating docker:", self)
-            subprocess.check_call(["docker", "kill", self.container])
+            if subprocess.call(["docker", "kill", self.container]) != 0:
+                print("Failed to terminate container.")
 
     def __str__(self):
         if self.container is not None:


### PR DESCRIPTION
* Move to ceph/daemon Docker images. It would appear that
  ceph/demo has been deprecated a while back (no more updates)
  but I failed to find any information about it.
* Ignore errors when trying to kill docker container (I'd might
  have died already.)