### PR TITLE
Implement `From<Result<T, E>> for RusotoFuture<T, E>` for mocking purpose.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Send parameters in request body instead of query string for query based services and EC2
 - Allow AWS credentials in environment variables to have a custom prefix
 - Fix bug in presigned URLs for S3
+- Add `From<Result<T, E>> for RusotoFuture<T, E>` implementation for mocking.
 
 ## [0.33.1] - 2018-08-07
 

--- a/rusoto/core/src/future.rs
+++ b/rusoto/core/src/future.rs
@@ -13,6 +13,41 @@ lazy_static! {
 }
 
 /// Future that is returned from all rusoto service APIs.
+///
+/// ## Mocking
+///
+/// To mock service traits, you can use the `From` implementation to create `RusotoFuture`
+/// instance.
+///
+/// ```rust,ignore
+/// use rusoto_core::RusotoFuture;
+/// use rusoto_s3::*;
+///
+/// pub struct S3Mock;
+///
+/// impl S3 for S3Mock {
+///     fn abort_multipart_upload(
+///         &self,
+///         _input: AbortMultipartUploadRequest,
+///     ) -> RusotoFuture<AbortMultipartUploadOutput, AbortMultipartUploadError> {
+///         unimplemented!();
+///     }
+///
+///     ...
+///
+///     fn put_object(&self, input: PutObjectRequest) -> RusotoFuture<PutObjectOutput, PutObjectError> {
+///         if input.bucket == "foo" {
+///             Ok(PutObjectOutput {
+///                 ..Default::default()
+///             }).into()
+///         } else {
+///             Err(PutObjectError::Validation("Invalid bucket".to_string())).into()
+///         }
+///     }
+///
+///     ...
+/// }
+/// ```
 pub struct RusotoFuture<T, E> {
     state: Option<RusotoFutureState<T, E>>
 }


### PR DESCRIPTION
Service traits like `S3` are meant to be mocked, but after `0.32` (async rusoto), there seems no way to return  `RusotoFuture<T, E>` from mocks.

There seems several ways to provide such API. I tried implementing one in this PR, but I'm not particularly fond of this approach. Any way to return `RusotoFuture<T, E>` is fine to me.