### PR TITLE
Move a changelog entry to correct spot.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Add Cloud9 support
 - Add Autoscaling Plans
 - Add MQ service
+- Add `From<Result<T, E>> for RusotoFuture<T, E>` implementation for mocking.
 
 ## [0.34.0] - 2018-09-05
 
@@ -28,7 +29,6 @@
 - Send parameters in request body instead of query string for query based services and EC2
 - Allow AWS credentials in environment variables to have a custom prefix
 - Fix bug in presigned URLs for S3
-- Add `From<Result<T, E>> for RusotoFuture<T, E>` implementation for mocking.
 
 ## [0.33.1] - 2018-08-07
 


### PR DESCRIPTION
https://github.com/rusoto/rusoto/pull/1128 had this in an already released version. This puts it in the right spot. 👍 