### PR TITLE
RFC: S3 head error fix

### DIFF
--- a/integration_tests/tests/s3.rs
+++ b/integration_tests/tests/s3.rs
@@ -28,10 +28,39 @@ use rusoto_s3::{S3, S3Client, HeadObjectRequest, CopyObjectRequest, GetObjectErr
 
 type TestClient = S3Client;
 
+#[test]
+fn test_head_object_404() {
+    let _ = env_logger::try_init();
+    let client = S3Client::new(Region::UsEast1);
+
+    // rusototestbucket has `no_credentials` in it
+    let head_obj_req = HeadObjectRequest {
+        bucket: "rusototestbucket".to_owned(),
+        key: "no_credentials".to_owned(),
+        ..Default::default()
+    };
+    let ok_head = client.head_object(head_obj_req).sync().unwrap();
+    println!("ok_head is {:?}", ok_head);
+
+    let head_obj_req = HeadObjectRequest {
+        bucket: "rusototestbucket".to_owned(),
+        key: "doesntexist".to_owned(),
+        ..Default::default()
+    };
+
+    match client.head_object(head_obj_req).sync() {
+        Err(e) => {
+            panic!("Got this error: {:?}", e);
+        },
+        Ok(res) => println!("Got {:?}", res),
+    }
+}
+
 // Rust is in bad need of an integration test harness
 // This creates the S3 resources needed for a suite of tests,
 // executes those tests, and then destroys the resources
 #[test]
+#[ignore]
 fn test_all_the_things() {
     let _ = env_logger::try_init();
 

--- a/integration_tests/tests/s3.rs
+++ b/integration_tests/tests/s3.rs
@@ -28,6 +28,8 @@ use rusoto_s3::{S3, S3Client, HeadObjectRequest, CopyObjectRequest, GetObjectErr
 
 type TestClient = S3Client;
 
+// A temporary test for iterating faster.
+// This will go away or change into something everyone can run.
 #[test]
 fn test_head_object_404() {
     let _ = env_logger::try_init();

--- a/rusoto/services/autoscaling/src/generated.rs
+++ b/rusoto/services/autoscaling/src/generated.rs
@@ -8339,7 +8339,7 @@ pub enum AttachInstancesError {
 }
 
 impl AttachInstancesError {
-    pub fn from_body(body: &str) -> AttachInstancesError {
+    pub fn from_body(body: &str, status: u16) -> AttachInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -8353,7 +8353,7 @@ impl AttachInstancesError {
                 ),
                 _ => AttachInstancesError::Unknown(String::from(body)),
             },
-            Err(_) => AttachInstancesError::Unknown(body.to_string()),
+            Err(_) => AttachInstancesError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -8422,7 +8422,7 @@ pub enum AttachLoadBalancerTargetGroupsError {
 }
 
 impl AttachLoadBalancerTargetGroupsError {
-    pub fn from_body(body: &str) -> AttachLoadBalancerTargetGroupsError {
+    pub fn from_body(body: &str, status: u16) -> AttachLoadBalancerTargetGroupsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -8440,7 +8440,11 @@ impl AttachLoadBalancerTargetGroupsError {
                 }
                 _ => AttachLoadBalancerTargetGroupsError::Unknown(String::from(body)),
             },
-            Err(_) => AttachLoadBalancerTargetGroupsError::Unknown(body.to_string()),
+            Err(_) => AttachLoadBalancerTargetGroupsError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -8511,7 +8515,7 @@ pub enum AttachLoadBalancersError {
 }
 
 impl AttachLoadBalancersError {
-    pub fn from_body(body: &str) -> AttachLoadBalancersError {
+    pub fn from_body(body: &str, status: u16) -> AttachLoadBalancersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -8525,7 +8529,7 @@ impl AttachLoadBalancersError {
                 ),
                 _ => AttachLoadBalancersError::Unknown(String::from(body)),
             },
-            Err(_) => AttachLoadBalancersError::Unknown(body.to_string()),
+            Err(_) => AttachLoadBalancersError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -8594,7 +8598,7 @@ pub enum CompleteLifecycleActionError {
 }
 
 impl CompleteLifecycleActionError {
-    pub fn from_body(body: &str) -> CompleteLifecycleActionError {
+    pub fn from_body(body: &str, status: u16) -> CompleteLifecycleActionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -8605,7 +8609,9 @@ impl CompleteLifecycleActionError {
                 ),
                 _ => CompleteLifecycleActionError::Unknown(String::from(body)),
             },
-            Err(_) => CompleteLifecycleActionError::Unknown(body.to_string()),
+            Err(_) => {
+                CompleteLifecycleActionError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -8679,7 +8685,7 @@ pub enum CreateAutoScalingGroupError {
 }
 
 impl CreateAutoScalingGroupError {
-    pub fn from_body(body: &str) -> CreateAutoScalingGroupError {
+    pub fn from_body(body: &str, status: u16) -> CreateAutoScalingGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -8701,7 +8707,9 @@ impl CreateAutoScalingGroupError {
                 }
                 _ => CreateAutoScalingGroupError::Unknown(String::from(body)),
             },
-            Err(_) => CreateAutoScalingGroupError::Unknown(body.to_string()),
+            Err(_) => {
+                CreateAutoScalingGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -8776,7 +8784,7 @@ pub enum CreateLaunchConfigurationError {
 }
 
 impl CreateLaunchConfigurationError {
-    pub fn from_body(body: &str) -> CreateLaunchConfigurationError {
+    pub fn from_body(body: &str, status: u16) -> CreateLaunchConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -8793,7 +8801,9 @@ impl CreateLaunchConfigurationError {
                 ),
                 _ => CreateLaunchConfigurationError::Unknown(String::from(body)),
             },
-            Err(_) => CreateLaunchConfigurationError::Unknown(body.to_string()),
+            Err(_) => {
+                CreateLaunchConfigurationError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -8869,7 +8879,7 @@ pub enum CreateOrUpdateTagsError {
 }
 
 impl CreateOrUpdateTagsError {
-    pub fn from_body(body: &str) -> CreateOrUpdateTagsError {
+    pub fn from_body(body: &str, status: u16) -> CreateOrUpdateTagsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -8889,7 +8899,7 @@ impl CreateOrUpdateTagsError {
                 }
                 _ => CreateOrUpdateTagsError::Unknown(String::from(body)),
             },
-            Err(_) => CreateOrUpdateTagsError::Unknown(body.to_string()),
+            Err(_) => CreateOrUpdateTagsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -8964,7 +8974,7 @@ pub enum DeleteAutoScalingGroupError {
 }
 
 impl DeleteAutoScalingGroupError {
-    pub fn from_body(body: &str) -> DeleteAutoScalingGroupError {
+    pub fn from_body(body: &str, status: u16) -> DeleteAutoScalingGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -8983,7 +8993,9 @@ impl DeleteAutoScalingGroupError {
                 }
                 _ => DeleteAutoScalingGroupError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteAutoScalingGroupError::Unknown(body.to_string()),
+            Err(_) => {
+                DeleteAutoScalingGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -9055,7 +9067,7 @@ pub enum DeleteLaunchConfigurationError {
 }
 
 impl DeleteLaunchConfigurationError {
-    pub fn from_body(body: &str) -> DeleteLaunchConfigurationError {
+    pub fn from_body(body: &str, status: u16) -> DeleteLaunchConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -9069,7 +9081,9 @@ impl DeleteLaunchConfigurationError {
                 ),
                 _ => DeleteLaunchConfigurationError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteLaunchConfigurationError::Unknown(body.to_string()),
+            Err(_) => {
+                DeleteLaunchConfigurationError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -9138,7 +9152,7 @@ pub enum DeleteLifecycleHookError {
 }
 
 impl DeleteLifecycleHookError {
-    pub fn from_body(body: &str) -> DeleteLifecycleHookError {
+    pub fn from_body(body: &str, status: u16) -> DeleteLifecycleHookError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -9149,7 +9163,7 @@ impl DeleteLifecycleHookError {
                 ),
                 _ => DeleteLifecycleHookError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteLifecycleHookError::Unknown(body.to_string()),
+            Err(_) => DeleteLifecycleHookError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -9217,7 +9231,7 @@ pub enum DeleteNotificationConfigurationError {
 }
 
 impl DeleteNotificationConfigurationError {
-    pub fn from_body(body: &str) -> DeleteNotificationConfigurationError {
+    pub fn from_body(body: &str, status: u16) -> DeleteNotificationConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -9230,7 +9244,11 @@ impl DeleteNotificationConfigurationError {
                 }
                 _ => DeleteNotificationConfigurationError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteNotificationConfigurationError::Unknown(body.to_string()),
+            Err(_) => DeleteNotificationConfigurationError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -9300,7 +9318,7 @@ pub enum DeletePolicyError {
 }
 
 impl DeletePolicyError {
-    pub fn from_body(body: &str) -> DeletePolicyError {
+    pub fn from_body(body: &str, status: u16) -> DeletePolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -9314,7 +9332,7 @@ impl DeletePolicyError {
                 }
                 _ => DeletePolicyError::Unknown(String::from(body)),
             },
-            Err(_) => DeletePolicyError::Unknown(body.to_string()),
+            Err(_) => DeletePolicyError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -9381,7 +9399,7 @@ pub enum DeleteScheduledActionError {
 }
 
 impl DeleteScheduledActionError {
-    pub fn from_body(body: &str) -> DeleteScheduledActionError {
+    pub fn from_body(body: &str, status: u16) -> DeleteScheduledActionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -9392,7 +9410,9 @@ impl DeleteScheduledActionError {
                 ),
                 _ => DeleteScheduledActionError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteScheduledActionError::Unknown(body.to_string()),
+            Err(_) => {
+                DeleteScheduledActionError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -9462,7 +9482,7 @@ pub enum DeleteTagsError {
 }
 
 impl DeleteTagsError {
-    pub fn from_body(body: &str) -> DeleteTagsError {
+    pub fn from_body(body: &str, status: u16) -> DeleteTagsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -9476,7 +9496,7 @@ impl DeleteTagsError {
                 }
                 _ => DeleteTagsError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteTagsError::Unknown(body.to_string()),
+            Err(_) => DeleteTagsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -9543,7 +9563,7 @@ pub enum DescribeAccountLimitsError {
 }
 
 impl DescribeAccountLimitsError {
-    pub fn from_body(body: &str) -> DescribeAccountLimitsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeAccountLimitsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -9554,7 +9574,9 @@ impl DescribeAccountLimitsError {
                 ),
                 _ => DescribeAccountLimitsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeAccountLimitsError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeAccountLimitsError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -9622,7 +9644,7 @@ pub enum DescribeAdjustmentTypesError {
 }
 
 impl DescribeAdjustmentTypesError {
-    pub fn from_body(body: &str) -> DescribeAdjustmentTypesError {
+    pub fn from_body(body: &str, status: u16) -> DescribeAdjustmentTypesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -9633,7 +9655,9 @@ impl DescribeAdjustmentTypesError {
                 ),
                 _ => DescribeAdjustmentTypesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeAdjustmentTypesError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeAdjustmentTypesError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -9703,7 +9727,7 @@ pub enum DescribeAutoScalingGroupsError {
 }
 
 impl DescribeAutoScalingGroupsError {
-    pub fn from_body(body: &str) -> DescribeAutoScalingGroupsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeAutoScalingGroupsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -9717,7 +9741,9 @@ impl DescribeAutoScalingGroupsError {
                 ),
                 _ => DescribeAutoScalingGroupsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeAutoScalingGroupsError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeAutoScalingGroupsError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -9788,7 +9814,7 @@ pub enum DescribeAutoScalingInstancesError {
 }
 
 impl DescribeAutoScalingInstancesError {
-    pub fn from_body(body: &str) -> DescribeAutoScalingInstancesError {
+    pub fn from_body(body: &str, status: u16) -> DescribeAutoScalingInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -9802,7 +9828,11 @@ impl DescribeAutoScalingInstancesError {
                 ),
                 _ => DescribeAutoScalingInstancesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeAutoScalingInstancesError::Unknown(body.to_string()),
+            Err(_) => DescribeAutoScalingInstancesError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -9871,7 +9901,7 @@ pub enum DescribeAutoScalingNotificationTypesError {
 }
 
 impl DescribeAutoScalingNotificationTypesError {
-    pub fn from_body(body: &str) -> DescribeAutoScalingNotificationTypesError {
+    pub fn from_body(body: &str, status: u16) -> DescribeAutoScalingNotificationTypesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -9884,7 +9914,11 @@ impl DescribeAutoScalingNotificationTypesError {
                 }
                 _ => DescribeAutoScalingNotificationTypesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeAutoScalingNotificationTypesError::Unknown(body.to_string()),
+            Err(_) => DescribeAutoScalingNotificationTypesError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -9954,7 +9988,7 @@ pub enum DescribeLaunchConfigurationsError {
 }
 
 impl DescribeLaunchConfigurationsError {
-    pub fn from_body(body: &str) -> DescribeLaunchConfigurationsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeLaunchConfigurationsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -9968,7 +10002,11 @@ impl DescribeLaunchConfigurationsError {
                 ),
                 _ => DescribeLaunchConfigurationsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeLaunchConfigurationsError::Unknown(body.to_string()),
+            Err(_) => DescribeLaunchConfigurationsError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -10037,7 +10075,7 @@ pub enum DescribeLifecycleHookTypesError {
 }
 
 impl DescribeLifecycleHookTypesError {
-    pub fn from_body(body: &str) -> DescribeLifecycleHookTypesError {
+    pub fn from_body(body: &str, status: u16) -> DescribeLifecycleHookTypesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10048,7 +10086,9 @@ impl DescribeLifecycleHookTypesError {
                 ),
                 _ => DescribeLifecycleHookTypesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeLifecycleHookTypesError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeLifecycleHookTypesError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -10116,7 +10156,7 @@ pub enum DescribeLifecycleHooksError {
 }
 
 impl DescribeLifecycleHooksError {
-    pub fn from_body(body: &str) -> DescribeLifecycleHooksError {
+    pub fn from_body(body: &str, status: u16) -> DescribeLifecycleHooksError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10127,7 +10167,9 @@ impl DescribeLifecycleHooksError {
                 ),
                 _ => DescribeLifecycleHooksError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeLifecycleHooksError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeLifecycleHooksError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -10195,7 +10237,7 @@ pub enum DescribeLoadBalancerTargetGroupsError {
 }
 
 impl DescribeLoadBalancerTargetGroupsError {
-    pub fn from_body(body: &str) -> DescribeLoadBalancerTargetGroupsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeLoadBalancerTargetGroupsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10208,7 +10250,11 @@ impl DescribeLoadBalancerTargetGroupsError {
                 }
                 _ => DescribeLoadBalancerTargetGroupsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeLoadBalancerTargetGroupsError::Unknown(body.to_string()),
+            Err(_) => DescribeLoadBalancerTargetGroupsError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -10276,7 +10322,7 @@ pub enum DescribeLoadBalancersError {
 }
 
 impl DescribeLoadBalancersError {
-    pub fn from_body(body: &str) -> DescribeLoadBalancersError {
+    pub fn from_body(body: &str, status: u16) -> DescribeLoadBalancersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10287,7 +10333,9 @@ impl DescribeLoadBalancersError {
                 ),
                 _ => DescribeLoadBalancersError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeLoadBalancersError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeLoadBalancersError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -10355,7 +10403,7 @@ pub enum DescribeMetricCollectionTypesError {
 }
 
 impl DescribeMetricCollectionTypesError {
-    pub fn from_body(body: &str) -> DescribeMetricCollectionTypesError {
+    pub fn from_body(body: &str, status: u16) -> DescribeMetricCollectionTypesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10368,7 +10416,11 @@ impl DescribeMetricCollectionTypesError {
                 }
                 _ => DescribeMetricCollectionTypesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeMetricCollectionTypesError::Unknown(body.to_string()),
+            Err(_) => DescribeMetricCollectionTypesError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -10438,7 +10490,7 @@ pub enum DescribeNotificationConfigurationsError {
 }
 
 impl DescribeNotificationConfigurationsError {
-    pub fn from_body(body: &str) -> DescribeNotificationConfigurationsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeNotificationConfigurationsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10454,7 +10506,11 @@ impl DescribeNotificationConfigurationsError {
                 }
                 _ => DescribeNotificationConfigurationsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeNotificationConfigurationsError::Unknown(body.to_string()),
+            Err(_) => DescribeNotificationConfigurationsError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -10527,7 +10583,7 @@ pub enum DescribePoliciesError {
 }
 
 impl DescribePoliciesError {
-    pub fn from_body(body: &str) -> DescribePoliciesError {
+    pub fn from_body(body: &str, status: u16) -> DescribePoliciesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10544,7 +10600,7 @@ impl DescribePoliciesError {
                 ),
                 _ => DescribePoliciesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribePoliciesError::Unknown(body.to_string()),
+            Err(_) => DescribePoliciesError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -10614,7 +10670,7 @@ pub enum DescribeScalingActivitiesError {
 }
 
 impl DescribeScalingActivitiesError {
-    pub fn from_body(body: &str) -> DescribeScalingActivitiesError {
+    pub fn from_body(body: &str, status: u16) -> DescribeScalingActivitiesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10628,7 +10684,9 @@ impl DescribeScalingActivitiesError {
                 ),
                 _ => DescribeScalingActivitiesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeScalingActivitiesError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeScalingActivitiesError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -10697,7 +10755,7 @@ pub enum DescribeScalingProcessTypesError {
 }
 
 impl DescribeScalingProcessTypesError {
-    pub fn from_body(body: &str) -> DescribeScalingProcessTypesError {
+    pub fn from_body(body: &str, status: u16) -> DescribeScalingProcessTypesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10708,7 +10766,11 @@ impl DescribeScalingProcessTypesError {
                 ),
                 _ => DescribeScalingProcessTypesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeScalingProcessTypesError::Unknown(body.to_string()),
+            Err(_) => DescribeScalingProcessTypesError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -10778,7 +10840,7 @@ pub enum DescribeScheduledActionsError {
 }
 
 impl DescribeScheduledActionsError {
-    pub fn from_body(body: &str) -> DescribeScheduledActionsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeScheduledActionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10792,7 +10854,9 @@ impl DescribeScheduledActionsError {
                 ),
                 _ => DescribeScheduledActionsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeScheduledActionsError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeScheduledActionsError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -10863,7 +10927,7 @@ pub enum DescribeTagsError {
 }
 
 impl DescribeTagsError {
-    pub fn from_body(body: &str) -> DescribeTagsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeTagsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10877,7 +10941,7 @@ impl DescribeTagsError {
                 }
                 _ => DescribeTagsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeTagsError::Unknown(body.to_string()),
+            Err(_) => DescribeTagsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -10944,7 +11008,7 @@ pub enum DescribeTerminationPolicyTypesError {
 }
 
 impl DescribeTerminationPolicyTypesError {
-    pub fn from_body(body: &str) -> DescribeTerminationPolicyTypesError {
+    pub fn from_body(body: &str, status: u16) -> DescribeTerminationPolicyTypesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10957,7 +11021,11 @@ impl DescribeTerminationPolicyTypesError {
                 }
                 _ => DescribeTerminationPolicyTypesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeTerminationPolicyTypesError::Unknown(body.to_string()),
+            Err(_) => DescribeTerminationPolicyTypesError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -11025,7 +11093,7 @@ pub enum DetachInstancesError {
 }
 
 impl DetachInstancesError {
-    pub fn from_body(body: &str) -> DetachInstancesError {
+    pub fn from_body(body: &str, status: u16) -> DetachInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11036,7 +11104,7 @@ impl DetachInstancesError {
                 ),
                 _ => DetachInstancesError::Unknown(String::from(body)),
             },
-            Err(_) => DetachInstancesError::Unknown(body.to_string()),
+            Err(_) => DetachInstancesError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -11102,7 +11170,7 @@ pub enum DetachLoadBalancerTargetGroupsError {
 }
 
 impl DetachLoadBalancerTargetGroupsError {
-    pub fn from_body(body: &str) -> DetachLoadBalancerTargetGroupsError {
+    pub fn from_body(body: &str, status: u16) -> DetachLoadBalancerTargetGroupsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11115,7 +11183,11 @@ impl DetachLoadBalancerTargetGroupsError {
                 }
                 _ => DetachLoadBalancerTargetGroupsError::Unknown(String::from(body)),
             },
-            Err(_) => DetachLoadBalancerTargetGroupsError::Unknown(body.to_string()),
+            Err(_) => DetachLoadBalancerTargetGroupsError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -11183,7 +11255,7 @@ pub enum DetachLoadBalancersError {
 }
 
 impl DetachLoadBalancersError {
-    pub fn from_body(body: &str) -> DetachLoadBalancersError {
+    pub fn from_body(body: &str, status: u16) -> DetachLoadBalancersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11194,7 +11266,7 @@ impl DetachLoadBalancersError {
                 ),
                 _ => DetachLoadBalancersError::Unknown(String::from(body)),
             },
-            Err(_) => DetachLoadBalancersError::Unknown(body.to_string()),
+            Err(_) => DetachLoadBalancersError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -11262,7 +11334,7 @@ pub enum DisableMetricsCollectionError {
 }
 
 impl DisableMetricsCollectionError {
-    pub fn from_body(body: &str) -> DisableMetricsCollectionError {
+    pub fn from_body(body: &str, status: u16) -> DisableMetricsCollectionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11273,7 +11345,9 @@ impl DisableMetricsCollectionError {
                 ),
                 _ => DisableMetricsCollectionError::Unknown(String::from(body)),
             },
-            Err(_) => DisableMetricsCollectionError::Unknown(body.to_string()),
+            Err(_) => {
+                DisableMetricsCollectionError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -11341,7 +11415,7 @@ pub enum EnableMetricsCollectionError {
 }
 
 impl EnableMetricsCollectionError {
-    pub fn from_body(body: &str) -> EnableMetricsCollectionError {
+    pub fn from_body(body: &str, status: u16) -> EnableMetricsCollectionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11352,7 +11426,9 @@ impl EnableMetricsCollectionError {
                 ),
                 _ => EnableMetricsCollectionError::Unknown(String::from(body)),
             },
-            Err(_) => EnableMetricsCollectionError::Unknown(body.to_string()),
+            Err(_) => {
+                EnableMetricsCollectionError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -11420,7 +11496,7 @@ pub enum EnterStandbyError {
 }
 
 impl EnterStandbyError {
-    pub fn from_body(body: &str) -> EnterStandbyError {
+    pub fn from_body(body: &str, status: u16) -> EnterStandbyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11431,7 +11507,7 @@ impl EnterStandbyError {
                 }
                 _ => EnterStandbyError::Unknown(String::from(body)),
             },
-            Err(_) => EnterStandbyError::Unknown(body.to_string()),
+            Err(_) => EnterStandbyError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -11499,7 +11575,7 @@ pub enum ExecutePolicyError {
 }
 
 impl ExecutePolicyError {
-    pub fn from_body(body: &str) -> ExecutePolicyError {
+    pub fn from_body(body: &str, status: u16) -> ExecutePolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11513,7 +11589,7 @@ impl ExecutePolicyError {
                 ),
                 _ => ExecutePolicyError::Unknown(String::from(body)),
             },
-            Err(_) => ExecutePolicyError::Unknown(body.to_string()),
+            Err(_) => ExecutePolicyError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -11580,7 +11656,7 @@ pub enum ExitStandbyError {
 }
 
 impl ExitStandbyError {
-    pub fn from_body(body: &str) -> ExitStandbyError {
+    pub fn from_body(body: &str, status: u16) -> ExitStandbyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11591,7 +11667,7 @@ impl ExitStandbyError {
                 }
                 _ => ExitStandbyError::Unknown(String::from(body)),
             },
-            Err(_) => ExitStandbyError::Unknown(body.to_string()),
+            Err(_) => ExitStandbyError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -11659,7 +11735,7 @@ pub enum PutLifecycleHookError {
 }
 
 impl PutLifecycleHookError {
-    pub fn from_body(body: &str) -> PutLifecycleHookError {
+    pub fn from_body(body: &str, status: u16) -> PutLifecycleHookError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11673,7 +11749,7 @@ impl PutLifecycleHookError {
                 ),
                 _ => PutLifecycleHookError::Unknown(String::from(body)),
             },
-            Err(_) => PutLifecycleHookError::Unknown(body.to_string()),
+            Err(_) => PutLifecycleHookError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -11744,7 +11820,7 @@ pub enum PutNotificationConfigurationError {
 }
 
 impl PutNotificationConfigurationError {
-    pub fn from_body(body: &str) -> PutNotificationConfigurationError {
+    pub fn from_body(body: &str, status: u16) -> PutNotificationConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11763,7 +11839,11 @@ impl PutNotificationConfigurationError {
                 }
                 _ => PutNotificationConfigurationError::Unknown(String::from(body)),
             },
-            Err(_) => PutNotificationConfigurationError::Unknown(body.to_string()),
+            Err(_) => PutNotificationConfigurationError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -11837,7 +11917,7 @@ pub enum PutScalingPolicyError {
 }
 
 impl PutScalingPolicyError {
-    pub fn from_body(body: &str) -> PutScalingPolicyError {
+    pub fn from_body(body: &str, status: u16) -> PutScalingPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11854,7 +11934,7 @@ impl PutScalingPolicyError {
                 ),
                 _ => PutScalingPolicyError::Unknown(String::from(body)),
             },
-            Err(_) => PutScalingPolicyError::Unknown(body.to_string()),
+            Err(_) => PutScalingPolicyError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -11926,7 +12006,7 @@ pub enum PutScheduledUpdateGroupActionError {
 }
 
 impl PutScheduledUpdateGroupActionError {
-    pub fn from_body(body: &str) -> PutScheduledUpdateGroupActionError {
+    pub fn from_body(body: &str, status: u16) -> PutScheduledUpdateGroupActionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11945,7 +12025,11 @@ impl PutScheduledUpdateGroupActionError {
                 }
                 _ => PutScheduledUpdateGroupActionError::Unknown(String::from(body)),
             },
-            Err(_) => PutScheduledUpdateGroupActionError::Unknown(body.to_string()),
+            Err(_) => PutScheduledUpdateGroupActionError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -12015,7 +12099,7 @@ pub enum RecordLifecycleActionHeartbeatError {
 }
 
 impl RecordLifecycleActionHeartbeatError {
-    pub fn from_body(body: &str) -> RecordLifecycleActionHeartbeatError {
+    pub fn from_body(body: &str, status: u16) -> RecordLifecycleActionHeartbeatError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -12028,7 +12112,11 @@ impl RecordLifecycleActionHeartbeatError {
                 }
                 _ => RecordLifecycleActionHeartbeatError::Unknown(String::from(body)),
             },
-            Err(_) => RecordLifecycleActionHeartbeatError::Unknown(body.to_string()),
+            Err(_) => RecordLifecycleActionHeartbeatError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -12098,7 +12186,7 @@ pub enum ResumeProcessesError {
 }
 
 impl ResumeProcessesError {
-    pub fn from_body(body: &str) -> ResumeProcessesError {
+    pub fn from_body(body: &str, status: u16) -> ResumeProcessesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -12112,7 +12200,7 @@ impl ResumeProcessesError {
                 }
                 _ => ResumeProcessesError::Unknown(String::from(body)),
             },
-            Err(_) => ResumeProcessesError::Unknown(body.to_string()),
+            Err(_) => ResumeProcessesError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -12181,7 +12269,7 @@ pub enum SetDesiredCapacityError {
 }
 
 impl SetDesiredCapacityError {
-    pub fn from_body(body: &str) -> SetDesiredCapacityError {
+    pub fn from_body(body: &str, status: u16) -> SetDesiredCapacityError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -12197,7 +12285,7 @@ impl SetDesiredCapacityError {
                 }
                 _ => SetDesiredCapacityError::Unknown(String::from(body)),
             },
-            Err(_) => SetDesiredCapacityError::Unknown(body.to_string()),
+            Err(_) => SetDesiredCapacityError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -12266,7 +12354,7 @@ pub enum SetInstanceHealthError {
 }
 
 impl SetInstanceHealthError {
-    pub fn from_body(body: &str) -> SetInstanceHealthError {
+    pub fn from_body(body: &str, status: u16) -> SetInstanceHealthError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -12277,7 +12365,7 @@ impl SetInstanceHealthError {
                 ),
                 _ => SetInstanceHealthError::Unknown(String::from(body)),
             },
-            Err(_) => SetInstanceHealthError::Unknown(body.to_string()),
+            Err(_) => SetInstanceHealthError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -12347,7 +12435,7 @@ pub enum SetInstanceProtectionError {
 }
 
 impl SetInstanceProtectionError {
-    pub fn from_body(body: &str) -> SetInstanceProtectionError {
+    pub fn from_body(body: &str, status: u16) -> SetInstanceProtectionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -12361,7 +12449,9 @@ impl SetInstanceProtectionError {
                 ),
                 _ => SetInstanceProtectionError::Unknown(String::from(body)),
             },
-            Err(_) => SetInstanceProtectionError::Unknown(body.to_string()),
+            Err(_) => {
+                SetInstanceProtectionError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -12432,7 +12522,7 @@ pub enum SuspendProcessesError {
 }
 
 impl SuspendProcessesError {
-    pub fn from_body(body: &str) -> SuspendProcessesError {
+    pub fn from_body(body: &str, status: u16) -> SuspendProcessesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -12446,7 +12536,7 @@ impl SuspendProcessesError {
                 }
                 _ => SuspendProcessesError::Unknown(String::from(body)),
             },
-            Err(_) => SuspendProcessesError::Unknown(body.to_string()),
+            Err(_) => SuspendProcessesError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -12515,7 +12605,7 @@ pub enum TerminateInstanceInAutoScalingGroupError {
 }
 
 impl TerminateInstanceInAutoScalingGroupError {
-    pub fn from_body(body: &str) -> TerminateInstanceInAutoScalingGroupError {
+    pub fn from_body(body: &str, status: u16) -> TerminateInstanceInAutoScalingGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -12533,7 +12623,11 @@ impl TerminateInstanceInAutoScalingGroupError {
                 }
                 _ => TerminateInstanceInAutoScalingGroupError::Unknown(String::from(body)),
             },
-            Err(_) => TerminateInstanceInAutoScalingGroupError::Unknown(body.to_string()),
+            Err(_) => TerminateInstanceInAutoScalingGroupError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -12608,7 +12702,7 @@ pub enum UpdateAutoScalingGroupError {
 }
 
 impl UpdateAutoScalingGroupError {
-    pub fn from_body(body: &str) -> UpdateAutoScalingGroupError {
+    pub fn from_body(body: &str, status: u16) -> UpdateAutoScalingGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -12629,7 +12723,9 @@ impl UpdateAutoScalingGroupError {
                 }
                 _ => UpdateAutoScalingGroupError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateAutoScalingGroupError::Unknown(body.to_string()),
+            Err(_) => {
+                UpdateAutoScalingGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 

--- a/rusoto/services/autoscaling/src/generated.rs
+++ b/rusoto/services/autoscaling/src/generated.rs
@@ -8353,7 +8353,13 @@ impl AttachInstancesError {
                 ),
                 _ => AttachInstancesError::Unknown(String::from(body)),
             },
-            Err(_) => AttachInstancesError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    AttachInstancesError::Unknown(format!("{}", status))
+                } else {
+                    AttachInstancesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -8440,11 +8446,17 @@ impl AttachLoadBalancerTargetGroupsError {
                 }
                 _ => AttachLoadBalancerTargetGroupsError::Unknown(String::from(body)),
             },
-            Err(_) => AttachLoadBalancerTargetGroupsError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    AttachLoadBalancerTargetGroupsError::Unknown(format!("{}", status))
+                } else {
+                    AttachLoadBalancerTargetGroupsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -8529,7 +8541,13 @@ impl AttachLoadBalancersError {
                 ),
                 _ => AttachLoadBalancersError::Unknown(String::from(body)),
             },
-            Err(_) => AttachLoadBalancersError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    AttachLoadBalancersError::Unknown(format!("{}", status))
+                } else {
+                    AttachLoadBalancersError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -8610,7 +8628,15 @@ impl CompleteLifecycleActionError {
                 _ => CompleteLifecycleActionError::Unknown(String::from(body)),
             },
             Err(_) => {
-                CompleteLifecycleActionError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    CompleteLifecycleActionError::Unknown(format!("{}", status))
+                } else {
+                    CompleteLifecycleActionError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -8708,7 +8734,11 @@ impl CreateAutoScalingGroupError {
                 _ => CreateAutoScalingGroupError::Unknown(String::from(body)),
             },
             Err(_) => {
-                CreateAutoScalingGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    CreateAutoScalingGroupError::Unknown(format!("{}", status))
+                } else {
+                    CreateAutoScalingGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -8802,7 +8832,15 @@ impl CreateLaunchConfigurationError {
                 _ => CreateLaunchConfigurationError::Unknown(String::from(body)),
             },
             Err(_) => {
-                CreateLaunchConfigurationError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    CreateLaunchConfigurationError::Unknown(format!("{}", status))
+                } else {
+                    CreateLaunchConfigurationError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -8899,7 +8937,13 @@ impl CreateOrUpdateTagsError {
                 }
                 _ => CreateOrUpdateTagsError::Unknown(String::from(body)),
             },
-            Err(_) => CreateOrUpdateTagsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateOrUpdateTagsError::Unknown(format!("{}", status))
+                } else {
+                    CreateOrUpdateTagsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -8994,7 +9038,11 @@ impl DeleteAutoScalingGroupError {
                 _ => DeleteAutoScalingGroupError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DeleteAutoScalingGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DeleteAutoScalingGroupError::Unknown(format!("{}", status))
+                } else {
+                    DeleteAutoScalingGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -9082,7 +9130,15 @@ impl DeleteLaunchConfigurationError {
                 _ => DeleteLaunchConfigurationError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DeleteLaunchConfigurationError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DeleteLaunchConfigurationError::Unknown(format!("{}", status))
+                } else {
+                    DeleteLaunchConfigurationError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -9163,7 +9219,13 @@ impl DeleteLifecycleHookError {
                 ),
                 _ => DeleteLifecycleHookError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteLifecycleHookError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteLifecycleHookError::Unknown(format!("{}", status))
+                } else {
+                    DeleteLifecycleHookError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -9244,11 +9306,17 @@ impl DeleteNotificationConfigurationError {
                 }
                 _ => DeleteNotificationConfigurationError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteNotificationConfigurationError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteNotificationConfigurationError::Unknown(format!("{}", status))
+                } else {
+                    DeleteNotificationConfigurationError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -9332,7 +9400,13 @@ impl DeletePolicyError {
                 }
                 _ => DeletePolicyError::Unknown(String::from(body)),
             },
-            Err(_) => DeletePolicyError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeletePolicyError::Unknown(format!("{}", status))
+                } else {
+                    DeletePolicyError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -9411,7 +9485,11 @@ impl DeleteScheduledActionError {
                 _ => DeleteScheduledActionError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DeleteScheduledActionError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DeleteScheduledActionError::Unknown(format!("{}", status))
+                } else {
+                    DeleteScheduledActionError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -9496,7 +9574,13 @@ impl DeleteTagsError {
                 }
                 _ => DeleteTagsError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteTagsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteTagsError::Unknown(format!("{}", status))
+                } else {
+                    DeleteTagsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -9575,7 +9659,11 @@ impl DescribeAccountLimitsError {
                 _ => DescribeAccountLimitsError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeAccountLimitsError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeAccountLimitsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeAccountLimitsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -9656,7 +9744,15 @@ impl DescribeAdjustmentTypesError {
                 _ => DescribeAdjustmentTypesError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeAdjustmentTypesError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeAdjustmentTypesError::Unknown(format!("{}", status))
+                } else {
+                    DescribeAdjustmentTypesError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -9742,7 +9838,15 @@ impl DescribeAutoScalingGroupsError {
                 _ => DescribeAutoScalingGroupsError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeAutoScalingGroupsError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeAutoScalingGroupsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeAutoScalingGroupsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -9828,11 +9932,17 @@ impl DescribeAutoScalingInstancesError {
                 ),
                 _ => DescribeAutoScalingInstancesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeAutoScalingInstancesError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeAutoScalingInstancesError::Unknown(format!("{}", status))
+                } else {
+                    DescribeAutoScalingInstancesError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -9914,11 +10024,17 @@ impl DescribeAutoScalingNotificationTypesError {
                 }
                 _ => DescribeAutoScalingNotificationTypesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeAutoScalingNotificationTypesError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeAutoScalingNotificationTypesError::Unknown(format!("{}", status))
+                } else {
+                    DescribeAutoScalingNotificationTypesError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -10002,11 +10118,17 @@ impl DescribeLaunchConfigurationsError {
                 ),
                 _ => DescribeLaunchConfigurationsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeLaunchConfigurationsError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeLaunchConfigurationsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeLaunchConfigurationsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -10087,7 +10209,15 @@ impl DescribeLifecycleHookTypesError {
                 _ => DescribeLifecycleHookTypesError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeLifecycleHookTypesError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeLifecycleHookTypesError::Unknown(format!("{}", status))
+                } else {
+                    DescribeLifecycleHookTypesError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -10168,7 +10298,11 @@ impl DescribeLifecycleHooksError {
                 _ => DescribeLifecycleHooksError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeLifecycleHooksError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeLifecycleHooksError::Unknown(format!("{}", status))
+                } else {
+                    DescribeLifecycleHooksError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -10250,11 +10384,17 @@ impl DescribeLoadBalancerTargetGroupsError {
                 }
                 _ => DescribeLoadBalancerTargetGroupsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeLoadBalancerTargetGroupsError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeLoadBalancerTargetGroupsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeLoadBalancerTargetGroupsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -10334,7 +10474,11 @@ impl DescribeLoadBalancersError {
                 _ => DescribeLoadBalancersError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeLoadBalancersError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeLoadBalancersError::Unknown(format!("{}", status))
+                } else {
+                    DescribeLoadBalancersError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -10416,11 +10560,17 @@ impl DescribeMetricCollectionTypesError {
                 }
                 _ => DescribeMetricCollectionTypesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeMetricCollectionTypesError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeMetricCollectionTypesError::Unknown(format!("{}", status))
+                } else {
+                    DescribeMetricCollectionTypesError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -10506,11 +10656,17 @@ impl DescribeNotificationConfigurationsError {
                 }
                 _ => DescribeNotificationConfigurationsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeNotificationConfigurationsError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeNotificationConfigurationsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeNotificationConfigurationsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -10600,7 +10756,13 @@ impl DescribePoliciesError {
                 ),
                 _ => DescribePoliciesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribePoliciesError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribePoliciesError::Unknown(format!("{}", status))
+                } else {
+                    DescribePoliciesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -10685,7 +10847,15 @@ impl DescribeScalingActivitiesError {
                 _ => DescribeScalingActivitiesError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeScalingActivitiesError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeScalingActivitiesError::Unknown(format!("{}", status))
+                } else {
+                    DescribeScalingActivitiesError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -10766,11 +10936,17 @@ impl DescribeScalingProcessTypesError {
                 ),
                 _ => DescribeScalingProcessTypesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeScalingProcessTypesError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeScalingProcessTypesError::Unknown(format!("{}", status))
+                } else {
+                    DescribeScalingProcessTypesError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -10855,7 +11031,15 @@ impl DescribeScheduledActionsError {
                 _ => DescribeScheduledActionsError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeScheduledActionsError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeScheduledActionsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeScheduledActionsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -10941,7 +11125,13 @@ impl DescribeTagsError {
                 }
                 _ => DescribeTagsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeTagsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeTagsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeTagsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -11021,11 +11211,17 @@ impl DescribeTerminationPolicyTypesError {
                 }
                 _ => DescribeTerminationPolicyTypesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeTerminationPolicyTypesError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeTerminationPolicyTypesError::Unknown(format!("{}", status))
+                } else {
+                    DescribeTerminationPolicyTypesError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -11104,7 +11300,13 @@ impl DetachInstancesError {
                 ),
                 _ => DetachInstancesError::Unknown(String::from(body)),
             },
-            Err(_) => DetachInstancesError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DetachInstancesError::Unknown(format!("{}", status))
+                } else {
+                    DetachInstancesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -11183,11 +11385,17 @@ impl DetachLoadBalancerTargetGroupsError {
                 }
                 _ => DetachLoadBalancerTargetGroupsError::Unknown(String::from(body)),
             },
-            Err(_) => DetachLoadBalancerTargetGroupsError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DetachLoadBalancerTargetGroupsError::Unknown(format!("{}", status))
+                } else {
+                    DetachLoadBalancerTargetGroupsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -11266,7 +11474,13 @@ impl DetachLoadBalancersError {
                 ),
                 _ => DetachLoadBalancersError::Unknown(String::from(body)),
             },
-            Err(_) => DetachLoadBalancersError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DetachLoadBalancersError::Unknown(format!("{}", status))
+                } else {
+                    DetachLoadBalancersError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -11346,7 +11560,15 @@ impl DisableMetricsCollectionError {
                 _ => DisableMetricsCollectionError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DisableMetricsCollectionError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DisableMetricsCollectionError::Unknown(format!("{}", status))
+                } else {
+                    DisableMetricsCollectionError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -11427,7 +11649,15 @@ impl EnableMetricsCollectionError {
                 _ => EnableMetricsCollectionError::Unknown(String::from(body)),
             },
             Err(_) => {
-                EnableMetricsCollectionError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    EnableMetricsCollectionError::Unknown(format!("{}", status))
+                } else {
+                    EnableMetricsCollectionError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -11507,7 +11737,13 @@ impl EnterStandbyError {
                 }
                 _ => EnterStandbyError::Unknown(String::from(body)),
             },
-            Err(_) => EnterStandbyError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    EnterStandbyError::Unknown(format!("{}", status))
+                } else {
+                    EnterStandbyError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -11589,7 +11825,13 @@ impl ExecutePolicyError {
                 ),
                 _ => ExecutePolicyError::Unknown(String::from(body)),
             },
-            Err(_) => ExecutePolicyError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ExecutePolicyError::Unknown(format!("{}", status))
+                } else {
+                    ExecutePolicyError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -11667,7 +11909,13 @@ impl ExitStandbyError {
                 }
                 _ => ExitStandbyError::Unknown(String::from(body)),
             },
-            Err(_) => ExitStandbyError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ExitStandbyError::Unknown(format!("{}", status))
+                } else {
+                    ExitStandbyError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -11749,7 +11997,13 @@ impl PutLifecycleHookError {
                 ),
                 _ => PutLifecycleHookError::Unknown(String::from(body)),
             },
-            Err(_) => PutLifecycleHookError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    PutLifecycleHookError::Unknown(format!("{}", status))
+                } else {
+                    PutLifecycleHookError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -11839,11 +12093,17 @@ impl PutNotificationConfigurationError {
                 }
                 _ => PutNotificationConfigurationError::Unknown(String::from(body)),
             },
-            Err(_) => PutNotificationConfigurationError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    PutNotificationConfigurationError::Unknown(format!("{}", status))
+                } else {
+                    PutNotificationConfigurationError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -11934,7 +12194,13 @@ impl PutScalingPolicyError {
                 ),
                 _ => PutScalingPolicyError::Unknown(String::from(body)),
             },
-            Err(_) => PutScalingPolicyError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    PutScalingPolicyError::Unknown(format!("{}", status))
+                } else {
+                    PutScalingPolicyError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -12025,11 +12291,17 @@ impl PutScheduledUpdateGroupActionError {
                 }
                 _ => PutScheduledUpdateGroupActionError::Unknown(String::from(body)),
             },
-            Err(_) => PutScheduledUpdateGroupActionError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    PutScheduledUpdateGroupActionError::Unknown(format!("{}", status))
+                } else {
+                    PutScheduledUpdateGroupActionError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -12112,11 +12384,17 @@ impl RecordLifecycleActionHeartbeatError {
                 }
                 _ => RecordLifecycleActionHeartbeatError::Unknown(String::from(body)),
             },
-            Err(_) => RecordLifecycleActionHeartbeatError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    RecordLifecycleActionHeartbeatError::Unknown(format!("{}", status))
+                } else {
+                    RecordLifecycleActionHeartbeatError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -12200,7 +12478,13 @@ impl ResumeProcessesError {
                 }
                 _ => ResumeProcessesError::Unknown(String::from(body)),
             },
-            Err(_) => ResumeProcessesError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ResumeProcessesError::Unknown(format!("{}", status))
+                } else {
+                    ResumeProcessesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -12285,7 +12569,13 @@ impl SetDesiredCapacityError {
                 }
                 _ => SetDesiredCapacityError::Unknown(String::from(body)),
             },
-            Err(_) => SetDesiredCapacityError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    SetDesiredCapacityError::Unknown(format!("{}", status))
+                } else {
+                    SetDesiredCapacityError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -12365,7 +12655,13 @@ impl SetInstanceHealthError {
                 ),
                 _ => SetInstanceHealthError::Unknown(String::from(body)),
             },
-            Err(_) => SetInstanceHealthError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    SetInstanceHealthError::Unknown(format!("{}", status))
+                } else {
+                    SetInstanceHealthError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -12450,7 +12746,11 @@ impl SetInstanceProtectionError {
                 _ => SetInstanceProtectionError::Unknown(String::from(body)),
             },
             Err(_) => {
-                SetInstanceProtectionError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    SetInstanceProtectionError::Unknown(format!("{}", status))
+                } else {
+                    SetInstanceProtectionError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -12536,7 +12836,13 @@ impl SuspendProcessesError {
                 }
                 _ => SuspendProcessesError::Unknown(String::from(body)),
             },
-            Err(_) => SuspendProcessesError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    SuspendProcessesError::Unknown(format!("{}", status))
+                } else {
+                    SuspendProcessesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -12623,11 +12929,17 @@ impl TerminateInstanceInAutoScalingGroupError {
                 }
                 _ => TerminateInstanceInAutoScalingGroupError::Unknown(String::from(body)),
             },
-            Err(_) => TerminateInstanceInAutoScalingGroupError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    TerminateInstanceInAutoScalingGroupError::Unknown(format!("{}", status))
+                } else {
+                    TerminateInstanceInAutoScalingGroupError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -12724,7 +13036,11 @@ impl UpdateAutoScalingGroupError {
                 _ => UpdateAutoScalingGroupError::Unknown(String::from(body)),
             },
             Err(_) => {
-                UpdateAutoScalingGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    UpdateAutoScalingGroupError::Unknown(format!("{}", status))
+                } else {
+                    UpdateAutoScalingGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }

--- a/rusoto/services/cloudformation/src/generated.rs
+++ b/rusoto/services/cloudformation/src/generated.rs
@@ -8790,7 +8790,13 @@ impl CancelUpdateStackError {
                 }
                 _ => CancelUpdateStackError::Unknown(String::from(body)),
             },
-            Err(_) => CancelUpdateStackError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CancelUpdateStackError::Unknown(format!("{}", status))
+                } else {
+                    CancelUpdateStackError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -8870,7 +8876,11 @@ impl ContinueUpdateRollbackError {
                 _ => ContinueUpdateRollbackError::Unknown(String::from(body)),
             },
             Err(_) => {
-                ContinueUpdateRollbackError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    ContinueUpdateRollbackError::Unknown(format!("{}", status))
+                } else {
+                    ContinueUpdateRollbackError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -8962,7 +8972,13 @@ impl CreateChangeSetError {
                 }
                 _ => CreateChangeSetError::Unknown(String::from(body)),
             },
-            Err(_) => CreateChangeSetError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateChangeSetError::Unknown(format!("{}", status))
+                } else {
+                    CreateChangeSetError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -9056,7 +9072,13 @@ impl CreateStackError {
                 }
                 _ => CreateStackError::Unknown(String::from(body)),
             },
-            Err(_) => CreateStackError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateStackError::Unknown(format!("{}", status))
+                } else {
+                    CreateStackError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -9164,7 +9186,11 @@ impl CreateStackInstancesError {
                 _ => CreateStackInstancesError::Unknown(String::from(body)),
             },
             Err(_) => {
-                CreateStackInstancesError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    CreateStackInstancesError::Unknown(format!("{}", status))
+                } else {
+                    CreateStackInstancesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -9259,7 +9285,13 @@ impl CreateStackSetError {
                 }
                 _ => CreateStackSetError::Unknown(String::from(body)),
             },
-            Err(_) => CreateStackSetError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateStackSetError::Unknown(format!("{}", status))
+                } else {
+                    CreateStackSetError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -9338,7 +9370,13 @@ impl DeleteChangeSetError {
                 }
                 _ => DeleteChangeSetError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteChangeSetError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteChangeSetError::Unknown(format!("{}", status))
+                } else {
+                    DeleteChangeSetError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -9415,7 +9453,13 @@ impl DeleteStackError {
                 }
                 _ => DeleteStackError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteStackError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteStackError::Unknown(format!("{}", status))
+                } else {
+                    DeleteStackError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -9515,7 +9559,11 @@ impl DeleteStackInstancesError {
                 _ => DeleteStackInstancesError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DeleteStackInstancesError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DeleteStackInstancesError::Unknown(format!("{}", status))
+                } else {
+                    DeleteStackInstancesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -9604,7 +9652,13 @@ impl DeleteStackSetError {
                 }
                 _ => DeleteStackSetError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteStackSetError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteStackSetError::Unknown(format!("{}", status))
+                } else {
+                    DeleteStackSetError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -9678,7 +9732,11 @@ impl DescribeAccountLimitsError {
                 _ => DescribeAccountLimitsError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeAccountLimitsError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeAccountLimitsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeAccountLimitsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -9757,7 +9815,13 @@ impl DescribeChangeSetError {
                 }
                 _ => DescribeChangeSetError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeChangeSetError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeChangeSetError::Unknown(format!("{}", status))
+                } else {
+                    DescribeChangeSetError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -9831,7 +9895,13 @@ impl DescribeStackEventsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeStackEventsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeStackEventsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeStackEventsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeStackEventsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -9917,7 +9987,11 @@ impl DescribeStackInstanceError {
                 _ => DescribeStackInstanceError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeStackInstanceError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeStackInstanceError::Unknown(format!("{}", status))
+                } else {
+                    DescribeStackInstanceError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -9994,7 +10068,11 @@ impl DescribeStackResourceError {
                 _ => DescribeStackResourceError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeStackResourceError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeStackResourceError::Unknown(format!("{}", status))
+                } else {
+                    DescribeStackResourceError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -10069,7 +10147,11 @@ impl DescribeStackResourcesError {
                 _ => DescribeStackResourcesError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeStackResourcesError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeStackResourcesError::Unknown(format!("{}", status))
+                } else {
+                    DescribeStackResourcesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -10148,7 +10230,13 @@ impl DescribeStackSetError {
                 }
                 _ => DescribeStackSetError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeStackSetError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeStackSetError::Unknown(format!("{}", status))
+                } else {
+                    DescribeStackSetError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -10231,7 +10319,15 @@ impl DescribeStackSetOperationError {
                 _ => DescribeStackSetOperationError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeStackSetOperationError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeStackSetOperationError::Unknown(format!("{}", status))
+                } else {
+                    DescribeStackSetOperationError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -10307,7 +10403,13 @@ impl DescribeStacksError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeStacksError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeStacksError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeStacksError::Unknown(format!("{}", status))
+                } else {
+                    DescribeStacksError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -10379,7 +10481,11 @@ impl EstimateTemplateCostError {
                 _ => EstimateTemplateCostError::Unknown(String::from(body)),
             },
             Err(_) => {
-                EstimateTemplateCostError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    EstimateTemplateCostError::Unknown(format!("{}", status))
+                } else {
+                    EstimateTemplateCostError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -10475,7 +10581,13 @@ impl ExecuteChangeSetError {
                 }
                 _ => ExecuteChangeSetError::Unknown(String::from(body)),
             },
-            Err(_) => ExecuteChangeSetError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ExecuteChangeSetError::Unknown(format!("{}", status))
+                } else {
+                    ExecuteChangeSetError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -10550,7 +10662,13 @@ impl GetStackPolicyError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetStackPolicyError::Unknown(String::from(body)),
             },
-            Err(_) => GetStackPolicyError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetStackPolicyError::Unknown(format!("{}", status))
+                } else {
+                    GetStackPolicyError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -10626,7 +10744,13 @@ impl GetTemplateError {
                 }
                 _ => GetTemplateError::Unknown(String::from(body)),
             },
-            Err(_) => GetTemplateError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetTemplateError::Unknown(format!("{}", status))
+                } else {
+                    GetTemplateError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -10703,7 +10827,13 @@ impl GetTemplateSummaryError {
                 }
                 _ => GetTemplateSummaryError::Unknown(String::from(body)),
             },
-            Err(_) => GetTemplateSummaryError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetTemplateSummaryError::Unknown(format!("{}", status))
+                } else {
+                    GetTemplateSummaryError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -10777,7 +10907,13 @@ impl ListChangeSetsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListChangeSetsError::Unknown(String::from(body)),
             },
-            Err(_) => ListChangeSetsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ListChangeSetsError::Unknown(format!("{}", status))
+                } else {
+                    ListChangeSetsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -10848,7 +10984,13 @@ impl ListExportsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListExportsError::Unknown(String::from(body)),
             },
-            Err(_) => ListExportsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ListExportsError::Unknown(format!("{}", status))
+                } else {
+                    ListExportsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -10919,7 +11061,13 @@ impl ListImportsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListImportsError::Unknown(String::from(body)),
             },
-            Err(_) => ListImportsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ListImportsError::Unknown(format!("{}", status))
+                } else {
+                    ListImportsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -10995,7 +11143,13 @@ impl ListStackInstancesError {
                 }
                 _ => ListStackInstancesError::Unknown(String::from(body)),
             },
-            Err(_) => ListStackInstancesError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ListStackInstancesError::Unknown(format!("{}", status))
+                } else {
+                    ListStackInstancesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -11069,7 +11223,13 @@ impl ListStackResourcesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListStackResourcesError::Unknown(String::from(body)),
             },
-            Err(_) => ListStackResourcesError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ListStackResourcesError::Unknown(format!("{}", status))
+                } else {
+                    ListStackResourcesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -11154,11 +11314,17 @@ impl ListStackSetOperationResultsError {
                 ),
                 _ => ListStackSetOperationResultsError::Unknown(String::from(body)),
             },
-            Err(_) => ListStackSetOperationResultsError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    ListStackSetOperationResultsError::Unknown(format!("{}", status))
+                } else {
+                    ListStackSetOperationResultsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -11239,7 +11405,11 @@ impl ListStackSetOperationsError {
                 _ => ListStackSetOperationsError::Unknown(String::from(body)),
             },
             Err(_) => {
-                ListStackSetOperationsError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    ListStackSetOperationsError::Unknown(format!("{}", status))
+                } else {
+                    ListStackSetOperationsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -11314,7 +11484,13 @@ impl ListStackSetsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListStackSetsError::Unknown(String::from(body)),
             },
-            Err(_) => ListStackSetsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ListStackSetsError::Unknown(format!("{}", status))
+                } else {
+                    ListStackSetsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -11385,7 +11561,13 @@ impl ListStacksError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListStacksError::Unknown(String::from(body)),
             },
-            Err(_) => ListStacksError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ListStacksError::Unknown(format!("{}", status))
+                } else {
+                    ListStacksError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -11456,7 +11638,13 @@ impl SetStackPolicyError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => SetStackPolicyError::Unknown(String::from(body)),
             },
-            Err(_) => SetStackPolicyError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    SetStackPolicyError::Unknown(format!("{}", status))
+                } else {
+                    SetStackPolicyError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -11527,7 +11715,13 @@ impl SignalResourceError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => SignalResourceError::Unknown(String::from(body)),
             },
-            Err(_) => SignalResourceError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    SignalResourceError::Unknown(format!("{}", status))
+                } else {
+                    SignalResourceError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -11614,7 +11808,11 @@ impl StopStackSetOperationError {
                 _ => StopStackSetOperationError::Unknown(String::from(body)),
             },
             Err(_) => {
-                StopStackSetOperationError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    StopStackSetOperationError::Unknown(format!("{}", status))
+                } else {
+                    StopStackSetOperationError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -11701,7 +11899,13 @@ impl UpdateStackError {
                 }
                 _ => UpdateStackError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateStackError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    UpdateStackError::Unknown(format!("{}", status))
+                } else {
+                    UpdateStackError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -11809,7 +12013,11 @@ impl UpdateStackInstancesError {
                 _ => UpdateStackInstancesError::Unknown(String::from(body)),
             },
             Err(_) => {
-                UpdateStackInstancesError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    UpdateStackInstancesError::Unknown(format!("{}", status))
+                } else {
+                    UpdateStackInstancesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -11921,7 +12129,13 @@ impl UpdateStackSetError {
                 }
                 _ => UpdateStackSetError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateStackSetError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    UpdateStackSetError::Unknown(format!("{}", status))
+                } else {
+                    UpdateStackSetError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -11998,11 +12212,17 @@ impl UpdateTerminationProtectionError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => UpdateTerminationProtectionError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateTerminationProtectionError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    UpdateTerminationProtectionError::Unknown(format!("{}", status))
+                } else {
+                    UpdateTerminationProtectionError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -12075,7 +12295,13 @@ impl ValidateTemplateError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ValidateTemplateError::Unknown(String::from(body)),
             },
-            Err(_) => ValidateTemplateError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ValidateTemplateError::Unknown(format!("{}", status))
+                } else {
+                    ValidateTemplateError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 

--- a/rusoto/services/cloudformation/src/generated.rs
+++ b/rusoto/services/cloudformation/src/generated.rs
@@ -8779,7 +8779,7 @@ pub enum CancelUpdateStackError {
 }
 
 impl CancelUpdateStackError {
-    pub fn from_body(body: &str) -> CancelUpdateStackError {
+    pub fn from_body(body: &str, status: u16) -> CancelUpdateStackError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -8790,7 +8790,7 @@ impl CancelUpdateStackError {
                 }
                 _ => CancelUpdateStackError::Unknown(String::from(body)),
             },
-            Err(_) => CancelUpdateStackError::Unknown(body.to_string()),
+            Err(_) => CancelUpdateStackError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -8858,7 +8858,7 @@ pub enum ContinueUpdateRollbackError {
 }
 
 impl ContinueUpdateRollbackError {
-    pub fn from_body(body: &str) -> ContinueUpdateRollbackError {
+    pub fn from_body(body: &str, status: u16) -> ContinueUpdateRollbackError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -8869,7 +8869,9 @@ impl ContinueUpdateRollbackError {
                 ),
                 _ => ContinueUpdateRollbackError::Unknown(String::from(body)),
             },
-            Err(_) => ContinueUpdateRollbackError::Unknown(body.to_string()),
+            Err(_) => {
+                ContinueUpdateRollbackError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -8941,7 +8943,7 @@ pub enum CreateChangeSetError {
 }
 
 impl CreateChangeSetError {
-    pub fn from_body(body: &str) -> CreateChangeSetError {
+    pub fn from_body(body: &str, status: u16) -> CreateChangeSetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -8960,7 +8962,7 @@ impl CreateChangeSetError {
                 }
                 _ => CreateChangeSetError::Unknown(String::from(body)),
             },
-            Err(_) => CreateChangeSetError::Unknown(body.to_string()),
+            Err(_) => CreateChangeSetError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -9034,7 +9036,7 @@ pub enum CreateStackError {
 }
 
 impl CreateStackError {
-    pub fn from_body(body: &str) -> CreateStackError {
+    pub fn from_body(body: &str, status: u16) -> CreateStackError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -9054,7 +9056,7 @@ impl CreateStackError {
                 }
                 _ => CreateStackError::Unknown(String::from(body)),
             },
-            Err(_) => CreateStackError::Unknown(body.to_string()),
+            Err(_) => CreateStackError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -9133,7 +9135,7 @@ pub enum CreateStackInstancesError {
 }
 
 impl CreateStackInstancesError {
-    pub fn from_body(body: &str) -> CreateStackInstancesError {
+    pub fn from_body(body: &str, status: u16) -> CreateStackInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -9161,7 +9163,9 @@ impl CreateStackInstancesError {
                 }
                 _ => CreateStackInstancesError::Unknown(String::from(body)),
             },
-            Err(_) => CreateStackInstancesError::Unknown(body.to_string()),
+            Err(_) => {
+                CreateStackInstancesError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -9238,7 +9242,7 @@ pub enum CreateStackSetError {
 }
 
 impl CreateStackSetError {
-    pub fn from_body(body: &str) -> CreateStackSetError {
+    pub fn from_body(body: &str, status: u16) -> CreateStackSetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -9255,7 +9259,7 @@ impl CreateStackSetError {
                 }
                 _ => CreateStackSetError::Unknown(String::from(body)),
             },
-            Err(_) => CreateStackSetError::Unknown(body.to_string()),
+            Err(_) => CreateStackSetError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -9323,7 +9327,7 @@ pub enum DeleteChangeSetError {
 }
 
 impl DeleteChangeSetError {
-    pub fn from_body(body: &str) -> DeleteChangeSetError {
+    pub fn from_body(body: &str, status: u16) -> DeleteChangeSetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -9334,7 +9338,7 @@ impl DeleteChangeSetError {
                 }
                 _ => DeleteChangeSetError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteChangeSetError::Unknown(body.to_string()),
+            Err(_) => DeleteChangeSetError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -9400,7 +9404,7 @@ pub enum DeleteStackError {
 }
 
 impl DeleteStackError {
-    pub fn from_body(body: &str) -> DeleteStackError {
+    pub fn from_body(body: &str, status: u16) -> DeleteStackError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -9411,7 +9415,7 @@ impl DeleteStackError {
                 }
                 _ => DeleteStackError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteStackError::Unknown(body.to_string()),
+            Err(_) => DeleteStackError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -9485,7 +9489,7 @@ pub enum DeleteStackInstancesError {
 }
 
 impl DeleteStackInstancesError {
-    pub fn from_body(body: &str) -> DeleteStackInstancesError {
+    pub fn from_body(body: &str, status: u16) -> DeleteStackInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -9510,7 +9514,9 @@ impl DeleteStackInstancesError {
                 }
                 _ => DeleteStackInstancesError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteStackInstancesError::Unknown(body.to_string()),
+            Err(_) => {
+                DeleteStackInstancesError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -9584,7 +9590,7 @@ pub enum DeleteStackSetError {
 }
 
 impl DeleteStackSetError {
-    pub fn from_body(body: &str) -> DeleteStackSetError {
+    pub fn from_body(body: &str, status: u16) -> DeleteStackSetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -9598,7 +9604,7 @@ impl DeleteStackSetError {
                 }
                 _ => DeleteStackSetError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteStackSetError::Unknown(body.to_string()),
+            Err(_) => DeleteStackSetError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -9663,7 +9669,7 @@ pub enum DescribeAccountLimitsError {
 }
 
 impl DescribeAccountLimitsError {
-    pub fn from_body(body: &str) -> DescribeAccountLimitsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeAccountLimitsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -9671,7 +9677,9 @@ impl DescribeAccountLimitsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeAccountLimitsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeAccountLimitsError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeAccountLimitsError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -9738,7 +9746,7 @@ pub enum DescribeChangeSetError {
 }
 
 impl DescribeChangeSetError {
-    pub fn from_body(body: &str) -> DescribeChangeSetError {
+    pub fn from_body(body: &str, status: u16) -> DescribeChangeSetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -9749,7 +9757,7 @@ impl DescribeChangeSetError {
                 }
                 _ => DescribeChangeSetError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeChangeSetError::Unknown(body.to_string()),
+            Err(_) => DescribeChangeSetError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -9815,7 +9823,7 @@ pub enum DescribeStackEventsError {
 }
 
 impl DescribeStackEventsError {
-    pub fn from_body(body: &str) -> DescribeStackEventsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeStackEventsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -9823,7 +9831,7 @@ impl DescribeStackEventsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeStackEventsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeStackEventsError::Unknown(body.to_string()),
+            Err(_) => DescribeStackEventsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -9892,7 +9900,7 @@ pub enum DescribeStackInstanceError {
 }
 
 impl DescribeStackInstanceError {
-    pub fn from_body(body: &str) -> DescribeStackInstanceError {
+    pub fn from_body(body: &str, status: u16) -> DescribeStackInstanceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -9908,7 +9916,9 @@ impl DescribeStackInstanceError {
                 }
                 _ => DescribeStackInstanceError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeStackInstanceError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeStackInstanceError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -9975,7 +9985,7 @@ pub enum DescribeStackResourceError {
 }
 
 impl DescribeStackResourceError {
-    pub fn from_body(body: &str) -> DescribeStackResourceError {
+    pub fn from_body(body: &str, status: u16) -> DescribeStackResourceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -9983,7 +9993,9 @@ impl DescribeStackResourceError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeStackResourceError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeStackResourceError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeStackResourceError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -10048,7 +10060,7 @@ pub enum DescribeStackResourcesError {
 }
 
 impl DescribeStackResourcesError {
-    pub fn from_body(body: &str) -> DescribeStackResourcesError {
+    pub fn from_body(body: &str, status: u16) -> DescribeStackResourcesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10056,7 +10068,9 @@ impl DescribeStackResourcesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeStackResourcesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeStackResourcesError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeStackResourcesError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -10123,7 +10137,7 @@ pub enum DescribeStackSetError {
 }
 
 impl DescribeStackSetError {
-    pub fn from_body(body: &str) -> DescribeStackSetError {
+    pub fn from_body(body: &str, status: u16) -> DescribeStackSetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10134,7 +10148,7 @@ impl DescribeStackSetError {
                 }
                 _ => DescribeStackSetError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeStackSetError::Unknown(body.to_string()),
+            Err(_) => DescribeStackSetError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -10202,7 +10216,7 @@ pub enum DescribeStackSetOperationError {
 }
 
 impl DescribeStackSetOperationError {
-    pub fn from_body(body: &str) -> DescribeStackSetOperationError {
+    pub fn from_body(body: &str, status: u16) -> DescribeStackSetOperationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10216,7 +10230,9 @@ impl DescribeStackSetOperationError {
                 ),
                 _ => DescribeStackSetOperationError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeStackSetOperationError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeStackSetOperationError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -10283,7 +10299,7 @@ pub enum DescribeStacksError {
 }
 
 impl DescribeStacksError {
-    pub fn from_body(body: &str) -> DescribeStacksError {
+    pub fn from_body(body: &str, status: u16) -> DescribeStacksError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10291,7 +10307,7 @@ impl DescribeStacksError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeStacksError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeStacksError::Unknown(body.to_string()),
+            Err(_) => DescribeStacksError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -10354,7 +10370,7 @@ pub enum EstimateTemplateCostError {
 }
 
 impl EstimateTemplateCostError {
-    pub fn from_body(body: &str) -> EstimateTemplateCostError {
+    pub fn from_body(body: &str, status: u16) -> EstimateTemplateCostError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10362,7 +10378,9 @@ impl EstimateTemplateCostError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => EstimateTemplateCostError::Unknown(String::from(body)),
             },
-            Err(_) => EstimateTemplateCostError::Unknown(body.to_string()),
+            Err(_) => {
+                EstimateTemplateCostError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -10435,7 +10453,7 @@ pub enum ExecuteChangeSetError {
 }
 
 impl ExecuteChangeSetError {
-    pub fn from_body(body: &str) -> ExecuteChangeSetError {
+    pub fn from_body(body: &str, status: u16) -> ExecuteChangeSetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10457,7 +10475,7 @@ impl ExecuteChangeSetError {
                 }
                 _ => ExecuteChangeSetError::Unknown(String::from(body)),
             },
-            Err(_) => ExecuteChangeSetError::Unknown(body.to_string()),
+            Err(_) => ExecuteChangeSetError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -10524,7 +10542,7 @@ pub enum GetStackPolicyError {
 }
 
 impl GetStackPolicyError {
-    pub fn from_body(body: &str) -> GetStackPolicyError {
+    pub fn from_body(body: &str, status: u16) -> GetStackPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10532,7 +10550,7 @@ impl GetStackPolicyError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetStackPolicyError::Unknown(String::from(body)),
             },
-            Err(_) => GetStackPolicyError::Unknown(body.to_string()),
+            Err(_) => GetStackPolicyError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -10597,7 +10615,7 @@ pub enum GetTemplateError {
 }
 
 impl GetTemplateError {
-    pub fn from_body(body: &str) -> GetTemplateError {
+    pub fn from_body(body: &str, status: u16) -> GetTemplateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10608,7 +10626,7 @@ impl GetTemplateError {
                 }
                 _ => GetTemplateError::Unknown(String::from(body)),
             },
-            Err(_) => GetTemplateError::Unknown(body.to_string()),
+            Err(_) => GetTemplateError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -10674,7 +10692,7 @@ pub enum GetTemplateSummaryError {
 }
 
 impl GetTemplateSummaryError {
-    pub fn from_body(body: &str) -> GetTemplateSummaryError {
+    pub fn from_body(body: &str, status: u16) -> GetTemplateSummaryError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10685,7 +10703,7 @@ impl GetTemplateSummaryError {
                 }
                 _ => GetTemplateSummaryError::Unknown(String::from(body)),
             },
-            Err(_) => GetTemplateSummaryError::Unknown(body.to_string()),
+            Err(_) => GetTemplateSummaryError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -10751,7 +10769,7 @@ pub enum ListChangeSetsError {
 }
 
 impl ListChangeSetsError {
-    pub fn from_body(body: &str) -> ListChangeSetsError {
+    pub fn from_body(body: &str, status: u16) -> ListChangeSetsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10759,7 +10777,7 @@ impl ListChangeSetsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListChangeSetsError::Unknown(String::from(body)),
             },
-            Err(_) => ListChangeSetsError::Unknown(body.to_string()),
+            Err(_) => ListChangeSetsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -10822,7 +10840,7 @@ pub enum ListExportsError {
 }
 
 impl ListExportsError {
-    pub fn from_body(body: &str) -> ListExportsError {
+    pub fn from_body(body: &str, status: u16) -> ListExportsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10830,7 +10848,7 @@ impl ListExportsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListExportsError::Unknown(String::from(body)),
             },
-            Err(_) => ListExportsError::Unknown(body.to_string()),
+            Err(_) => ListExportsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -10893,7 +10911,7 @@ pub enum ListImportsError {
 }
 
 impl ListImportsError {
-    pub fn from_body(body: &str) -> ListImportsError {
+    pub fn from_body(body: &str, status: u16) -> ListImportsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10901,7 +10919,7 @@ impl ListImportsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListImportsError::Unknown(String::from(body)),
             },
-            Err(_) => ListImportsError::Unknown(body.to_string()),
+            Err(_) => ListImportsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -10966,7 +10984,7 @@ pub enum ListStackInstancesError {
 }
 
 impl ListStackInstancesError {
-    pub fn from_body(body: &str) -> ListStackInstancesError {
+    pub fn from_body(body: &str, status: u16) -> ListStackInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10977,7 +10995,7 @@ impl ListStackInstancesError {
                 }
                 _ => ListStackInstancesError::Unknown(String::from(body)),
             },
-            Err(_) => ListStackInstancesError::Unknown(body.to_string()),
+            Err(_) => ListStackInstancesError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -11043,7 +11061,7 @@ pub enum ListStackResourcesError {
 }
 
 impl ListStackResourcesError {
-    pub fn from_body(body: &str) -> ListStackResourcesError {
+    pub fn from_body(body: &str, status: u16) -> ListStackResourcesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11051,7 +11069,7 @@ impl ListStackResourcesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListStackResourcesError::Unknown(String::from(body)),
             },
-            Err(_) => ListStackResourcesError::Unknown(body.to_string()),
+            Err(_) => ListStackResourcesError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -11120,7 +11138,7 @@ pub enum ListStackSetOperationResultsError {
 }
 
 impl ListStackSetOperationResultsError {
-    pub fn from_body(body: &str) -> ListStackSetOperationResultsError {
+    pub fn from_body(body: &str, status: u16) -> ListStackSetOperationResultsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11136,7 +11154,11 @@ impl ListStackSetOperationResultsError {
                 ),
                 _ => ListStackSetOperationResultsError::Unknown(String::from(body)),
             },
-            Err(_) => ListStackSetOperationResultsError::Unknown(body.to_string()),
+            Err(_) => ListStackSetOperationResultsError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -11205,7 +11227,7 @@ pub enum ListStackSetOperationsError {
 }
 
 impl ListStackSetOperationsError {
-    pub fn from_body(body: &str) -> ListStackSetOperationsError {
+    pub fn from_body(body: &str, status: u16) -> ListStackSetOperationsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11216,7 +11238,9 @@ impl ListStackSetOperationsError {
                 ),
                 _ => ListStackSetOperationsError::Unknown(String::from(body)),
             },
-            Err(_) => ListStackSetOperationsError::Unknown(body.to_string()),
+            Err(_) => {
+                ListStackSetOperationsError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -11282,7 +11306,7 @@ pub enum ListStackSetsError {
 }
 
 impl ListStackSetsError {
-    pub fn from_body(body: &str) -> ListStackSetsError {
+    pub fn from_body(body: &str, status: u16) -> ListStackSetsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11290,7 +11314,7 @@ impl ListStackSetsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListStackSetsError::Unknown(String::from(body)),
             },
-            Err(_) => ListStackSetsError::Unknown(body.to_string()),
+            Err(_) => ListStackSetsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -11353,7 +11377,7 @@ pub enum ListStacksError {
 }
 
 impl ListStacksError {
-    pub fn from_body(body: &str) -> ListStacksError {
+    pub fn from_body(body: &str, status: u16) -> ListStacksError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11361,7 +11385,7 @@ impl ListStacksError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListStacksError::Unknown(String::from(body)),
             },
-            Err(_) => ListStacksError::Unknown(body.to_string()),
+            Err(_) => ListStacksError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -11424,7 +11448,7 @@ pub enum SetStackPolicyError {
 }
 
 impl SetStackPolicyError {
-    pub fn from_body(body: &str) -> SetStackPolicyError {
+    pub fn from_body(body: &str, status: u16) -> SetStackPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11432,7 +11456,7 @@ impl SetStackPolicyError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => SetStackPolicyError::Unknown(String::from(body)),
             },
-            Err(_) => SetStackPolicyError::Unknown(body.to_string()),
+            Err(_) => SetStackPolicyError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -11495,7 +11519,7 @@ pub enum SignalResourceError {
 }
 
 impl SignalResourceError {
-    pub fn from_body(body: &str) -> SignalResourceError {
+    pub fn from_body(body: &str, status: u16) -> SignalResourceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11503,7 +11527,7 @@ impl SignalResourceError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => SignalResourceError::Unknown(String::from(body)),
             },
-            Err(_) => SignalResourceError::Unknown(body.to_string()),
+            Err(_) => SignalResourceError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -11572,7 +11596,7 @@ pub enum StopStackSetOperationError {
 }
 
 impl StopStackSetOperationError {
-    pub fn from_body(body: &str) -> StopStackSetOperationError {
+    pub fn from_body(body: &str, status: u16) -> StopStackSetOperationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11589,7 +11613,9 @@ impl StopStackSetOperationError {
                 }
                 _ => StopStackSetOperationError::Unknown(String::from(body)),
             },
-            Err(_) => StopStackSetOperationError::Unknown(body.to_string()),
+            Err(_) => {
+                StopStackSetOperationError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -11661,7 +11687,7 @@ pub enum UpdateStackError {
 }
 
 impl UpdateStackError {
-    pub fn from_body(body: &str) -> UpdateStackError {
+    pub fn from_body(body: &str, status: u16) -> UpdateStackError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11675,7 +11701,7 @@ impl UpdateStackError {
                 }
                 _ => UpdateStackError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateStackError::Unknown(body.to_string()),
+            Err(_) => UpdateStackError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -11752,7 +11778,7 @@ pub enum UpdateStackInstancesError {
 }
 
 impl UpdateStackInstancesError {
-    pub fn from_body(body: &str) -> UpdateStackInstancesError {
+    pub fn from_body(body: &str, status: u16) -> UpdateStackInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11782,7 +11808,9 @@ impl UpdateStackInstancesError {
                 }
                 _ => UpdateStackInstancesError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateStackInstancesError::Unknown(body.to_string()),
+            Err(_) => {
+                UpdateStackInstancesError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -11865,7 +11893,7 @@ pub enum UpdateStackSetError {
 }
 
 impl UpdateStackSetError {
-    pub fn from_body(body: &str) -> UpdateStackSetError {
+    pub fn from_body(body: &str, status: u16) -> UpdateStackSetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11893,7 +11921,7 @@ impl UpdateStackSetError {
                 }
                 _ => UpdateStackSetError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateStackSetError::Unknown(body.to_string()),
+            Err(_) => UpdateStackSetError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -11962,7 +11990,7 @@ pub enum UpdateTerminationProtectionError {
 }
 
 impl UpdateTerminationProtectionError {
-    pub fn from_body(body: &str) -> UpdateTerminationProtectionError {
+    pub fn from_body(body: &str, status: u16) -> UpdateTerminationProtectionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11970,7 +11998,11 @@ impl UpdateTerminationProtectionError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => UpdateTerminationProtectionError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateTerminationProtectionError::Unknown(body.to_string()),
+            Err(_) => UpdateTerminationProtectionError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -12035,7 +12067,7 @@ pub enum ValidateTemplateError {
 }
 
 impl ValidateTemplateError {
-    pub fn from_body(body: &str) -> ValidateTemplateError {
+    pub fn from_body(body: &str, status: u16) -> ValidateTemplateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -12043,7 +12075,7 @@ impl ValidateTemplateError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ValidateTemplateError::Unknown(String::from(body)),
             },
-            Err(_) => ValidateTemplateError::Unknown(body.to_string()),
+            Err(_) => ValidateTemplateError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 

--- a/rusoto/services/cloudfront/src/generated.rs
+++ b/rusoto/services/cloudfront/src/generated.rs
@@ -8102,7 +8102,7 @@ pub enum CreateCloudFrontOriginAccessIdentityError {
 }
 
 impl CreateCloudFrontOriginAccessIdentityError {
-    pub fn from_body(body: &str) -> CreateCloudFrontOriginAccessIdentityError {
+    pub fn from_body(body: &str, status: u16) -> CreateCloudFrontOriginAccessIdentityError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -8112,7 +8112,7 @@ impl CreateCloudFrontOriginAccessIdentityError {
                                     "CloudFrontOriginAccessIdentityAlreadyExists" => CreateCloudFrontOriginAccessIdentityError::CloudFrontOriginAccessIdentityAlreadyExists(String::from(parsed_error.message)),"InconsistentQuantities" => CreateCloudFrontOriginAccessIdentityError::InconsistentQuantities(String::from(parsed_error.message)),"InvalidArgument" => CreateCloudFrontOriginAccessIdentityError::InvalidArgument(String::from(parsed_error.message)),"MissingBody" => CreateCloudFrontOriginAccessIdentityError::MissingBody(String::from(parsed_error.message)),"TooManyCloudFrontOriginAccessIdentities" => CreateCloudFrontOriginAccessIdentityError::TooManyCloudFrontOriginAccessIdentities(String::from(parsed_error.message)),_ => CreateCloudFrontOriginAccessIdentityError::Unknown(String::from(body))
                                 }
                            },
-                           Err(_) => CreateCloudFrontOriginAccessIdentityError::Unknown(body.to_string())
+                           Err(_) => CreateCloudFrontOriginAccessIdentityError::Unknown(format!("{}:{}", body.to_string(), status))
                        }
     }
 
@@ -8260,7 +8260,7 @@ pub enum CreateDistributionError {
 }
 
 impl CreateDistributionError {
-    pub fn from_body(body: &str) -> CreateDistributionError {
+    pub fn from_body(body: &str, status: u16) -> CreateDistributionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -8412,7 +8412,7 @@ impl CreateDistributionError {
                 ),
                 _ => CreateDistributionError::Unknown(String::from(body)),
             },
-            Err(_) => CreateDistributionError::Unknown(body.to_string()),
+            Err(_) => CreateDistributionError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -8599,7 +8599,7 @@ pub enum CreateDistributionWithTagsError {
 }
 
 impl CreateDistributionWithTagsError {
-    pub fn from_body(body: &str) -> CreateDistributionWithTagsError {
+    pub fn from_body(body: &str, status: u16) -> CreateDistributionWithTagsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -8774,7 +8774,9 @@ impl CreateDistributionWithTagsError {
                 }
                 _ => CreateDistributionWithTagsError::Unknown(String::from(body)),
             },
-            Err(_) => CreateDistributionWithTagsError::Unknown(body.to_string()),
+            Err(_) => {
+                CreateDistributionWithTagsError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -8896,7 +8898,7 @@ pub enum CreateInvalidationError {
 }
 
 impl CreateInvalidationError {
-    pub fn from_body(body: &str) -> CreateInvalidationError {
+    pub fn from_body(body: &str, status: u16) -> CreateInvalidationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -8927,7 +8929,7 @@ impl CreateInvalidationError {
                 }
                 _ => CreateInvalidationError::Unknown(String::from(body)),
             },
-            Err(_) => CreateInvalidationError::Unknown(body.to_string()),
+            Err(_) => CreateInvalidationError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -9023,7 +9025,7 @@ pub enum CreateStreamingDistributionError {
 }
 
 impl CreateStreamingDistributionError {
-    pub fn from_body(body: &str) -> CreateStreamingDistributionError {
+    pub fn from_body(body: &str, status: u16) -> CreateStreamingDistributionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -9079,7 +9081,11 @@ impl CreateStreamingDistributionError {
                 }
                 _ => CreateStreamingDistributionError::Unknown(String::from(body)),
             },
-            Err(_) => CreateStreamingDistributionError::Unknown(body.to_string()),
+            Err(_) => CreateStreamingDistributionError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -9186,7 +9192,7 @@ pub enum CreateStreamingDistributionWithTagsError {
 }
 
 impl CreateStreamingDistributionWithTagsError {
-    pub fn from_body(body: &str) -> CreateStreamingDistributionWithTagsError {
+    pub fn from_body(body: &str, status: u16) -> CreateStreamingDistributionWithTagsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -9249,7 +9255,11 @@ impl CreateStreamingDistributionWithTagsError {
                 }
                 _ => CreateStreamingDistributionWithTagsError::Unknown(String::from(body)),
             },
-            Err(_) => CreateStreamingDistributionWithTagsError::Unknown(body.to_string()),
+            Err(_) => CreateStreamingDistributionWithTagsError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -9345,7 +9355,7 @@ pub enum DeleteCloudFrontOriginAccessIdentityError {
 }
 
 impl DeleteCloudFrontOriginAccessIdentityError {
-    pub fn from_body(body: &str) -> DeleteCloudFrontOriginAccessIdentityError {
+    pub fn from_body(body: &str, status: u16) -> DeleteCloudFrontOriginAccessIdentityError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -9376,7 +9386,11 @@ impl DeleteCloudFrontOriginAccessIdentityError {
                 }
                 _ => DeleteCloudFrontOriginAccessIdentityError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteCloudFrontOriginAccessIdentityError::Unknown(body.to_string()),
+            Err(_) => DeleteCloudFrontOriginAccessIdentityError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -9460,7 +9474,7 @@ pub enum DeleteDistributionError {
 }
 
 impl DeleteDistributionError {
-    pub fn from_body(body: &str) -> DeleteDistributionError {
+    pub fn from_body(body: &str, status: u16) -> DeleteDistributionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -9483,7 +9497,7 @@ impl DeleteDistributionError {
                 }
                 _ => DeleteDistributionError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteDistributionError::Unknown(body.to_string()),
+            Err(_) => DeleteDistributionError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -9561,7 +9575,7 @@ pub enum DeleteServiceLinkedRoleError {
 }
 
 impl DeleteServiceLinkedRoleError {
-    pub fn from_body(body: &str) -> DeleteServiceLinkedRoleError {
+    pub fn from_body(body: &str, status: u16) -> DeleteServiceLinkedRoleError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -9581,7 +9595,9 @@ impl DeleteServiceLinkedRoleError {
                 }
                 _ => DeleteServiceLinkedRoleError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteServiceLinkedRoleError::Unknown(body.to_string()),
+            Err(_) => {
+                DeleteServiceLinkedRoleError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -9660,7 +9676,7 @@ pub enum DeleteStreamingDistributionError {
 }
 
 impl DeleteStreamingDistributionError {
-    pub fn from_body(body: &str) -> DeleteStreamingDistributionError {
+    pub fn from_body(body: &str, status: u16) -> DeleteStreamingDistributionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -9687,7 +9703,11 @@ impl DeleteStreamingDistributionError {
                 }
                 _ => DeleteStreamingDistributionError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteStreamingDistributionError::Unknown(body.to_string()),
+            Err(_) => DeleteStreamingDistributionError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -9761,7 +9781,7 @@ pub enum GetCloudFrontOriginAccessIdentityError {
 }
 
 impl GetCloudFrontOriginAccessIdentityError {
-    pub fn from_body(body: &str) -> GetCloudFrontOriginAccessIdentityError {
+    pub fn from_body(body: &str, status: u16) -> GetCloudFrontOriginAccessIdentityError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -9777,7 +9797,11 @@ impl GetCloudFrontOriginAccessIdentityError {
                 }
                 _ => GetCloudFrontOriginAccessIdentityError::Unknown(String::from(body)),
             },
-            Err(_) => GetCloudFrontOriginAccessIdentityError::Unknown(body.to_string()),
+            Err(_) => GetCloudFrontOriginAccessIdentityError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -9850,7 +9874,7 @@ pub enum GetCloudFrontOriginAccessIdentityConfigError {
 }
 
 impl GetCloudFrontOriginAccessIdentityConfigError {
-    pub fn from_body(body: &str) -> GetCloudFrontOriginAccessIdentityConfigError {
+    pub fn from_body(body: &str, status: u16) -> GetCloudFrontOriginAccessIdentityConfigError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -9860,7 +9884,7 @@ impl GetCloudFrontOriginAccessIdentityConfigError {
                                     "AccessDenied" => GetCloudFrontOriginAccessIdentityConfigError::AccessDenied(String::from(parsed_error.message)),"NoSuchCloudFrontOriginAccessIdentity" => GetCloudFrontOriginAccessIdentityConfigError::NoSuchCloudFrontOriginAccessIdentity(String::from(parsed_error.message)),_ => GetCloudFrontOriginAccessIdentityConfigError::Unknown(String::from(body))
                                 }
                            },
-                           Err(_) => GetCloudFrontOriginAccessIdentityConfigError::Unknown(body.to_string())
+                           Err(_) => GetCloudFrontOriginAccessIdentityConfigError::Unknown(format!("{}:{}", body.to_string(), status))
                        }
     }
 
@@ -9933,7 +9957,7 @@ pub enum GetDistributionError {
 }
 
 impl GetDistributionError {
-    pub fn from_body(body: &str) -> GetDistributionError {
+    pub fn from_body(body: &str, status: u16) -> GetDistributionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -9947,7 +9971,7 @@ impl GetDistributionError {
                 }
                 _ => GetDistributionError::Unknown(String::from(body)),
             },
-            Err(_) => GetDistributionError::Unknown(body.to_string()),
+            Err(_) => GetDistributionError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -10016,7 +10040,7 @@ pub enum GetDistributionConfigError {
 }
 
 impl GetDistributionConfigError {
-    pub fn from_body(body: &str) -> GetDistributionConfigError {
+    pub fn from_body(body: &str, status: u16) -> GetDistributionConfigError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10030,7 +10054,9 @@ impl GetDistributionConfigError {
                 ),
                 _ => GetDistributionConfigError::Unknown(String::from(body)),
             },
-            Err(_) => GetDistributionConfigError::Unknown(body.to_string()),
+            Err(_) => {
+                GetDistributionConfigError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -10103,7 +10129,7 @@ pub enum GetInvalidationError {
 }
 
 impl GetInvalidationError {
-    pub fn from_body(body: &str) -> GetInvalidationError {
+    pub fn from_body(body: &str, status: u16) -> GetInvalidationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10120,7 +10146,7 @@ impl GetInvalidationError {
                 }
                 _ => GetInvalidationError::Unknown(String::from(body)),
             },
-            Err(_) => GetInvalidationError::Unknown(body.to_string()),
+            Err(_) => GetInvalidationError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -10190,7 +10216,7 @@ pub enum GetStreamingDistributionError {
 }
 
 impl GetStreamingDistributionError {
-    pub fn from_body(body: &str) -> GetStreamingDistributionError {
+    pub fn from_body(body: &str, status: u16) -> GetStreamingDistributionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10206,7 +10232,9 @@ impl GetStreamingDistributionError {
                 }
                 _ => GetStreamingDistributionError::Unknown(String::from(body)),
             },
-            Err(_) => GetStreamingDistributionError::Unknown(body.to_string()),
+            Err(_) => {
+                GetStreamingDistributionError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -10277,7 +10305,7 @@ pub enum GetStreamingDistributionConfigError {
 }
 
 impl GetStreamingDistributionConfigError {
-    pub fn from_body(body: &str) -> GetStreamingDistributionConfigError {
+    pub fn from_body(body: &str, status: u16) -> GetStreamingDistributionConfigError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10293,7 +10321,11 @@ impl GetStreamingDistributionConfigError {
                 }
                 _ => GetStreamingDistributionConfigError::Unknown(String::from(body)),
             },
-            Err(_) => GetStreamingDistributionConfigError::Unknown(body.to_string()),
+            Err(_) => GetStreamingDistributionConfigError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -10362,7 +10394,7 @@ pub enum ListCloudFrontOriginAccessIdentitiesError {
 }
 
 impl ListCloudFrontOriginAccessIdentitiesError {
-    pub fn from_body(body: &str) -> ListCloudFrontOriginAccessIdentitiesError {
+    pub fn from_body(body: &str, status: u16) -> ListCloudFrontOriginAccessIdentitiesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10373,7 +10405,11 @@ impl ListCloudFrontOriginAccessIdentitiesError {
                 ),
                 _ => ListCloudFrontOriginAccessIdentitiesError::Unknown(String::from(body)),
             },
-            Err(_) => ListCloudFrontOriginAccessIdentitiesError::Unknown(body.to_string()),
+            Err(_) => ListCloudFrontOriginAccessIdentitiesError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -10441,7 +10477,7 @@ pub enum ListDistributionsError {
 }
 
 impl ListDistributionsError {
-    pub fn from_body(body: &str) -> ListDistributionsError {
+    pub fn from_body(body: &str, status: u16) -> ListDistributionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10452,7 +10488,7 @@ impl ListDistributionsError {
                 }
                 _ => ListDistributionsError::Unknown(String::from(body)),
             },
-            Err(_) => ListDistributionsError::Unknown(body.to_string()),
+            Err(_) => ListDistributionsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -10522,7 +10558,7 @@ pub enum ListDistributionsByWebACLIdError {
 }
 
 impl ListDistributionsByWebACLIdError {
-    pub fn from_body(body: &str) -> ListDistributionsByWebACLIdError {
+    pub fn from_body(body: &str, status: u16) -> ListDistributionsByWebACLIdError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10536,7 +10572,11 @@ impl ListDistributionsByWebACLIdError {
                 ),
                 _ => ListDistributionsByWebACLIdError::Unknown(String::from(body)),
             },
-            Err(_) => ListDistributionsByWebACLIdError::Unknown(body.to_string()),
+            Err(_) => ListDistributionsByWebACLIdError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -10609,7 +10649,7 @@ pub enum ListInvalidationsError {
 }
 
 impl ListInvalidationsError {
-    pub fn from_body(body: &str) -> ListInvalidationsError {
+    pub fn from_body(body: &str, status: u16) -> ListInvalidationsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10626,7 +10666,7 @@ impl ListInvalidationsError {
                 }
                 _ => ListInvalidationsError::Unknown(String::from(body)),
             },
-            Err(_) => ListInvalidationsError::Unknown(body.to_string()),
+            Err(_) => ListInvalidationsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -10696,7 +10736,7 @@ pub enum ListStreamingDistributionsError {
 }
 
 impl ListStreamingDistributionsError {
-    pub fn from_body(body: &str) -> ListStreamingDistributionsError {
+    pub fn from_body(body: &str, status: u16) -> ListStreamingDistributionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10707,7 +10747,9 @@ impl ListStreamingDistributionsError {
                 ),
                 _ => ListStreamingDistributionsError::Unknown(String::from(body)),
             },
-            Err(_) => ListStreamingDistributionsError::Unknown(body.to_string()),
+            Err(_) => {
+                ListStreamingDistributionsError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -10781,7 +10823,7 @@ pub enum ListTagsForResourceError {
 }
 
 impl ListTagsForResourceError {
-    pub fn from_body(body: &str) -> ListTagsForResourceError {
+    pub fn from_body(body: &str, status: u16) -> ListTagsForResourceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10801,7 +10843,7 @@ impl ListTagsForResourceError {
                 }
                 _ => ListTagsForResourceError::Unknown(String::from(body)),
             },
-            Err(_) => ListTagsForResourceError::Unknown(body.to_string()),
+            Err(_) => ListTagsForResourceError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -10878,7 +10920,7 @@ pub enum TagResourceError {
 }
 
 impl TagResourceError {
-    pub fn from_body(body: &str) -> TagResourceError {
+    pub fn from_body(body: &str, status: u16) -> TagResourceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10898,7 +10940,7 @@ impl TagResourceError {
                 }
                 _ => TagResourceError::Unknown(String::from(body)),
             },
-            Err(_) => TagResourceError::Unknown(body.to_string()),
+            Err(_) => TagResourceError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -10973,7 +11015,7 @@ pub enum UntagResourceError {
 }
 
 impl UntagResourceError {
-    pub fn from_body(body: &str) -> UntagResourceError {
+    pub fn from_body(body: &str, status: u16) -> UntagResourceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10993,7 +11035,7 @@ impl UntagResourceError {
                 }
                 _ => UntagResourceError::Unknown(String::from(body)),
             },
-            Err(_) => UntagResourceError::Unknown(body.to_string()),
+            Err(_) => UntagResourceError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -11076,7 +11118,7 @@ pub enum UpdateCloudFrontOriginAccessIdentityError {
 }
 
 impl UpdateCloudFrontOriginAccessIdentityError {
-    pub fn from_body(body: &str) -> UpdateCloudFrontOriginAccessIdentityError {
+    pub fn from_body(body: &str, status: u16) -> UpdateCloudFrontOriginAccessIdentityError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11116,7 +11158,11 @@ impl UpdateCloudFrontOriginAccessIdentityError {
                 }
                 _ => UpdateCloudFrontOriginAccessIdentityError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateCloudFrontOriginAccessIdentityError::Unknown(body.to_string()),
+            Err(_) => UpdateCloudFrontOriginAccessIdentityError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -11271,7 +11317,7 @@ pub enum UpdateDistributionError {
 }
 
 impl UpdateDistributionError {
-    pub fn from_body(body: &str) -> UpdateDistributionError {
+    pub fn from_body(body: &str, status: u16) -> UpdateDistributionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11423,7 +11469,7 @@ impl UpdateDistributionError {
                 ),
                 _ => UpdateDistributionError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateDistributionError::Unknown(body.to_string()),
+            Err(_) => UpdateDistributionError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -11554,7 +11600,7 @@ pub enum UpdateStreamingDistributionError {
 }
 
 impl UpdateStreamingDistributionError {
-    pub fn from_body(body: &str) -> UpdateStreamingDistributionError {
+    pub fn from_body(body: &str, status: u16) -> UpdateStreamingDistributionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11611,7 +11657,11 @@ impl UpdateStreamingDistributionError {
                 }
                 _ => UpdateStreamingDistributionError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateStreamingDistributionError::Unknown(body.to_string()),
+            Err(_) => UpdateStreamingDistributionError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -11917,6 +11967,7 @@ impl CloudFront for CloudFrontClient {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(CreateCloudFrontOriginAccessIdentityError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -11978,6 +12029,7 @@ impl CloudFront for CloudFrontClient {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(CreateDistributionError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -12040,6 +12092,7 @@ impl CloudFront for CloudFrontClient {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(CreateDistributionWithTagsError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -12102,6 +12155,7 @@ impl CloudFront for CloudFrontClient {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(CreateInvalidationError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -12157,6 +12211,7 @@ impl CloudFront for CloudFrontClient {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(CreateStreamingDistributionError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -12222,6 +12277,7 @@ impl CloudFront for CloudFrontClient {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(CreateStreamingDistributionWithTagsError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -12282,6 +12338,7 @@ impl CloudFront for CloudFrontClient {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(DeleteCloudFrontOriginAccessIdentityError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -12309,6 +12366,7 @@ impl CloudFront for CloudFrontClient {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(DeleteDistributionError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -12334,6 +12392,7 @@ impl CloudFront for CloudFrontClient {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(DeleteServiceLinkedRoleError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -12361,6 +12420,7 @@ impl CloudFront for CloudFrontClient {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(DeleteStreamingDistributionError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -12388,6 +12448,7 @@ impl CloudFront for CloudFrontClient {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(GetCloudFrontOriginAccessIdentityError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -12443,6 +12504,7 @@ impl CloudFront for CloudFrontClient {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(GetCloudFrontOriginAccessIdentityConfigError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -12492,6 +12554,7 @@ impl CloudFront for CloudFrontClient {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(GetDistributionError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -12539,6 +12602,7 @@ impl CloudFront for CloudFrontClient {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(GetDistributionConfigError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -12590,6 +12654,7 @@ impl CloudFront for CloudFrontClient {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(GetInvalidationError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -12633,6 +12698,7 @@ impl CloudFront for CloudFrontClient {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(GetStreamingDistributionError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -12684,6 +12750,7 @@ impl CloudFront for CloudFrontClient {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(GetStreamingDistributionConfigError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -12745,6 +12812,7 @@ impl CloudFront for CloudFrontClient {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(ListCloudFrontOriginAccessIdentitiesError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -12799,6 +12867,7 @@ impl CloudFront for CloudFrontClient {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(ListDistributionsError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -12854,6 +12923,7 @@ impl CloudFront for CloudFrontClient {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(ListDistributionsByWebACLIdError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -12909,6 +12979,7 @@ impl CloudFront for CloudFrontClient {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(ListInvalidationsError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -12961,6 +13032,7 @@ impl CloudFront for CloudFrontClient {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(ListStreamingDistributionsError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -13008,6 +13080,7 @@ impl CloudFront for CloudFrontClient {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(ListTagsForResourceError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -13056,6 +13129,7 @@ impl CloudFront for CloudFrontClient {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(TagResourceError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -13084,6 +13158,7 @@ impl CloudFront for CloudFrontClient {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(UntagResourceError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -13125,6 +13200,7 @@ impl CloudFront for CloudFrontClient {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(UpdateCloudFrontOriginAccessIdentityError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -13186,6 +13262,7 @@ impl CloudFront for CloudFrontClient {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(UpdateDistributionError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -13248,6 +13325,7 @@ impl CloudFront for CloudFrontClient {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(UpdateStreamingDistributionError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }

--- a/rusoto/services/cloudfront/src/generated.rs
+++ b/rusoto/services/cloudfront/src/generated.rs
@@ -8112,7 +8112,13 @@ impl CreateCloudFrontOriginAccessIdentityError {
                                     "CloudFrontOriginAccessIdentityAlreadyExists" => CreateCloudFrontOriginAccessIdentityError::CloudFrontOriginAccessIdentityAlreadyExists(String::from(parsed_error.message)),"InconsistentQuantities" => CreateCloudFrontOriginAccessIdentityError::InconsistentQuantities(String::from(parsed_error.message)),"InvalidArgument" => CreateCloudFrontOriginAccessIdentityError::InvalidArgument(String::from(parsed_error.message)),"MissingBody" => CreateCloudFrontOriginAccessIdentityError::MissingBody(String::from(parsed_error.message)),"TooManyCloudFrontOriginAccessIdentities" => CreateCloudFrontOriginAccessIdentityError::TooManyCloudFrontOriginAccessIdentities(String::from(parsed_error.message)),_ => CreateCloudFrontOriginAccessIdentityError::Unknown(String::from(body))
                                 }
                            },
-                           Err(_) => CreateCloudFrontOriginAccessIdentityError::Unknown(format!("{}:{}", body.to_string(), status))
+                           Err(_) => {
+                               if body.len() == 0 {
+                                   CreateCloudFrontOriginAccessIdentityError::Unknown(format!("{}", status))
+                               } else {
+                                   CreateCloudFrontOriginAccessIdentityError::Unknown(format!("{}:{}", body.to_string(), status))
+                               }
+                            }
                        }
     }
 
@@ -8412,7 +8418,13 @@ impl CreateDistributionError {
                 ),
                 _ => CreateDistributionError::Unknown(String::from(body)),
             },
-            Err(_) => CreateDistributionError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateDistributionError::Unknown(format!("{}", status))
+                } else {
+                    CreateDistributionError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -8775,7 +8787,15 @@ impl CreateDistributionWithTagsError {
                 _ => CreateDistributionWithTagsError::Unknown(String::from(body)),
             },
             Err(_) => {
-                CreateDistributionWithTagsError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    CreateDistributionWithTagsError::Unknown(format!("{}", status))
+                } else {
+                    CreateDistributionWithTagsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -8929,7 +8949,13 @@ impl CreateInvalidationError {
                 }
                 _ => CreateInvalidationError::Unknown(String::from(body)),
             },
-            Err(_) => CreateInvalidationError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateInvalidationError::Unknown(format!("{}", status))
+                } else {
+                    CreateInvalidationError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -9081,11 +9107,17 @@ impl CreateStreamingDistributionError {
                 }
                 _ => CreateStreamingDistributionError::Unknown(String::from(body)),
             },
-            Err(_) => CreateStreamingDistributionError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateStreamingDistributionError::Unknown(format!("{}", status))
+                } else {
+                    CreateStreamingDistributionError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -9255,11 +9287,17 @@ impl CreateStreamingDistributionWithTagsError {
                 }
                 _ => CreateStreamingDistributionWithTagsError::Unknown(String::from(body)),
             },
-            Err(_) => CreateStreamingDistributionWithTagsError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateStreamingDistributionWithTagsError::Unknown(format!("{}", status))
+                } else {
+                    CreateStreamingDistributionWithTagsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -9386,11 +9424,17 @@ impl DeleteCloudFrontOriginAccessIdentityError {
                 }
                 _ => DeleteCloudFrontOriginAccessIdentityError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteCloudFrontOriginAccessIdentityError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteCloudFrontOriginAccessIdentityError::Unknown(format!("{}", status))
+                } else {
+                    DeleteCloudFrontOriginAccessIdentityError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -9497,7 +9541,13 @@ impl DeleteDistributionError {
                 }
                 _ => DeleteDistributionError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteDistributionError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteDistributionError::Unknown(format!("{}", status))
+                } else {
+                    DeleteDistributionError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -9596,7 +9646,15 @@ impl DeleteServiceLinkedRoleError {
                 _ => DeleteServiceLinkedRoleError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DeleteServiceLinkedRoleError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DeleteServiceLinkedRoleError::Unknown(format!("{}", status))
+                } else {
+                    DeleteServiceLinkedRoleError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -9703,11 +9761,17 @@ impl DeleteStreamingDistributionError {
                 }
                 _ => DeleteStreamingDistributionError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteStreamingDistributionError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteStreamingDistributionError::Unknown(format!("{}", status))
+                } else {
+                    DeleteStreamingDistributionError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -9797,11 +9861,17 @@ impl GetCloudFrontOriginAccessIdentityError {
                 }
                 _ => GetCloudFrontOriginAccessIdentityError::Unknown(String::from(body)),
             },
-            Err(_) => GetCloudFrontOriginAccessIdentityError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetCloudFrontOriginAccessIdentityError::Unknown(format!("{}", status))
+                } else {
+                    GetCloudFrontOriginAccessIdentityError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -9884,7 +9954,13 @@ impl GetCloudFrontOriginAccessIdentityConfigError {
                                     "AccessDenied" => GetCloudFrontOriginAccessIdentityConfigError::AccessDenied(String::from(parsed_error.message)),"NoSuchCloudFrontOriginAccessIdentity" => GetCloudFrontOriginAccessIdentityConfigError::NoSuchCloudFrontOriginAccessIdentity(String::from(parsed_error.message)),_ => GetCloudFrontOriginAccessIdentityConfigError::Unknown(String::from(body))
                                 }
                            },
-                           Err(_) => GetCloudFrontOriginAccessIdentityConfigError::Unknown(format!("{}:{}", body.to_string(), status))
+                           Err(_) => {
+                               if body.len() == 0 {
+                                   GetCloudFrontOriginAccessIdentityConfigError::Unknown(format!("{}", status))
+                               } else {
+                                   GetCloudFrontOriginAccessIdentityConfigError::Unknown(format!("{}:{}", body.to_string(), status))
+                               }
+                            }
                        }
     }
 
@@ -9971,7 +10047,13 @@ impl GetDistributionError {
                 }
                 _ => GetDistributionError::Unknown(String::from(body)),
             },
-            Err(_) => GetDistributionError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetDistributionError::Unknown(format!("{}", status))
+                } else {
+                    GetDistributionError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -10055,7 +10137,11 @@ impl GetDistributionConfigError {
                 _ => GetDistributionConfigError::Unknown(String::from(body)),
             },
             Err(_) => {
-                GetDistributionConfigError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    GetDistributionConfigError::Unknown(format!("{}", status))
+                } else {
+                    GetDistributionConfigError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -10146,7 +10232,13 @@ impl GetInvalidationError {
                 }
                 _ => GetInvalidationError::Unknown(String::from(body)),
             },
-            Err(_) => GetInvalidationError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetInvalidationError::Unknown(format!("{}", status))
+                } else {
+                    GetInvalidationError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -10233,7 +10325,15 @@ impl GetStreamingDistributionError {
                 _ => GetStreamingDistributionError::Unknown(String::from(body)),
             },
             Err(_) => {
-                GetStreamingDistributionError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    GetStreamingDistributionError::Unknown(format!("{}", status))
+                } else {
+                    GetStreamingDistributionError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -10321,11 +10421,17 @@ impl GetStreamingDistributionConfigError {
                 }
                 _ => GetStreamingDistributionConfigError::Unknown(String::from(body)),
             },
-            Err(_) => GetStreamingDistributionConfigError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetStreamingDistributionConfigError::Unknown(format!("{}", status))
+                } else {
+                    GetStreamingDistributionConfigError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -10405,11 +10511,17 @@ impl ListCloudFrontOriginAccessIdentitiesError {
                 ),
                 _ => ListCloudFrontOriginAccessIdentitiesError::Unknown(String::from(body)),
             },
-            Err(_) => ListCloudFrontOriginAccessIdentitiesError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    ListCloudFrontOriginAccessIdentitiesError::Unknown(format!("{}", status))
+                } else {
+                    ListCloudFrontOriginAccessIdentitiesError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -10488,7 +10600,13 @@ impl ListDistributionsError {
                 }
                 _ => ListDistributionsError::Unknown(String::from(body)),
             },
-            Err(_) => ListDistributionsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ListDistributionsError::Unknown(format!("{}", status))
+                } else {
+                    ListDistributionsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -10572,11 +10690,17 @@ impl ListDistributionsByWebACLIdError {
                 ),
                 _ => ListDistributionsByWebACLIdError::Unknown(String::from(body)),
             },
-            Err(_) => ListDistributionsByWebACLIdError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    ListDistributionsByWebACLIdError::Unknown(format!("{}", status))
+                } else {
+                    ListDistributionsByWebACLIdError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -10666,7 +10790,13 @@ impl ListInvalidationsError {
                 }
                 _ => ListInvalidationsError::Unknown(String::from(body)),
             },
-            Err(_) => ListInvalidationsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ListInvalidationsError::Unknown(format!("{}", status))
+                } else {
+                    ListInvalidationsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -10748,7 +10878,15 @@ impl ListStreamingDistributionsError {
                 _ => ListStreamingDistributionsError::Unknown(String::from(body)),
             },
             Err(_) => {
-                ListStreamingDistributionsError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    ListStreamingDistributionsError::Unknown(format!("{}", status))
+                } else {
+                    ListStreamingDistributionsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -10843,7 +10981,13 @@ impl ListTagsForResourceError {
                 }
                 _ => ListTagsForResourceError::Unknown(String::from(body)),
             },
-            Err(_) => ListTagsForResourceError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ListTagsForResourceError::Unknown(format!("{}", status))
+                } else {
+                    ListTagsForResourceError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -10940,7 +11084,13 @@ impl TagResourceError {
                 }
                 _ => TagResourceError::Unknown(String::from(body)),
             },
-            Err(_) => TagResourceError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    TagResourceError::Unknown(format!("{}", status))
+                } else {
+                    TagResourceError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -11035,7 +11185,13 @@ impl UntagResourceError {
                 }
                 _ => UntagResourceError::Unknown(String::from(body)),
             },
-            Err(_) => UntagResourceError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    UntagResourceError::Unknown(format!("{}", status))
+                } else {
+                    UntagResourceError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -11158,11 +11314,17 @@ impl UpdateCloudFrontOriginAccessIdentityError {
                 }
                 _ => UpdateCloudFrontOriginAccessIdentityError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateCloudFrontOriginAccessIdentityError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    UpdateCloudFrontOriginAccessIdentityError::Unknown(format!("{}", status))
+                } else {
+                    UpdateCloudFrontOriginAccessIdentityError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -11469,7 +11631,13 @@ impl UpdateDistributionError {
                 ),
                 _ => UpdateDistributionError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateDistributionError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    UpdateDistributionError::Unknown(format!("{}", status))
+                } else {
+                    UpdateDistributionError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -11657,11 +11825,17 @@ impl UpdateStreamingDistributionError {
                 }
                 _ => UpdateStreamingDistributionError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateStreamingDistributionError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    UpdateStreamingDistributionError::Unknown(format!("{}", status))
+                } else {
+                    UpdateStreamingDistributionError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 

--- a/rusoto/services/cloudsearch/src/generated.rs
+++ b/rusoto/services/cloudsearch/src/generated.rs
@@ -5358,7 +5358,13 @@ impl BuildSuggestersError {
                 }
                 _ => BuildSuggestersError::Unknown(String::from(body)),
             },
-            Err(_) => BuildSuggestersError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    BuildSuggestersError::Unknown(format!("{}", status))
+                } else {
+                    BuildSuggestersError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -5445,7 +5451,13 @@ impl CreateDomainError {
                 }
                 _ => CreateDomainError::Unknown(String::from(body)),
             },
-            Err(_) => CreateDomainError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateDomainError::Unknown(format!("{}", status))
+                } else {
+                    CreateDomainError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -5545,7 +5557,11 @@ impl DefineAnalysisSchemeError {
                 _ => DefineAnalysisSchemeError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DefineAnalysisSchemeError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DefineAnalysisSchemeError::Unknown(format!("{}", status))
+                } else {
+                    DefineAnalysisSchemeError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -5647,7 +5663,13 @@ impl DefineExpressionError {
                 }
                 _ => DefineExpressionError::Unknown(String::from(body)),
             },
-            Err(_) => DefineExpressionError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DefineExpressionError::Unknown(format!("{}", status))
+                } else {
+                    DefineExpressionError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -5746,7 +5768,13 @@ impl DefineIndexFieldError {
                 }
                 _ => DefineIndexFieldError::Unknown(String::from(body)),
             },
-            Err(_) => DefineIndexFieldError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DefineIndexFieldError::Unknown(format!("{}", status))
+                } else {
+                    DefineIndexFieldError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -5845,7 +5873,13 @@ impl DefineSuggesterError {
                 }
                 _ => DefineSuggesterError::Unknown(String::from(body)),
             },
-            Err(_) => DefineSuggesterError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DefineSuggesterError::Unknown(format!("{}", status))
+                } else {
+                    DefineSuggesterError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -5942,7 +5976,11 @@ impl DeleteAnalysisSchemeError {
                 _ => DeleteAnalysisSchemeError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DeleteAnalysisSchemeError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DeleteAnalysisSchemeError::Unknown(format!("{}", status))
+                } else {
+                    DeleteAnalysisSchemeError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -6028,7 +6066,13 @@ impl DeleteDomainError {
                 }
                 _ => DeleteDomainError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteDomainError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteDomainError::Unknown(format!("{}", status))
+                } else {
+                    DeleteDomainError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -6119,7 +6163,13 @@ impl DeleteExpressionError {
                 }
                 _ => DeleteExpressionError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteExpressionError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteExpressionError::Unknown(format!("{}", status))
+                } else {
+                    DeleteExpressionError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -6212,7 +6262,13 @@ impl DeleteIndexFieldError {
                 }
                 _ => DeleteIndexFieldError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteIndexFieldError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteIndexFieldError::Unknown(format!("{}", status))
+                } else {
+                    DeleteIndexFieldError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -6305,7 +6361,13 @@ impl DeleteSuggesterError {
                 }
                 _ => DeleteSuggesterError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteSuggesterError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteSuggesterError::Unknown(format!("{}", status))
+                } else {
+                    DeleteSuggesterError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -6396,7 +6458,15 @@ impl DescribeAnalysisSchemesError {
                 _ => DescribeAnalysisSchemesError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeAnalysisSchemesError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeAnalysisSchemesError::Unknown(format!("{}", status))
+                } else {
+                    DescribeAnalysisSchemesError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -6503,11 +6573,17 @@ impl DescribeAvailabilityOptionsError {
                 ),
                 _ => DescribeAvailabilityOptionsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeAvailabilityOptionsError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeAvailabilityOptionsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeAvailabilityOptionsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -6594,7 +6670,13 @@ impl DescribeDomainsError {
                 }
                 _ => DescribeDomainsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeDomainsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeDomainsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeDomainsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -6682,7 +6764,13 @@ impl DescribeExpressionsError {
                 }
                 _ => DescribeExpressionsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeExpressionsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeExpressionsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeExpressionsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -6773,7 +6861,13 @@ impl DescribeIndexFieldsError {
                 }
                 _ => DescribeIndexFieldsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeIndexFieldsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeIndexFieldsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeIndexFieldsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -6865,7 +6959,15 @@ impl DescribeScalingParametersError {
                 _ => DescribeScalingParametersError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeScalingParametersError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeScalingParametersError::Unknown(format!("{}", status))
+                } else {
+                    DescribeScalingParametersError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -6957,11 +7059,17 @@ impl DescribeServiceAccessPoliciesError {
                 ),
                 _ => DescribeServiceAccessPoliciesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeServiceAccessPoliciesError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeServiceAccessPoliciesError::Unknown(format!("{}", status))
+                } else {
+                    DescribeServiceAccessPoliciesError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -7052,7 +7160,13 @@ impl DescribeSuggestersError {
                 }
                 _ => DescribeSuggestersError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeSuggestersError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeSuggestersError::Unknown(format!("{}", status))
+                } else {
+                    DescribeSuggestersError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -7141,7 +7255,13 @@ impl IndexDocumentsError {
                 }
                 _ => IndexDocumentsError::Unknown(String::from(body)),
             },
-            Err(_) => IndexDocumentsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    IndexDocumentsError::Unknown(format!("{}", status))
+                } else {
+                    IndexDocumentsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -7218,7 +7338,13 @@ impl ListDomainNamesError {
                 "BaseException" => ListDomainNamesError::Base(String::from(parsed_error.message)),
                 _ => ListDomainNamesError::Unknown(String::from(body)),
             },
-            Err(_) => ListDomainNamesError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ListDomainNamesError::Unknown(format!("{}", status))
+                } else {
+                    ListDomainNamesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -7321,7 +7447,15 @@ impl UpdateAvailabilityOptionsError {
                 _ => UpdateAvailabilityOptionsError::Unknown(String::from(body)),
             },
             Err(_) => {
-                UpdateAvailabilityOptionsError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    UpdateAvailabilityOptionsError::Unknown(format!("{}", status))
+                } else {
+                    UpdateAvailabilityOptionsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -7427,7 +7561,15 @@ impl UpdateScalingParametersError {
                 _ => UpdateScalingParametersError::Unknown(String::from(body)),
             },
             Err(_) => {
-                UpdateScalingParametersError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    UpdateScalingParametersError::Unknown(format!("{}", status))
+                } else {
+                    UpdateScalingParametersError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -7531,11 +7673,17 @@ impl UpdateServiceAccessPoliciesError {
                 ),
                 _ => UpdateServiceAccessPoliciesError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateServiceAccessPoliciesError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    UpdateServiceAccessPoliciesError::Unknown(format!("{}", status))
+                } else {
+                    UpdateServiceAccessPoliciesError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 

--- a/rusoto/services/cloudsearch/src/generated.rs
+++ b/rusoto/services/cloudsearch/src/generated.rs
@@ -5343,7 +5343,7 @@ pub enum BuildSuggestersError {
 }
 
 impl BuildSuggestersError {
-    pub fn from_body(body: &str) -> BuildSuggestersError {
+    pub fn from_body(body: &str, status: u16) -> BuildSuggestersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -5358,7 +5358,7 @@ impl BuildSuggestersError {
                 }
                 _ => BuildSuggestersError::Unknown(String::from(body)),
             },
-            Err(_) => BuildSuggestersError::Unknown(body.to_string()),
+            Err(_) => BuildSuggestersError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -5430,7 +5430,7 @@ pub enum CreateDomainError {
 }
 
 impl CreateDomainError {
-    pub fn from_body(body: &str) -> CreateDomainError {
+    pub fn from_body(body: &str, status: u16) -> CreateDomainError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -5445,7 +5445,7 @@ impl CreateDomainError {
                 }
                 _ => CreateDomainError::Unknown(String::from(body)),
             },
-            Err(_) => CreateDomainError::Unknown(body.to_string()),
+            Err(_) => CreateDomainError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -5521,7 +5521,7 @@ pub enum DefineAnalysisSchemeError {
 }
 
 impl DefineAnalysisSchemeError {
-    pub fn from_body(body: &str) -> DefineAnalysisSchemeError {
+    pub fn from_body(body: &str, status: u16) -> DefineAnalysisSchemeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -5544,7 +5544,9 @@ impl DefineAnalysisSchemeError {
                 }
                 _ => DefineAnalysisSchemeError::Unknown(String::from(body)),
             },
-            Err(_) => DefineAnalysisSchemeError::Unknown(body.to_string()),
+            Err(_) => {
+                DefineAnalysisSchemeError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -5624,7 +5626,7 @@ pub enum DefineExpressionError {
 }
 
 impl DefineExpressionError {
-    pub fn from_body(body: &str) -> DefineExpressionError {
+    pub fn from_body(body: &str, status: u16) -> DefineExpressionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -5645,7 +5647,7 @@ impl DefineExpressionError {
                 }
                 _ => DefineExpressionError::Unknown(String::from(body)),
             },
-            Err(_) => DefineExpressionError::Unknown(body.to_string()),
+            Err(_) => DefineExpressionError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -5723,7 +5725,7 @@ pub enum DefineIndexFieldError {
 }
 
 impl DefineIndexFieldError {
-    pub fn from_body(body: &str) -> DefineIndexFieldError {
+    pub fn from_body(body: &str, status: u16) -> DefineIndexFieldError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -5744,7 +5746,7 @@ impl DefineIndexFieldError {
                 }
                 _ => DefineIndexFieldError::Unknown(String::from(body)),
             },
-            Err(_) => DefineIndexFieldError::Unknown(body.to_string()),
+            Err(_) => DefineIndexFieldError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -5822,7 +5824,7 @@ pub enum DefineSuggesterError {
 }
 
 impl DefineSuggesterError {
-    pub fn from_body(body: &str) -> DefineSuggesterError {
+    pub fn from_body(body: &str, status: u16) -> DefineSuggesterError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -5843,7 +5845,7 @@ impl DefineSuggesterError {
                 }
                 _ => DefineSuggesterError::Unknown(String::from(body)),
             },
-            Err(_) => DefineSuggesterError::Unknown(body.to_string()),
+            Err(_) => DefineSuggesterError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -5919,7 +5921,7 @@ pub enum DeleteAnalysisSchemeError {
 }
 
 impl DeleteAnalysisSchemeError {
-    pub fn from_body(body: &str) -> DeleteAnalysisSchemeError {
+    pub fn from_body(body: &str, status: u16) -> DeleteAnalysisSchemeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -5939,7 +5941,9 @@ impl DeleteAnalysisSchemeError {
                 }
                 _ => DeleteAnalysisSchemeError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteAnalysisSchemeError::Unknown(body.to_string()),
+            Err(_) => {
+                DeleteAnalysisSchemeError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -6012,7 +6016,7 @@ pub enum DeleteDomainError {
 }
 
 impl DeleteDomainError {
-    pub fn from_body(body: &str) -> DeleteDomainError {
+    pub fn from_body(body: &str, status: u16) -> DeleteDomainError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -6024,7 +6028,7 @@ impl DeleteDomainError {
                 }
                 _ => DeleteDomainError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteDomainError::Unknown(body.to_string()),
+            Err(_) => DeleteDomainError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -6097,7 +6101,7 @@ pub enum DeleteExpressionError {
 }
 
 impl DeleteExpressionError {
-    pub fn from_body(body: &str) -> DeleteExpressionError {
+    pub fn from_body(body: &str, status: u16) -> DeleteExpressionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -6115,7 +6119,7 @@ impl DeleteExpressionError {
                 }
                 _ => DeleteExpressionError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteExpressionError::Unknown(body.to_string()),
+            Err(_) => DeleteExpressionError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -6190,7 +6194,7 @@ pub enum DeleteIndexFieldError {
 }
 
 impl DeleteIndexFieldError {
-    pub fn from_body(body: &str) -> DeleteIndexFieldError {
+    pub fn from_body(body: &str, status: u16) -> DeleteIndexFieldError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -6208,7 +6212,7 @@ impl DeleteIndexFieldError {
                 }
                 _ => DeleteIndexFieldError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteIndexFieldError::Unknown(body.to_string()),
+            Err(_) => DeleteIndexFieldError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -6283,7 +6287,7 @@ pub enum DeleteSuggesterError {
 }
 
 impl DeleteSuggesterError {
-    pub fn from_body(body: &str) -> DeleteSuggesterError {
+    pub fn from_body(body: &str, status: u16) -> DeleteSuggesterError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -6301,7 +6305,7 @@ impl DeleteSuggesterError {
                 }
                 _ => DeleteSuggesterError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteSuggesterError::Unknown(body.to_string()),
+            Err(_) => DeleteSuggesterError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -6374,7 +6378,7 @@ pub enum DescribeAnalysisSchemesError {
 }
 
 impl DescribeAnalysisSchemesError {
-    pub fn from_body(body: &str) -> DescribeAnalysisSchemesError {
+    pub fn from_body(body: &str, status: u16) -> DescribeAnalysisSchemesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -6391,7 +6395,9 @@ impl DescribeAnalysisSchemesError {
                 )),
                 _ => DescribeAnalysisSchemesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeAnalysisSchemesError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeAnalysisSchemesError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -6471,7 +6477,7 @@ pub enum DescribeAvailabilityOptionsError {
 }
 
 impl DescribeAvailabilityOptionsError {
-    pub fn from_body(body: &str) -> DescribeAvailabilityOptionsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeAvailabilityOptionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -6497,7 +6503,11 @@ impl DescribeAvailabilityOptionsError {
                 ),
                 _ => DescribeAvailabilityOptionsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeAvailabilityOptionsError::Unknown(body.to_string()),
+            Err(_) => DescribeAvailabilityOptionsError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -6572,7 +6582,7 @@ pub enum DescribeDomainsError {
 }
 
 impl DescribeDomainsError {
-    pub fn from_body(body: &str) -> DescribeDomainsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeDomainsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -6584,7 +6594,7 @@ impl DescribeDomainsError {
                 }
                 _ => DescribeDomainsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeDomainsError::Unknown(body.to_string()),
+            Err(_) => DescribeDomainsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -6655,7 +6665,7 @@ pub enum DescribeExpressionsError {
 }
 
 impl DescribeExpressionsError {
-    pub fn from_body(body: &str) -> DescribeExpressionsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeExpressionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -6672,7 +6682,7 @@ impl DescribeExpressionsError {
                 }
                 _ => DescribeExpressionsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeExpressionsError::Unknown(body.to_string()),
+            Err(_) => DescribeExpressionsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -6746,7 +6756,7 @@ pub enum DescribeIndexFieldsError {
 }
 
 impl DescribeIndexFieldsError {
-    pub fn from_body(body: &str) -> DescribeIndexFieldsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeIndexFieldsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -6763,7 +6773,7 @@ impl DescribeIndexFieldsError {
                 }
                 _ => DescribeIndexFieldsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeIndexFieldsError::Unknown(body.to_string()),
+            Err(_) => DescribeIndexFieldsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -6837,7 +6847,7 @@ pub enum DescribeScalingParametersError {
 }
 
 impl DescribeScalingParametersError {
-    pub fn from_body(body: &str) -> DescribeScalingParametersError {
+    pub fn from_body(body: &str, status: u16) -> DescribeScalingParametersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -6854,7 +6864,9 @@ impl DescribeScalingParametersError {
                 ),
                 _ => DescribeScalingParametersError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeScalingParametersError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeScalingParametersError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -6928,7 +6940,7 @@ pub enum DescribeServiceAccessPoliciesError {
 }
 
 impl DescribeServiceAccessPoliciesError {
-    pub fn from_body(body: &str) -> DescribeServiceAccessPoliciesError {
+    pub fn from_body(body: &str, status: u16) -> DescribeServiceAccessPoliciesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -6945,7 +6957,11 @@ impl DescribeServiceAccessPoliciesError {
                 ),
                 _ => DescribeServiceAccessPoliciesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeServiceAccessPoliciesError::Unknown(body.to_string()),
+            Err(_) => DescribeServiceAccessPoliciesError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -7019,7 +7035,7 @@ pub enum DescribeSuggestersError {
 }
 
 impl DescribeSuggestersError {
-    pub fn from_body(body: &str) -> DescribeSuggestersError {
+    pub fn from_body(body: &str, status: u16) -> DescribeSuggestersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -7036,7 +7052,7 @@ impl DescribeSuggestersError {
                 }
                 _ => DescribeSuggestersError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeSuggestersError::Unknown(body.to_string()),
+            Err(_) => DescribeSuggestersError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -7110,7 +7126,7 @@ pub enum IndexDocumentsError {
 }
 
 impl IndexDocumentsError {
-    pub fn from_body(body: &str) -> IndexDocumentsError {
+    pub fn from_body(body: &str, status: u16) -> IndexDocumentsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -7125,7 +7141,7 @@ impl IndexDocumentsError {
                 }
                 _ => IndexDocumentsError::Unknown(String::from(body)),
             },
-            Err(_) => IndexDocumentsError::Unknown(body.to_string()),
+            Err(_) => IndexDocumentsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -7193,7 +7209,7 @@ pub enum ListDomainNamesError {
 }
 
 impl ListDomainNamesError {
-    pub fn from_body(body: &str) -> ListDomainNamesError {
+    pub fn from_body(body: &str, status: u16) -> ListDomainNamesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -7202,7 +7218,7 @@ impl ListDomainNamesError {
                 "BaseException" => ListDomainNamesError::Base(String::from(parsed_error.message)),
                 _ => ListDomainNamesError::Unknown(String::from(body)),
             },
-            Err(_) => ListDomainNamesError::Unknown(body.to_string()),
+            Err(_) => ListDomainNamesError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -7278,7 +7294,7 @@ pub enum UpdateAvailabilityOptionsError {
 }
 
 impl UpdateAvailabilityOptionsError {
-    pub fn from_body(body: &str) -> UpdateAvailabilityOptionsError {
+    pub fn from_body(body: &str, status: u16) -> UpdateAvailabilityOptionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -7304,7 +7320,9 @@ impl UpdateAvailabilityOptionsError {
                 ),
                 _ => UpdateAvailabilityOptionsError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateAvailabilityOptionsError::Unknown(body.to_string()),
+            Err(_) => {
+                UpdateAvailabilityOptionsError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -7385,7 +7403,7 @@ pub enum UpdateScalingParametersError {
 }
 
 impl UpdateScalingParametersError {
-    pub fn from_body(body: &str) -> UpdateScalingParametersError {
+    pub fn from_body(body: &str, status: u16) -> UpdateScalingParametersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -7408,7 +7426,9 @@ impl UpdateScalingParametersError {
                 )),
                 _ => UpdateScalingParametersError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateScalingParametersError::Unknown(body.to_string()),
+            Err(_) => {
+                UpdateScalingParametersError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -7488,7 +7508,7 @@ pub enum UpdateServiceAccessPoliciesError {
 }
 
 impl UpdateServiceAccessPoliciesError {
-    pub fn from_body(body: &str) -> UpdateServiceAccessPoliciesError {
+    pub fn from_body(body: &str, status: u16) -> UpdateServiceAccessPoliciesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -7511,7 +7531,11 @@ impl UpdateServiceAccessPoliciesError {
                 ),
                 _ => UpdateServiceAccessPoliciesError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateServiceAccessPoliciesError::Unknown(body.to_string()),
+            Err(_) => UpdateServiceAccessPoliciesError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 

--- a/rusoto/services/cloudwatch/src/generated.rs
+++ b/rusoto/services/cloudwatch/src/generated.rs
@@ -3403,7 +3403,7 @@ pub enum DeleteAlarmsError {
 }
 
 impl DeleteAlarmsError {
-    pub fn from_body(body: &str) -> DeleteAlarmsError {
+    pub fn from_body(body: &str, status: u16) -> DeleteAlarmsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -3414,7 +3414,7 @@ impl DeleteAlarmsError {
                 }
                 _ => DeleteAlarmsError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteAlarmsError::Unknown(body.to_string()),
+            Err(_) => DeleteAlarmsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -3484,7 +3484,7 @@ pub enum DeleteDashboardsError {
 }
 
 impl DeleteDashboardsError {
-    pub fn from_body(body: &str) -> DeleteDashboardsError {
+    pub fn from_body(body: &str, status: u16) -> DeleteDashboardsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -3501,7 +3501,7 @@ impl DeleteDashboardsError {
                 }
                 _ => DeleteDashboardsError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteDashboardsError::Unknown(body.to_string()),
+            Err(_) => DeleteDashboardsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -3569,7 +3569,7 @@ pub enum DescribeAlarmHistoryError {
 }
 
 impl DescribeAlarmHistoryError {
-    pub fn from_body(body: &str) -> DescribeAlarmHistoryError {
+    pub fn from_body(body: &str, status: u16) -> DescribeAlarmHistoryError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -3580,7 +3580,9 @@ impl DescribeAlarmHistoryError {
                 }
                 _ => DescribeAlarmHistoryError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeAlarmHistoryError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeAlarmHistoryError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -3648,7 +3650,7 @@ pub enum DescribeAlarmsError {
 }
 
 impl DescribeAlarmsError {
-    pub fn from_body(body: &str) -> DescribeAlarmsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeAlarmsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -3659,7 +3661,7 @@ impl DescribeAlarmsError {
                 }
                 _ => DescribeAlarmsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeAlarmsError::Unknown(body.to_string()),
+            Err(_) => DescribeAlarmsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -3723,7 +3725,7 @@ pub enum DescribeAlarmsForMetricError {
 }
 
 impl DescribeAlarmsForMetricError {
-    pub fn from_body(body: &str) -> DescribeAlarmsForMetricError {
+    pub fn from_body(body: &str, status: u16) -> DescribeAlarmsForMetricError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -3731,7 +3733,9 @@ impl DescribeAlarmsForMetricError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeAlarmsForMetricError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeAlarmsForMetricError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeAlarmsForMetricError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -3796,7 +3800,7 @@ pub enum DisableAlarmActionsError {
 }
 
 impl DisableAlarmActionsError {
-    pub fn from_body(body: &str) -> DisableAlarmActionsError {
+    pub fn from_body(body: &str, status: u16) -> DisableAlarmActionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -3804,7 +3808,7 @@ impl DisableAlarmActionsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DisableAlarmActionsError::Unknown(String::from(body)),
             },
-            Err(_) => DisableAlarmActionsError::Unknown(body.to_string()),
+            Err(_) => DisableAlarmActionsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -3869,7 +3873,7 @@ pub enum EnableAlarmActionsError {
 }
 
 impl EnableAlarmActionsError {
-    pub fn from_body(body: &str) -> EnableAlarmActionsError {
+    pub fn from_body(body: &str, status: u16) -> EnableAlarmActionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -3877,7 +3881,7 @@ impl EnableAlarmActionsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => EnableAlarmActionsError::Unknown(String::from(body)),
             },
-            Err(_) => EnableAlarmActionsError::Unknown(body.to_string()),
+            Err(_) => EnableAlarmActionsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -3948,7 +3952,7 @@ pub enum GetDashboardError {
 }
 
 impl GetDashboardError {
-    pub fn from_body(body: &str) -> GetDashboardError {
+    pub fn from_body(body: &str, status: u16) -> GetDashboardError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -3965,7 +3969,7 @@ impl GetDashboardError {
                 }
                 _ => GetDashboardError::Unknown(String::from(body)),
             },
-            Err(_) => GetDashboardError::Unknown(body.to_string()),
+            Err(_) => GetDashboardError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -4033,7 +4037,7 @@ pub enum GetMetricDataError {
 }
 
 impl GetMetricDataError {
-    pub fn from_body(body: &str) -> GetMetricDataError {
+    pub fn from_body(body: &str, status: u16) -> GetMetricDataError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -4044,7 +4048,7 @@ impl GetMetricDataError {
                 }
                 _ => GetMetricDataError::Unknown(String::from(body)),
             },
-            Err(_) => GetMetricDataError::Unknown(body.to_string()),
+            Err(_) => GetMetricDataError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -4116,7 +4120,7 @@ pub enum GetMetricStatisticsError {
 }
 
 impl GetMetricStatisticsError {
-    pub fn from_body(body: &str) -> GetMetricStatisticsError {
+    pub fn from_body(body: &str, status: u16) -> GetMetricStatisticsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -4138,7 +4142,7 @@ impl GetMetricStatisticsError {
                 ),
                 _ => GetMetricStatisticsError::Unknown(String::from(body)),
             },
-            Err(_) => GetMetricStatisticsError::Unknown(body.to_string()),
+            Err(_) => GetMetricStatisticsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -4211,7 +4215,7 @@ pub enum ListDashboardsError {
 }
 
 impl ListDashboardsError {
-    pub fn from_body(body: &str) -> ListDashboardsError {
+    pub fn from_body(body: &str, status: u16) -> ListDashboardsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -4225,7 +4229,7 @@ impl ListDashboardsError {
                 }
                 _ => ListDashboardsError::Unknown(String::from(body)),
             },
-            Err(_) => ListDashboardsError::Unknown(body.to_string()),
+            Err(_) => ListDashboardsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -4294,7 +4298,7 @@ pub enum ListMetricsError {
 }
 
 impl ListMetricsError {
-    pub fn from_body(body: &str) -> ListMetricsError {
+    pub fn from_body(body: &str, status: u16) -> ListMetricsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -4308,7 +4312,7 @@ impl ListMetricsError {
                 }
                 _ => ListMetricsError::Unknown(String::from(body)),
             },
-            Err(_) => ListMetricsError::Unknown(body.to_string()),
+            Err(_) => ListMetricsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -4377,7 +4381,7 @@ pub enum PutDashboardError {
 }
 
 impl PutDashboardError {
-    pub fn from_body(body: &str) -> PutDashboardError {
+    pub fn from_body(body: &str, status: u16) -> PutDashboardError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -4391,7 +4395,7 @@ impl PutDashboardError {
                 }
                 _ => PutDashboardError::Unknown(String::from(body)),
             },
-            Err(_) => PutDashboardError::Unknown(body.to_string()),
+            Err(_) => PutDashboardError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -4458,7 +4462,7 @@ pub enum PutMetricAlarmError {
 }
 
 impl PutMetricAlarmError {
-    pub fn from_body(body: &str) -> PutMetricAlarmError {
+    pub fn from_body(body: &str, status: u16) -> PutMetricAlarmError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -4469,7 +4473,7 @@ impl PutMetricAlarmError {
                 }
                 _ => PutMetricAlarmError::Unknown(String::from(body)),
             },
-            Err(_) => PutMetricAlarmError::Unknown(body.to_string()),
+            Err(_) => PutMetricAlarmError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -4541,7 +4545,7 @@ pub enum PutMetricDataError {
 }
 
 impl PutMetricDataError {
-    pub fn from_body(body: &str) -> PutMetricDataError {
+    pub fn from_body(body: &str, status: u16) -> PutMetricDataError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -4561,7 +4565,7 @@ impl PutMetricDataError {
                 }
                 _ => PutMetricDataError::Unknown(String::from(body)),
             },
-            Err(_) => PutMetricDataError::Unknown(body.to_string()),
+            Err(_) => PutMetricDataError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -4632,7 +4636,7 @@ pub enum SetAlarmStateError {
 }
 
 impl SetAlarmStateError {
-    pub fn from_body(body: &str) -> SetAlarmStateError {
+    pub fn from_body(body: &str, status: u16) -> SetAlarmStateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -4646,7 +4650,7 @@ impl SetAlarmStateError {
                 }
                 _ => SetAlarmStateError::Unknown(String::from(body)),
             },
-            Err(_) => SetAlarmStateError::Unknown(body.to_string()),
+            Err(_) => SetAlarmStateError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 

--- a/rusoto/services/cloudwatch/src/generated.rs
+++ b/rusoto/services/cloudwatch/src/generated.rs
@@ -3414,7 +3414,13 @@ impl DeleteAlarmsError {
                 }
                 _ => DeleteAlarmsError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteAlarmsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteAlarmsError::Unknown(format!("{}", status))
+                } else {
+                    DeleteAlarmsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -3501,7 +3507,13 @@ impl DeleteDashboardsError {
                 }
                 _ => DeleteDashboardsError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteDashboardsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteDashboardsError::Unknown(format!("{}", status))
+                } else {
+                    DeleteDashboardsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -3581,7 +3593,11 @@ impl DescribeAlarmHistoryError {
                 _ => DescribeAlarmHistoryError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeAlarmHistoryError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeAlarmHistoryError::Unknown(format!("{}", status))
+                } else {
+                    DescribeAlarmHistoryError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -3661,7 +3677,13 @@ impl DescribeAlarmsError {
                 }
                 _ => DescribeAlarmsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeAlarmsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeAlarmsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeAlarmsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -3734,7 +3756,15 @@ impl DescribeAlarmsForMetricError {
                 _ => DescribeAlarmsForMetricError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeAlarmsForMetricError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeAlarmsForMetricError::Unknown(format!("{}", status))
+                } else {
+                    DescribeAlarmsForMetricError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -3808,7 +3838,13 @@ impl DisableAlarmActionsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DisableAlarmActionsError::Unknown(String::from(body)),
             },
-            Err(_) => DisableAlarmActionsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DisableAlarmActionsError::Unknown(format!("{}", status))
+                } else {
+                    DisableAlarmActionsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -3881,7 +3917,13 @@ impl EnableAlarmActionsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => EnableAlarmActionsError::Unknown(String::from(body)),
             },
-            Err(_) => EnableAlarmActionsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    EnableAlarmActionsError::Unknown(format!("{}", status))
+                } else {
+                    EnableAlarmActionsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -3969,7 +4011,13 @@ impl GetDashboardError {
                 }
                 _ => GetDashboardError::Unknown(String::from(body)),
             },
-            Err(_) => GetDashboardError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetDashboardError::Unknown(format!("{}", status))
+                } else {
+                    GetDashboardError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -4048,7 +4096,13 @@ impl GetMetricDataError {
                 }
                 _ => GetMetricDataError::Unknown(String::from(body)),
             },
-            Err(_) => GetMetricDataError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetMetricDataError::Unknown(format!("{}", status))
+                } else {
+                    GetMetricDataError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -4142,7 +4196,13 @@ impl GetMetricStatisticsError {
                 ),
                 _ => GetMetricStatisticsError::Unknown(String::from(body)),
             },
-            Err(_) => GetMetricStatisticsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetMetricStatisticsError::Unknown(format!("{}", status))
+                } else {
+                    GetMetricStatisticsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -4229,7 +4289,13 @@ impl ListDashboardsError {
                 }
                 _ => ListDashboardsError::Unknown(String::from(body)),
             },
-            Err(_) => ListDashboardsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ListDashboardsError::Unknown(format!("{}", status))
+                } else {
+                    ListDashboardsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -4312,7 +4378,13 @@ impl ListMetricsError {
                 }
                 _ => ListMetricsError::Unknown(String::from(body)),
             },
-            Err(_) => ListMetricsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ListMetricsError::Unknown(format!("{}", status))
+                } else {
+                    ListMetricsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -4395,7 +4467,13 @@ impl PutDashboardError {
                 }
                 _ => PutDashboardError::Unknown(String::from(body)),
             },
-            Err(_) => PutDashboardError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    PutDashboardError::Unknown(format!("{}", status))
+                } else {
+                    PutDashboardError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -4473,7 +4551,13 @@ impl PutMetricAlarmError {
                 }
                 _ => PutMetricAlarmError::Unknown(String::from(body)),
             },
-            Err(_) => PutMetricAlarmError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    PutMetricAlarmError::Unknown(format!("{}", status))
+                } else {
+                    PutMetricAlarmError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -4565,7 +4649,13 @@ impl PutMetricDataError {
                 }
                 _ => PutMetricDataError::Unknown(String::from(body)),
             },
-            Err(_) => PutMetricDataError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    PutMetricDataError::Unknown(format!("{}", status))
+                } else {
+                    PutMetricDataError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -4650,7 +4740,13 @@ impl SetAlarmStateError {
                 }
                 _ => SetAlarmStateError::Unknown(String::from(body)),
             },
-            Err(_) => SetAlarmStateError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    SetAlarmStateError::Unknown(format!("{}", status))
+                } else {
+                    SetAlarmStateError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 

--- a/rusoto/services/ec2/src/generated.rs
+++ b/rusoto/services/ec2/src/generated.rs
@@ -54349,11 +54349,17 @@ impl AcceptReservedInstancesExchangeQuoteError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AcceptReservedInstancesExchangeQuoteError::Unknown(String::from(body)),
             },
-            Err(_) => AcceptReservedInstancesExchangeQuoteError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    AcceptReservedInstancesExchangeQuoteError::Unknown(format!("{}", status))
+                } else {
+                    AcceptReservedInstancesExchangeQuoteError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -54427,11 +54433,17 @@ impl AcceptVpcEndpointConnectionsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AcceptVpcEndpointConnectionsError::Unknown(String::from(body)),
             },
-            Err(_) => AcceptVpcEndpointConnectionsError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    AcceptVpcEndpointConnectionsError::Unknown(format!("{}", status))
+                } else {
+                    AcceptVpcEndpointConnectionsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -54506,7 +54518,15 @@ impl AcceptVpcPeeringConnectionError {
                 _ => AcceptVpcPeeringConnectionError::Unknown(String::from(body)),
             },
             Err(_) => {
-                AcceptVpcPeeringConnectionError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    AcceptVpcPeeringConnectionError::Unknown(format!("{}", status))
+                } else {
+                    AcceptVpcPeeringConnectionError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -54581,7 +54601,13 @@ impl AllocateAddressError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AllocateAddressError::Unknown(String::from(body)),
             },
-            Err(_) => AllocateAddressError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    AllocateAddressError::Unknown(format!("{}", status))
+                } else {
+                    AllocateAddressError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -54653,7 +54679,13 @@ impl AllocateHostsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AllocateHostsError::Unknown(String::from(body)),
             },
-            Err(_) => AllocateHostsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    AllocateHostsError::Unknown(format!("{}", status))
+                } else {
+                    AllocateHostsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -54725,7 +54757,13 @@ impl AssignIpv6AddressesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AssignIpv6AddressesError::Unknown(String::from(body)),
             },
-            Err(_) => AssignIpv6AddressesError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    AssignIpv6AddressesError::Unknown(format!("{}", status))
+                } else {
+                    AssignIpv6AddressesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -54800,7 +54838,15 @@ impl AssignPrivateIpAddressesError {
                 _ => AssignPrivateIpAddressesError::Unknown(String::from(body)),
             },
             Err(_) => {
-                AssignPrivateIpAddressesError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    AssignPrivateIpAddressesError::Unknown(format!("{}", status))
+                } else {
+                    AssignPrivateIpAddressesError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -54875,7 +54921,13 @@ impl AssociateAddressError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AssociateAddressError::Unknown(String::from(body)),
             },
-            Err(_) => AssociateAddressError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    AssociateAddressError::Unknown(format!("{}", status))
+                } else {
+                    AssociateAddressError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -54948,7 +55000,11 @@ impl AssociateDhcpOptionsError {
                 _ => AssociateDhcpOptionsError::Unknown(String::from(body)),
             },
             Err(_) => {
-                AssociateDhcpOptionsError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    AssociateDhcpOptionsError::Unknown(format!("{}", status))
+                } else {
+                    AssociateDhcpOptionsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -55023,11 +55079,17 @@ impl AssociateIamInstanceProfileError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AssociateIamInstanceProfileError::Unknown(String::from(body)),
             },
-            Err(_) => AssociateIamInstanceProfileError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    AssociateIamInstanceProfileError::Unknown(format!("{}", status))
+                } else {
+                    AssociateIamInstanceProfileError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -55101,7 +55163,13 @@ impl AssociateRouteTableError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AssociateRouteTableError::Unknown(String::from(body)),
             },
-            Err(_) => AssociateRouteTableError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    AssociateRouteTableError::Unknown(format!("{}", status))
+                } else {
+                    AssociateRouteTableError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -55176,7 +55244,15 @@ impl AssociateSubnetCidrBlockError {
                 _ => AssociateSubnetCidrBlockError::Unknown(String::from(body)),
             },
             Err(_) => {
-                AssociateSubnetCidrBlockError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    AssociateSubnetCidrBlockError::Unknown(format!("{}", status))
+                } else {
+                    AssociateSubnetCidrBlockError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -55252,7 +55328,11 @@ impl AssociateVpcCidrBlockError {
                 _ => AssociateVpcCidrBlockError::Unknown(String::from(body)),
             },
             Err(_) => {
-                AssociateVpcCidrBlockError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    AssociateVpcCidrBlockError::Unknown(format!("{}", status))
+                } else {
+                    AssociateVpcCidrBlockError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -55328,7 +55408,11 @@ impl AttachClassicLinkVpcError {
                 _ => AttachClassicLinkVpcError::Unknown(String::from(body)),
             },
             Err(_) => {
-                AttachClassicLinkVpcError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    AttachClassicLinkVpcError::Unknown(format!("{}", status))
+                } else {
+                    AttachClassicLinkVpcError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -55404,7 +55488,11 @@ impl AttachInternetGatewayError {
                 _ => AttachInternetGatewayError::Unknown(String::from(body)),
             },
             Err(_) => {
-                AttachInternetGatewayError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    AttachInternetGatewayError::Unknown(format!("{}", status))
+                } else {
+                    AttachInternetGatewayError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -55480,7 +55568,11 @@ impl AttachNetworkInterfaceError {
                 _ => AttachNetworkInterfaceError::Unknown(String::from(body)),
             },
             Err(_) => {
-                AttachNetworkInterfaceError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    AttachNetworkInterfaceError::Unknown(format!("{}", status))
+                } else {
+                    AttachNetworkInterfaceError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -55555,7 +55647,13 @@ impl AttachVolumeError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AttachVolumeError::Unknown(String::from(body)),
             },
-            Err(_) => AttachVolumeError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    AttachVolumeError::Unknown(format!("{}", status))
+                } else {
+                    AttachVolumeError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -55627,7 +55725,13 @@ impl AttachVpnGatewayError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AttachVpnGatewayError::Unknown(String::from(body)),
             },
-            Err(_) => AttachVpnGatewayError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    AttachVpnGatewayError::Unknown(format!("{}", status))
+                } else {
+                    AttachVpnGatewayError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -55699,11 +55803,17 @@ impl AuthorizeSecurityGroupEgressError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AuthorizeSecurityGroupEgressError::Unknown(String::from(body)),
             },
-            Err(_) => AuthorizeSecurityGroupEgressError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    AuthorizeSecurityGroupEgressError::Unknown(format!("{}", status))
+                } else {
+                    AuthorizeSecurityGroupEgressError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -55777,11 +55887,17 @@ impl AuthorizeSecurityGroupIngressError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AuthorizeSecurityGroupIngressError::Unknown(String::from(body)),
             },
-            Err(_) => AuthorizeSecurityGroupIngressError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    AuthorizeSecurityGroupIngressError::Unknown(format!("{}", status))
+                } else {
+                    AuthorizeSecurityGroupIngressError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -55855,7 +55971,13 @@ impl BundleInstanceError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => BundleInstanceError::Unknown(String::from(body)),
             },
-            Err(_) => BundleInstanceError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    BundleInstanceError::Unknown(format!("{}", status))
+                } else {
+                    BundleInstanceError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -55927,7 +56049,13 @@ impl CancelBundleTaskError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CancelBundleTaskError::Unknown(String::from(body)),
             },
-            Err(_) => CancelBundleTaskError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CancelBundleTaskError::Unknown(format!("{}", status))
+                } else {
+                    CancelBundleTaskError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -56000,7 +56128,11 @@ impl CancelConversionTaskError {
                 _ => CancelConversionTaskError::Unknown(String::from(body)),
             },
             Err(_) => {
-                CancelConversionTaskError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    CancelConversionTaskError::Unknown(format!("{}", status))
+                } else {
+                    CancelConversionTaskError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -56075,7 +56207,13 @@ impl CancelExportTaskError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CancelExportTaskError::Unknown(String::from(body)),
             },
-            Err(_) => CancelExportTaskError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CancelExportTaskError::Unknown(format!("{}", status))
+                } else {
+                    CancelExportTaskError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -56147,7 +56285,13 @@ impl CancelImportTaskError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CancelImportTaskError::Unknown(String::from(body)),
             },
-            Err(_) => CancelImportTaskError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CancelImportTaskError::Unknown(format!("{}", status))
+                } else {
+                    CancelImportTaskError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -56219,11 +56363,17 @@ impl CancelReservedInstancesListingError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CancelReservedInstancesListingError::Unknown(String::from(body)),
             },
-            Err(_) => CancelReservedInstancesListingError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    CancelReservedInstancesListingError::Unknown(format!("{}", status))
+                } else {
+                    CancelReservedInstancesListingError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -56298,7 +56448,15 @@ impl EC2CancelSpotFleetRequestsError {
                 _ => EC2CancelSpotFleetRequestsError::Unknown(String::from(body)),
             },
             Err(_) => {
-                EC2CancelSpotFleetRequestsError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    EC2CancelSpotFleetRequestsError::Unknown(format!("{}", status))
+                } else {
+                    EC2CancelSpotFleetRequestsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -56374,7 +56532,15 @@ impl CancelSpotInstanceRequestsError {
                 _ => CancelSpotInstanceRequestsError::Unknown(String::from(body)),
             },
             Err(_) => {
-                CancelSpotInstanceRequestsError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    CancelSpotInstanceRequestsError::Unknown(format!("{}", status))
+                } else {
+                    CancelSpotInstanceRequestsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -56450,7 +56616,11 @@ impl ConfirmProductInstanceError {
                 _ => ConfirmProductInstanceError::Unknown(String::from(body)),
             },
             Err(_) => {
-                ConfirmProductInstanceError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    ConfirmProductInstanceError::Unknown(format!("{}", status))
+                } else {
+                    ConfirmProductInstanceError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -56525,7 +56695,13 @@ impl CopyFpgaImageError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CopyFpgaImageError::Unknown(String::from(body)),
             },
-            Err(_) => CopyFpgaImageError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CopyFpgaImageError::Unknown(format!("{}", status))
+                } else {
+                    CopyFpgaImageError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -56597,7 +56773,13 @@ impl CopyImageError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CopyImageError::Unknown(String::from(body)),
             },
-            Err(_) => CopyImageError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CopyImageError::Unknown(format!("{}", status))
+                } else {
+                    CopyImageError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -56669,7 +56851,13 @@ impl CopySnapshotError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CopySnapshotError::Unknown(String::from(body)),
             },
-            Err(_) => CopySnapshotError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CopySnapshotError::Unknown(format!("{}", status))
+                } else {
+                    CopySnapshotError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -56742,7 +56930,11 @@ impl CreateCustomerGatewayError {
                 _ => CreateCustomerGatewayError::Unknown(String::from(body)),
             },
             Err(_) => {
-                CreateCustomerGatewayError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    CreateCustomerGatewayError::Unknown(format!("{}", status))
+                } else {
+                    CreateCustomerGatewayError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -56817,7 +57009,13 @@ impl CreateDefaultSubnetError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateDefaultSubnetError::Unknown(String::from(body)),
             },
-            Err(_) => CreateDefaultSubnetError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateDefaultSubnetError::Unknown(format!("{}", status))
+                } else {
+                    CreateDefaultSubnetError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -56891,7 +57089,13 @@ impl CreateDefaultVpcError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateDefaultVpcError::Unknown(String::from(body)),
             },
-            Err(_) => CreateDefaultVpcError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateDefaultVpcError::Unknown(format!("{}", status))
+                } else {
+                    CreateDefaultVpcError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -56963,7 +57167,13 @@ impl CreateDhcpOptionsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateDhcpOptionsError::Unknown(String::from(body)),
             },
-            Err(_) => CreateDhcpOptionsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateDhcpOptionsError::Unknown(format!("{}", status))
+                } else {
+                    CreateDhcpOptionsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -57037,11 +57247,17 @@ impl CreateEgressOnlyInternetGatewayError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateEgressOnlyInternetGatewayError::Unknown(String::from(body)),
             },
-            Err(_) => CreateEgressOnlyInternetGatewayError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateEgressOnlyInternetGatewayError::Unknown(format!("{}", status))
+                } else {
+                    CreateEgressOnlyInternetGatewayError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -57115,7 +57331,13 @@ impl CreateFleetError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateFleetError::Unknown(String::from(body)),
             },
-            Err(_) => CreateFleetError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateFleetError::Unknown(format!("{}", status))
+                } else {
+                    CreateFleetError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -57187,7 +57409,13 @@ impl CreateFlowLogsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateFlowLogsError::Unknown(String::from(body)),
             },
-            Err(_) => CreateFlowLogsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateFlowLogsError::Unknown(format!("{}", status))
+                } else {
+                    CreateFlowLogsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -57259,7 +57487,13 @@ impl CreateFpgaImageError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateFpgaImageError::Unknown(String::from(body)),
             },
-            Err(_) => CreateFpgaImageError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateFpgaImageError::Unknown(format!("{}", status))
+                } else {
+                    CreateFpgaImageError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -57331,7 +57565,13 @@ impl CreateImageError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateImageError::Unknown(String::from(body)),
             },
-            Err(_) => CreateImageError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateImageError::Unknown(format!("{}", status))
+                } else {
+                    CreateImageError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -57404,7 +57644,15 @@ impl CreateInstanceExportTaskError {
                 _ => CreateInstanceExportTaskError::Unknown(String::from(body)),
             },
             Err(_) => {
-                CreateInstanceExportTaskError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    CreateInstanceExportTaskError::Unknown(format!("{}", status))
+                } else {
+                    CreateInstanceExportTaskError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -57480,7 +57728,11 @@ impl CreateInternetGatewayError {
                 _ => CreateInternetGatewayError::Unknown(String::from(body)),
             },
             Err(_) => {
-                CreateInternetGatewayError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    CreateInternetGatewayError::Unknown(format!("{}", status))
+                } else {
+                    CreateInternetGatewayError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -57555,7 +57807,13 @@ impl CreateKeyPairError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateKeyPairError::Unknown(String::from(body)),
             },
-            Err(_) => CreateKeyPairError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateKeyPairError::Unknown(format!("{}", status))
+                } else {
+                    CreateKeyPairError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -57628,7 +57886,11 @@ impl CreateLaunchTemplateError {
                 _ => CreateLaunchTemplateError::Unknown(String::from(body)),
             },
             Err(_) => {
-                CreateLaunchTemplateError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    CreateLaunchTemplateError::Unknown(format!("{}", status))
+                } else {
+                    CreateLaunchTemplateError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -57703,11 +57965,17 @@ impl CreateLaunchTemplateVersionError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateLaunchTemplateVersionError::Unknown(String::from(body)),
             },
-            Err(_) => CreateLaunchTemplateVersionError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateLaunchTemplateVersionError::Unknown(format!("{}", status))
+                } else {
+                    CreateLaunchTemplateVersionError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -57781,7 +58049,13 @@ impl CreateNatGatewayError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateNatGatewayError::Unknown(String::from(body)),
             },
-            Err(_) => CreateNatGatewayError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateNatGatewayError::Unknown(format!("{}", status))
+                } else {
+                    CreateNatGatewayError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -57853,7 +58127,13 @@ impl CreateNetworkAclError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateNetworkAclError::Unknown(String::from(body)),
             },
-            Err(_) => CreateNetworkAclError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateNetworkAclError::Unknown(format!("{}", status))
+                } else {
+                    CreateNetworkAclError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -57926,7 +58206,11 @@ impl CreateNetworkAclEntryError {
                 _ => CreateNetworkAclEntryError::Unknown(String::from(body)),
             },
             Err(_) => {
-                CreateNetworkAclEntryError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    CreateNetworkAclEntryError::Unknown(format!("{}", status))
+                } else {
+                    CreateNetworkAclEntryError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -58002,7 +58286,11 @@ impl CreateNetworkInterfaceError {
                 _ => CreateNetworkInterfaceError::Unknown(String::from(body)),
             },
             Err(_) => {
-                CreateNetworkInterfaceError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    CreateNetworkInterfaceError::Unknown(format!("{}", status))
+                } else {
+                    CreateNetworkInterfaceError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -58077,11 +58365,17 @@ impl CreateNetworkInterfacePermissionError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateNetworkInterfacePermissionError::Unknown(String::from(body)),
             },
-            Err(_) => CreateNetworkInterfacePermissionError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateNetworkInterfacePermissionError::Unknown(format!("{}", status))
+                } else {
+                    CreateNetworkInterfacePermissionError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -58156,7 +58450,11 @@ impl CreatePlacementGroupError {
                 _ => CreatePlacementGroupError::Unknown(String::from(body)),
             },
             Err(_) => {
-                CreatePlacementGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    CreatePlacementGroupError::Unknown(format!("{}", status))
+                } else {
+                    CreatePlacementGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -58231,11 +58529,17 @@ impl CreateReservedInstancesListingError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateReservedInstancesListingError::Unknown(String::from(body)),
             },
-            Err(_) => CreateReservedInstancesListingError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateReservedInstancesListingError::Unknown(format!("{}", status))
+                } else {
+                    CreateReservedInstancesListingError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -58309,7 +58613,13 @@ impl CreateRouteError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateRouteError::Unknown(String::from(body)),
             },
-            Err(_) => CreateRouteError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateRouteError::Unknown(format!("{}", status))
+                } else {
+                    CreateRouteError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -58381,7 +58691,13 @@ impl CreateRouteTableError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateRouteTableError::Unknown(String::from(body)),
             },
-            Err(_) => CreateRouteTableError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateRouteTableError::Unknown(format!("{}", status))
+                } else {
+                    CreateRouteTableError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -58453,7 +58769,13 @@ impl CreateSecurityGroupError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateSecurityGroupError::Unknown(String::from(body)),
             },
-            Err(_) => CreateSecurityGroupError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateSecurityGroupError::Unknown(format!("{}", status))
+                } else {
+                    CreateSecurityGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -58527,7 +58849,13 @@ impl CreateSnapshotError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateSnapshotError::Unknown(String::from(body)),
             },
-            Err(_) => CreateSnapshotError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateSnapshotError::Unknown(format!("{}", status))
+                } else {
+                    CreateSnapshotError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -58599,11 +58927,17 @@ impl CreateSpotDatafeedSubscriptionError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateSpotDatafeedSubscriptionError::Unknown(String::from(body)),
             },
-            Err(_) => CreateSpotDatafeedSubscriptionError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateSpotDatafeedSubscriptionError::Unknown(format!("{}", status))
+                } else {
+                    CreateSpotDatafeedSubscriptionError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -58677,7 +59011,13 @@ impl CreateSubnetError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateSubnetError::Unknown(String::from(body)),
             },
-            Err(_) => CreateSubnetError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateSubnetError::Unknown(format!("{}", status))
+                } else {
+                    CreateSubnetError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -58749,7 +59089,13 @@ impl CreateTagsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateTagsError::Unknown(String::from(body)),
             },
-            Err(_) => CreateTagsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateTagsError::Unknown(format!("{}", status))
+                } else {
+                    CreateTagsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -58821,7 +59167,13 @@ impl CreateVolumeError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateVolumeError::Unknown(String::from(body)),
             },
-            Err(_) => CreateVolumeError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateVolumeError::Unknown(format!("{}", status))
+                } else {
+                    CreateVolumeError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -58893,7 +59245,13 @@ impl CreateVpcError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateVpcError::Unknown(String::from(body)),
             },
-            Err(_) => CreateVpcError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateVpcError::Unknown(format!("{}", status))
+                } else {
+                    CreateVpcError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -58965,7 +59323,13 @@ impl CreateVpcEndpointError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateVpcEndpointError::Unknown(String::from(body)),
             },
-            Err(_) => CreateVpcEndpointError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateVpcEndpointError::Unknown(format!("{}", status))
+                } else {
+                    CreateVpcEndpointError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -59039,11 +59403,17 @@ impl CreateVpcEndpointConnectionNotificationError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateVpcEndpointConnectionNotificationError::Unknown(String::from(body)),
             },
-            Err(_) => CreateVpcEndpointConnectionNotificationError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateVpcEndpointConnectionNotificationError::Unknown(format!("{}", status))
+                } else {
+                    CreateVpcEndpointConnectionNotificationError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -59117,11 +59487,17 @@ impl CreateVpcEndpointServiceConfigurationError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateVpcEndpointServiceConfigurationError::Unknown(String::from(body)),
             },
-            Err(_) => CreateVpcEndpointServiceConfigurationError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateVpcEndpointServiceConfigurationError::Unknown(format!("{}", status))
+                } else {
+                    CreateVpcEndpointServiceConfigurationError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -59196,7 +59572,15 @@ impl CreateVpcPeeringConnectionError {
                 _ => CreateVpcPeeringConnectionError::Unknown(String::from(body)),
             },
             Err(_) => {
-                CreateVpcPeeringConnectionError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    CreateVpcPeeringConnectionError::Unknown(format!("{}", status))
+                } else {
+                    CreateVpcPeeringConnectionError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -59271,7 +59655,13 @@ impl CreateVpnConnectionError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateVpnConnectionError::Unknown(String::from(body)),
             },
-            Err(_) => CreateVpnConnectionError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateVpnConnectionError::Unknown(format!("{}", status))
+                } else {
+                    CreateVpnConnectionError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -59346,7 +59736,15 @@ impl CreateVpnConnectionRouteError {
                 _ => CreateVpnConnectionRouteError::Unknown(String::from(body)),
             },
             Err(_) => {
-                CreateVpnConnectionRouteError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    CreateVpnConnectionRouteError::Unknown(format!("{}", status))
+                } else {
+                    CreateVpnConnectionRouteError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -59421,7 +59819,13 @@ impl CreateVpnGatewayError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateVpnGatewayError::Unknown(String::from(body)),
             },
-            Err(_) => CreateVpnGatewayError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateVpnGatewayError::Unknown(format!("{}", status))
+                } else {
+                    CreateVpnGatewayError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -59494,7 +59898,11 @@ impl DeleteCustomerGatewayError {
                 _ => DeleteCustomerGatewayError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DeleteCustomerGatewayError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DeleteCustomerGatewayError::Unknown(format!("{}", status))
+                } else {
+                    DeleteCustomerGatewayError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -59569,7 +59977,13 @@ impl DeleteDhcpOptionsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteDhcpOptionsError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteDhcpOptionsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteDhcpOptionsError::Unknown(format!("{}", status))
+                } else {
+                    DeleteDhcpOptionsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -59643,11 +60057,17 @@ impl DeleteEgressOnlyInternetGatewayError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteEgressOnlyInternetGatewayError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteEgressOnlyInternetGatewayError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteEgressOnlyInternetGatewayError::Unknown(format!("{}", status))
+                } else {
+                    DeleteEgressOnlyInternetGatewayError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -59721,7 +60141,13 @@ impl DeleteFleetsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteFleetsError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteFleetsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteFleetsError::Unknown(format!("{}", status))
+                } else {
+                    DeleteFleetsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -59793,7 +60219,13 @@ impl DeleteFlowLogsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteFlowLogsError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteFlowLogsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteFlowLogsError::Unknown(format!("{}", status))
+                } else {
+                    DeleteFlowLogsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -59865,7 +60297,13 @@ impl DeleteFpgaImageError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteFpgaImageError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteFpgaImageError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteFpgaImageError::Unknown(format!("{}", status))
+                } else {
+                    DeleteFpgaImageError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -59938,7 +60376,11 @@ impl DeleteInternetGatewayError {
                 _ => DeleteInternetGatewayError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DeleteInternetGatewayError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DeleteInternetGatewayError::Unknown(format!("{}", status))
+                } else {
+                    DeleteInternetGatewayError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -60013,7 +60455,13 @@ impl DeleteKeyPairError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteKeyPairError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteKeyPairError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteKeyPairError::Unknown(format!("{}", status))
+                } else {
+                    DeleteKeyPairError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -60086,7 +60534,11 @@ impl DeleteLaunchTemplateError {
                 _ => DeleteLaunchTemplateError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DeleteLaunchTemplateError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DeleteLaunchTemplateError::Unknown(format!("{}", status))
+                } else {
+                    DeleteLaunchTemplateError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -60161,11 +60613,17 @@ impl DeleteLaunchTemplateVersionsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteLaunchTemplateVersionsError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteLaunchTemplateVersionsError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteLaunchTemplateVersionsError::Unknown(format!("{}", status))
+                } else {
+                    DeleteLaunchTemplateVersionsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -60239,7 +60697,13 @@ impl DeleteNatGatewayError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteNatGatewayError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteNatGatewayError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteNatGatewayError::Unknown(format!("{}", status))
+                } else {
+                    DeleteNatGatewayError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -60311,7 +60775,13 @@ impl DeleteNetworkAclError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteNetworkAclError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteNetworkAclError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteNetworkAclError::Unknown(format!("{}", status))
+                } else {
+                    DeleteNetworkAclError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -60384,7 +60854,11 @@ impl DeleteNetworkAclEntryError {
                 _ => DeleteNetworkAclEntryError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DeleteNetworkAclEntryError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DeleteNetworkAclEntryError::Unknown(format!("{}", status))
+                } else {
+                    DeleteNetworkAclEntryError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -60460,7 +60934,11 @@ impl DeleteNetworkInterfaceError {
                 _ => DeleteNetworkInterfaceError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DeleteNetworkInterfaceError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DeleteNetworkInterfaceError::Unknown(format!("{}", status))
+                } else {
+                    DeleteNetworkInterfaceError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -60535,11 +61013,17 @@ impl DeleteNetworkInterfacePermissionError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteNetworkInterfacePermissionError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteNetworkInterfacePermissionError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteNetworkInterfacePermissionError::Unknown(format!("{}", status))
+                } else {
+                    DeleteNetworkInterfacePermissionError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -60614,7 +61098,11 @@ impl DeletePlacementGroupError {
                 _ => DeletePlacementGroupError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DeletePlacementGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DeletePlacementGroupError::Unknown(format!("{}", status))
+                } else {
+                    DeletePlacementGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -60689,7 +61177,13 @@ impl DeleteRouteError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteRouteError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteRouteError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteRouteError::Unknown(format!("{}", status))
+                } else {
+                    DeleteRouteError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -60761,7 +61255,13 @@ impl DeleteRouteTableError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteRouteTableError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteRouteTableError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteRouteTableError::Unknown(format!("{}", status))
+                } else {
+                    DeleteRouteTableError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -60833,7 +61333,13 @@ impl DeleteSecurityGroupError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteSecurityGroupError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteSecurityGroupError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteSecurityGroupError::Unknown(format!("{}", status))
+                } else {
+                    DeleteSecurityGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -60907,7 +61413,13 @@ impl DeleteSnapshotError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteSnapshotError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteSnapshotError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteSnapshotError::Unknown(format!("{}", status))
+                } else {
+                    DeleteSnapshotError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -60979,11 +61491,17 @@ impl DeleteSpotDatafeedSubscriptionError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteSpotDatafeedSubscriptionError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteSpotDatafeedSubscriptionError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteSpotDatafeedSubscriptionError::Unknown(format!("{}", status))
+                } else {
+                    DeleteSpotDatafeedSubscriptionError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -61057,7 +61575,13 @@ impl DeleteSubnetError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteSubnetError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteSubnetError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteSubnetError::Unknown(format!("{}", status))
+                } else {
+                    DeleteSubnetError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -61129,7 +61653,13 @@ impl DeleteTagsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteTagsError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteTagsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteTagsError::Unknown(format!("{}", status))
+                } else {
+                    DeleteTagsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -61201,7 +61731,13 @@ impl DeleteVolumeError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteVolumeError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteVolumeError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteVolumeError::Unknown(format!("{}", status))
+                } else {
+                    DeleteVolumeError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -61273,7 +61809,13 @@ impl DeleteVpcError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteVpcError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteVpcError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteVpcError::Unknown(format!("{}", status))
+                } else {
+                    DeleteVpcError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -61345,11 +61887,17 @@ impl DeleteVpcEndpointConnectionNotificationsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteVpcEndpointConnectionNotificationsError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteVpcEndpointConnectionNotificationsError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteVpcEndpointConnectionNotificationsError::Unknown(format!("{}", status))
+                } else {
+                    DeleteVpcEndpointConnectionNotificationsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -61425,11 +61973,17 @@ impl DeleteVpcEndpointServiceConfigurationsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteVpcEndpointServiceConfigurationsError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteVpcEndpointServiceConfigurationsError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteVpcEndpointServiceConfigurationsError::Unknown(format!("{}", status))
+                } else {
+                    DeleteVpcEndpointServiceConfigurationsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -61503,7 +62057,13 @@ impl DeleteVpcEndpointsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteVpcEndpointsError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteVpcEndpointsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteVpcEndpointsError::Unknown(format!("{}", status))
+                } else {
+                    DeleteVpcEndpointsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -61578,7 +62138,15 @@ impl DeleteVpcPeeringConnectionError {
                 _ => DeleteVpcPeeringConnectionError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DeleteVpcPeeringConnectionError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DeleteVpcPeeringConnectionError::Unknown(format!("{}", status))
+                } else {
+                    DeleteVpcPeeringConnectionError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -61653,7 +62221,13 @@ impl DeleteVpnConnectionError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteVpnConnectionError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteVpnConnectionError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteVpnConnectionError::Unknown(format!("{}", status))
+                } else {
+                    DeleteVpnConnectionError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -61728,7 +62302,15 @@ impl DeleteVpnConnectionRouteError {
                 _ => DeleteVpnConnectionRouteError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DeleteVpnConnectionRouteError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DeleteVpnConnectionRouteError::Unknown(format!("{}", status))
+                } else {
+                    DeleteVpnConnectionRouteError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -61803,7 +62385,13 @@ impl DeleteVpnGatewayError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteVpnGatewayError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteVpnGatewayError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteVpnGatewayError::Unknown(format!("{}", status))
+                } else {
+                    DeleteVpnGatewayError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -61875,7 +62463,13 @@ impl DeregisterImageError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeregisterImageError::Unknown(String::from(body)),
             },
-            Err(_) => DeregisterImageError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeregisterImageError::Unknown(format!("{}", status))
+                } else {
+                    DeregisterImageError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -61948,7 +62542,15 @@ impl DescribeAccountAttributesError {
                 _ => DescribeAccountAttributesError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeAccountAttributesError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeAccountAttributesError::Unknown(format!("{}", status))
+                } else {
+                    DescribeAccountAttributesError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -62023,7 +62625,13 @@ impl DescribeAddressesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeAddressesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeAddressesError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeAddressesError::Unknown(format!("{}", status))
+                } else {
+                    DescribeAddressesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -62098,7 +62706,15 @@ impl DescribeAggregateIdFormatError {
                 _ => DescribeAggregateIdFormatError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeAggregateIdFormatError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeAggregateIdFormatError::Unknown(format!("{}", status))
+                } else {
+                    DescribeAggregateIdFormatError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -62174,7 +62790,15 @@ impl DescribeAvailabilityZonesError {
                 _ => DescribeAvailabilityZonesError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeAvailabilityZonesError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeAvailabilityZonesError::Unknown(format!("{}", status))
+                } else {
+                    DescribeAvailabilityZonesError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -62249,7 +62873,13 @@ impl DescribeBundleTasksError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeBundleTasksError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeBundleTasksError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeBundleTasksError::Unknown(format!("{}", status))
+                } else {
+                    DescribeBundleTasksError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -62323,11 +62953,17 @@ impl DescribeClassicLinkInstancesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeClassicLinkInstancesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeClassicLinkInstancesError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeClassicLinkInstancesError::Unknown(format!("{}", status))
+                } else {
+                    DescribeClassicLinkInstancesError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -62402,7 +63038,15 @@ impl DescribeConversionTasksError {
                 _ => DescribeConversionTasksError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeConversionTasksError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeConversionTasksError::Unknown(format!("{}", status))
+                } else {
+                    DescribeConversionTasksError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -62478,7 +63122,15 @@ impl DescribeCustomerGatewaysError {
                 _ => DescribeCustomerGatewaysError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeCustomerGatewaysError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeCustomerGatewaysError::Unknown(format!("{}", status))
+                } else {
+                    DescribeCustomerGatewaysError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -62553,7 +63205,13 @@ impl DescribeDhcpOptionsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeDhcpOptionsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeDhcpOptionsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeDhcpOptionsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeDhcpOptionsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -62627,11 +63285,17 @@ impl DescribeEgressOnlyInternetGatewaysError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeEgressOnlyInternetGatewaysError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeEgressOnlyInternetGatewaysError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeEgressOnlyInternetGatewaysError::Unknown(format!("{}", status))
+                } else {
+                    DescribeEgressOnlyInternetGatewaysError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -62705,7 +63369,13 @@ impl DescribeElasticGpusError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeElasticGpusError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeElasticGpusError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeElasticGpusError::Unknown(format!("{}", status))
+                } else {
+                    DescribeElasticGpusError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -62779,7 +63449,13 @@ impl DescribeExportTasksError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeExportTasksError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeExportTasksError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeExportTasksError::Unknown(format!("{}", status))
+                } else {
+                    DescribeExportTasksError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -62854,7 +63530,11 @@ impl DescribeFleetHistoryError {
                 _ => DescribeFleetHistoryError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeFleetHistoryError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeFleetHistoryError::Unknown(format!("{}", status))
+                } else {
+                    DescribeFleetHistoryError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -62930,7 +63610,11 @@ impl DescribeFleetInstancesError {
                 _ => DescribeFleetInstancesError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeFleetInstancesError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeFleetInstancesError::Unknown(format!("{}", status))
+                } else {
+                    DescribeFleetInstancesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -63005,7 +63689,13 @@ impl DescribeFleetsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeFleetsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeFleetsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeFleetsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeFleetsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -63077,7 +63767,13 @@ impl DescribeFlowLogsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeFlowLogsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeFlowLogsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeFlowLogsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeFlowLogsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -63150,7 +63846,15 @@ impl DescribeFpgaImageAttributeError {
                 _ => DescribeFpgaImageAttributeError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeFpgaImageAttributeError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeFpgaImageAttributeError::Unknown(format!("{}", status))
+                } else {
+                    DescribeFpgaImageAttributeError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -63225,7 +63929,13 @@ impl DescribeFpgaImagesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeFpgaImagesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeFpgaImagesError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeFpgaImagesError::Unknown(format!("{}", status))
+                } else {
+                    DescribeFpgaImagesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -63299,11 +64009,17 @@ impl DescribeHostReservationOfferingsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeHostReservationOfferingsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeHostReservationOfferingsError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeHostReservationOfferingsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeHostReservationOfferingsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -63378,7 +64094,15 @@ impl DescribeHostReservationsError {
                 _ => DescribeHostReservationsError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeHostReservationsError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeHostReservationsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeHostReservationsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -63453,7 +64177,13 @@ impl DescribeHostsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeHostsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeHostsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeHostsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeHostsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -63525,11 +64255,17 @@ impl DescribeIamInstanceProfileAssociationsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeIamInstanceProfileAssociationsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeIamInstanceProfileAssociationsError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeIamInstanceProfileAssociationsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeIamInstanceProfileAssociationsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -63603,7 +64339,13 @@ impl DescribeIdFormatError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeIdFormatError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeIdFormatError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeIdFormatError::Unknown(format!("{}", status))
+                } else {
+                    DescribeIdFormatError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -63676,7 +64418,15 @@ impl DescribeIdentityIdFormatError {
                 _ => DescribeIdentityIdFormatError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeIdentityIdFormatError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeIdentityIdFormatError::Unknown(format!("{}", status))
+                } else {
+                    DescribeIdentityIdFormatError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -63752,7 +64502,11 @@ impl DescribeImageAttributeError {
                 _ => DescribeImageAttributeError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeImageAttributeError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeImageAttributeError::Unknown(format!("{}", status))
+                } else {
+                    DescribeImageAttributeError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -63827,7 +64581,13 @@ impl DescribeImagesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeImagesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeImagesError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeImagesError::Unknown(format!("{}", status))
+                } else {
+                    DescribeImagesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -63900,7 +64660,15 @@ impl DescribeImportImageTasksError {
                 _ => DescribeImportImageTasksError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeImportImageTasksError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeImportImageTasksError::Unknown(format!("{}", status))
+                } else {
+                    DescribeImportImageTasksError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -63975,11 +64743,17 @@ impl DescribeImportSnapshotTasksError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeImportSnapshotTasksError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeImportSnapshotTasksError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeImportSnapshotTasksError::Unknown(format!("{}", status))
+                } else {
+                    DescribeImportSnapshotTasksError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -64054,7 +64828,15 @@ impl DescribeInstanceAttributeError {
                 _ => DescribeInstanceAttributeError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeInstanceAttributeError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeInstanceAttributeError::Unknown(format!("{}", status))
+                } else {
+                    DescribeInstanceAttributeError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -64129,11 +64911,17 @@ impl DescribeInstanceCreditSpecificationsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeInstanceCreditSpecificationsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeInstanceCreditSpecificationsError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeInstanceCreditSpecificationsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeInstanceCreditSpecificationsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -64208,7 +64996,11 @@ impl DescribeInstanceStatusError {
                 _ => DescribeInstanceStatusError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeInstanceStatusError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeInstanceStatusError::Unknown(format!("{}", status))
+                } else {
+                    DescribeInstanceStatusError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -64283,7 +65075,13 @@ impl DescribeInstancesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeInstancesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeInstancesError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeInstancesError::Unknown(format!("{}", status))
+                } else {
+                    DescribeInstancesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -64358,7 +65156,15 @@ impl DescribeInternetGatewaysError {
                 _ => DescribeInternetGatewaysError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeInternetGatewaysError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeInternetGatewaysError::Unknown(format!("{}", status))
+                } else {
+                    DescribeInternetGatewaysError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -64433,7 +65239,13 @@ impl DescribeKeyPairsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeKeyPairsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeKeyPairsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeKeyPairsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeKeyPairsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -64505,11 +65317,17 @@ impl DescribeLaunchTemplateVersionsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeLaunchTemplateVersionsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeLaunchTemplateVersionsError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeLaunchTemplateVersionsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeLaunchTemplateVersionsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -64584,7 +65402,15 @@ impl DescribeLaunchTemplatesError {
                 _ => DescribeLaunchTemplatesError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeLaunchTemplatesError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeLaunchTemplatesError::Unknown(format!("{}", status))
+                } else {
+                    DescribeLaunchTemplatesError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -64660,7 +65486,15 @@ impl DescribeMovingAddressesError {
                 _ => DescribeMovingAddressesError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeMovingAddressesError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeMovingAddressesError::Unknown(format!("{}", status))
+                } else {
+                    DescribeMovingAddressesError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -64735,7 +65569,13 @@ impl DescribeNatGatewaysError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeNatGatewaysError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeNatGatewaysError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeNatGatewaysError::Unknown(format!("{}", status))
+                } else {
+                    DescribeNatGatewaysError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -64809,7 +65649,13 @@ impl DescribeNetworkAclsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeNetworkAclsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeNetworkAclsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeNetworkAclsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeNetworkAclsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -64883,11 +65729,17 @@ impl DescribeNetworkInterfaceAttributeError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeNetworkInterfaceAttributeError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeNetworkInterfaceAttributeError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeNetworkInterfaceAttributeError::Unknown(format!("{}", status))
+                } else {
+                    DescribeNetworkInterfaceAttributeError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -64961,11 +65813,17 @@ impl DescribeNetworkInterfacePermissionsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeNetworkInterfacePermissionsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeNetworkInterfacePermissionsError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeNetworkInterfacePermissionsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeNetworkInterfacePermissionsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -65040,7 +65898,15 @@ impl DescribeNetworkInterfacesError {
                 _ => DescribeNetworkInterfacesError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeNetworkInterfacesError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeNetworkInterfacesError::Unknown(format!("{}", status))
+                } else {
+                    DescribeNetworkInterfacesError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -65116,7 +65982,15 @@ impl DescribePlacementGroupsError {
                 _ => DescribePlacementGroupsError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribePlacementGroupsError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribePlacementGroupsError::Unknown(format!("{}", status))
+                } else {
+                    DescribePlacementGroupsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -65191,7 +66065,13 @@ impl DescribePrefixListsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribePrefixListsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribePrefixListsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribePrefixListsError::Unknown(format!("{}", status))
+                } else {
+                    DescribePrefixListsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -65266,7 +66146,15 @@ impl DescribePrincipalIdFormatError {
                 _ => DescribePrincipalIdFormatError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribePrincipalIdFormatError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribePrincipalIdFormatError::Unknown(format!("{}", status))
+                } else {
+                    DescribePrincipalIdFormatError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -65341,7 +66229,13 @@ impl DescribeRegionsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeRegionsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeRegionsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeRegionsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeRegionsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -65414,7 +66308,15 @@ impl DescribeReservedInstancesError {
                 _ => DescribeReservedInstancesError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeReservedInstancesError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeReservedInstancesError::Unknown(format!("{}", status))
+                } else {
+                    DescribeReservedInstancesError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -65489,11 +66391,17 @@ impl DescribeReservedInstancesListingsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeReservedInstancesListingsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeReservedInstancesListingsError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeReservedInstancesListingsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeReservedInstancesListingsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -65567,11 +66475,17 @@ impl DescribeReservedInstancesModificationsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeReservedInstancesModificationsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeReservedInstancesModificationsError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeReservedInstancesModificationsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeReservedInstancesModificationsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -65645,11 +66559,17 @@ impl DescribeReservedInstancesOfferingsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeReservedInstancesOfferingsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeReservedInstancesOfferingsError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeReservedInstancesOfferingsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeReservedInstancesOfferingsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -65723,7 +66643,13 @@ impl DescribeRouteTablesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeRouteTablesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeRouteTablesError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeRouteTablesError::Unknown(format!("{}", status))
+                } else {
+                    DescribeRouteTablesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -65797,11 +66723,17 @@ impl DescribeScheduledInstanceAvailabilityError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeScheduledInstanceAvailabilityError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeScheduledInstanceAvailabilityError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeScheduledInstanceAvailabilityError::Unknown(format!("{}", status))
+                } else {
+                    DescribeScheduledInstanceAvailabilityError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -65876,7 +66808,15 @@ impl DescribeScheduledInstancesError {
                 _ => DescribeScheduledInstancesError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeScheduledInstancesError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeScheduledInstancesError::Unknown(format!("{}", status))
+                } else {
+                    DescribeScheduledInstancesError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -65951,11 +66891,17 @@ impl DescribeSecurityGroupReferencesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeSecurityGroupReferencesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeSecurityGroupReferencesError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeSecurityGroupReferencesError::Unknown(format!("{}", status))
+                } else {
+                    DescribeSecurityGroupReferencesError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -66030,7 +66976,11 @@ impl DescribeSecurityGroupsError {
                 _ => DescribeSecurityGroupsError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeSecurityGroupsError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeSecurityGroupsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeSecurityGroupsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -66106,7 +67056,15 @@ impl DescribeSnapshotAttributeError {
                 _ => DescribeSnapshotAttributeError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeSnapshotAttributeError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeSnapshotAttributeError::Unknown(format!("{}", status))
+                } else {
+                    DescribeSnapshotAttributeError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -66181,7 +67139,13 @@ impl DescribeSnapshotsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeSnapshotsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeSnapshotsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeSnapshotsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeSnapshotsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -66255,11 +67219,17 @@ impl DescribeSpotDatafeedSubscriptionError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeSpotDatafeedSubscriptionError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeSpotDatafeedSubscriptionError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeSpotDatafeedSubscriptionError::Unknown(format!("{}", status))
+                } else {
+                    DescribeSpotDatafeedSubscriptionError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -66334,7 +67304,15 @@ impl DescribeSpotFleetInstancesError {
                 _ => DescribeSpotFleetInstancesError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeSpotFleetInstancesError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeSpotFleetInstancesError::Unknown(format!("{}", status))
+                } else {
+                    DescribeSpotFleetInstancesError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -66409,11 +67387,17 @@ impl DescribeSpotFleetRequestHistoryError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeSpotFleetRequestHistoryError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeSpotFleetRequestHistoryError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeSpotFleetRequestHistoryError::Unknown(format!("{}", status))
+                } else {
+                    DescribeSpotFleetRequestHistoryError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -66488,7 +67472,15 @@ impl DescribeSpotFleetRequestsError {
                 _ => DescribeSpotFleetRequestsError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeSpotFleetRequestsError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeSpotFleetRequestsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeSpotFleetRequestsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -66563,11 +67555,17 @@ impl DescribeSpotInstanceRequestsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeSpotInstanceRequestsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeSpotInstanceRequestsError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeSpotInstanceRequestsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeSpotInstanceRequestsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -66642,7 +67640,15 @@ impl DescribeSpotPriceHistoryError {
                 _ => DescribeSpotPriceHistoryError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeSpotPriceHistoryError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeSpotPriceHistoryError::Unknown(format!("{}", status))
+                } else {
+                    DescribeSpotPriceHistoryError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -66717,11 +67723,17 @@ impl DescribeStaleSecurityGroupsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeStaleSecurityGroupsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeStaleSecurityGroupsError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeStaleSecurityGroupsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeStaleSecurityGroupsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -66795,7 +67807,13 @@ impl DescribeSubnetsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeSubnetsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeSubnetsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeSubnetsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeSubnetsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -66867,7 +67885,13 @@ impl DescribeTagsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeTagsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeTagsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeTagsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeTagsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -66940,7 +67964,15 @@ impl DescribeVolumeAttributeError {
                 _ => DescribeVolumeAttributeError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeVolumeAttributeError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeVolumeAttributeError::Unknown(format!("{}", status))
+                } else {
+                    DescribeVolumeAttributeError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -67016,7 +68048,11 @@ impl DescribeVolumeStatusError {
                 _ => DescribeVolumeStatusError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeVolumeStatusError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeVolumeStatusError::Unknown(format!("{}", status))
+                } else {
+                    DescribeVolumeStatusError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -67091,7 +68127,13 @@ impl DescribeVolumesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeVolumesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeVolumesError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeVolumesError::Unknown(format!("{}", status))
+                } else {
+                    DescribeVolumesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -67163,11 +68205,17 @@ impl DescribeVolumesModificationsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeVolumesModificationsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeVolumesModificationsError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeVolumesModificationsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeVolumesModificationsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -67242,7 +68290,11 @@ impl DescribeVpcAttributeError {
                 _ => DescribeVpcAttributeError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeVpcAttributeError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeVpcAttributeError::Unknown(format!("{}", status))
+                } else {
+                    DescribeVpcAttributeError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -67318,7 +68370,11 @@ impl DescribeVpcClassicLinkError {
                 _ => DescribeVpcClassicLinkError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeVpcClassicLinkError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeVpcClassicLinkError::Unknown(format!("{}", status))
+                } else {
+                    DescribeVpcClassicLinkError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -67393,11 +68449,17 @@ impl DescribeVpcClassicLinkDnsSupportError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeVpcClassicLinkDnsSupportError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeVpcClassicLinkDnsSupportError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeVpcClassicLinkDnsSupportError::Unknown(format!("{}", status))
+                } else {
+                    DescribeVpcClassicLinkDnsSupportError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -67471,11 +68533,17 @@ impl DescribeVpcEndpointConnectionNotificationsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeVpcEndpointConnectionNotificationsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeVpcEndpointConnectionNotificationsError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeVpcEndpointConnectionNotificationsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeVpcEndpointConnectionNotificationsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -67551,11 +68619,17 @@ impl DescribeVpcEndpointConnectionsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeVpcEndpointConnectionsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeVpcEndpointConnectionsError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeVpcEndpointConnectionsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeVpcEndpointConnectionsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -67629,11 +68703,17 @@ impl DescribeVpcEndpointServiceConfigurationsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeVpcEndpointServiceConfigurationsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeVpcEndpointServiceConfigurationsError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeVpcEndpointServiceConfigurationsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeVpcEndpointServiceConfigurationsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -67709,11 +68789,17 @@ impl DescribeVpcEndpointServicePermissionsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeVpcEndpointServicePermissionsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeVpcEndpointServicePermissionsError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeVpcEndpointServicePermissionsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeVpcEndpointServicePermissionsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -67787,11 +68873,17 @@ impl DescribeVpcEndpointServicesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeVpcEndpointServicesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeVpcEndpointServicesError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeVpcEndpointServicesError::Unknown(format!("{}", status))
+                } else {
+                    DescribeVpcEndpointServicesError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -67866,7 +68958,11 @@ impl DescribeVpcEndpointsError {
                 _ => DescribeVpcEndpointsError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeVpcEndpointsError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeVpcEndpointsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeVpcEndpointsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -67941,11 +69037,17 @@ impl DescribeVpcPeeringConnectionsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeVpcPeeringConnectionsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeVpcPeeringConnectionsError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeVpcPeeringConnectionsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeVpcPeeringConnectionsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -68019,7 +69121,13 @@ impl DescribeVpcsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeVpcsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeVpcsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeVpcsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeVpcsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -68092,7 +69200,11 @@ impl DescribeVpnConnectionsError {
                 _ => DescribeVpnConnectionsError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeVpnConnectionsError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeVpnConnectionsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeVpnConnectionsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -68167,7 +69279,13 @@ impl DescribeVpnGatewaysError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeVpnGatewaysError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeVpnGatewaysError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeVpnGatewaysError::Unknown(format!("{}", status))
+                } else {
+                    DescribeVpnGatewaysError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -68242,7 +69360,11 @@ impl DetachClassicLinkVpcError {
                 _ => DetachClassicLinkVpcError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DetachClassicLinkVpcError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DetachClassicLinkVpcError::Unknown(format!("{}", status))
+                } else {
+                    DetachClassicLinkVpcError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -68318,7 +69440,11 @@ impl DetachInternetGatewayError {
                 _ => DetachInternetGatewayError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DetachInternetGatewayError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DetachInternetGatewayError::Unknown(format!("{}", status))
+                } else {
+                    DetachInternetGatewayError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -68394,7 +69520,11 @@ impl DetachNetworkInterfaceError {
                 _ => DetachNetworkInterfaceError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DetachNetworkInterfaceError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DetachNetworkInterfaceError::Unknown(format!("{}", status))
+                } else {
+                    DetachNetworkInterfaceError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -68469,7 +69599,13 @@ impl DetachVolumeError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DetachVolumeError::Unknown(String::from(body)),
             },
-            Err(_) => DetachVolumeError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DetachVolumeError::Unknown(format!("{}", status))
+                } else {
+                    DetachVolumeError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -68541,7 +69677,13 @@ impl DetachVpnGatewayError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DetachVpnGatewayError::Unknown(String::from(body)),
             },
-            Err(_) => DetachVpnGatewayError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DetachVpnGatewayError::Unknown(format!("{}", status))
+                } else {
+                    DetachVpnGatewayError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -68614,7 +69756,15 @@ impl DisableVgwRoutePropagationError {
                 _ => DisableVgwRoutePropagationError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DisableVgwRoutePropagationError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DisableVgwRoutePropagationError::Unknown(format!("{}", status))
+                } else {
+                    DisableVgwRoutePropagationError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -68690,7 +69840,11 @@ impl DisableVpcClassicLinkError {
                 _ => DisableVpcClassicLinkError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DisableVpcClassicLinkError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DisableVpcClassicLinkError::Unknown(format!("{}", status))
+                } else {
+                    DisableVpcClassicLinkError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -68765,11 +69919,17 @@ impl DisableVpcClassicLinkDnsSupportError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DisableVpcClassicLinkDnsSupportError::Unknown(String::from(body)),
             },
-            Err(_) => DisableVpcClassicLinkDnsSupportError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DisableVpcClassicLinkDnsSupportError::Unknown(format!("{}", status))
+                } else {
+                    DisableVpcClassicLinkDnsSupportError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -68843,7 +70003,13 @@ impl DisassociateAddressError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DisassociateAddressError::Unknown(String::from(body)),
             },
-            Err(_) => DisassociateAddressError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DisassociateAddressError::Unknown(format!("{}", status))
+                } else {
+                    DisassociateAddressError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -68917,11 +70083,17 @@ impl DisassociateIamInstanceProfileError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DisassociateIamInstanceProfileError::Unknown(String::from(body)),
             },
-            Err(_) => DisassociateIamInstanceProfileError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DisassociateIamInstanceProfileError::Unknown(format!("{}", status))
+                } else {
+                    DisassociateIamInstanceProfileError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -68996,7 +70168,11 @@ impl DisassociateRouteTableError {
                 _ => DisassociateRouteTableError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DisassociateRouteTableError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DisassociateRouteTableError::Unknown(format!("{}", status))
+                } else {
+                    DisassociateRouteTableError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -69071,11 +70247,17 @@ impl DisassociateSubnetCidrBlockError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DisassociateSubnetCidrBlockError::Unknown(String::from(body)),
             },
-            Err(_) => DisassociateSubnetCidrBlockError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DisassociateSubnetCidrBlockError::Unknown(format!("{}", status))
+                } else {
+                    DisassociateSubnetCidrBlockError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -69150,7 +70332,15 @@ impl DisassociateVpcCidrBlockError {
                 _ => DisassociateVpcCidrBlockError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DisassociateVpcCidrBlockError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DisassociateVpcCidrBlockError::Unknown(format!("{}", status))
+                } else {
+                    DisassociateVpcCidrBlockError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -69226,7 +70416,15 @@ impl EnableVgwRoutePropagationError {
                 _ => EnableVgwRoutePropagationError::Unknown(String::from(body)),
             },
             Err(_) => {
-                EnableVgwRoutePropagationError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    EnableVgwRoutePropagationError::Unknown(format!("{}", status))
+                } else {
+                    EnableVgwRoutePropagationError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -69301,7 +70499,13 @@ impl EnableVolumeIOError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => EnableVolumeIOError::Unknown(String::from(body)),
             },
-            Err(_) => EnableVolumeIOError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    EnableVolumeIOError::Unknown(format!("{}", status))
+                } else {
+                    EnableVolumeIOError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -69374,7 +70578,11 @@ impl EnableVpcClassicLinkError {
                 _ => EnableVpcClassicLinkError::Unknown(String::from(body)),
             },
             Err(_) => {
-                EnableVpcClassicLinkError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    EnableVpcClassicLinkError::Unknown(format!("{}", status))
+                } else {
+                    EnableVpcClassicLinkError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -69449,11 +70657,17 @@ impl EnableVpcClassicLinkDnsSupportError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => EnableVpcClassicLinkDnsSupportError::Unknown(String::from(body)),
             },
-            Err(_) => EnableVpcClassicLinkDnsSupportError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    EnableVpcClassicLinkDnsSupportError::Unknown(format!("{}", status))
+                } else {
+                    EnableVpcClassicLinkDnsSupportError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -69527,7 +70741,13 @@ impl GetConsoleOutputError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetConsoleOutputError::Unknown(String::from(body)),
             },
-            Err(_) => GetConsoleOutputError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetConsoleOutputError::Unknown(format!("{}", status))
+                } else {
+                    GetConsoleOutputError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -69600,7 +70820,11 @@ impl GetConsoleScreenshotError {
                 _ => GetConsoleScreenshotError::Unknown(String::from(body)),
             },
             Err(_) => {
-                GetConsoleScreenshotError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    GetConsoleScreenshotError::Unknown(format!("{}", status))
+                } else {
+                    GetConsoleScreenshotError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -69675,11 +70899,17 @@ impl GetHostReservationPurchasePreviewError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetHostReservationPurchasePreviewError::Unknown(String::from(body)),
             },
-            Err(_) => GetHostReservationPurchasePreviewError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetHostReservationPurchasePreviewError::Unknown(format!("{}", status))
+                } else {
+                    GetHostReservationPurchasePreviewError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -69754,7 +70984,11 @@ impl GetLaunchTemplateDataError {
                 _ => GetLaunchTemplateDataError::Unknown(String::from(body)),
             },
             Err(_) => {
-                GetLaunchTemplateDataError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    GetLaunchTemplateDataError::Unknown(format!("{}", status))
+                } else {
+                    GetLaunchTemplateDataError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -69829,7 +71063,13 @@ impl GetPasswordDataError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetPasswordDataError::Unknown(String::from(body)),
             },
-            Err(_) => GetPasswordDataError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetPasswordDataError::Unknown(format!("{}", status))
+                } else {
+                    GetPasswordDataError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -69901,11 +71141,17 @@ impl GetReservedInstancesExchangeQuoteError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetReservedInstancesExchangeQuoteError::Unknown(String::from(body)),
             },
-            Err(_) => GetReservedInstancesExchangeQuoteError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetReservedInstancesExchangeQuoteError::Unknown(format!("{}", status))
+                } else {
+                    GetReservedInstancesExchangeQuoteError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -69979,7 +71225,13 @@ impl ImportImageError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ImportImageError::Unknown(String::from(body)),
             },
-            Err(_) => ImportImageError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ImportImageError::Unknown(format!("{}", status))
+                } else {
+                    ImportImageError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -70051,7 +71303,13 @@ impl ImportInstanceError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ImportInstanceError::Unknown(String::from(body)),
             },
-            Err(_) => ImportInstanceError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ImportInstanceError::Unknown(format!("{}", status))
+                } else {
+                    ImportInstanceError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -70123,7 +71381,13 @@ impl ImportKeyPairError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ImportKeyPairError::Unknown(String::from(body)),
             },
-            Err(_) => ImportKeyPairError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ImportKeyPairError::Unknown(format!("{}", status))
+                } else {
+                    ImportKeyPairError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -70195,7 +71459,13 @@ impl ImportSnapshotError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ImportSnapshotError::Unknown(String::from(body)),
             },
-            Err(_) => ImportSnapshotError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ImportSnapshotError::Unknown(format!("{}", status))
+                } else {
+                    ImportSnapshotError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -70267,7 +71537,13 @@ impl ImportVolumeError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ImportVolumeError::Unknown(String::from(body)),
             },
-            Err(_) => ImportVolumeError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ImportVolumeError::Unknown(format!("{}", status))
+                } else {
+                    ImportVolumeError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -70339,7 +71615,13 @@ impl ModifyFleetError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifyFleetError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyFleetError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ModifyFleetError::Unknown(format!("{}", status))
+                } else {
+                    ModifyFleetError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -70412,7 +71694,15 @@ impl ModifyFpgaImageAttributeError {
                 _ => ModifyFpgaImageAttributeError::Unknown(String::from(body)),
             },
             Err(_) => {
-                ModifyFpgaImageAttributeError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    ModifyFpgaImageAttributeError::Unknown(format!("{}", status))
+                } else {
+                    ModifyFpgaImageAttributeError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -70487,7 +71777,13 @@ impl ModifyHostsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifyHostsError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyHostsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ModifyHostsError::Unknown(format!("{}", status))
+                } else {
+                    ModifyHostsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -70559,7 +71855,13 @@ impl ModifyIdFormatError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifyIdFormatError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyIdFormatError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ModifyIdFormatError::Unknown(format!("{}", status))
+                } else {
+                    ModifyIdFormatError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -70632,7 +71934,11 @@ impl ModifyIdentityIdFormatError {
                 _ => ModifyIdentityIdFormatError::Unknown(String::from(body)),
             },
             Err(_) => {
-                ModifyIdentityIdFormatError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    ModifyIdentityIdFormatError::Unknown(format!("{}", status))
+                } else {
+                    ModifyIdentityIdFormatError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -70708,7 +72014,11 @@ impl ModifyImageAttributeError {
                 _ => ModifyImageAttributeError::Unknown(String::from(body)),
             },
             Err(_) => {
-                ModifyImageAttributeError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    ModifyImageAttributeError::Unknown(format!("{}", status))
+                } else {
+                    ModifyImageAttributeError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -70784,7 +72094,15 @@ impl ModifyInstanceAttributeError {
                 _ => ModifyInstanceAttributeError::Unknown(String::from(body)),
             },
             Err(_) => {
-                ModifyInstanceAttributeError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    ModifyInstanceAttributeError::Unknown(format!("{}", status))
+                } else {
+                    ModifyInstanceAttributeError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -70859,11 +72177,17 @@ impl ModifyInstanceCreditSpecificationError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifyInstanceCreditSpecificationError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyInstanceCreditSpecificationError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    ModifyInstanceCreditSpecificationError::Unknown(format!("{}", status))
+                } else {
+                    ModifyInstanceCreditSpecificationError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -70938,7 +72262,15 @@ impl ModifyInstancePlacementError {
                 _ => ModifyInstancePlacementError::Unknown(String::from(body)),
             },
             Err(_) => {
-                ModifyInstancePlacementError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    ModifyInstancePlacementError::Unknown(format!("{}", status))
+                } else {
+                    ModifyInstancePlacementError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -71014,7 +72346,11 @@ impl ModifyLaunchTemplateError {
                 _ => ModifyLaunchTemplateError::Unknown(String::from(body)),
             },
             Err(_) => {
-                ModifyLaunchTemplateError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    ModifyLaunchTemplateError::Unknown(format!("{}", status))
+                } else {
+                    ModifyLaunchTemplateError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -71089,11 +72425,17 @@ impl ModifyNetworkInterfaceAttributeError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifyNetworkInterfaceAttributeError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyNetworkInterfaceAttributeError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    ModifyNetworkInterfaceAttributeError::Unknown(format!("{}", status))
+                } else {
+                    ModifyNetworkInterfaceAttributeError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -71168,7 +72510,15 @@ impl ModifyReservedInstancesError {
                 _ => ModifyReservedInstancesError::Unknown(String::from(body)),
             },
             Err(_) => {
-                ModifyReservedInstancesError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    ModifyReservedInstancesError::Unknown(format!("{}", status))
+                } else {
+                    ModifyReservedInstancesError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -71244,7 +72594,15 @@ impl ModifySnapshotAttributeError {
                 _ => ModifySnapshotAttributeError::Unknown(String::from(body)),
             },
             Err(_) => {
-                ModifySnapshotAttributeError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    ModifySnapshotAttributeError::Unknown(format!("{}", status))
+                } else {
+                    ModifySnapshotAttributeError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -71320,7 +72678,11 @@ impl ModifySpotFleetRequestError {
                 _ => ModifySpotFleetRequestError::Unknown(String::from(body)),
             },
             Err(_) => {
-                ModifySpotFleetRequestError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    ModifySpotFleetRequestError::Unknown(format!("{}", status))
+                } else {
+                    ModifySpotFleetRequestError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -71396,7 +72758,11 @@ impl ModifySubnetAttributeError {
                 _ => ModifySubnetAttributeError::Unknown(String::from(body)),
             },
             Err(_) => {
-                ModifySubnetAttributeError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    ModifySubnetAttributeError::Unknown(format!("{}", status))
+                } else {
+                    ModifySubnetAttributeError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -71471,7 +72837,13 @@ impl ModifyVolumeError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifyVolumeError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyVolumeError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ModifyVolumeError::Unknown(format!("{}", status))
+                } else {
+                    ModifyVolumeError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -71544,7 +72916,11 @@ impl ModifyVolumeAttributeError {
                 _ => ModifyVolumeAttributeError::Unknown(String::from(body)),
             },
             Err(_) => {
-                ModifyVolumeAttributeError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    ModifyVolumeAttributeError::Unknown(format!("{}", status))
+                } else {
+                    ModifyVolumeAttributeError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -71619,7 +72995,13 @@ impl ModifyVpcAttributeError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifyVpcAttributeError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyVpcAttributeError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ModifyVpcAttributeError::Unknown(format!("{}", status))
+                } else {
+                    ModifyVpcAttributeError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -71693,7 +73075,13 @@ impl ModifyVpcEndpointError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifyVpcEndpointError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyVpcEndpointError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ModifyVpcEndpointError::Unknown(format!("{}", status))
+                } else {
+                    ModifyVpcEndpointError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -71767,11 +73155,17 @@ impl ModifyVpcEndpointConnectionNotificationError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifyVpcEndpointConnectionNotificationError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyVpcEndpointConnectionNotificationError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    ModifyVpcEndpointConnectionNotificationError::Unknown(format!("{}", status))
+                } else {
+                    ModifyVpcEndpointConnectionNotificationError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -71845,11 +73239,17 @@ impl ModifyVpcEndpointServiceConfigurationError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifyVpcEndpointServiceConfigurationError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyVpcEndpointServiceConfigurationError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    ModifyVpcEndpointServiceConfigurationError::Unknown(format!("{}", status))
+                } else {
+                    ModifyVpcEndpointServiceConfigurationError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -71923,11 +73323,17 @@ impl ModifyVpcEndpointServicePermissionsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifyVpcEndpointServicePermissionsError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyVpcEndpointServicePermissionsError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    ModifyVpcEndpointServicePermissionsError::Unknown(format!("{}", status))
+                } else {
+                    ModifyVpcEndpointServicePermissionsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -72001,11 +73407,17 @@ impl ModifyVpcPeeringConnectionOptionsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifyVpcPeeringConnectionOptionsError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyVpcPeeringConnectionOptionsError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    ModifyVpcPeeringConnectionOptionsError::Unknown(format!("{}", status))
+                } else {
+                    ModifyVpcPeeringConnectionOptionsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -72079,7 +73491,13 @@ impl ModifyVpcTenancyError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifyVpcTenancyError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyVpcTenancyError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ModifyVpcTenancyError::Unknown(format!("{}", status))
+                } else {
+                    ModifyVpcTenancyError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -72151,7 +73569,13 @@ impl MonitorInstancesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => MonitorInstancesError::Unknown(String::from(body)),
             },
-            Err(_) => MonitorInstancesError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    MonitorInstancesError::Unknown(format!("{}", status))
+                } else {
+                    MonitorInstancesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -72223,7 +73647,13 @@ impl MoveAddressToVpcError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => MoveAddressToVpcError::Unknown(String::from(body)),
             },
-            Err(_) => MoveAddressToVpcError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    MoveAddressToVpcError::Unknown(format!("{}", status))
+                } else {
+                    MoveAddressToVpcError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -72296,7 +73726,15 @@ impl PurchaseHostReservationError {
                 _ => PurchaseHostReservationError::Unknown(String::from(body)),
             },
             Err(_) => {
-                PurchaseHostReservationError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    PurchaseHostReservationError::Unknown(format!("{}", status))
+                } else {
+                    PurchaseHostReservationError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -72371,11 +73809,17 @@ impl PurchaseReservedInstancesOfferingError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PurchaseReservedInstancesOfferingError::Unknown(String::from(body)),
             },
-            Err(_) => PurchaseReservedInstancesOfferingError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    PurchaseReservedInstancesOfferingError::Unknown(format!("{}", status))
+                } else {
+                    PurchaseReservedInstancesOfferingError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -72450,7 +73894,15 @@ impl PurchaseScheduledInstancesError {
                 _ => PurchaseScheduledInstancesError::Unknown(String::from(body)),
             },
             Err(_) => {
-                PurchaseScheduledInstancesError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    PurchaseScheduledInstancesError::Unknown(format!("{}", status))
+                } else {
+                    PurchaseScheduledInstancesError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -72525,7 +73977,13 @@ impl RebootInstancesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => RebootInstancesError::Unknown(String::from(body)),
             },
-            Err(_) => RebootInstancesError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    RebootInstancesError::Unknown(format!("{}", status))
+                } else {
+                    RebootInstancesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -72597,7 +74055,13 @@ impl RegisterImageError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => RegisterImageError::Unknown(String::from(body)),
             },
-            Err(_) => RegisterImageError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    RegisterImageError::Unknown(format!("{}", status))
+                } else {
+                    RegisterImageError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -72669,11 +74133,17 @@ impl RejectVpcEndpointConnectionsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => RejectVpcEndpointConnectionsError::Unknown(String::from(body)),
             },
-            Err(_) => RejectVpcEndpointConnectionsError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    RejectVpcEndpointConnectionsError::Unknown(format!("{}", status))
+                } else {
+                    RejectVpcEndpointConnectionsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -72748,7 +74218,15 @@ impl RejectVpcPeeringConnectionError {
                 _ => RejectVpcPeeringConnectionError::Unknown(String::from(body)),
             },
             Err(_) => {
-                RejectVpcPeeringConnectionError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    RejectVpcPeeringConnectionError::Unknown(format!("{}", status))
+                } else {
+                    RejectVpcPeeringConnectionError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -72823,7 +74301,13 @@ impl ReleaseAddressError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ReleaseAddressError::Unknown(String::from(body)),
             },
-            Err(_) => ReleaseAddressError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ReleaseAddressError::Unknown(format!("{}", status))
+                } else {
+                    ReleaseAddressError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -72895,7 +74379,13 @@ impl ReleaseHostsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ReleaseHostsError::Unknown(String::from(body)),
             },
-            Err(_) => ReleaseHostsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ReleaseHostsError::Unknown(format!("{}", status))
+                } else {
+                    ReleaseHostsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -72967,11 +74457,17 @@ impl ReplaceIamInstanceProfileAssociationError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ReplaceIamInstanceProfileAssociationError::Unknown(String::from(body)),
             },
-            Err(_) => ReplaceIamInstanceProfileAssociationError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    ReplaceIamInstanceProfileAssociationError::Unknown(format!("{}", status))
+                } else {
+                    ReplaceIamInstanceProfileAssociationError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -73045,11 +74541,17 @@ impl ReplaceNetworkAclAssociationError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ReplaceNetworkAclAssociationError::Unknown(String::from(body)),
             },
-            Err(_) => ReplaceNetworkAclAssociationError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    ReplaceNetworkAclAssociationError::Unknown(format!("{}", status))
+                } else {
+                    ReplaceNetworkAclAssociationError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -73124,7 +74626,11 @@ impl ReplaceNetworkAclEntryError {
                 _ => ReplaceNetworkAclEntryError::Unknown(String::from(body)),
             },
             Err(_) => {
-                ReplaceNetworkAclEntryError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    ReplaceNetworkAclEntryError::Unknown(format!("{}", status))
+                } else {
+                    ReplaceNetworkAclEntryError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -73199,7 +74705,13 @@ impl ReplaceRouteError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ReplaceRouteError::Unknown(String::from(body)),
             },
-            Err(_) => ReplaceRouteError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ReplaceRouteError::Unknown(format!("{}", status))
+                } else {
+                    ReplaceRouteError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -73271,11 +74783,17 @@ impl ReplaceRouteTableAssociationError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ReplaceRouteTableAssociationError::Unknown(String::from(body)),
             },
-            Err(_) => ReplaceRouteTableAssociationError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    ReplaceRouteTableAssociationError::Unknown(format!("{}", status))
+                } else {
+                    ReplaceRouteTableAssociationError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -73350,7 +74868,11 @@ impl ReportInstanceStatusError {
                 _ => ReportInstanceStatusError::Unknown(String::from(body)),
             },
             Err(_) => {
-                ReportInstanceStatusError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    ReportInstanceStatusError::Unknown(format!("{}", status))
+                } else {
+                    ReportInstanceStatusError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -73425,7 +74947,13 @@ impl RequestSpotFleetError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => RequestSpotFleetError::Unknown(String::from(body)),
             },
-            Err(_) => RequestSpotFleetError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    RequestSpotFleetError::Unknown(format!("{}", status))
+                } else {
+                    RequestSpotFleetError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -73498,7 +75026,11 @@ impl RequestSpotInstancesError {
                 _ => RequestSpotInstancesError::Unknown(String::from(body)),
             },
             Err(_) => {
-                RequestSpotInstancesError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    RequestSpotInstancesError::Unknown(format!("{}", status))
+                } else {
+                    RequestSpotInstancesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -73574,7 +75106,15 @@ impl ResetFpgaImageAttributeError {
                 _ => ResetFpgaImageAttributeError::Unknown(String::from(body)),
             },
             Err(_) => {
-                ResetFpgaImageAttributeError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    ResetFpgaImageAttributeError::Unknown(format!("{}", status))
+                } else {
+                    ResetFpgaImageAttributeError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -73649,7 +75189,13 @@ impl ResetImageAttributeError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ResetImageAttributeError::Unknown(String::from(body)),
             },
-            Err(_) => ResetImageAttributeError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ResetImageAttributeError::Unknown(format!("{}", status))
+                } else {
+                    ResetImageAttributeError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -73724,7 +75270,11 @@ impl ResetInstanceAttributeError {
                 _ => ResetInstanceAttributeError::Unknown(String::from(body)),
             },
             Err(_) => {
-                ResetInstanceAttributeError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    ResetInstanceAttributeError::Unknown(format!("{}", status))
+                } else {
+                    ResetInstanceAttributeError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -73799,11 +75349,17 @@ impl ResetNetworkInterfaceAttributeError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ResetNetworkInterfaceAttributeError::Unknown(String::from(body)),
             },
-            Err(_) => ResetNetworkInterfaceAttributeError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    ResetNetworkInterfaceAttributeError::Unknown(format!("{}", status))
+                } else {
+                    ResetNetworkInterfaceAttributeError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -73878,7 +75434,11 @@ impl ResetSnapshotAttributeError {
                 _ => ResetSnapshotAttributeError::Unknown(String::from(body)),
             },
             Err(_) => {
-                ResetSnapshotAttributeError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    ResetSnapshotAttributeError::Unknown(format!("{}", status))
+                } else {
+                    ResetSnapshotAttributeError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -73954,7 +75514,15 @@ impl RestoreAddressToClassicError {
                 _ => RestoreAddressToClassicError::Unknown(String::from(body)),
             },
             Err(_) => {
-                RestoreAddressToClassicError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    RestoreAddressToClassicError::Unknown(format!("{}", status))
+                } else {
+                    RestoreAddressToClassicError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -74030,7 +75598,15 @@ impl RevokeSecurityGroupEgressError {
                 _ => RevokeSecurityGroupEgressError::Unknown(String::from(body)),
             },
             Err(_) => {
-                RevokeSecurityGroupEgressError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    RevokeSecurityGroupEgressError::Unknown(format!("{}", status))
+                } else {
+                    RevokeSecurityGroupEgressError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -74106,7 +75682,15 @@ impl RevokeSecurityGroupIngressError {
                 _ => RevokeSecurityGroupIngressError::Unknown(String::from(body)),
             },
             Err(_) => {
-                RevokeSecurityGroupIngressError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    RevokeSecurityGroupIngressError::Unknown(format!("{}", status))
+                } else {
+                    RevokeSecurityGroupIngressError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -74181,7 +75765,13 @@ impl RunInstancesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => RunInstancesError::Unknown(String::from(body)),
             },
-            Err(_) => RunInstancesError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    RunInstancesError::Unknown(format!("{}", status))
+                } else {
+                    RunInstancesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -74254,7 +75844,11 @@ impl RunScheduledInstancesError {
                 _ => RunScheduledInstancesError::Unknown(String::from(body)),
             },
             Err(_) => {
-                RunScheduledInstancesError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    RunScheduledInstancesError::Unknown(format!("{}", status))
+                } else {
+                    RunScheduledInstancesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -74329,7 +75923,13 @@ impl StartInstancesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => StartInstancesError::Unknown(String::from(body)),
             },
-            Err(_) => StartInstancesError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    StartInstancesError::Unknown(format!("{}", status))
+                } else {
+                    StartInstancesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -74401,7 +76001,13 @@ impl StopInstancesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => StopInstancesError::Unknown(String::from(body)),
             },
-            Err(_) => StopInstancesError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    StopInstancesError::Unknown(format!("{}", status))
+                } else {
+                    StopInstancesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -74473,7 +76079,13 @@ impl TerminateInstancesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => TerminateInstancesError::Unknown(String::from(body)),
             },
-            Err(_) => TerminateInstancesError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    TerminateInstancesError::Unknown(format!("{}", status))
+                } else {
+                    TerminateInstancesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -74548,7 +76160,11 @@ impl UnassignIpv6AddressesError {
                 _ => UnassignIpv6AddressesError::Unknown(String::from(body)),
             },
             Err(_) => {
-                UnassignIpv6AddressesError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    UnassignIpv6AddressesError::Unknown(format!("{}", status))
+                } else {
+                    UnassignIpv6AddressesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -74624,7 +76240,15 @@ impl UnassignPrivateIpAddressesError {
                 _ => UnassignPrivateIpAddressesError::Unknown(String::from(body)),
             },
             Err(_) => {
-                UnassignPrivateIpAddressesError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    UnassignPrivateIpAddressesError::Unknown(format!("{}", status))
+                } else {
+                    UnassignPrivateIpAddressesError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -74699,7 +76323,13 @@ impl UnmonitorInstancesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => UnmonitorInstancesError::Unknown(String::from(body)),
             },
-            Err(_) => UnmonitorInstancesError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    UnmonitorInstancesError::Unknown(format!("{}", status))
+                } else {
+                    UnmonitorInstancesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -74773,11 +76403,17 @@ impl UpdateSecurityGroupRuleDescriptionsEgressError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => UpdateSecurityGroupRuleDescriptionsEgressError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateSecurityGroupRuleDescriptionsEgressError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    UpdateSecurityGroupRuleDescriptionsEgressError::Unknown(format!("{}", status))
+                } else {
+                    UpdateSecurityGroupRuleDescriptionsEgressError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -74853,11 +76489,17 @@ impl UpdateSecurityGroupRuleDescriptionsIngressError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => UpdateSecurityGroupRuleDescriptionsIngressError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateSecurityGroupRuleDescriptionsIngressError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    UpdateSecurityGroupRuleDescriptionsIngressError::Unknown(format!("{}", status))
+                } else {
+                    UpdateSecurityGroupRuleDescriptionsIngressError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 

--- a/rusoto/services/ec2/src/generated.rs
+++ b/rusoto/services/ec2/src/generated.rs
@@ -54341,7 +54341,7 @@ pub enum AcceptReservedInstancesExchangeQuoteError {
 }
 
 impl AcceptReservedInstancesExchangeQuoteError {
-    pub fn from_body(body: &str) -> AcceptReservedInstancesExchangeQuoteError {
+    pub fn from_body(body: &str, status: u16) -> AcceptReservedInstancesExchangeQuoteError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -54349,7 +54349,11 @@ impl AcceptReservedInstancesExchangeQuoteError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AcceptReservedInstancesExchangeQuoteError::Unknown(String::from(body)),
             },
-            Err(_) => AcceptReservedInstancesExchangeQuoteError::Unknown(body.to_string()),
+            Err(_) => AcceptReservedInstancesExchangeQuoteError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -54415,7 +54419,7 @@ pub enum AcceptVpcEndpointConnectionsError {
 }
 
 impl AcceptVpcEndpointConnectionsError {
-    pub fn from_body(body: &str) -> AcceptVpcEndpointConnectionsError {
+    pub fn from_body(body: &str, status: u16) -> AcceptVpcEndpointConnectionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -54423,7 +54427,11 @@ impl AcceptVpcEndpointConnectionsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AcceptVpcEndpointConnectionsError::Unknown(String::from(body)),
             },
-            Err(_) => AcceptVpcEndpointConnectionsError::Unknown(body.to_string()),
+            Err(_) => AcceptVpcEndpointConnectionsError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -54489,7 +54497,7 @@ pub enum AcceptVpcPeeringConnectionError {
 }
 
 impl AcceptVpcPeeringConnectionError {
-    pub fn from_body(body: &str) -> AcceptVpcPeeringConnectionError {
+    pub fn from_body(body: &str, status: u16) -> AcceptVpcPeeringConnectionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -54497,7 +54505,9 @@ impl AcceptVpcPeeringConnectionError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AcceptVpcPeeringConnectionError::Unknown(String::from(body)),
             },
-            Err(_) => AcceptVpcPeeringConnectionError::Unknown(body.to_string()),
+            Err(_) => {
+                AcceptVpcPeeringConnectionError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -54563,7 +54573,7 @@ pub enum AllocateAddressError {
 }
 
 impl AllocateAddressError {
-    pub fn from_body(body: &str) -> AllocateAddressError {
+    pub fn from_body(body: &str, status: u16) -> AllocateAddressError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -54571,7 +54581,7 @@ impl AllocateAddressError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AllocateAddressError::Unknown(String::from(body)),
             },
-            Err(_) => AllocateAddressError::Unknown(body.to_string()),
+            Err(_) => AllocateAddressError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -54635,7 +54645,7 @@ pub enum AllocateHostsError {
 }
 
 impl AllocateHostsError {
-    pub fn from_body(body: &str) -> AllocateHostsError {
+    pub fn from_body(body: &str, status: u16) -> AllocateHostsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -54643,7 +54653,7 @@ impl AllocateHostsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AllocateHostsError::Unknown(String::from(body)),
             },
-            Err(_) => AllocateHostsError::Unknown(body.to_string()),
+            Err(_) => AllocateHostsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -54707,7 +54717,7 @@ pub enum AssignIpv6AddressesError {
 }
 
 impl AssignIpv6AddressesError {
-    pub fn from_body(body: &str) -> AssignIpv6AddressesError {
+    pub fn from_body(body: &str, status: u16) -> AssignIpv6AddressesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -54715,7 +54725,7 @@ impl AssignIpv6AddressesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AssignIpv6AddressesError::Unknown(String::from(body)),
             },
-            Err(_) => AssignIpv6AddressesError::Unknown(body.to_string()),
+            Err(_) => AssignIpv6AddressesError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -54781,7 +54791,7 @@ pub enum AssignPrivateIpAddressesError {
 }
 
 impl AssignPrivateIpAddressesError {
-    pub fn from_body(body: &str) -> AssignPrivateIpAddressesError {
+    pub fn from_body(body: &str, status: u16) -> AssignPrivateIpAddressesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -54789,7 +54799,9 @@ impl AssignPrivateIpAddressesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AssignPrivateIpAddressesError::Unknown(String::from(body)),
             },
-            Err(_) => AssignPrivateIpAddressesError::Unknown(body.to_string()),
+            Err(_) => {
+                AssignPrivateIpAddressesError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -54855,7 +54867,7 @@ pub enum AssociateAddressError {
 }
 
 impl AssociateAddressError {
-    pub fn from_body(body: &str) -> AssociateAddressError {
+    pub fn from_body(body: &str, status: u16) -> AssociateAddressError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -54863,7 +54875,7 @@ impl AssociateAddressError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AssociateAddressError::Unknown(String::from(body)),
             },
-            Err(_) => AssociateAddressError::Unknown(body.to_string()),
+            Err(_) => AssociateAddressError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -54927,7 +54939,7 @@ pub enum AssociateDhcpOptionsError {
 }
 
 impl AssociateDhcpOptionsError {
-    pub fn from_body(body: &str) -> AssociateDhcpOptionsError {
+    pub fn from_body(body: &str, status: u16) -> AssociateDhcpOptionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -54935,7 +54947,9 @@ impl AssociateDhcpOptionsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AssociateDhcpOptionsError::Unknown(String::from(body)),
             },
-            Err(_) => AssociateDhcpOptionsError::Unknown(body.to_string()),
+            Err(_) => {
+                AssociateDhcpOptionsError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -55001,7 +55015,7 @@ pub enum AssociateIamInstanceProfileError {
 }
 
 impl AssociateIamInstanceProfileError {
-    pub fn from_body(body: &str) -> AssociateIamInstanceProfileError {
+    pub fn from_body(body: &str, status: u16) -> AssociateIamInstanceProfileError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -55009,7 +55023,11 @@ impl AssociateIamInstanceProfileError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AssociateIamInstanceProfileError::Unknown(String::from(body)),
             },
-            Err(_) => AssociateIamInstanceProfileError::Unknown(body.to_string()),
+            Err(_) => AssociateIamInstanceProfileError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -55075,7 +55093,7 @@ pub enum AssociateRouteTableError {
 }
 
 impl AssociateRouteTableError {
-    pub fn from_body(body: &str) -> AssociateRouteTableError {
+    pub fn from_body(body: &str, status: u16) -> AssociateRouteTableError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -55083,7 +55101,7 @@ impl AssociateRouteTableError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AssociateRouteTableError::Unknown(String::from(body)),
             },
-            Err(_) => AssociateRouteTableError::Unknown(body.to_string()),
+            Err(_) => AssociateRouteTableError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -55149,7 +55167,7 @@ pub enum AssociateSubnetCidrBlockError {
 }
 
 impl AssociateSubnetCidrBlockError {
-    pub fn from_body(body: &str) -> AssociateSubnetCidrBlockError {
+    pub fn from_body(body: &str, status: u16) -> AssociateSubnetCidrBlockError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -55157,7 +55175,9 @@ impl AssociateSubnetCidrBlockError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AssociateSubnetCidrBlockError::Unknown(String::from(body)),
             },
-            Err(_) => AssociateSubnetCidrBlockError::Unknown(body.to_string()),
+            Err(_) => {
+                AssociateSubnetCidrBlockError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -55223,7 +55243,7 @@ pub enum AssociateVpcCidrBlockError {
 }
 
 impl AssociateVpcCidrBlockError {
-    pub fn from_body(body: &str) -> AssociateVpcCidrBlockError {
+    pub fn from_body(body: &str, status: u16) -> AssociateVpcCidrBlockError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -55231,7 +55251,9 @@ impl AssociateVpcCidrBlockError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AssociateVpcCidrBlockError::Unknown(String::from(body)),
             },
-            Err(_) => AssociateVpcCidrBlockError::Unknown(body.to_string()),
+            Err(_) => {
+                AssociateVpcCidrBlockError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -55297,7 +55319,7 @@ pub enum AttachClassicLinkVpcError {
 }
 
 impl AttachClassicLinkVpcError {
-    pub fn from_body(body: &str) -> AttachClassicLinkVpcError {
+    pub fn from_body(body: &str, status: u16) -> AttachClassicLinkVpcError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -55305,7 +55327,9 @@ impl AttachClassicLinkVpcError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AttachClassicLinkVpcError::Unknown(String::from(body)),
             },
-            Err(_) => AttachClassicLinkVpcError::Unknown(body.to_string()),
+            Err(_) => {
+                AttachClassicLinkVpcError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -55371,7 +55395,7 @@ pub enum AttachInternetGatewayError {
 }
 
 impl AttachInternetGatewayError {
-    pub fn from_body(body: &str) -> AttachInternetGatewayError {
+    pub fn from_body(body: &str, status: u16) -> AttachInternetGatewayError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -55379,7 +55403,9 @@ impl AttachInternetGatewayError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AttachInternetGatewayError::Unknown(String::from(body)),
             },
-            Err(_) => AttachInternetGatewayError::Unknown(body.to_string()),
+            Err(_) => {
+                AttachInternetGatewayError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -55445,7 +55471,7 @@ pub enum AttachNetworkInterfaceError {
 }
 
 impl AttachNetworkInterfaceError {
-    pub fn from_body(body: &str) -> AttachNetworkInterfaceError {
+    pub fn from_body(body: &str, status: u16) -> AttachNetworkInterfaceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -55453,7 +55479,9 @@ impl AttachNetworkInterfaceError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AttachNetworkInterfaceError::Unknown(String::from(body)),
             },
-            Err(_) => AttachNetworkInterfaceError::Unknown(body.to_string()),
+            Err(_) => {
+                AttachNetworkInterfaceError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -55519,7 +55547,7 @@ pub enum AttachVolumeError {
 }
 
 impl AttachVolumeError {
-    pub fn from_body(body: &str) -> AttachVolumeError {
+    pub fn from_body(body: &str, status: u16) -> AttachVolumeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -55527,7 +55555,7 @@ impl AttachVolumeError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AttachVolumeError::Unknown(String::from(body)),
             },
-            Err(_) => AttachVolumeError::Unknown(body.to_string()),
+            Err(_) => AttachVolumeError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -55591,7 +55619,7 @@ pub enum AttachVpnGatewayError {
 }
 
 impl AttachVpnGatewayError {
-    pub fn from_body(body: &str) -> AttachVpnGatewayError {
+    pub fn from_body(body: &str, status: u16) -> AttachVpnGatewayError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -55599,7 +55627,7 @@ impl AttachVpnGatewayError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AttachVpnGatewayError::Unknown(String::from(body)),
             },
-            Err(_) => AttachVpnGatewayError::Unknown(body.to_string()),
+            Err(_) => AttachVpnGatewayError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -55663,7 +55691,7 @@ pub enum AuthorizeSecurityGroupEgressError {
 }
 
 impl AuthorizeSecurityGroupEgressError {
-    pub fn from_body(body: &str) -> AuthorizeSecurityGroupEgressError {
+    pub fn from_body(body: &str, status: u16) -> AuthorizeSecurityGroupEgressError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -55671,7 +55699,11 @@ impl AuthorizeSecurityGroupEgressError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AuthorizeSecurityGroupEgressError::Unknown(String::from(body)),
             },
-            Err(_) => AuthorizeSecurityGroupEgressError::Unknown(body.to_string()),
+            Err(_) => AuthorizeSecurityGroupEgressError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -55737,7 +55769,7 @@ pub enum AuthorizeSecurityGroupIngressError {
 }
 
 impl AuthorizeSecurityGroupIngressError {
-    pub fn from_body(body: &str) -> AuthorizeSecurityGroupIngressError {
+    pub fn from_body(body: &str, status: u16) -> AuthorizeSecurityGroupIngressError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -55745,7 +55777,11 @@ impl AuthorizeSecurityGroupIngressError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => AuthorizeSecurityGroupIngressError::Unknown(String::from(body)),
             },
-            Err(_) => AuthorizeSecurityGroupIngressError::Unknown(body.to_string()),
+            Err(_) => AuthorizeSecurityGroupIngressError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -55811,7 +55847,7 @@ pub enum BundleInstanceError {
 }
 
 impl BundleInstanceError {
-    pub fn from_body(body: &str) -> BundleInstanceError {
+    pub fn from_body(body: &str, status: u16) -> BundleInstanceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -55819,7 +55855,7 @@ impl BundleInstanceError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => BundleInstanceError::Unknown(String::from(body)),
             },
-            Err(_) => BundleInstanceError::Unknown(body.to_string()),
+            Err(_) => BundleInstanceError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -55883,7 +55919,7 @@ pub enum CancelBundleTaskError {
 }
 
 impl CancelBundleTaskError {
-    pub fn from_body(body: &str) -> CancelBundleTaskError {
+    pub fn from_body(body: &str, status: u16) -> CancelBundleTaskError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -55891,7 +55927,7 @@ impl CancelBundleTaskError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CancelBundleTaskError::Unknown(String::from(body)),
             },
-            Err(_) => CancelBundleTaskError::Unknown(body.to_string()),
+            Err(_) => CancelBundleTaskError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -55955,7 +55991,7 @@ pub enum CancelConversionTaskError {
 }
 
 impl CancelConversionTaskError {
-    pub fn from_body(body: &str) -> CancelConversionTaskError {
+    pub fn from_body(body: &str, status: u16) -> CancelConversionTaskError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -55963,7 +55999,9 @@ impl CancelConversionTaskError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CancelConversionTaskError::Unknown(String::from(body)),
             },
-            Err(_) => CancelConversionTaskError::Unknown(body.to_string()),
+            Err(_) => {
+                CancelConversionTaskError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -56029,7 +56067,7 @@ pub enum CancelExportTaskError {
 }
 
 impl CancelExportTaskError {
-    pub fn from_body(body: &str) -> CancelExportTaskError {
+    pub fn from_body(body: &str, status: u16) -> CancelExportTaskError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -56037,7 +56075,7 @@ impl CancelExportTaskError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CancelExportTaskError::Unknown(String::from(body)),
             },
-            Err(_) => CancelExportTaskError::Unknown(body.to_string()),
+            Err(_) => CancelExportTaskError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -56101,7 +56139,7 @@ pub enum CancelImportTaskError {
 }
 
 impl CancelImportTaskError {
-    pub fn from_body(body: &str) -> CancelImportTaskError {
+    pub fn from_body(body: &str, status: u16) -> CancelImportTaskError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -56109,7 +56147,7 @@ impl CancelImportTaskError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CancelImportTaskError::Unknown(String::from(body)),
             },
-            Err(_) => CancelImportTaskError::Unknown(body.to_string()),
+            Err(_) => CancelImportTaskError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -56173,7 +56211,7 @@ pub enum CancelReservedInstancesListingError {
 }
 
 impl CancelReservedInstancesListingError {
-    pub fn from_body(body: &str) -> CancelReservedInstancesListingError {
+    pub fn from_body(body: &str, status: u16) -> CancelReservedInstancesListingError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -56181,7 +56219,11 @@ impl CancelReservedInstancesListingError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CancelReservedInstancesListingError::Unknown(String::from(body)),
             },
-            Err(_) => CancelReservedInstancesListingError::Unknown(body.to_string()),
+            Err(_) => CancelReservedInstancesListingError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -56247,7 +56289,7 @@ pub enum EC2CancelSpotFleetRequestsError {
 }
 
 impl EC2CancelSpotFleetRequestsError {
-    pub fn from_body(body: &str) -> EC2CancelSpotFleetRequestsError {
+    pub fn from_body(body: &str, status: u16) -> EC2CancelSpotFleetRequestsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -56255,7 +56297,9 @@ impl EC2CancelSpotFleetRequestsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => EC2CancelSpotFleetRequestsError::Unknown(String::from(body)),
             },
-            Err(_) => EC2CancelSpotFleetRequestsError::Unknown(body.to_string()),
+            Err(_) => {
+                EC2CancelSpotFleetRequestsError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -56321,7 +56365,7 @@ pub enum CancelSpotInstanceRequestsError {
 }
 
 impl CancelSpotInstanceRequestsError {
-    pub fn from_body(body: &str) -> CancelSpotInstanceRequestsError {
+    pub fn from_body(body: &str, status: u16) -> CancelSpotInstanceRequestsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -56329,7 +56373,9 @@ impl CancelSpotInstanceRequestsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CancelSpotInstanceRequestsError::Unknown(String::from(body)),
             },
-            Err(_) => CancelSpotInstanceRequestsError::Unknown(body.to_string()),
+            Err(_) => {
+                CancelSpotInstanceRequestsError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -56395,7 +56441,7 @@ pub enum ConfirmProductInstanceError {
 }
 
 impl ConfirmProductInstanceError {
-    pub fn from_body(body: &str) -> ConfirmProductInstanceError {
+    pub fn from_body(body: &str, status: u16) -> ConfirmProductInstanceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -56403,7 +56449,9 @@ impl ConfirmProductInstanceError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ConfirmProductInstanceError::Unknown(String::from(body)),
             },
-            Err(_) => ConfirmProductInstanceError::Unknown(body.to_string()),
+            Err(_) => {
+                ConfirmProductInstanceError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -56469,7 +56517,7 @@ pub enum CopyFpgaImageError {
 }
 
 impl CopyFpgaImageError {
-    pub fn from_body(body: &str) -> CopyFpgaImageError {
+    pub fn from_body(body: &str, status: u16) -> CopyFpgaImageError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -56477,7 +56525,7 @@ impl CopyFpgaImageError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CopyFpgaImageError::Unknown(String::from(body)),
             },
-            Err(_) => CopyFpgaImageError::Unknown(body.to_string()),
+            Err(_) => CopyFpgaImageError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -56541,7 +56589,7 @@ pub enum CopyImageError {
 }
 
 impl CopyImageError {
-    pub fn from_body(body: &str) -> CopyImageError {
+    pub fn from_body(body: &str, status: u16) -> CopyImageError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -56549,7 +56597,7 @@ impl CopyImageError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CopyImageError::Unknown(String::from(body)),
             },
-            Err(_) => CopyImageError::Unknown(body.to_string()),
+            Err(_) => CopyImageError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -56613,7 +56661,7 @@ pub enum CopySnapshotError {
 }
 
 impl CopySnapshotError {
-    pub fn from_body(body: &str) -> CopySnapshotError {
+    pub fn from_body(body: &str, status: u16) -> CopySnapshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -56621,7 +56669,7 @@ impl CopySnapshotError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CopySnapshotError::Unknown(String::from(body)),
             },
-            Err(_) => CopySnapshotError::Unknown(body.to_string()),
+            Err(_) => CopySnapshotError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -56685,7 +56733,7 @@ pub enum CreateCustomerGatewayError {
 }
 
 impl CreateCustomerGatewayError {
-    pub fn from_body(body: &str) -> CreateCustomerGatewayError {
+    pub fn from_body(body: &str, status: u16) -> CreateCustomerGatewayError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -56693,7 +56741,9 @@ impl CreateCustomerGatewayError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateCustomerGatewayError::Unknown(String::from(body)),
             },
-            Err(_) => CreateCustomerGatewayError::Unknown(body.to_string()),
+            Err(_) => {
+                CreateCustomerGatewayError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -56759,7 +56809,7 @@ pub enum CreateDefaultSubnetError {
 }
 
 impl CreateDefaultSubnetError {
-    pub fn from_body(body: &str) -> CreateDefaultSubnetError {
+    pub fn from_body(body: &str, status: u16) -> CreateDefaultSubnetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -56767,7 +56817,7 @@ impl CreateDefaultSubnetError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateDefaultSubnetError::Unknown(String::from(body)),
             },
-            Err(_) => CreateDefaultSubnetError::Unknown(body.to_string()),
+            Err(_) => CreateDefaultSubnetError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -56833,7 +56883,7 @@ pub enum CreateDefaultVpcError {
 }
 
 impl CreateDefaultVpcError {
-    pub fn from_body(body: &str) -> CreateDefaultVpcError {
+    pub fn from_body(body: &str, status: u16) -> CreateDefaultVpcError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -56841,7 +56891,7 @@ impl CreateDefaultVpcError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateDefaultVpcError::Unknown(String::from(body)),
             },
-            Err(_) => CreateDefaultVpcError::Unknown(body.to_string()),
+            Err(_) => CreateDefaultVpcError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -56905,7 +56955,7 @@ pub enum CreateDhcpOptionsError {
 }
 
 impl CreateDhcpOptionsError {
-    pub fn from_body(body: &str) -> CreateDhcpOptionsError {
+    pub fn from_body(body: &str, status: u16) -> CreateDhcpOptionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -56913,7 +56963,7 @@ impl CreateDhcpOptionsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateDhcpOptionsError::Unknown(String::from(body)),
             },
-            Err(_) => CreateDhcpOptionsError::Unknown(body.to_string()),
+            Err(_) => CreateDhcpOptionsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -56979,7 +57029,7 @@ pub enum CreateEgressOnlyInternetGatewayError {
 }
 
 impl CreateEgressOnlyInternetGatewayError {
-    pub fn from_body(body: &str) -> CreateEgressOnlyInternetGatewayError {
+    pub fn from_body(body: &str, status: u16) -> CreateEgressOnlyInternetGatewayError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -56987,7 +57037,11 @@ impl CreateEgressOnlyInternetGatewayError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateEgressOnlyInternetGatewayError::Unknown(String::from(body)),
             },
-            Err(_) => CreateEgressOnlyInternetGatewayError::Unknown(body.to_string()),
+            Err(_) => CreateEgressOnlyInternetGatewayError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -57053,7 +57107,7 @@ pub enum CreateFleetError {
 }
 
 impl CreateFleetError {
-    pub fn from_body(body: &str) -> CreateFleetError {
+    pub fn from_body(body: &str, status: u16) -> CreateFleetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -57061,7 +57115,7 @@ impl CreateFleetError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateFleetError::Unknown(String::from(body)),
             },
-            Err(_) => CreateFleetError::Unknown(body.to_string()),
+            Err(_) => CreateFleetError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -57125,7 +57179,7 @@ pub enum CreateFlowLogsError {
 }
 
 impl CreateFlowLogsError {
-    pub fn from_body(body: &str) -> CreateFlowLogsError {
+    pub fn from_body(body: &str, status: u16) -> CreateFlowLogsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -57133,7 +57187,7 @@ impl CreateFlowLogsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateFlowLogsError::Unknown(String::from(body)),
             },
-            Err(_) => CreateFlowLogsError::Unknown(body.to_string()),
+            Err(_) => CreateFlowLogsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -57197,7 +57251,7 @@ pub enum CreateFpgaImageError {
 }
 
 impl CreateFpgaImageError {
-    pub fn from_body(body: &str) -> CreateFpgaImageError {
+    pub fn from_body(body: &str, status: u16) -> CreateFpgaImageError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -57205,7 +57259,7 @@ impl CreateFpgaImageError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateFpgaImageError::Unknown(String::from(body)),
             },
-            Err(_) => CreateFpgaImageError::Unknown(body.to_string()),
+            Err(_) => CreateFpgaImageError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -57269,7 +57323,7 @@ pub enum CreateImageError {
 }
 
 impl CreateImageError {
-    pub fn from_body(body: &str) -> CreateImageError {
+    pub fn from_body(body: &str, status: u16) -> CreateImageError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -57277,7 +57331,7 @@ impl CreateImageError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateImageError::Unknown(String::from(body)),
             },
-            Err(_) => CreateImageError::Unknown(body.to_string()),
+            Err(_) => CreateImageError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -57341,7 +57395,7 @@ pub enum CreateInstanceExportTaskError {
 }
 
 impl CreateInstanceExportTaskError {
-    pub fn from_body(body: &str) -> CreateInstanceExportTaskError {
+    pub fn from_body(body: &str, status: u16) -> CreateInstanceExportTaskError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -57349,7 +57403,9 @@ impl CreateInstanceExportTaskError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateInstanceExportTaskError::Unknown(String::from(body)),
             },
-            Err(_) => CreateInstanceExportTaskError::Unknown(body.to_string()),
+            Err(_) => {
+                CreateInstanceExportTaskError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -57415,7 +57471,7 @@ pub enum CreateInternetGatewayError {
 }
 
 impl CreateInternetGatewayError {
-    pub fn from_body(body: &str) -> CreateInternetGatewayError {
+    pub fn from_body(body: &str, status: u16) -> CreateInternetGatewayError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -57423,7 +57479,9 @@ impl CreateInternetGatewayError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateInternetGatewayError::Unknown(String::from(body)),
             },
-            Err(_) => CreateInternetGatewayError::Unknown(body.to_string()),
+            Err(_) => {
+                CreateInternetGatewayError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -57489,7 +57547,7 @@ pub enum CreateKeyPairError {
 }
 
 impl CreateKeyPairError {
-    pub fn from_body(body: &str) -> CreateKeyPairError {
+    pub fn from_body(body: &str, status: u16) -> CreateKeyPairError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -57497,7 +57555,7 @@ impl CreateKeyPairError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateKeyPairError::Unknown(String::from(body)),
             },
-            Err(_) => CreateKeyPairError::Unknown(body.to_string()),
+            Err(_) => CreateKeyPairError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -57561,7 +57619,7 @@ pub enum CreateLaunchTemplateError {
 }
 
 impl CreateLaunchTemplateError {
-    pub fn from_body(body: &str) -> CreateLaunchTemplateError {
+    pub fn from_body(body: &str, status: u16) -> CreateLaunchTemplateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -57569,7 +57627,9 @@ impl CreateLaunchTemplateError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateLaunchTemplateError::Unknown(String::from(body)),
             },
-            Err(_) => CreateLaunchTemplateError::Unknown(body.to_string()),
+            Err(_) => {
+                CreateLaunchTemplateError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -57635,7 +57695,7 @@ pub enum CreateLaunchTemplateVersionError {
 }
 
 impl CreateLaunchTemplateVersionError {
-    pub fn from_body(body: &str) -> CreateLaunchTemplateVersionError {
+    pub fn from_body(body: &str, status: u16) -> CreateLaunchTemplateVersionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -57643,7 +57703,11 @@ impl CreateLaunchTemplateVersionError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateLaunchTemplateVersionError::Unknown(String::from(body)),
             },
-            Err(_) => CreateLaunchTemplateVersionError::Unknown(body.to_string()),
+            Err(_) => CreateLaunchTemplateVersionError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -57709,7 +57773,7 @@ pub enum CreateNatGatewayError {
 }
 
 impl CreateNatGatewayError {
-    pub fn from_body(body: &str) -> CreateNatGatewayError {
+    pub fn from_body(body: &str, status: u16) -> CreateNatGatewayError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -57717,7 +57781,7 @@ impl CreateNatGatewayError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateNatGatewayError::Unknown(String::from(body)),
             },
-            Err(_) => CreateNatGatewayError::Unknown(body.to_string()),
+            Err(_) => CreateNatGatewayError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -57781,7 +57845,7 @@ pub enum CreateNetworkAclError {
 }
 
 impl CreateNetworkAclError {
-    pub fn from_body(body: &str) -> CreateNetworkAclError {
+    pub fn from_body(body: &str, status: u16) -> CreateNetworkAclError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -57789,7 +57853,7 @@ impl CreateNetworkAclError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateNetworkAclError::Unknown(String::from(body)),
             },
-            Err(_) => CreateNetworkAclError::Unknown(body.to_string()),
+            Err(_) => CreateNetworkAclError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -57853,7 +57917,7 @@ pub enum CreateNetworkAclEntryError {
 }
 
 impl CreateNetworkAclEntryError {
-    pub fn from_body(body: &str) -> CreateNetworkAclEntryError {
+    pub fn from_body(body: &str, status: u16) -> CreateNetworkAclEntryError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -57861,7 +57925,9 @@ impl CreateNetworkAclEntryError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateNetworkAclEntryError::Unknown(String::from(body)),
             },
-            Err(_) => CreateNetworkAclEntryError::Unknown(body.to_string()),
+            Err(_) => {
+                CreateNetworkAclEntryError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -57927,7 +57993,7 @@ pub enum CreateNetworkInterfaceError {
 }
 
 impl CreateNetworkInterfaceError {
-    pub fn from_body(body: &str) -> CreateNetworkInterfaceError {
+    pub fn from_body(body: &str, status: u16) -> CreateNetworkInterfaceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -57935,7 +58001,9 @@ impl CreateNetworkInterfaceError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateNetworkInterfaceError::Unknown(String::from(body)),
             },
-            Err(_) => CreateNetworkInterfaceError::Unknown(body.to_string()),
+            Err(_) => {
+                CreateNetworkInterfaceError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -58001,7 +58069,7 @@ pub enum CreateNetworkInterfacePermissionError {
 }
 
 impl CreateNetworkInterfacePermissionError {
-    pub fn from_body(body: &str) -> CreateNetworkInterfacePermissionError {
+    pub fn from_body(body: &str, status: u16) -> CreateNetworkInterfacePermissionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -58009,7 +58077,11 @@ impl CreateNetworkInterfacePermissionError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateNetworkInterfacePermissionError::Unknown(String::from(body)),
             },
-            Err(_) => CreateNetworkInterfacePermissionError::Unknown(body.to_string()),
+            Err(_) => CreateNetworkInterfacePermissionError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -58075,7 +58147,7 @@ pub enum CreatePlacementGroupError {
 }
 
 impl CreatePlacementGroupError {
-    pub fn from_body(body: &str) -> CreatePlacementGroupError {
+    pub fn from_body(body: &str, status: u16) -> CreatePlacementGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -58083,7 +58155,9 @@ impl CreatePlacementGroupError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreatePlacementGroupError::Unknown(String::from(body)),
             },
-            Err(_) => CreatePlacementGroupError::Unknown(body.to_string()),
+            Err(_) => {
+                CreatePlacementGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -58149,7 +58223,7 @@ pub enum CreateReservedInstancesListingError {
 }
 
 impl CreateReservedInstancesListingError {
-    pub fn from_body(body: &str) -> CreateReservedInstancesListingError {
+    pub fn from_body(body: &str, status: u16) -> CreateReservedInstancesListingError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -58157,7 +58231,11 @@ impl CreateReservedInstancesListingError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateReservedInstancesListingError::Unknown(String::from(body)),
             },
-            Err(_) => CreateReservedInstancesListingError::Unknown(body.to_string()),
+            Err(_) => CreateReservedInstancesListingError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -58223,7 +58301,7 @@ pub enum CreateRouteError {
 }
 
 impl CreateRouteError {
-    pub fn from_body(body: &str) -> CreateRouteError {
+    pub fn from_body(body: &str, status: u16) -> CreateRouteError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -58231,7 +58309,7 @@ impl CreateRouteError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateRouteError::Unknown(String::from(body)),
             },
-            Err(_) => CreateRouteError::Unknown(body.to_string()),
+            Err(_) => CreateRouteError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -58295,7 +58373,7 @@ pub enum CreateRouteTableError {
 }
 
 impl CreateRouteTableError {
-    pub fn from_body(body: &str) -> CreateRouteTableError {
+    pub fn from_body(body: &str, status: u16) -> CreateRouteTableError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -58303,7 +58381,7 @@ impl CreateRouteTableError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateRouteTableError::Unknown(String::from(body)),
             },
-            Err(_) => CreateRouteTableError::Unknown(body.to_string()),
+            Err(_) => CreateRouteTableError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -58367,7 +58445,7 @@ pub enum CreateSecurityGroupError {
 }
 
 impl CreateSecurityGroupError {
-    pub fn from_body(body: &str) -> CreateSecurityGroupError {
+    pub fn from_body(body: &str, status: u16) -> CreateSecurityGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -58375,7 +58453,7 @@ impl CreateSecurityGroupError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateSecurityGroupError::Unknown(String::from(body)),
             },
-            Err(_) => CreateSecurityGroupError::Unknown(body.to_string()),
+            Err(_) => CreateSecurityGroupError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -58441,7 +58519,7 @@ pub enum CreateSnapshotError {
 }
 
 impl CreateSnapshotError {
-    pub fn from_body(body: &str) -> CreateSnapshotError {
+    pub fn from_body(body: &str, status: u16) -> CreateSnapshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -58449,7 +58527,7 @@ impl CreateSnapshotError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateSnapshotError::Unknown(String::from(body)),
             },
-            Err(_) => CreateSnapshotError::Unknown(body.to_string()),
+            Err(_) => CreateSnapshotError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -58513,7 +58591,7 @@ pub enum CreateSpotDatafeedSubscriptionError {
 }
 
 impl CreateSpotDatafeedSubscriptionError {
-    pub fn from_body(body: &str) -> CreateSpotDatafeedSubscriptionError {
+    pub fn from_body(body: &str, status: u16) -> CreateSpotDatafeedSubscriptionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -58521,7 +58599,11 @@ impl CreateSpotDatafeedSubscriptionError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateSpotDatafeedSubscriptionError::Unknown(String::from(body)),
             },
-            Err(_) => CreateSpotDatafeedSubscriptionError::Unknown(body.to_string()),
+            Err(_) => CreateSpotDatafeedSubscriptionError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -58587,7 +58669,7 @@ pub enum CreateSubnetError {
 }
 
 impl CreateSubnetError {
-    pub fn from_body(body: &str) -> CreateSubnetError {
+    pub fn from_body(body: &str, status: u16) -> CreateSubnetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -58595,7 +58677,7 @@ impl CreateSubnetError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateSubnetError::Unknown(String::from(body)),
             },
-            Err(_) => CreateSubnetError::Unknown(body.to_string()),
+            Err(_) => CreateSubnetError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -58659,7 +58741,7 @@ pub enum CreateTagsError {
 }
 
 impl CreateTagsError {
-    pub fn from_body(body: &str) -> CreateTagsError {
+    pub fn from_body(body: &str, status: u16) -> CreateTagsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -58667,7 +58749,7 @@ impl CreateTagsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateTagsError::Unknown(String::from(body)),
             },
-            Err(_) => CreateTagsError::Unknown(body.to_string()),
+            Err(_) => CreateTagsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -58731,7 +58813,7 @@ pub enum CreateVolumeError {
 }
 
 impl CreateVolumeError {
-    pub fn from_body(body: &str) -> CreateVolumeError {
+    pub fn from_body(body: &str, status: u16) -> CreateVolumeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -58739,7 +58821,7 @@ impl CreateVolumeError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateVolumeError::Unknown(String::from(body)),
             },
-            Err(_) => CreateVolumeError::Unknown(body.to_string()),
+            Err(_) => CreateVolumeError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -58803,7 +58885,7 @@ pub enum CreateVpcError {
 }
 
 impl CreateVpcError {
-    pub fn from_body(body: &str) -> CreateVpcError {
+    pub fn from_body(body: &str, status: u16) -> CreateVpcError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -58811,7 +58893,7 @@ impl CreateVpcError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateVpcError::Unknown(String::from(body)),
             },
-            Err(_) => CreateVpcError::Unknown(body.to_string()),
+            Err(_) => CreateVpcError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -58875,7 +58957,7 @@ pub enum CreateVpcEndpointError {
 }
 
 impl CreateVpcEndpointError {
-    pub fn from_body(body: &str) -> CreateVpcEndpointError {
+    pub fn from_body(body: &str, status: u16) -> CreateVpcEndpointError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -58883,7 +58965,7 @@ impl CreateVpcEndpointError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateVpcEndpointError::Unknown(String::from(body)),
             },
-            Err(_) => CreateVpcEndpointError::Unknown(body.to_string()),
+            Err(_) => CreateVpcEndpointError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -58949,7 +59031,7 @@ pub enum CreateVpcEndpointConnectionNotificationError {
 }
 
 impl CreateVpcEndpointConnectionNotificationError {
-    pub fn from_body(body: &str) -> CreateVpcEndpointConnectionNotificationError {
+    pub fn from_body(body: &str, status: u16) -> CreateVpcEndpointConnectionNotificationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -58957,7 +59039,11 @@ impl CreateVpcEndpointConnectionNotificationError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateVpcEndpointConnectionNotificationError::Unknown(String::from(body)),
             },
-            Err(_) => CreateVpcEndpointConnectionNotificationError::Unknown(body.to_string()),
+            Err(_) => CreateVpcEndpointConnectionNotificationError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -59023,7 +59109,7 @@ pub enum CreateVpcEndpointServiceConfigurationError {
 }
 
 impl CreateVpcEndpointServiceConfigurationError {
-    pub fn from_body(body: &str) -> CreateVpcEndpointServiceConfigurationError {
+    pub fn from_body(body: &str, status: u16) -> CreateVpcEndpointServiceConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -59031,7 +59117,11 @@ impl CreateVpcEndpointServiceConfigurationError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateVpcEndpointServiceConfigurationError::Unknown(String::from(body)),
             },
-            Err(_) => CreateVpcEndpointServiceConfigurationError::Unknown(body.to_string()),
+            Err(_) => CreateVpcEndpointServiceConfigurationError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -59097,7 +59187,7 @@ pub enum CreateVpcPeeringConnectionError {
 }
 
 impl CreateVpcPeeringConnectionError {
-    pub fn from_body(body: &str) -> CreateVpcPeeringConnectionError {
+    pub fn from_body(body: &str, status: u16) -> CreateVpcPeeringConnectionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -59105,7 +59195,9 @@ impl CreateVpcPeeringConnectionError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateVpcPeeringConnectionError::Unknown(String::from(body)),
             },
-            Err(_) => CreateVpcPeeringConnectionError::Unknown(body.to_string()),
+            Err(_) => {
+                CreateVpcPeeringConnectionError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -59171,7 +59263,7 @@ pub enum CreateVpnConnectionError {
 }
 
 impl CreateVpnConnectionError {
-    pub fn from_body(body: &str) -> CreateVpnConnectionError {
+    pub fn from_body(body: &str, status: u16) -> CreateVpnConnectionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -59179,7 +59271,7 @@ impl CreateVpnConnectionError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateVpnConnectionError::Unknown(String::from(body)),
             },
-            Err(_) => CreateVpnConnectionError::Unknown(body.to_string()),
+            Err(_) => CreateVpnConnectionError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -59245,7 +59337,7 @@ pub enum CreateVpnConnectionRouteError {
 }
 
 impl CreateVpnConnectionRouteError {
-    pub fn from_body(body: &str) -> CreateVpnConnectionRouteError {
+    pub fn from_body(body: &str, status: u16) -> CreateVpnConnectionRouteError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -59253,7 +59345,9 @@ impl CreateVpnConnectionRouteError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateVpnConnectionRouteError::Unknown(String::from(body)),
             },
-            Err(_) => CreateVpnConnectionRouteError::Unknown(body.to_string()),
+            Err(_) => {
+                CreateVpnConnectionRouteError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -59319,7 +59413,7 @@ pub enum CreateVpnGatewayError {
 }
 
 impl CreateVpnGatewayError {
-    pub fn from_body(body: &str) -> CreateVpnGatewayError {
+    pub fn from_body(body: &str, status: u16) -> CreateVpnGatewayError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -59327,7 +59421,7 @@ impl CreateVpnGatewayError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateVpnGatewayError::Unknown(String::from(body)),
             },
-            Err(_) => CreateVpnGatewayError::Unknown(body.to_string()),
+            Err(_) => CreateVpnGatewayError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -59391,7 +59485,7 @@ pub enum DeleteCustomerGatewayError {
 }
 
 impl DeleteCustomerGatewayError {
-    pub fn from_body(body: &str) -> DeleteCustomerGatewayError {
+    pub fn from_body(body: &str, status: u16) -> DeleteCustomerGatewayError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -59399,7 +59493,9 @@ impl DeleteCustomerGatewayError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteCustomerGatewayError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteCustomerGatewayError::Unknown(body.to_string()),
+            Err(_) => {
+                DeleteCustomerGatewayError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -59465,7 +59561,7 @@ pub enum DeleteDhcpOptionsError {
 }
 
 impl DeleteDhcpOptionsError {
-    pub fn from_body(body: &str) -> DeleteDhcpOptionsError {
+    pub fn from_body(body: &str, status: u16) -> DeleteDhcpOptionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -59473,7 +59569,7 @@ impl DeleteDhcpOptionsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteDhcpOptionsError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteDhcpOptionsError::Unknown(body.to_string()),
+            Err(_) => DeleteDhcpOptionsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -59539,7 +59635,7 @@ pub enum DeleteEgressOnlyInternetGatewayError {
 }
 
 impl DeleteEgressOnlyInternetGatewayError {
-    pub fn from_body(body: &str) -> DeleteEgressOnlyInternetGatewayError {
+    pub fn from_body(body: &str, status: u16) -> DeleteEgressOnlyInternetGatewayError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -59547,7 +59643,11 @@ impl DeleteEgressOnlyInternetGatewayError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteEgressOnlyInternetGatewayError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteEgressOnlyInternetGatewayError::Unknown(body.to_string()),
+            Err(_) => DeleteEgressOnlyInternetGatewayError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -59613,7 +59713,7 @@ pub enum DeleteFleetsError {
 }
 
 impl DeleteFleetsError {
-    pub fn from_body(body: &str) -> DeleteFleetsError {
+    pub fn from_body(body: &str, status: u16) -> DeleteFleetsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -59621,7 +59721,7 @@ impl DeleteFleetsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteFleetsError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteFleetsError::Unknown(body.to_string()),
+            Err(_) => DeleteFleetsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -59685,7 +59785,7 @@ pub enum DeleteFlowLogsError {
 }
 
 impl DeleteFlowLogsError {
-    pub fn from_body(body: &str) -> DeleteFlowLogsError {
+    pub fn from_body(body: &str, status: u16) -> DeleteFlowLogsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -59693,7 +59793,7 @@ impl DeleteFlowLogsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteFlowLogsError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteFlowLogsError::Unknown(body.to_string()),
+            Err(_) => DeleteFlowLogsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -59757,7 +59857,7 @@ pub enum DeleteFpgaImageError {
 }
 
 impl DeleteFpgaImageError {
-    pub fn from_body(body: &str) -> DeleteFpgaImageError {
+    pub fn from_body(body: &str, status: u16) -> DeleteFpgaImageError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -59765,7 +59865,7 @@ impl DeleteFpgaImageError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteFpgaImageError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteFpgaImageError::Unknown(body.to_string()),
+            Err(_) => DeleteFpgaImageError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -59829,7 +59929,7 @@ pub enum DeleteInternetGatewayError {
 }
 
 impl DeleteInternetGatewayError {
-    pub fn from_body(body: &str) -> DeleteInternetGatewayError {
+    pub fn from_body(body: &str, status: u16) -> DeleteInternetGatewayError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -59837,7 +59937,9 @@ impl DeleteInternetGatewayError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteInternetGatewayError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteInternetGatewayError::Unknown(body.to_string()),
+            Err(_) => {
+                DeleteInternetGatewayError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -59903,7 +60005,7 @@ pub enum DeleteKeyPairError {
 }
 
 impl DeleteKeyPairError {
-    pub fn from_body(body: &str) -> DeleteKeyPairError {
+    pub fn from_body(body: &str, status: u16) -> DeleteKeyPairError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -59911,7 +60013,7 @@ impl DeleteKeyPairError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteKeyPairError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteKeyPairError::Unknown(body.to_string()),
+            Err(_) => DeleteKeyPairError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -59975,7 +60077,7 @@ pub enum DeleteLaunchTemplateError {
 }
 
 impl DeleteLaunchTemplateError {
-    pub fn from_body(body: &str) -> DeleteLaunchTemplateError {
+    pub fn from_body(body: &str, status: u16) -> DeleteLaunchTemplateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -59983,7 +60085,9 @@ impl DeleteLaunchTemplateError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteLaunchTemplateError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteLaunchTemplateError::Unknown(body.to_string()),
+            Err(_) => {
+                DeleteLaunchTemplateError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -60049,7 +60153,7 @@ pub enum DeleteLaunchTemplateVersionsError {
 }
 
 impl DeleteLaunchTemplateVersionsError {
-    pub fn from_body(body: &str) -> DeleteLaunchTemplateVersionsError {
+    pub fn from_body(body: &str, status: u16) -> DeleteLaunchTemplateVersionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -60057,7 +60161,11 @@ impl DeleteLaunchTemplateVersionsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteLaunchTemplateVersionsError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteLaunchTemplateVersionsError::Unknown(body.to_string()),
+            Err(_) => DeleteLaunchTemplateVersionsError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -60123,7 +60231,7 @@ pub enum DeleteNatGatewayError {
 }
 
 impl DeleteNatGatewayError {
-    pub fn from_body(body: &str) -> DeleteNatGatewayError {
+    pub fn from_body(body: &str, status: u16) -> DeleteNatGatewayError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -60131,7 +60239,7 @@ impl DeleteNatGatewayError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteNatGatewayError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteNatGatewayError::Unknown(body.to_string()),
+            Err(_) => DeleteNatGatewayError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -60195,7 +60303,7 @@ pub enum DeleteNetworkAclError {
 }
 
 impl DeleteNetworkAclError {
-    pub fn from_body(body: &str) -> DeleteNetworkAclError {
+    pub fn from_body(body: &str, status: u16) -> DeleteNetworkAclError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -60203,7 +60311,7 @@ impl DeleteNetworkAclError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteNetworkAclError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteNetworkAclError::Unknown(body.to_string()),
+            Err(_) => DeleteNetworkAclError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -60267,7 +60375,7 @@ pub enum DeleteNetworkAclEntryError {
 }
 
 impl DeleteNetworkAclEntryError {
-    pub fn from_body(body: &str) -> DeleteNetworkAclEntryError {
+    pub fn from_body(body: &str, status: u16) -> DeleteNetworkAclEntryError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -60275,7 +60383,9 @@ impl DeleteNetworkAclEntryError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteNetworkAclEntryError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteNetworkAclEntryError::Unknown(body.to_string()),
+            Err(_) => {
+                DeleteNetworkAclEntryError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -60341,7 +60451,7 @@ pub enum DeleteNetworkInterfaceError {
 }
 
 impl DeleteNetworkInterfaceError {
-    pub fn from_body(body: &str) -> DeleteNetworkInterfaceError {
+    pub fn from_body(body: &str, status: u16) -> DeleteNetworkInterfaceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -60349,7 +60459,9 @@ impl DeleteNetworkInterfaceError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteNetworkInterfaceError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteNetworkInterfaceError::Unknown(body.to_string()),
+            Err(_) => {
+                DeleteNetworkInterfaceError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -60415,7 +60527,7 @@ pub enum DeleteNetworkInterfacePermissionError {
 }
 
 impl DeleteNetworkInterfacePermissionError {
-    pub fn from_body(body: &str) -> DeleteNetworkInterfacePermissionError {
+    pub fn from_body(body: &str, status: u16) -> DeleteNetworkInterfacePermissionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -60423,7 +60535,11 @@ impl DeleteNetworkInterfacePermissionError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteNetworkInterfacePermissionError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteNetworkInterfacePermissionError::Unknown(body.to_string()),
+            Err(_) => DeleteNetworkInterfacePermissionError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -60489,7 +60605,7 @@ pub enum DeletePlacementGroupError {
 }
 
 impl DeletePlacementGroupError {
-    pub fn from_body(body: &str) -> DeletePlacementGroupError {
+    pub fn from_body(body: &str, status: u16) -> DeletePlacementGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -60497,7 +60613,9 @@ impl DeletePlacementGroupError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeletePlacementGroupError::Unknown(String::from(body)),
             },
-            Err(_) => DeletePlacementGroupError::Unknown(body.to_string()),
+            Err(_) => {
+                DeletePlacementGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -60563,7 +60681,7 @@ pub enum DeleteRouteError {
 }
 
 impl DeleteRouteError {
-    pub fn from_body(body: &str) -> DeleteRouteError {
+    pub fn from_body(body: &str, status: u16) -> DeleteRouteError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -60571,7 +60689,7 @@ impl DeleteRouteError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteRouteError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteRouteError::Unknown(body.to_string()),
+            Err(_) => DeleteRouteError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -60635,7 +60753,7 @@ pub enum DeleteRouteTableError {
 }
 
 impl DeleteRouteTableError {
-    pub fn from_body(body: &str) -> DeleteRouteTableError {
+    pub fn from_body(body: &str, status: u16) -> DeleteRouteTableError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -60643,7 +60761,7 @@ impl DeleteRouteTableError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteRouteTableError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteRouteTableError::Unknown(body.to_string()),
+            Err(_) => DeleteRouteTableError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -60707,7 +60825,7 @@ pub enum DeleteSecurityGroupError {
 }
 
 impl DeleteSecurityGroupError {
-    pub fn from_body(body: &str) -> DeleteSecurityGroupError {
+    pub fn from_body(body: &str, status: u16) -> DeleteSecurityGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -60715,7 +60833,7 @@ impl DeleteSecurityGroupError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteSecurityGroupError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteSecurityGroupError::Unknown(body.to_string()),
+            Err(_) => DeleteSecurityGroupError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -60781,7 +60899,7 @@ pub enum DeleteSnapshotError {
 }
 
 impl DeleteSnapshotError {
-    pub fn from_body(body: &str) -> DeleteSnapshotError {
+    pub fn from_body(body: &str, status: u16) -> DeleteSnapshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -60789,7 +60907,7 @@ impl DeleteSnapshotError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteSnapshotError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteSnapshotError::Unknown(body.to_string()),
+            Err(_) => DeleteSnapshotError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -60853,7 +60971,7 @@ pub enum DeleteSpotDatafeedSubscriptionError {
 }
 
 impl DeleteSpotDatafeedSubscriptionError {
-    pub fn from_body(body: &str) -> DeleteSpotDatafeedSubscriptionError {
+    pub fn from_body(body: &str, status: u16) -> DeleteSpotDatafeedSubscriptionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -60861,7 +60979,11 @@ impl DeleteSpotDatafeedSubscriptionError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteSpotDatafeedSubscriptionError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteSpotDatafeedSubscriptionError::Unknown(body.to_string()),
+            Err(_) => DeleteSpotDatafeedSubscriptionError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -60927,7 +61049,7 @@ pub enum DeleteSubnetError {
 }
 
 impl DeleteSubnetError {
-    pub fn from_body(body: &str) -> DeleteSubnetError {
+    pub fn from_body(body: &str, status: u16) -> DeleteSubnetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -60935,7 +61057,7 @@ impl DeleteSubnetError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteSubnetError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteSubnetError::Unknown(body.to_string()),
+            Err(_) => DeleteSubnetError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -60999,7 +61121,7 @@ pub enum DeleteTagsError {
 }
 
 impl DeleteTagsError {
-    pub fn from_body(body: &str) -> DeleteTagsError {
+    pub fn from_body(body: &str, status: u16) -> DeleteTagsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -61007,7 +61129,7 @@ impl DeleteTagsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteTagsError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteTagsError::Unknown(body.to_string()),
+            Err(_) => DeleteTagsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -61071,7 +61193,7 @@ pub enum DeleteVolumeError {
 }
 
 impl DeleteVolumeError {
-    pub fn from_body(body: &str) -> DeleteVolumeError {
+    pub fn from_body(body: &str, status: u16) -> DeleteVolumeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -61079,7 +61201,7 @@ impl DeleteVolumeError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteVolumeError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteVolumeError::Unknown(body.to_string()),
+            Err(_) => DeleteVolumeError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -61143,7 +61265,7 @@ pub enum DeleteVpcError {
 }
 
 impl DeleteVpcError {
-    pub fn from_body(body: &str) -> DeleteVpcError {
+    pub fn from_body(body: &str, status: u16) -> DeleteVpcError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -61151,7 +61273,7 @@ impl DeleteVpcError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteVpcError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteVpcError::Unknown(body.to_string()),
+            Err(_) => DeleteVpcError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -61215,7 +61337,7 @@ pub enum DeleteVpcEndpointConnectionNotificationsError {
 }
 
 impl DeleteVpcEndpointConnectionNotificationsError {
-    pub fn from_body(body: &str) -> DeleteVpcEndpointConnectionNotificationsError {
+    pub fn from_body(body: &str, status: u16) -> DeleteVpcEndpointConnectionNotificationsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -61223,7 +61345,11 @@ impl DeleteVpcEndpointConnectionNotificationsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteVpcEndpointConnectionNotificationsError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteVpcEndpointConnectionNotificationsError::Unknown(body.to_string()),
+            Err(_) => DeleteVpcEndpointConnectionNotificationsError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -61291,7 +61417,7 @@ pub enum DeleteVpcEndpointServiceConfigurationsError {
 }
 
 impl DeleteVpcEndpointServiceConfigurationsError {
-    pub fn from_body(body: &str) -> DeleteVpcEndpointServiceConfigurationsError {
+    pub fn from_body(body: &str, status: u16) -> DeleteVpcEndpointServiceConfigurationsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -61299,7 +61425,11 @@ impl DeleteVpcEndpointServiceConfigurationsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteVpcEndpointServiceConfigurationsError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteVpcEndpointServiceConfigurationsError::Unknown(body.to_string()),
+            Err(_) => DeleteVpcEndpointServiceConfigurationsError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -61365,7 +61495,7 @@ pub enum DeleteVpcEndpointsError {
 }
 
 impl DeleteVpcEndpointsError {
-    pub fn from_body(body: &str) -> DeleteVpcEndpointsError {
+    pub fn from_body(body: &str, status: u16) -> DeleteVpcEndpointsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -61373,7 +61503,7 @@ impl DeleteVpcEndpointsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteVpcEndpointsError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteVpcEndpointsError::Unknown(body.to_string()),
+            Err(_) => DeleteVpcEndpointsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -61439,7 +61569,7 @@ pub enum DeleteVpcPeeringConnectionError {
 }
 
 impl DeleteVpcPeeringConnectionError {
-    pub fn from_body(body: &str) -> DeleteVpcPeeringConnectionError {
+    pub fn from_body(body: &str, status: u16) -> DeleteVpcPeeringConnectionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -61447,7 +61577,9 @@ impl DeleteVpcPeeringConnectionError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteVpcPeeringConnectionError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteVpcPeeringConnectionError::Unknown(body.to_string()),
+            Err(_) => {
+                DeleteVpcPeeringConnectionError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -61513,7 +61645,7 @@ pub enum DeleteVpnConnectionError {
 }
 
 impl DeleteVpnConnectionError {
-    pub fn from_body(body: &str) -> DeleteVpnConnectionError {
+    pub fn from_body(body: &str, status: u16) -> DeleteVpnConnectionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -61521,7 +61653,7 @@ impl DeleteVpnConnectionError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteVpnConnectionError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteVpnConnectionError::Unknown(body.to_string()),
+            Err(_) => DeleteVpnConnectionError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -61587,7 +61719,7 @@ pub enum DeleteVpnConnectionRouteError {
 }
 
 impl DeleteVpnConnectionRouteError {
-    pub fn from_body(body: &str) -> DeleteVpnConnectionRouteError {
+    pub fn from_body(body: &str, status: u16) -> DeleteVpnConnectionRouteError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -61595,7 +61727,9 @@ impl DeleteVpnConnectionRouteError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteVpnConnectionRouteError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteVpnConnectionRouteError::Unknown(body.to_string()),
+            Err(_) => {
+                DeleteVpnConnectionRouteError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -61661,7 +61795,7 @@ pub enum DeleteVpnGatewayError {
 }
 
 impl DeleteVpnGatewayError {
-    pub fn from_body(body: &str) -> DeleteVpnGatewayError {
+    pub fn from_body(body: &str, status: u16) -> DeleteVpnGatewayError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -61669,7 +61803,7 @@ impl DeleteVpnGatewayError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteVpnGatewayError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteVpnGatewayError::Unknown(body.to_string()),
+            Err(_) => DeleteVpnGatewayError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -61733,7 +61867,7 @@ pub enum DeregisterImageError {
 }
 
 impl DeregisterImageError {
-    pub fn from_body(body: &str) -> DeregisterImageError {
+    pub fn from_body(body: &str, status: u16) -> DeregisterImageError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -61741,7 +61875,7 @@ impl DeregisterImageError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeregisterImageError::Unknown(String::from(body)),
             },
-            Err(_) => DeregisterImageError::Unknown(body.to_string()),
+            Err(_) => DeregisterImageError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -61805,7 +61939,7 @@ pub enum DescribeAccountAttributesError {
 }
 
 impl DescribeAccountAttributesError {
-    pub fn from_body(body: &str) -> DescribeAccountAttributesError {
+    pub fn from_body(body: &str, status: u16) -> DescribeAccountAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -61813,7 +61947,9 @@ impl DescribeAccountAttributesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeAccountAttributesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeAccountAttributesError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeAccountAttributesError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -61879,7 +62015,7 @@ pub enum DescribeAddressesError {
 }
 
 impl DescribeAddressesError {
-    pub fn from_body(body: &str) -> DescribeAddressesError {
+    pub fn from_body(body: &str, status: u16) -> DescribeAddressesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -61887,7 +62023,7 @@ impl DescribeAddressesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeAddressesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeAddressesError::Unknown(body.to_string()),
+            Err(_) => DescribeAddressesError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -61953,7 +62089,7 @@ pub enum DescribeAggregateIdFormatError {
 }
 
 impl DescribeAggregateIdFormatError {
-    pub fn from_body(body: &str) -> DescribeAggregateIdFormatError {
+    pub fn from_body(body: &str, status: u16) -> DescribeAggregateIdFormatError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -61961,7 +62097,9 @@ impl DescribeAggregateIdFormatError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeAggregateIdFormatError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeAggregateIdFormatError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeAggregateIdFormatError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -62027,7 +62165,7 @@ pub enum DescribeAvailabilityZonesError {
 }
 
 impl DescribeAvailabilityZonesError {
-    pub fn from_body(body: &str) -> DescribeAvailabilityZonesError {
+    pub fn from_body(body: &str, status: u16) -> DescribeAvailabilityZonesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -62035,7 +62173,9 @@ impl DescribeAvailabilityZonesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeAvailabilityZonesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeAvailabilityZonesError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeAvailabilityZonesError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -62101,7 +62241,7 @@ pub enum DescribeBundleTasksError {
 }
 
 impl DescribeBundleTasksError {
-    pub fn from_body(body: &str) -> DescribeBundleTasksError {
+    pub fn from_body(body: &str, status: u16) -> DescribeBundleTasksError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -62109,7 +62249,7 @@ impl DescribeBundleTasksError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeBundleTasksError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeBundleTasksError::Unknown(body.to_string()),
+            Err(_) => DescribeBundleTasksError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -62175,7 +62315,7 @@ pub enum DescribeClassicLinkInstancesError {
 }
 
 impl DescribeClassicLinkInstancesError {
-    pub fn from_body(body: &str) -> DescribeClassicLinkInstancesError {
+    pub fn from_body(body: &str, status: u16) -> DescribeClassicLinkInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -62183,7 +62323,11 @@ impl DescribeClassicLinkInstancesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeClassicLinkInstancesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeClassicLinkInstancesError::Unknown(body.to_string()),
+            Err(_) => DescribeClassicLinkInstancesError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -62249,7 +62393,7 @@ pub enum DescribeConversionTasksError {
 }
 
 impl DescribeConversionTasksError {
-    pub fn from_body(body: &str) -> DescribeConversionTasksError {
+    pub fn from_body(body: &str, status: u16) -> DescribeConversionTasksError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -62257,7 +62401,9 @@ impl DescribeConversionTasksError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeConversionTasksError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeConversionTasksError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeConversionTasksError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -62323,7 +62469,7 @@ pub enum DescribeCustomerGatewaysError {
 }
 
 impl DescribeCustomerGatewaysError {
-    pub fn from_body(body: &str) -> DescribeCustomerGatewaysError {
+    pub fn from_body(body: &str, status: u16) -> DescribeCustomerGatewaysError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -62331,7 +62477,9 @@ impl DescribeCustomerGatewaysError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeCustomerGatewaysError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeCustomerGatewaysError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeCustomerGatewaysError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -62397,7 +62545,7 @@ pub enum DescribeDhcpOptionsError {
 }
 
 impl DescribeDhcpOptionsError {
-    pub fn from_body(body: &str) -> DescribeDhcpOptionsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeDhcpOptionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -62405,7 +62553,7 @@ impl DescribeDhcpOptionsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeDhcpOptionsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeDhcpOptionsError::Unknown(body.to_string()),
+            Err(_) => DescribeDhcpOptionsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -62471,7 +62619,7 @@ pub enum DescribeEgressOnlyInternetGatewaysError {
 }
 
 impl DescribeEgressOnlyInternetGatewaysError {
-    pub fn from_body(body: &str) -> DescribeEgressOnlyInternetGatewaysError {
+    pub fn from_body(body: &str, status: u16) -> DescribeEgressOnlyInternetGatewaysError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -62479,7 +62627,11 @@ impl DescribeEgressOnlyInternetGatewaysError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeEgressOnlyInternetGatewaysError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeEgressOnlyInternetGatewaysError::Unknown(body.to_string()),
+            Err(_) => DescribeEgressOnlyInternetGatewaysError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -62545,7 +62697,7 @@ pub enum DescribeElasticGpusError {
 }
 
 impl DescribeElasticGpusError {
-    pub fn from_body(body: &str) -> DescribeElasticGpusError {
+    pub fn from_body(body: &str, status: u16) -> DescribeElasticGpusError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -62553,7 +62705,7 @@ impl DescribeElasticGpusError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeElasticGpusError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeElasticGpusError::Unknown(body.to_string()),
+            Err(_) => DescribeElasticGpusError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -62619,7 +62771,7 @@ pub enum DescribeExportTasksError {
 }
 
 impl DescribeExportTasksError {
-    pub fn from_body(body: &str) -> DescribeExportTasksError {
+    pub fn from_body(body: &str, status: u16) -> DescribeExportTasksError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -62627,7 +62779,7 @@ impl DescribeExportTasksError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeExportTasksError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeExportTasksError::Unknown(body.to_string()),
+            Err(_) => DescribeExportTasksError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -62693,7 +62845,7 @@ pub enum DescribeFleetHistoryError {
 }
 
 impl DescribeFleetHistoryError {
-    pub fn from_body(body: &str) -> DescribeFleetHistoryError {
+    pub fn from_body(body: &str, status: u16) -> DescribeFleetHistoryError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -62701,7 +62853,9 @@ impl DescribeFleetHistoryError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeFleetHistoryError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeFleetHistoryError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeFleetHistoryError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -62767,7 +62921,7 @@ pub enum DescribeFleetInstancesError {
 }
 
 impl DescribeFleetInstancesError {
-    pub fn from_body(body: &str) -> DescribeFleetInstancesError {
+    pub fn from_body(body: &str, status: u16) -> DescribeFleetInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -62775,7 +62929,9 @@ impl DescribeFleetInstancesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeFleetInstancesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeFleetInstancesError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeFleetInstancesError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -62841,7 +62997,7 @@ pub enum DescribeFleetsError {
 }
 
 impl DescribeFleetsError {
-    pub fn from_body(body: &str) -> DescribeFleetsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeFleetsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -62849,7 +63005,7 @@ impl DescribeFleetsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeFleetsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeFleetsError::Unknown(body.to_string()),
+            Err(_) => DescribeFleetsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -62913,7 +63069,7 @@ pub enum DescribeFlowLogsError {
 }
 
 impl DescribeFlowLogsError {
-    pub fn from_body(body: &str) -> DescribeFlowLogsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeFlowLogsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -62921,7 +63077,7 @@ impl DescribeFlowLogsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeFlowLogsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeFlowLogsError::Unknown(body.to_string()),
+            Err(_) => DescribeFlowLogsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -62985,7 +63141,7 @@ pub enum DescribeFpgaImageAttributeError {
 }
 
 impl DescribeFpgaImageAttributeError {
-    pub fn from_body(body: &str) -> DescribeFpgaImageAttributeError {
+    pub fn from_body(body: &str, status: u16) -> DescribeFpgaImageAttributeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -62993,7 +63149,9 @@ impl DescribeFpgaImageAttributeError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeFpgaImageAttributeError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeFpgaImageAttributeError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeFpgaImageAttributeError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -63059,7 +63217,7 @@ pub enum DescribeFpgaImagesError {
 }
 
 impl DescribeFpgaImagesError {
-    pub fn from_body(body: &str) -> DescribeFpgaImagesError {
+    pub fn from_body(body: &str, status: u16) -> DescribeFpgaImagesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -63067,7 +63225,7 @@ impl DescribeFpgaImagesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeFpgaImagesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeFpgaImagesError::Unknown(body.to_string()),
+            Err(_) => DescribeFpgaImagesError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -63133,7 +63291,7 @@ pub enum DescribeHostReservationOfferingsError {
 }
 
 impl DescribeHostReservationOfferingsError {
-    pub fn from_body(body: &str) -> DescribeHostReservationOfferingsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeHostReservationOfferingsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -63141,7 +63299,11 @@ impl DescribeHostReservationOfferingsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeHostReservationOfferingsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeHostReservationOfferingsError::Unknown(body.to_string()),
+            Err(_) => DescribeHostReservationOfferingsError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -63207,7 +63369,7 @@ pub enum DescribeHostReservationsError {
 }
 
 impl DescribeHostReservationsError {
-    pub fn from_body(body: &str) -> DescribeHostReservationsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeHostReservationsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -63215,7 +63377,9 @@ impl DescribeHostReservationsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeHostReservationsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeHostReservationsError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeHostReservationsError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -63281,7 +63445,7 @@ pub enum DescribeHostsError {
 }
 
 impl DescribeHostsError {
-    pub fn from_body(body: &str) -> DescribeHostsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeHostsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -63289,7 +63453,7 @@ impl DescribeHostsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeHostsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeHostsError::Unknown(body.to_string()),
+            Err(_) => DescribeHostsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -63353,7 +63517,7 @@ pub enum DescribeIamInstanceProfileAssociationsError {
 }
 
 impl DescribeIamInstanceProfileAssociationsError {
-    pub fn from_body(body: &str) -> DescribeIamInstanceProfileAssociationsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeIamInstanceProfileAssociationsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -63361,7 +63525,11 @@ impl DescribeIamInstanceProfileAssociationsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeIamInstanceProfileAssociationsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeIamInstanceProfileAssociationsError::Unknown(body.to_string()),
+            Err(_) => DescribeIamInstanceProfileAssociationsError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -63427,7 +63595,7 @@ pub enum DescribeIdFormatError {
 }
 
 impl DescribeIdFormatError {
-    pub fn from_body(body: &str) -> DescribeIdFormatError {
+    pub fn from_body(body: &str, status: u16) -> DescribeIdFormatError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -63435,7 +63603,7 @@ impl DescribeIdFormatError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeIdFormatError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeIdFormatError::Unknown(body.to_string()),
+            Err(_) => DescribeIdFormatError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -63499,7 +63667,7 @@ pub enum DescribeIdentityIdFormatError {
 }
 
 impl DescribeIdentityIdFormatError {
-    pub fn from_body(body: &str) -> DescribeIdentityIdFormatError {
+    pub fn from_body(body: &str, status: u16) -> DescribeIdentityIdFormatError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -63507,7 +63675,9 @@ impl DescribeIdentityIdFormatError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeIdentityIdFormatError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeIdentityIdFormatError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeIdentityIdFormatError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -63573,7 +63743,7 @@ pub enum DescribeImageAttributeError {
 }
 
 impl DescribeImageAttributeError {
-    pub fn from_body(body: &str) -> DescribeImageAttributeError {
+    pub fn from_body(body: &str, status: u16) -> DescribeImageAttributeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -63581,7 +63751,9 @@ impl DescribeImageAttributeError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeImageAttributeError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeImageAttributeError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeImageAttributeError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -63647,7 +63819,7 @@ pub enum DescribeImagesError {
 }
 
 impl DescribeImagesError {
-    pub fn from_body(body: &str) -> DescribeImagesError {
+    pub fn from_body(body: &str, status: u16) -> DescribeImagesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -63655,7 +63827,7 @@ impl DescribeImagesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeImagesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeImagesError::Unknown(body.to_string()),
+            Err(_) => DescribeImagesError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -63719,7 +63891,7 @@ pub enum DescribeImportImageTasksError {
 }
 
 impl DescribeImportImageTasksError {
-    pub fn from_body(body: &str) -> DescribeImportImageTasksError {
+    pub fn from_body(body: &str, status: u16) -> DescribeImportImageTasksError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -63727,7 +63899,9 @@ impl DescribeImportImageTasksError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeImportImageTasksError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeImportImageTasksError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeImportImageTasksError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -63793,7 +63967,7 @@ pub enum DescribeImportSnapshotTasksError {
 }
 
 impl DescribeImportSnapshotTasksError {
-    pub fn from_body(body: &str) -> DescribeImportSnapshotTasksError {
+    pub fn from_body(body: &str, status: u16) -> DescribeImportSnapshotTasksError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -63801,7 +63975,11 @@ impl DescribeImportSnapshotTasksError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeImportSnapshotTasksError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeImportSnapshotTasksError::Unknown(body.to_string()),
+            Err(_) => DescribeImportSnapshotTasksError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -63867,7 +64045,7 @@ pub enum DescribeInstanceAttributeError {
 }
 
 impl DescribeInstanceAttributeError {
-    pub fn from_body(body: &str) -> DescribeInstanceAttributeError {
+    pub fn from_body(body: &str, status: u16) -> DescribeInstanceAttributeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -63875,7 +64053,9 @@ impl DescribeInstanceAttributeError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeInstanceAttributeError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeInstanceAttributeError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeInstanceAttributeError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -63941,7 +64121,7 @@ pub enum DescribeInstanceCreditSpecificationsError {
 }
 
 impl DescribeInstanceCreditSpecificationsError {
-    pub fn from_body(body: &str) -> DescribeInstanceCreditSpecificationsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeInstanceCreditSpecificationsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -63949,7 +64129,11 @@ impl DescribeInstanceCreditSpecificationsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeInstanceCreditSpecificationsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeInstanceCreditSpecificationsError::Unknown(body.to_string()),
+            Err(_) => DescribeInstanceCreditSpecificationsError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -64015,7 +64199,7 @@ pub enum DescribeInstanceStatusError {
 }
 
 impl DescribeInstanceStatusError {
-    pub fn from_body(body: &str) -> DescribeInstanceStatusError {
+    pub fn from_body(body: &str, status: u16) -> DescribeInstanceStatusError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -64023,7 +64207,9 @@ impl DescribeInstanceStatusError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeInstanceStatusError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeInstanceStatusError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeInstanceStatusError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -64089,7 +64275,7 @@ pub enum DescribeInstancesError {
 }
 
 impl DescribeInstancesError {
-    pub fn from_body(body: &str) -> DescribeInstancesError {
+    pub fn from_body(body: &str, status: u16) -> DescribeInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -64097,7 +64283,7 @@ impl DescribeInstancesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeInstancesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeInstancesError::Unknown(body.to_string()),
+            Err(_) => DescribeInstancesError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -64163,7 +64349,7 @@ pub enum DescribeInternetGatewaysError {
 }
 
 impl DescribeInternetGatewaysError {
-    pub fn from_body(body: &str) -> DescribeInternetGatewaysError {
+    pub fn from_body(body: &str, status: u16) -> DescribeInternetGatewaysError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -64171,7 +64357,9 @@ impl DescribeInternetGatewaysError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeInternetGatewaysError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeInternetGatewaysError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeInternetGatewaysError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -64237,7 +64425,7 @@ pub enum DescribeKeyPairsError {
 }
 
 impl DescribeKeyPairsError {
-    pub fn from_body(body: &str) -> DescribeKeyPairsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeKeyPairsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -64245,7 +64433,7 @@ impl DescribeKeyPairsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeKeyPairsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeKeyPairsError::Unknown(body.to_string()),
+            Err(_) => DescribeKeyPairsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -64309,7 +64497,7 @@ pub enum DescribeLaunchTemplateVersionsError {
 }
 
 impl DescribeLaunchTemplateVersionsError {
-    pub fn from_body(body: &str) -> DescribeLaunchTemplateVersionsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeLaunchTemplateVersionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -64317,7 +64505,11 @@ impl DescribeLaunchTemplateVersionsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeLaunchTemplateVersionsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeLaunchTemplateVersionsError::Unknown(body.to_string()),
+            Err(_) => DescribeLaunchTemplateVersionsError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -64383,7 +64575,7 @@ pub enum DescribeLaunchTemplatesError {
 }
 
 impl DescribeLaunchTemplatesError {
-    pub fn from_body(body: &str) -> DescribeLaunchTemplatesError {
+    pub fn from_body(body: &str, status: u16) -> DescribeLaunchTemplatesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -64391,7 +64583,9 @@ impl DescribeLaunchTemplatesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeLaunchTemplatesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeLaunchTemplatesError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeLaunchTemplatesError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -64457,7 +64651,7 @@ pub enum DescribeMovingAddressesError {
 }
 
 impl DescribeMovingAddressesError {
-    pub fn from_body(body: &str) -> DescribeMovingAddressesError {
+    pub fn from_body(body: &str, status: u16) -> DescribeMovingAddressesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -64465,7 +64659,9 @@ impl DescribeMovingAddressesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeMovingAddressesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeMovingAddressesError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeMovingAddressesError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -64531,7 +64727,7 @@ pub enum DescribeNatGatewaysError {
 }
 
 impl DescribeNatGatewaysError {
-    pub fn from_body(body: &str) -> DescribeNatGatewaysError {
+    pub fn from_body(body: &str, status: u16) -> DescribeNatGatewaysError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -64539,7 +64735,7 @@ impl DescribeNatGatewaysError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeNatGatewaysError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeNatGatewaysError::Unknown(body.to_string()),
+            Err(_) => DescribeNatGatewaysError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -64605,7 +64801,7 @@ pub enum DescribeNetworkAclsError {
 }
 
 impl DescribeNetworkAclsError {
-    pub fn from_body(body: &str) -> DescribeNetworkAclsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeNetworkAclsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -64613,7 +64809,7 @@ impl DescribeNetworkAclsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeNetworkAclsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeNetworkAclsError::Unknown(body.to_string()),
+            Err(_) => DescribeNetworkAclsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -64679,7 +64875,7 @@ pub enum DescribeNetworkInterfaceAttributeError {
 }
 
 impl DescribeNetworkInterfaceAttributeError {
-    pub fn from_body(body: &str) -> DescribeNetworkInterfaceAttributeError {
+    pub fn from_body(body: &str, status: u16) -> DescribeNetworkInterfaceAttributeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -64687,7 +64883,11 @@ impl DescribeNetworkInterfaceAttributeError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeNetworkInterfaceAttributeError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeNetworkInterfaceAttributeError::Unknown(body.to_string()),
+            Err(_) => DescribeNetworkInterfaceAttributeError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -64753,7 +64953,7 @@ pub enum DescribeNetworkInterfacePermissionsError {
 }
 
 impl DescribeNetworkInterfacePermissionsError {
-    pub fn from_body(body: &str) -> DescribeNetworkInterfacePermissionsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeNetworkInterfacePermissionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -64761,7 +64961,11 @@ impl DescribeNetworkInterfacePermissionsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeNetworkInterfacePermissionsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeNetworkInterfacePermissionsError::Unknown(body.to_string()),
+            Err(_) => DescribeNetworkInterfacePermissionsError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -64827,7 +65031,7 @@ pub enum DescribeNetworkInterfacesError {
 }
 
 impl DescribeNetworkInterfacesError {
-    pub fn from_body(body: &str) -> DescribeNetworkInterfacesError {
+    pub fn from_body(body: &str, status: u16) -> DescribeNetworkInterfacesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -64835,7 +65039,9 @@ impl DescribeNetworkInterfacesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeNetworkInterfacesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeNetworkInterfacesError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeNetworkInterfacesError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -64901,7 +65107,7 @@ pub enum DescribePlacementGroupsError {
 }
 
 impl DescribePlacementGroupsError {
-    pub fn from_body(body: &str) -> DescribePlacementGroupsError {
+    pub fn from_body(body: &str, status: u16) -> DescribePlacementGroupsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -64909,7 +65115,9 @@ impl DescribePlacementGroupsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribePlacementGroupsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribePlacementGroupsError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribePlacementGroupsError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -64975,7 +65183,7 @@ pub enum DescribePrefixListsError {
 }
 
 impl DescribePrefixListsError {
-    pub fn from_body(body: &str) -> DescribePrefixListsError {
+    pub fn from_body(body: &str, status: u16) -> DescribePrefixListsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -64983,7 +65191,7 @@ impl DescribePrefixListsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribePrefixListsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribePrefixListsError::Unknown(body.to_string()),
+            Err(_) => DescribePrefixListsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -65049,7 +65257,7 @@ pub enum DescribePrincipalIdFormatError {
 }
 
 impl DescribePrincipalIdFormatError {
-    pub fn from_body(body: &str) -> DescribePrincipalIdFormatError {
+    pub fn from_body(body: &str, status: u16) -> DescribePrincipalIdFormatError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -65057,7 +65265,9 @@ impl DescribePrincipalIdFormatError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribePrincipalIdFormatError::Unknown(String::from(body)),
             },
-            Err(_) => DescribePrincipalIdFormatError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribePrincipalIdFormatError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -65123,7 +65333,7 @@ pub enum DescribeRegionsError {
 }
 
 impl DescribeRegionsError {
-    pub fn from_body(body: &str) -> DescribeRegionsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeRegionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -65131,7 +65341,7 @@ impl DescribeRegionsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeRegionsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeRegionsError::Unknown(body.to_string()),
+            Err(_) => DescribeRegionsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -65195,7 +65405,7 @@ pub enum DescribeReservedInstancesError {
 }
 
 impl DescribeReservedInstancesError {
-    pub fn from_body(body: &str) -> DescribeReservedInstancesError {
+    pub fn from_body(body: &str, status: u16) -> DescribeReservedInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -65203,7 +65413,9 @@ impl DescribeReservedInstancesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeReservedInstancesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeReservedInstancesError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeReservedInstancesError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -65269,7 +65481,7 @@ pub enum DescribeReservedInstancesListingsError {
 }
 
 impl DescribeReservedInstancesListingsError {
-    pub fn from_body(body: &str) -> DescribeReservedInstancesListingsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeReservedInstancesListingsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -65277,7 +65489,11 @@ impl DescribeReservedInstancesListingsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeReservedInstancesListingsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeReservedInstancesListingsError::Unknown(body.to_string()),
+            Err(_) => DescribeReservedInstancesListingsError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -65343,7 +65559,7 @@ pub enum DescribeReservedInstancesModificationsError {
 }
 
 impl DescribeReservedInstancesModificationsError {
-    pub fn from_body(body: &str) -> DescribeReservedInstancesModificationsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeReservedInstancesModificationsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -65351,7 +65567,11 @@ impl DescribeReservedInstancesModificationsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeReservedInstancesModificationsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeReservedInstancesModificationsError::Unknown(body.to_string()),
+            Err(_) => DescribeReservedInstancesModificationsError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -65417,7 +65637,7 @@ pub enum DescribeReservedInstancesOfferingsError {
 }
 
 impl DescribeReservedInstancesOfferingsError {
-    pub fn from_body(body: &str) -> DescribeReservedInstancesOfferingsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeReservedInstancesOfferingsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -65425,7 +65645,11 @@ impl DescribeReservedInstancesOfferingsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeReservedInstancesOfferingsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeReservedInstancesOfferingsError::Unknown(body.to_string()),
+            Err(_) => DescribeReservedInstancesOfferingsError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -65491,7 +65715,7 @@ pub enum DescribeRouteTablesError {
 }
 
 impl DescribeRouteTablesError {
-    pub fn from_body(body: &str) -> DescribeRouteTablesError {
+    pub fn from_body(body: &str, status: u16) -> DescribeRouteTablesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -65499,7 +65723,7 @@ impl DescribeRouteTablesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeRouteTablesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeRouteTablesError::Unknown(body.to_string()),
+            Err(_) => DescribeRouteTablesError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -65565,7 +65789,7 @@ pub enum DescribeScheduledInstanceAvailabilityError {
 }
 
 impl DescribeScheduledInstanceAvailabilityError {
-    pub fn from_body(body: &str) -> DescribeScheduledInstanceAvailabilityError {
+    pub fn from_body(body: &str, status: u16) -> DescribeScheduledInstanceAvailabilityError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -65573,7 +65797,11 @@ impl DescribeScheduledInstanceAvailabilityError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeScheduledInstanceAvailabilityError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeScheduledInstanceAvailabilityError::Unknown(body.to_string()),
+            Err(_) => DescribeScheduledInstanceAvailabilityError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -65639,7 +65867,7 @@ pub enum DescribeScheduledInstancesError {
 }
 
 impl DescribeScheduledInstancesError {
-    pub fn from_body(body: &str) -> DescribeScheduledInstancesError {
+    pub fn from_body(body: &str, status: u16) -> DescribeScheduledInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -65647,7 +65875,9 @@ impl DescribeScheduledInstancesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeScheduledInstancesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeScheduledInstancesError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeScheduledInstancesError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -65713,7 +65943,7 @@ pub enum DescribeSecurityGroupReferencesError {
 }
 
 impl DescribeSecurityGroupReferencesError {
-    pub fn from_body(body: &str) -> DescribeSecurityGroupReferencesError {
+    pub fn from_body(body: &str, status: u16) -> DescribeSecurityGroupReferencesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -65721,7 +65951,11 @@ impl DescribeSecurityGroupReferencesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeSecurityGroupReferencesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeSecurityGroupReferencesError::Unknown(body.to_string()),
+            Err(_) => DescribeSecurityGroupReferencesError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -65787,7 +66021,7 @@ pub enum DescribeSecurityGroupsError {
 }
 
 impl DescribeSecurityGroupsError {
-    pub fn from_body(body: &str) -> DescribeSecurityGroupsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeSecurityGroupsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -65795,7 +66029,9 @@ impl DescribeSecurityGroupsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeSecurityGroupsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeSecurityGroupsError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeSecurityGroupsError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -65861,7 +66097,7 @@ pub enum DescribeSnapshotAttributeError {
 }
 
 impl DescribeSnapshotAttributeError {
-    pub fn from_body(body: &str) -> DescribeSnapshotAttributeError {
+    pub fn from_body(body: &str, status: u16) -> DescribeSnapshotAttributeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -65869,7 +66105,9 @@ impl DescribeSnapshotAttributeError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeSnapshotAttributeError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeSnapshotAttributeError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeSnapshotAttributeError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -65935,7 +66173,7 @@ pub enum DescribeSnapshotsError {
 }
 
 impl DescribeSnapshotsError {
-    pub fn from_body(body: &str) -> DescribeSnapshotsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeSnapshotsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -65943,7 +66181,7 @@ impl DescribeSnapshotsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeSnapshotsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeSnapshotsError::Unknown(body.to_string()),
+            Err(_) => DescribeSnapshotsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -66009,7 +66247,7 @@ pub enum DescribeSpotDatafeedSubscriptionError {
 }
 
 impl DescribeSpotDatafeedSubscriptionError {
-    pub fn from_body(body: &str) -> DescribeSpotDatafeedSubscriptionError {
+    pub fn from_body(body: &str, status: u16) -> DescribeSpotDatafeedSubscriptionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -66017,7 +66255,11 @@ impl DescribeSpotDatafeedSubscriptionError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeSpotDatafeedSubscriptionError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeSpotDatafeedSubscriptionError::Unknown(body.to_string()),
+            Err(_) => DescribeSpotDatafeedSubscriptionError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -66083,7 +66325,7 @@ pub enum DescribeSpotFleetInstancesError {
 }
 
 impl DescribeSpotFleetInstancesError {
-    pub fn from_body(body: &str) -> DescribeSpotFleetInstancesError {
+    pub fn from_body(body: &str, status: u16) -> DescribeSpotFleetInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -66091,7 +66333,9 @@ impl DescribeSpotFleetInstancesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeSpotFleetInstancesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeSpotFleetInstancesError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeSpotFleetInstancesError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -66157,7 +66401,7 @@ pub enum DescribeSpotFleetRequestHistoryError {
 }
 
 impl DescribeSpotFleetRequestHistoryError {
-    pub fn from_body(body: &str) -> DescribeSpotFleetRequestHistoryError {
+    pub fn from_body(body: &str, status: u16) -> DescribeSpotFleetRequestHistoryError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -66165,7 +66409,11 @@ impl DescribeSpotFleetRequestHistoryError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeSpotFleetRequestHistoryError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeSpotFleetRequestHistoryError::Unknown(body.to_string()),
+            Err(_) => DescribeSpotFleetRequestHistoryError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -66231,7 +66479,7 @@ pub enum DescribeSpotFleetRequestsError {
 }
 
 impl DescribeSpotFleetRequestsError {
-    pub fn from_body(body: &str) -> DescribeSpotFleetRequestsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeSpotFleetRequestsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -66239,7 +66487,9 @@ impl DescribeSpotFleetRequestsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeSpotFleetRequestsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeSpotFleetRequestsError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeSpotFleetRequestsError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -66305,7 +66555,7 @@ pub enum DescribeSpotInstanceRequestsError {
 }
 
 impl DescribeSpotInstanceRequestsError {
-    pub fn from_body(body: &str) -> DescribeSpotInstanceRequestsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeSpotInstanceRequestsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -66313,7 +66563,11 @@ impl DescribeSpotInstanceRequestsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeSpotInstanceRequestsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeSpotInstanceRequestsError::Unknown(body.to_string()),
+            Err(_) => DescribeSpotInstanceRequestsError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -66379,7 +66633,7 @@ pub enum DescribeSpotPriceHistoryError {
 }
 
 impl DescribeSpotPriceHistoryError {
-    pub fn from_body(body: &str) -> DescribeSpotPriceHistoryError {
+    pub fn from_body(body: &str, status: u16) -> DescribeSpotPriceHistoryError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -66387,7 +66641,9 @@ impl DescribeSpotPriceHistoryError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeSpotPriceHistoryError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeSpotPriceHistoryError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeSpotPriceHistoryError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -66453,7 +66709,7 @@ pub enum DescribeStaleSecurityGroupsError {
 }
 
 impl DescribeStaleSecurityGroupsError {
-    pub fn from_body(body: &str) -> DescribeStaleSecurityGroupsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeStaleSecurityGroupsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -66461,7 +66717,11 @@ impl DescribeStaleSecurityGroupsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeStaleSecurityGroupsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeStaleSecurityGroupsError::Unknown(body.to_string()),
+            Err(_) => DescribeStaleSecurityGroupsError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -66527,7 +66787,7 @@ pub enum DescribeSubnetsError {
 }
 
 impl DescribeSubnetsError {
-    pub fn from_body(body: &str) -> DescribeSubnetsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeSubnetsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -66535,7 +66795,7 @@ impl DescribeSubnetsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeSubnetsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeSubnetsError::Unknown(body.to_string()),
+            Err(_) => DescribeSubnetsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -66599,7 +66859,7 @@ pub enum DescribeTagsError {
 }
 
 impl DescribeTagsError {
-    pub fn from_body(body: &str) -> DescribeTagsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeTagsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -66607,7 +66867,7 @@ impl DescribeTagsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeTagsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeTagsError::Unknown(body.to_string()),
+            Err(_) => DescribeTagsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -66671,7 +66931,7 @@ pub enum DescribeVolumeAttributeError {
 }
 
 impl DescribeVolumeAttributeError {
-    pub fn from_body(body: &str) -> DescribeVolumeAttributeError {
+    pub fn from_body(body: &str, status: u16) -> DescribeVolumeAttributeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -66679,7 +66939,9 @@ impl DescribeVolumeAttributeError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeVolumeAttributeError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeVolumeAttributeError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeVolumeAttributeError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -66745,7 +67007,7 @@ pub enum DescribeVolumeStatusError {
 }
 
 impl DescribeVolumeStatusError {
-    pub fn from_body(body: &str) -> DescribeVolumeStatusError {
+    pub fn from_body(body: &str, status: u16) -> DescribeVolumeStatusError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -66753,7 +67015,9 @@ impl DescribeVolumeStatusError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeVolumeStatusError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeVolumeStatusError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeVolumeStatusError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -66819,7 +67083,7 @@ pub enum DescribeVolumesError {
 }
 
 impl DescribeVolumesError {
-    pub fn from_body(body: &str) -> DescribeVolumesError {
+    pub fn from_body(body: &str, status: u16) -> DescribeVolumesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -66827,7 +67091,7 @@ impl DescribeVolumesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeVolumesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeVolumesError::Unknown(body.to_string()),
+            Err(_) => DescribeVolumesError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -66891,7 +67155,7 @@ pub enum DescribeVolumesModificationsError {
 }
 
 impl DescribeVolumesModificationsError {
-    pub fn from_body(body: &str) -> DescribeVolumesModificationsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeVolumesModificationsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -66899,7 +67163,11 @@ impl DescribeVolumesModificationsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeVolumesModificationsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeVolumesModificationsError::Unknown(body.to_string()),
+            Err(_) => DescribeVolumesModificationsError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -66965,7 +67233,7 @@ pub enum DescribeVpcAttributeError {
 }
 
 impl DescribeVpcAttributeError {
-    pub fn from_body(body: &str) -> DescribeVpcAttributeError {
+    pub fn from_body(body: &str, status: u16) -> DescribeVpcAttributeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -66973,7 +67241,9 @@ impl DescribeVpcAttributeError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeVpcAttributeError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeVpcAttributeError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeVpcAttributeError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -67039,7 +67309,7 @@ pub enum DescribeVpcClassicLinkError {
 }
 
 impl DescribeVpcClassicLinkError {
-    pub fn from_body(body: &str) -> DescribeVpcClassicLinkError {
+    pub fn from_body(body: &str, status: u16) -> DescribeVpcClassicLinkError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -67047,7 +67317,9 @@ impl DescribeVpcClassicLinkError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeVpcClassicLinkError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeVpcClassicLinkError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeVpcClassicLinkError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -67113,7 +67385,7 @@ pub enum DescribeVpcClassicLinkDnsSupportError {
 }
 
 impl DescribeVpcClassicLinkDnsSupportError {
-    pub fn from_body(body: &str) -> DescribeVpcClassicLinkDnsSupportError {
+    pub fn from_body(body: &str, status: u16) -> DescribeVpcClassicLinkDnsSupportError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -67121,7 +67393,11 @@ impl DescribeVpcClassicLinkDnsSupportError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeVpcClassicLinkDnsSupportError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeVpcClassicLinkDnsSupportError::Unknown(body.to_string()),
+            Err(_) => DescribeVpcClassicLinkDnsSupportError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -67187,7 +67463,7 @@ pub enum DescribeVpcEndpointConnectionNotificationsError {
 }
 
 impl DescribeVpcEndpointConnectionNotificationsError {
-    pub fn from_body(body: &str) -> DescribeVpcEndpointConnectionNotificationsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeVpcEndpointConnectionNotificationsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -67195,7 +67471,11 @@ impl DescribeVpcEndpointConnectionNotificationsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeVpcEndpointConnectionNotificationsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeVpcEndpointConnectionNotificationsError::Unknown(body.to_string()),
+            Err(_) => DescribeVpcEndpointConnectionNotificationsError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -67263,7 +67543,7 @@ pub enum DescribeVpcEndpointConnectionsError {
 }
 
 impl DescribeVpcEndpointConnectionsError {
-    pub fn from_body(body: &str) -> DescribeVpcEndpointConnectionsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeVpcEndpointConnectionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -67271,7 +67551,11 @@ impl DescribeVpcEndpointConnectionsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeVpcEndpointConnectionsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeVpcEndpointConnectionsError::Unknown(body.to_string()),
+            Err(_) => DescribeVpcEndpointConnectionsError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -67337,7 +67621,7 @@ pub enum DescribeVpcEndpointServiceConfigurationsError {
 }
 
 impl DescribeVpcEndpointServiceConfigurationsError {
-    pub fn from_body(body: &str) -> DescribeVpcEndpointServiceConfigurationsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeVpcEndpointServiceConfigurationsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -67345,7 +67629,11 @@ impl DescribeVpcEndpointServiceConfigurationsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeVpcEndpointServiceConfigurationsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeVpcEndpointServiceConfigurationsError::Unknown(body.to_string()),
+            Err(_) => DescribeVpcEndpointServiceConfigurationsError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -67413,7 +67701,7 @@ pub enum DescribeVpcEndpointServicePermissionsError {
 }
 
 impl DescribeVpcEndpointServicePermissionsError {
-    pub fn from_body(body: &str) -> DescribeVpcEndpointServicePermissionsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeVpcEndpointServicePermissionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -67421,7 +67709,11 @@ impl DescribeVpcEndpointServicePermissionsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeVpcEndpointServicePermissionsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeVpcEndpointServicePermissionsError::Unknown(body.to_string()),
+            Err(_) => DescribeVpcEndpointServicePermissionsError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -67487,7 +67779,7 @@ pub enum DescribeVpcEndpointServicesError {
 }
 
 impl DescribeVpcEndpointServicesError {
-    pub fn from_body(body: &str) -> DescribeVpcEndpointServicesError {
+    pub fn from_body(body: &str, status: u16) -> DescribeVpcEndpointServicesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -67495,7 +67787,11 @@ impl DescribeVpcEndpointServicesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeVpcEndpointServicesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeVpcEndpointServicesError::Unknown(body.to_string()),
+            Err(_) => DescribeVpcEndpointServicesError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -67561,7 +67857,7 @@ pub enum DescribeVpcEndpointsError {
 }
 
 impl DescribeVpcEndpointsError {
-    pub fn from_body(body: &str) -> DescribeVpcEndpointsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeVpcEndpointsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -67569,7 +67865,9 @@ impl DescribeVpcEndpointsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeVpcEndpointsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeVpcEndpointsError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeVpcEndpointsError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -67635,7 +67933,7 @@ pub enum DescribeVpcPeeringConnectionsError {
 }
 
 impl DescribeVpcPeeringConnectionsError {
-    pub fn from_body(body: &str) -> DescribeVpcPeeringConnectionsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeVpcPeeringConnectionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -67643,7 +67941,11 @@ impl DescribeVpcPeeringConnectionsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeVpcPeeringConnectionsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeVpcPeeringConnectionsError::Unknown(body.to_string()),
+            Err(_) => DescribeVpcPeeringConnectionsError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -67709,7 +68011,7 @@ pub enum DescribeVpcsError {
 }
 
 impl DescribeVpcsError {
-    pub fn from_body(body: &str) -> DescribeVpcsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeVpcsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -67717,7 +68019,7 @@ impl DescribeVpcsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeVpcsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeVpcsError::Unknown(body.to_string()),
+            Err(_) => DescribeVpcsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -67781,7 +68083,7 @@ pub enum DescribeVpnConnectionsError {
 }
 
 impl DescribeVpnConnectionsError {
-    pub fn from_body(body: &str) -> DescribeVpnConnectionsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeVpnConnectionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -67789,7 +68091,9 @@ impl DescribeVpnConnectionsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeVpnConnectionsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeVpnConnectionsError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeVpnConnectionsError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -67855,7 +68159,7 @@ pub enum DescribeVpnGatewaysError {
 }
 
 impl DescribeVpnGatewaysError {
-    pub fn from_body(body: &str) -> DescribeVpnGatewaysError {
+    pub fn from_body(body: &str, status: u16) -> DescribeVpnGatewaysError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -67863,7 +68167,7 @@ impl DescribeVpnGatewaysError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeVpnGatewaysError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeVpnGatewaysError::Unknown(body.to_string()),
+            Err(_) => DescribeVpnGatewaysError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -67929,7 +68233,7 @@ pub enum DetachClassicLinkVpcError {
 }
 
 impl DetachClassicLinkVpcError {
-    pub fn from_body(body: &str) -> DetachClassicLinkVpcError {
+    pub fn from_body(body: &str, status: u16) -> DetachClassicLinkVpcError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -67937,7 +68241,9 @@ impl DetachClassicLinkVpcError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DetachClassicLinkVpcError::Unknown(String::from(body)),
             },
-            Err(_) => DetachClassicLinkVpcError::Unknown(body.to_string()),
+            Err(_) => {
+                DetachClassicLinkVpcError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -68003,7 +68309,7 @@ pub enum DetachInternetGatewayError {
 }
 
 impl DetachInternetGatewayError {
-    pub fn from_body(body: &str) -> DetachInternetGatewayError {
+    pub fn from_body(body: &str, status: u16) -> DetachInternetGatewayError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -68011,7 +68317,9 @@ impl DetachInternetGatewayError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DetachInternetGatewayError::Unknown(String::from(body)),
             },
-            Err(_) => DetachInternetGatewayError::Unknown(body.to_string()),
+            Err(_) => {
+                DetachInternetGatewayError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -68077,7 +68385,7 @@ pub enum DetachNetworkInterfaceError {
 }
 
 impl DetachNetworkInterfaceError {
-    pub fn from_body(body: &str) -> DetachNetworkInterfaceError {
+    pub fn from_body(body: &str, status: u16) -> DetachNetworkInterfaceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -68085,7 +68393,9 @@ impl DetachNetworkInterfaceError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DetachNetworkInterfaceError::Unknown(String::from(body)),
             },
-            Err(_) => DetachNetworkInterfaceError::Unknown(body.to_string()),
+            Err(_) => {
+                DetachNetworkInterfaceError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -68151,7 +68461,7 @@ pub enum DetachVolumeError {
 }
 
 impl DetachVolumeError {
-    pub fn from_body(body: &str) -> DetachVolumeError {
+    pub fn from_body(body: &str, status: u16) -> DetachVolumeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -68159,7 +68469,7 @@ impl DetachVolumeError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DetachVolumeError::Unknown(String::from(body)),
             },
-            Err(_) => DetachVolumeError::Unknown(body.to_string()),
+            Err(_) => DetachVolumeError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -68223,7 +68533,7 @@ pub enum DetachVpnGatewayError {
 }
 
 impl DetachVpnGatewayError {
-    pub fn from_body(body: &str) -> DetachVpnGatewayError {
+    pub fn from_body(body: &str, status: u16) -> DetachVpnGatewayError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -68231,7 +68541,7 @@ impl DetachVpnGatewayError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DetachVpnGatewayError::Unknown(String::from(body)),
             },
-            Err(_) => DetachVpnGatewayError::Unknown(body.to_string()),
+            Err(_) => DetachVpnGatewayError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -68295,7 +68605,7 @@ pub enum DisableVgwRoutePropagationError {
 }
 
 impl DisableVgwRoutePropagationError {
-    pub fn from_body(body: &str) -> DisableVgwRoutePropagationError {
+    pub fn from_body(body: &str, status: u16) -> DisableVgwRoutePropagationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -68303,7 +68613,9 @@ impl DisableVgwRoutePropagationError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DisableVgwRoutePropagationError::Unknown(String::from(body)),
             },
-            Err(_) => DisableVgwRoutePropagationError::Unknown(body.to_string()),
+            Err(_) => {
+                DisableVgwRoutePropagationError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -68369,7 +68681,7 @@ pub enum DisableVpcClassicLinkError {
 }
 
 impl DisableVpcClassicLinkError {
-    pub fn from_body(body: &str) -> DisableVpcClassicLinkError {
+    pub fn from_body(body: &str, status: u16) -> DisableVpcClassicLinkError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -68377,7 +68689,9 @@ impl DisableVpcClassicLinkError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DisableVpcClassicLinkError::Unknown(String::from(body)),
             },
-            Err(_) => DisableVpcClassicLinkError::Unknown(body.to_string()),
+            Err(_) => {
+                DisableVpcClassicLinkError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -68443,7 +68757,7 @@ pub enum DisableVpcClassicLinkDnsSupportError {
 }
 
 impl DisableVpcClassicLinkDnsSupportError {
-    pub fn from_body(body: &str) -> DisableVpcClassicLinkDnsSupportError {
+    pub fn from_body(body: &str, status: u16) -> DisableVpcClassicLinkDnsSupportError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -68451,7 +68765,11 @@ impl DisableVpcClassicLinkDnsSupportError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DisableVpcClassicLinkDnsSupportError::Unknown(String::from(body)),
             },
-            Err(_) => DisableVpcClassicLinkDnsSupportError::Unknown(body.to_string()),
+            Err(_) => DisableVpcClassicLinkDnsSupportError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -68517,7 +68835,7 @@ pub enum DisassociateAddressError {
 }
 
 impl DisassociateAddressError {
-    pub fn from_body(body: &str) -> DisassociateAddressError {
+    pub fn from_body(body: &str, status: u16) -> DisassociateAddressError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -68525,7 +68843,7 @@ impl DisassociateAddressError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DisassociateAddressError::Unknown(String::from(body)),
             },
-            Err(_) => DisassociateAddressError::Unknown(body.to_string()),
+            Err(_) => DisassociateAddressError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -68591,7 +68909,7 @@ pub enum DisassociateIamInstanceProfileError {
 }
 
 impl DisassociateIamInstanceProfileError {
-    pub fn from_body(body: &str) -> DisassociateIamInstanceProfileError {
+    pub fn from_body(body: &str, status: u16) -> DisassociateIamInstanceProfileError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -68599,7 +68917,11 @@ impl DisassociateIamInstanceProfileError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DisassociateIamInstanceProfileError::Unknown(String::from(body)),
             },
-            Err(_) => DisassociateIamInstanceProfileError::Unknown(body.to_string()),
+            Err(_) => DisassociateIamInstanceProfileError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -68665,7 +68987,7 @@ pub enum DisassociateRouteTableError {
 }
 
 impl DisassociateRouteTableError {
-    pub fn from_body(body: &str) -> DisassociateRouteTableError {
+    pub fn from_body(body: &str, status: u16) -> DisassociateRouteTableError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -68673,7 +68995,9 @@ impl DisassociateRouteTableError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DisassociateRouteTableError::Unknown(String::from(body)),
             },
-            Err(_) => DisassociateRouteTableError::Unknown(body.to_string()),
+            Err(_) => {
+                DisassociateRouteTableError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -68739,7 +69063,7 @@ pub enum DisassociateSubnetCidrBlockError {
 }
 
 impl DisassociateSubnetCidrBlockError {
-    pub fn from_body(body: &str) -> DisassociateSubnetCidrBlockError {
+    pub fn from_body(body: &str, status: u16) -> DisassociateSubnetCidrBlockError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -68747,7 +69071,11 @@ impl DisassociateSubnetCidrBlockError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DisassociateSubnetCidrBlockError::Unknown(String::from(body)),
             },
-            Err(_) => DisassociateSubnetCidrBlockError::Unknown(body.to_string()),
+            Err(_) => DisassociateSubnetCidrBlockError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -68813,7 +69141,7 @@ pub enum DisassociateVpcCidrBlockError {
 }
 
 impl DisassociateVpcCidrBlockError {
-    pub fn from_body(body: &str) -> DisassociateVpcCidrBlockError {
+    pub fn from_body(body: &str, status: u16) -> DisassociateVpcCidrBlockError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -68821,7 +69149,9 @@ impl DisassociateVpcCidrBlockError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DisassociateVpcCidrBlockError::Unknown(String::from(body)),
             },
-            Err(_) => DisassociateVpcCidrBlockError::Unknown(body.to_string()),
+            Err(_) => {
+                DisassociateVpcCidrBlockError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -68887,7 +69217,7 @@ pub enum EnableVgwRoutePropagationError {
 }
 
 impl EnableVgwRoutePropagationError {
-    pub fn from_body(body: &str) -> EnableVgwRoutePropagationError {
+    pub fn from_body(body: &str, status: u16) -> EnableVgwRoutePropagationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -68895,7 +69225,9 @@ impl EnableVgwRoutePropagationError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => EnableVgwRoutePropagationError::Unknown(String::from(body)),
             },
-            Err(_) => EnableVgwRoutePropagationError::Unknown(body.to_string()),
+            Err(_) => {
+                EnableVgwRoutePropagationError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -68961,7 +69293,7 @@ pub enum EnableVolumeIOError {
 }
 
 impl EnableVolumeIOError {
-    pub fn from_body(body: &str) -> EnableVolumeIOError {
+    pub fn from_body(body: &str, status: u16) -> EnableVolumeIOError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -68969,7 +69301,7 @@ impl EnableVolumeIOError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => EnableVolumeIOError::Unknown(String::from(body)),
             },
-            Err(_) => EnableVolumeIOError::Unknown(body.to_string()),
+            Err(_) => EnableVolumeIOError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -69033,7 +69365,7 @@ pub enum EnableVpcClassicLinkError {
 }
 
 impl EnableVpcClassicLinkError {
-    pub fn from_body(body: &str) -> EnableVpcClassicLinkError {
+    pub fn from_body(body: &str, status: u16) -> EnableVpcClassicLinkError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -69041,7 +69373,9 @@ impl EnableVpcClassicLinkError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => EnableVpcClassicLinkError::Unknown(String::from(body)),
             },
-            Err(_) => EnableVpcClassicLinkError::Unknown(body.to_string()),
+            Err(_) => {
+                EnableVpcClassicLinkError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -69107,7 +69441,7 @@ pub enum EnableVpcClassicLinkDnsSupportError {
 }
 
 impl EnableVpcClassicLinkDnsSupportError {
-    pub fn from_body(body: &str) -> EnableVpcClassicLinkDnsSupportError {
+    pub fn from_body(body: &str, status: u16) -> EnableVpcClassicLinkDnsSupportError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -69115,7 +69449,11 @@ impl EnableVpcClassicLinkDnsSupportError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => EnableVpcClassicLinkDnsSupportError::Unknown(String::from(body)),
             },
-            Err(_) => EnableVpcClassicLinkDnsSupportError::Unknown(body.to_string()),
+            Err(_) => EnableVpcClassicLinkDnsSupportError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -69181,7 +69519,7 @@ pub enum GetConsoleOutputError {
 }
 
 impl GetConsoleOutputError {
-    pub fn from_body(body: &str) -> GetConsoleOutputError {
+    pub fn from_body(body: &str, status: u16) -> GetConsoleOutputError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -69189,7 +69527,7 @@ impl GetConsoleOutputError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetConsoleOutputError::Unknown(String::from(body)),
             },
-            Err(_) => GetConsoleOutputError::Unknown(body.to_string()),
+            Err(_) => GetConsoleOutputError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -69253,7 +69591,7 @@ pub enum GetConsoleScreenshotError {
 }
 
 impl GetConsoleScreenshotError {
-    pub fn from_body(body: &str) -> GetConsoleScreenshotError {
+    pub fn from_body(body: &str, status: u16) -> GetConsoleScreenshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -69261,7 +69599,9 @@ impl GetConsoleScreenshotError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetConsoleScreenshotError::Unknown(String::from(body)),
             },
-            Err(_) => GetConsoleScreenshotError::Unknown(body.to_string()),
+            Err(_) => {
+                GetConsoleScreenshotError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -69327,7 +69667,7 @@ pub enum GetHostReservationPurchasePreviewError {
 }
 
 impl GetHostReservationPurchasePreviewError {
-    pub fn from_body(body: &str) -> GetHostReservationPurchasePreviewError {
+    pub fn from_body(body: &str, status: u16) -> GetHostReservationPurchasePreviewError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -69335,7 +69675,11 @@ impl GetHostReservationPurchasePreviewError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetHostReservationPurchasePreviewError::Unknown(String::from(body)),
             },
-            Err(_) => GetHostReservationPurchasePreviewError::Unknown(body.to_string()),
+            Err(_) => GetHostReservationPurchasePreviewError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -69401,7 +69745,7 @@ pub enum GetLaunchTemplateDataError {
 }
 
 impl GetLaunchTemplateDataError {
-    pub fn from_body(body: &str) -> GetLaunchTemplateDataError {
+    pub fn from_body(body: &str, status: u16) -> GetLaunchTemplateDataError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -69409,7 +69753,9 @@ impl GetLaunchTemplateDataError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetLaunchTemplateDataError::Unknown(String::from(body)),
             },
-            Err(_) => GetLaunchTemplateDataError::Unknown(body.to_string()),
+            Err(_) => {
+                GetLaunchTemplateDataError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -69475,7 +69821,7 @@ pub enum GetPasswordDataError {
 }
 
 impl GetPasswordDataError {
-    pub fn from_body(body: &str) -> GetPasswordDataError {
+    pub fn from_body(body: &str, status: u16) -> GetPasswordDataError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -69483,7 +69829,7 @@ impl GetPasswordDataError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetPasswordDataError::Unknown(String::from(body)),
             },
-            Err(_) => GetPasswordDataError::Unknown(body.to_string()),
+            Err(_) => GetPasswordDataError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -69547,7 +69893,7 @@ pub enum GetReservedInstancesExchangeQuoteError {
 }
 
 impl GetReservedInstancesExchangeQuoteError {
-    pub fn from_body(body: &str) -> GetReservedInstancesExchangeQuoteError {
+    pub fn from_body(body: &str, status: u16) -> GetReservedInstancesExchangeQuoteError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -69555,7 +69901,11 @@ impl GetReservedInstancesExchangeQuoteError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetReservedInstancesExchangeQuoteError::Unknown(String::from(body)),
             },
-            Err(_) => GetReservedInstancesExchangeQuoteError::Unknown(body.to_string()),
+            Err(_) => GetReservedInstancesExchangeQuoteError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -69621,7 +69971,7 @@ pub enum ImportImageError {
 }
 
 impl ImportImageError {
-    pub fn from_body(body: &str) -> ImportImageError {
+    pub fn from_body(body: &str, status: u16) -> ImportImageError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -69629,7 +69979,7 @@ impl ImportImageError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ImportImageError::Unknown(String::from(body)),
             },
-            Err(_) => ImportImageError::Unknown(body.to_string()),
+            Err(_) => ImportImageError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -69693,7 +70043,7 @@ pub enum ImportInstanceError {
 }
 
 impl ImportInstanceError {
-    pub fn from_body(body: &str) -> ImportInstanceError {
+    pub fn from_body(body: &str, status: u16) -> ImportInstanceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -69701,7 +70051,7 @@ impl ImportInstanceError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ImportInstanceError::Unknown(String::from(body)),
             },
-            Err(_) => ImportInstanceError::Unknown(body.to_string()),
+            Err(_) => ImportInstanceError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -69765,7 +70115,7 @@ pub enum ImportKeyPairError {
 }
 
 impl ImportKeyPairError {
-    pub fn from_body(body: &str) -> ImportKeyPairError {
+    pub fn from_body(body: &str, status: u16) -> ImportKeyPairError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -69773,7 +70123,7 @@ impl ImportKeyPairError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ImportKeyPairError::Unknown(String::from(body)),
             },
-            Err(_) => ImportKeyPairError::Unknown(body.to_string()),
+            Err(_) => ImportKeyPairError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -69837,7 +70187,7 @@ pub enum ImportSnapshotError {
 }
 
 impl ImportSnapshotError {
-    pub fn from_body(body: &str) -> ImportSnapshotError {
+    pub fn from_body(body: &str, status: u16) -> ImportSnapshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -69845,7 +70195,7 @@ impl ImportSnapshotError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ImportSnapshotError::Unknown(String::from(body)),
             },
-            Err(_) => ImportSnapshotError::Unknown(body.to_string()),
+            Err(_) => ImportSnapshotError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -69909,7 +70259,7 @@ pub enum ImportVolumeError {
 }
 
 impl ImportVolumeError {
-    pub fn from_body(body: &str) -> ImportVolumeError {
+    pub fn from_body(body: &str, status: u16) -> ImportVolumeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -69917,7 +70267,7 @@ impl ImportVolumeError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ImportVolumeError::Unknown(String::from(body)),
             },
-            Err(_) => ImportVolumeError::Unknown(body.to_string()),
+            Err(_) => ImportVolumeError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -69981,7 +70331,7 @@ pub enum ModifyFleetError {
 }
 
 impl ModifyFleetError {
-    pub fn from_body(body: &str) -> ModifyFleetError {
+    pub fn from_body(body: &str, status: u16) -> ModifyFleetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -69989,7 +70339,7 @@ impl ModifyFleetError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifyFleetError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyFleetError::Unknown(body.to_string()),
+            Err(_) => ModifyFleetError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -70053,7 +70403,7 @@ pub enum ModifyFpgaImageAttributeError {
 }
 
 impl ModifyFpgaImageAttributeError {
-    pub fn from_body(body: &str) -> ModifyFpgaImageAttributeError {
+    pub fn from_body(body: &str, status: u16) -> ModifyFpgaImageAttributeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -70061,7 +70411,9 @@ impl ModifyFpgaImageAttributeError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifyFpgaImageAttributeError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyFpgaImageAttributeError::Unknown(body.to_string()),
+            Err(_) => {
+                ModifyFpgaImageAttributeError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -70127,7 +70479,7 @@ pub enum ModifyHostsError {
 }
 
 impl ModifyHostsError {
-    pub fn from_body(body: &str) -> ModifyHostsError {
+    pub fn from_body(body: &str, status: u16) -> ModifyHostsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -70135,7 +70487,7 @@ impl ModifyHostsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifyHostsError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyHostsError::Unknown(body.to_string()),
+            Err(_) => ModifyHostsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -70199,7 +70551,7 @@ pub enum ModifyIdFormatError {
 }
 
 impl ModifyIdFormatError {
-    pub fn from_body(body: &str) -> ModifyIdFormatError {
+    pub fn from_body(body: &str, status: u16) -> ModifyIdFormatError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -70207,7 +70559,7 @@ impl ModifyIdFormatError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifyIdFormatError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyIdFormatError::Unknown(body.to_string()),
+            Err(_) => ModifyIdFormatError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -70271,7 +70623,7 @@ pub enum ModifyIdentityIdFormatError {
 }
 
 impl ModifyIdentityIdFormatError {
-    pub fn from_body(body: &str) -> ModifyIdentityIdFormatError {
+    pub fn from_body(body: &str, status: u16) -> ModifyIdentityIdFormatError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -70279,7 +70631,9 @@ impl ModifyIdentityIdFormatError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifyIdentityIdFormatError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyIdentityIdFormatError::Unknown(body.to_string()),
+            Err(_) => {
+                ModifyIdentityIdFormatError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -70345,7 +70699,7 @@ pub enum ModifyImageAttributeError {
 }
 
 impl ModifyImageAttributeError {
-    pub fn from_body(body: &str) -> ModifyImageAttributeError {
+    pub fn from_body(body: &str, status: u16) -> ModifyImageAttributeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -70353,7 +70707,9 @@ impl ModifyImageAttributeError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifyImageAttributeError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyImageAttributeError::Unknown(body.to_string()),
+            Err(_) => {
+                ModifyImageAttributeError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -70419,7 +70775,7 @@ pub enum ModifyInstanceAttributeError {
 }
 
 impl ModifyInstanceAttributeError {
-    pub fn from_body(body: &str) -> ModifyInstanceAttributeError {
+    pub fn from_body(body: &str, status: u16) -> ModifyInstanceAttributeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -70427,7 +70783,9 @@ impl ModifyInstanceAttributeError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifyInstanceAttributeError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyInstanceAttributeError::Unknown(body.to_string()),
+            Err(_) => {
+                ModifyInstanceAttributeError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -70493,7 +70851,7 @@ pub enum ModifyInstanceCreditSpecificationError {
 }
 
 impl ModifyInstanceCreditSpecificationError {
-    pub fn from_body(body: &str) -> ModifyInstanceCreditSpecificationError {
+    pub fn from_body(body: &str, status: u16) -> ModifyInstanceCreditSpecificationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -70501,7 +70859,11 @@ impl ModifyInstanceCreditSpecificationError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifyInstanceCreditSpecificationError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyInstanceCreditSpecificationError::Unknown(body.to_string()),
+            Err(_) => ModifyInstanceCreditSpecificationError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -70567,7 +70929,7 @@ pub enum ModifyInstancePlacementError {
 }
 
 impl ModifyInstancePlacementError {
-    pub fn from_body(body: &str) -> ModifyInstancePlacementError {
+    pub fn from_body(body: &str, status: u16) -> ModifyInstancePlacementError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -70575,7 +70937,9 @@ impl ModifyInstancePlacementError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifyInstancePlacementError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyInstancePlacementError::Unknown(body.to_string()),
+            Err(_) => {
+                ModifyInstancePlacementError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -70641,7 +71005,7 @@ pub enum ModifyLaunchTemplateError {
 }
 
 impl ModifyLaunchTemplateError {
-    pub fn from_body(body: &str) -> ModifyLaunchTemplateError {
+    pub fn from_body(body: &str, status: u16) -> ModifyLaunchTemplateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -70649,7 +71013,9 @@ impl ModifyLaunchTemplateError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifyLaunchTemplateError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyLaunchTemplateError::Unknown(body.to_string()),
+            Err(_) => {
+                ModifyLaunchTemplateError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -70715,7 +71081,7 @@ pub enum ModifyNetworkInterfaceAttributeError {
 }
 
 impl ModifyNetworkInterfaceAttributeError {
-    pub fn from_body(body: &str) -> ModifyNetworkInterfaceAttributeError {
+    pub fn from_body(body: &str, status: u16) -> ModifyNetworkInterfaceAttributeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -70723,7 +71089,11 @@ impl ModifyNetworkInterfaceAttributeError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifyNetworkInterfaceAttributeError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyNetworkInterfaceAttributeError::Unknown(body.to_string()),
+            Err(_) => ModifyNetworkInterfaceAttributeError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -70789,7 +71159,7 @@ pub enum ModifyReservedInstancesError {
 }
 
 impl ModifyReservedInstancesError {
-    pub fn from_body(body: &str) -> ModifyReservedInstancesError {
+    pub fn from_body(body: &str, status: u16) -> ModifyReservedInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -70797,7 +71167,9 @@ impl ModifyReservedInstancesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifyReservedInstancesError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyReservedInstancesError::Unknown(body.to_string()),
+            Err(_) => {
+                ModifyReservedInstancesError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -70863,7 +71235,7 @@ pub enum ModifySnapshotAttributeError {
 }
 
 impl ModifySnapshotAttributeError {
-    pub fn from_body(body: &str) -> ModifySnapshotAttributeError {
+    pub fn from_body(body: &str, status: u16) -> ModifySnapshotAttributeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -70871,7 +71243,9 @@ impl ModifySnapshotAttributeError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifySnapshotAttributeError::Unknown(String::from(body)),
             },
-            Err(_) => ModifySnapshotAttributeError::Unknown(body.to_string()),
+            Err(_) => {
+                ModifySnapshotAttributeError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -70937,7 +71311,7 @@ pub enum ModifySpotFleetRequestError {
 }
 
 impl ModifySpotFleetRequestError {
-    pub fn from_body(body: &str) -> ModifySpotFleetRequestError {
+    pub fn from_body(body: &str, status: u16) -> ModifySpotFleetRequestError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -70945,7 +71319,9 @@ impl ModifySpotFleetRequestError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifySpotFleetRequestError::Unknown(String::from(body)),
             },
-            Err(_) => ModifySpotFleetRequestError::Unknown(body.to_string()),
+            Err(_) => {
+                ModifySpotFleetRequestError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -71011,7 +71387,7 @@ pub enum ModifySubnetAttributeError {
 }
 
 impl ModifySubnetAttributeError {
-    pub fn from_body(body: &str) -> ModifySubnetAttributeError {
+    pub fn from_body(body: &str, status: u16) -> ModifySubnetAttributeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -71019,7 +71395,9 @@ impl ModifySubnetAttributeError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifySubnetAttributeError::Unknown(String::from(body)),
             },
-            Err(_) => ModifySubnetAttributeError::Unknown(body.to_string()),
+            Err(_) => {
+                ModifySubnetAttributeError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -71085,7 +71463,7 @@ pub enum ModifyVolumeError {
 }
 
 impl ModifyVolumeError {
-    pub fn from_body(body: &str) -> ModifyVolumeError {
+    pub fn from_body(body: &str, status: u16) -> ModifyVolumeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -71093,7 +71471,7 @@ impl ModifyVolumeError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifyVolumeError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyVolumeError::Unknown(body.to_string()),
+            Err(_) => ModifyVolumeError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -71157,7 +71535,7 @@ pub enum ModifyVolumeAttributeError {
 }
 
 impl ModifyVolumeAttributeError {
-    pub fn from_body(body: &str) -> ModifyVolumeAttributeError {
+    pub fn from_body(body: &str, status: u16) -> ModifyVolumeAttributeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -71165,7 +71543,9 @@ impl ModifyVolumeAttributeError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifyVolumeAttributeError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyVolumeAttributeError::Unknown(body.to_string()),
+            Err(_) => {
+                ModifyVolumeAttributeError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -71231,7 +71611,7 @@ pub enum ModifyVpcAttributeError {
 }
 
 impl ModifyVpcAttributeError {
-    pub fn from_body(body: &str) -> ModifyVpcAttributeError {
+    pub fn from_body(body: &str, status: u16) -> ModifyVpcAttributeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -71239,7 +71619,7 @@ impl ModifyVpcAttributeError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifyVpcAttributeError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyVpcAttributeError::Unknown(body.to_string()),
+            Err(_) => ModifyVpcAttributeError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -71305,7 +71685,7 @@ pub enum ModifyVpcEndpointError {
 }
 
 impl ModifyVpcEndpointError {
-    pub fn from_body(body: &str) -> ModifyVpcEndpointError {
+    pub fn from_body(body: &str, status: u16) -> ModifyVpcEndpointError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -71313,7 +71693,7 @@ impl ModifyVpcEndpointError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifyVpcEndpointError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyVpcEndpointError::Unknown(body.to_string()),
+            Err(_) => ModifyVpcEndpointError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -71379,7 +71759,7 @@ pub enum ModifyVpcEndpointConnectionNotificationError {
 }
 
 impl ModifyVpcEndpointConnectionNotificationError {
-    pub fn from_body(body: &str) -> ModifyVpcEndpointConnectionNotificationError {
+    pub fn from_body(body: &str, status: u16) -> ModifyVpcEndpointConnectionNotificationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -71387,7 +71767,11 @@ impl ModifyVpcEndpointConnectionNotificationError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifyVpcEndpointConnectionNotificationError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyVpcEndpointConnectionNotificationError::Unknown(body.to_string()),
+            Err(_) => ModifyVpcEndpointConnectionNotificationError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -71453,7 +71837,7 @@ pub enum ModifyVpcEndpointServiceConfigurationError {
 }
 
 impl ModifyVpcEndpointServiceConfigurationError {
-    pub fn from_body(body: &str) -> ModifyVpcEndpointServiceConfigurationError {
+    pub fn from_body(body: &str, status: u16) -> ModifyVpcEndpointServiceConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -71461,7 +71845,11 @@ impl ModifyVpcEndpointServiceConfigurationError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifyVpcEndpointServiceConfigurationError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyVpcEndpointServiceConfigurationError::Unknown(body.to_string()),
+            Err(_) => ModifyVpcEndpointServiceConfigurationError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -71527,7 +71915,7 @@ pub enum ModifyVpcEndpointServicePermissionsError {
 }
 
 impl ModifyVpcEndpointServicePermissionsError {
-    pub fn from_body(body: &str) -> ModifyVpcEndpointServicePermissionsError {
+    pub fn from_body(body: &str, status: u16) -> ModifyVpcEndpointServicePermissionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -71535,7 +71923,11 @@ impl ModifyVpcEndpointServicePermissionsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifyVpcEndpointServicePermissionsError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyVpcEndpointServicePermissionsError::Unknown(body.to_string()),
+            Err(_) => ModifyVpcEndpointServicePermissionsError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -71601,7 +71993,7 @@ pub enum ModifyVpcPeeringConnectionOptionsError {
 }
 
 impl ModifyVpcPeeringConnectionOptionsError {
-    pub fn from_body(body: &str) -> ModifyVpcPeeringConnectionOptionsError {
+    pub fn from_body(body: &str, status: u16) -> ModifyVpcPeeringConnectionOptionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -71609,7 +72001,11 @@ impl ModifyVpcPeeringConnectionOptionsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifyVpcPeeringConnectionOptionsError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyVpcPeeringConnectionOptionsError::Unknown(body.to_string()),
+            Err(_) => ModifyVpcPeeringConnectionOptionsError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -71675,7 +72071,7 @@ pub enum ModifyVpcTenancyError {
 }
 
 impl ModifyVpcTenancyError {
-    pub fn from_body(body: &str) -> ModifyVpcTenancyError {
+    pub fn from_body(body: &str, status: u16) -> ModifyVpcTenancyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -71683,7 +72079,7 @@ impl ModifyVpcTenancyError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ModifyVpcTenancyError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyVpcTenancyError::Unknown(body.to_string()),
+            Err(_) => ModifyVpcTenancyError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -71747,7 +72143,7 @@ pub enum MonitorInstancesError {
 }
 
 impl MonitorInstancesError {
-    pub fn from_body(body: &str) -> MonitorInstancesError {
+    pub fn from_body(body: &str, status: u16) -> MonitorInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -71755,7 +72151,7 @@ impl MonitorInstancesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => MonitorInstancesError::Unknown(String::from(body)),
             },
-            Err(_) => MonitorInstancesError::Unknown(body.to_string()),
+            Err(_) => MonitorInstancesError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -71819,7 +72215,7 @@ pub enum MoveAddressToVpcError {
 }
 
 impl MoveAddressToVpcError {
-    pub fn from_body(body: &str) -> MoveAddressToVpcError {
+    pub fn from_body(body: &str, status: u16) -> MoveAddressToVpcError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -71827,7 +72223,7 @@ impl MoveAddressToVpcError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => MoveAddressToVpcError::Unknown(String::from(body)),
             },
-            Err(_) => MoveAddressToVpcError::Unknown(body.to_string()),
+            Err(_) => MoveAddressToVpcError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -71891,7 +72287,7 @@ pub enum PurchaseHostReservationError {
 }
 
 impl PurchaseHostReservationError {
-    pub fn from_body(body: &str) -> PurchaseHostReservationError {
+    pub fn from_body(body: &str, status: u16) -> PurchaseHostReservationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -71899,7 +72295,9 @@ impl PurchaseHostReservationError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PurchaseHostReservationError::Unknown(String::from(body)),
             },
-            Err(_) => PurchaseHostReservationError::Unknown(body.to_string()),
+            Err(_) => {
+                PurchaseHostReservationError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -71965,7 +72363,7 @@ pub enum PurchaseReservedInstancesOfferingError {
 }
 
 impl PurchaseReservedInstancesOfferingError {
-    pub fn from_body(body: &str) -> PurchaseReservedInstancesOfferingError {
+    pub fn from_body(body: &str, status: u16) -> PurchaseReservedInstancesOfferingError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -71973,7 +72371,11 @@ impl PurchaseReservedInstancesOfferingError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PurchaseReservedInstancesOfferingError::Unknown(String::from(body)),
             },
-            Err(_) => PurchaseReservedInstancesOfferingError::Unknown(body.to_string()),
+            Err(_) => PurchaseReservedInstancesOfferingError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -72039,7 +72441,7 @@ pub enum PurchaseScheduledInstancesError {
 }
 
 impl PurchaseScheduledInstancesError {
-    pub fn from_body(body: &str) -> PurchaseScheduledInstancesError {
+    pub fn from_body(body: &str, status: u16) -> PurchaseScheduledInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -72047,7 +72449,9 @@ impl PurchaseScheduledInstancesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PurchaseScheduledInstancesError::Unknown(String::from(body)),
             },
-            Err(_) => PurchaseScheduledInstancesError::Unknown(body.to_string()),
+            Err(_) => {
+                PurchaseScheduledInstancesError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -72113,7 +72517,7 @@ pub enum RebootInstancesError {
 }
 
 impl RebootInstancesError {
-    pub fn from_body(body: &str) -> RebootInstancesError {
+    pub fn from_body(body: &str, status: u16) -> RebootInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -72121,7 +72525,7 @@ impl RebootInstancesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => RebootInstancesError::Unknown(String::from(body)),
             },
-            Err(_) => RebootInstancesError::Unknown(body.to_string()),
+            Err(_) => RebootInstancesError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -72185,7 +72589,7 @@ pub enum RegisterImageError {
 }
 
 impl RegisterImageError {
-    pub fn from_body(body: &str) -> RegisterImageError {
+    pub fn from_body(body: &str, status: u16) -> RegisterImageError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -72193,7 +72597,7 @@ impl RegisterImageError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => RegisterImageError::Unknown(String::from(body)),
             },
-            Err(_) => RegisterImageError::Unknown(body.to_string()),
+            Err(_) => RegisterImageError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -72257,7 +72661,7 @@ pub enum RejectVpcEndpointConnectionsError {
 }
 
 impl RejectVpcEndpointConnectionsError {
-    pub fn from_body(body: &str) -> RejectVpcEndpointConnectionsError {
+    pub fn from_body(body: &str, status: u16) -> RejectVpcEndpointConnectionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -72265,7 +72669,11 @@ impl RejectVpcEndpointConnectionsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => RejectVpcEndpointConnectionsError::Unknown(String::from(body)),
             },
-            Err(_) => RejectVpcEndpointConnectionsError::Unknown(body.to_string()),
+            Err(_) => RejectVpcEndpointConnectionsError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -72331,7 +72739,7 @@ pub enum RejectVpcPeeringConnectionError {
 }
 
 impl RejectVpcPeeringConnectionError {
-    pub fn from_body(body: &str) -> RejectVpcPeeringConnectionError {
+    pub fn from_body(body: &str, status: u16) -> RejectVpcPeeringConnectionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -72339,7 +72747,9 @@ impl RejectVpcPeeringConnectionError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => RejectVpcPeeringConnectionError::Unknown(String::from(body)),
             },
-            Err(_) => RejectVpcPeeringConnectionError::Unknown(body.to_string()),
+            Err(_) => {
+                RejectVpcPeeringConnectionError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -72405,7 +72815,7 @@ pub enum ReleaseAddressError {
 }
 
 impl ReleaseAddressError {
-    pub fn from_body(body: &str) -> ReleaseAddressError {
+    pub fn from_body(body: &str, status: u16) -> ReleaseAddressError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -72413,7 +72823,7 @@ impl ReleaseAddressError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ReleaseAddressError::Unknown(String::from(body)),
             },
-            Err(_) => ReleaseAddressError::Unknown(body.to_string()),
+            Err(_) => ReleaseAddressError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -72477,7 +72887,7 @@ pub enum ReleaseHostsError {
 }
 
 impl ReleaseHostsError {
-    pub fn from_body(body: &str) -> ReleaseHostsError {
+    pub fn from_body(body: &str, status: u16) -> ReleaseHostsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -72485,7 +72895,7 @@ impl ReleaseHostsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ReleaseHostsError::Unknown(String::from(body)),
             },
-            Err(_) => ReleaseHostsError::Unknown(body.to_string()),
+            Err(_) => ReleaseHostsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -72549,7 +72959,7 @@ pub enum ReplaceIamInstanceProfileAssociationError {
 }
 
 impl ReplaceIamInstanceProfileAssociationError {
-    pub fn from_body(body: &str) -> ReplaceIamInstanceProfileAssociationError {
+    pub fn from_body(body: &str, status: u16) -> ReplaceIamInstanceProfileAssociationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -72557,7 +72967,11 @@ impl ReplaceIamInstanceProfileAssociationError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ReplaceIamInstanceProfileAssociationError::Unknown(String::from(body)),
             },
-            Err(_) => ReplaceIamInstanceProfileAssociationError::Unknown(body.to_string()),
+            Err(_) => ReplaceIamInstanceProfileAssociationError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -72623,7 +73037,7 @@ pub enum ReplaceNetworkAclAssociationError {
 }
 
 impl ReplaceNetworkAclAssociationError {
-    pub fn from_body(body: &str) -> ReplaceNetworkAclAssociationError {
+    pub fn from_body(body: &str, status: u16) -> ReplaceNetworkAclAssociationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -72631,7 +73045,11 @@ impl ReplaceNetworkAclAssociationError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ReplaceNetworkAclAssociationError::Unknown(String::from(body)),
             },
-            Err(_) => ReplaceNetworkAclAssociationError::Unknown(body.to_string()),
+            Err(_) => ReplaceNetworkAclAssociationError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -72697,7 +73115,7 @@ pub enum ReplaceNetworkAclEntryError {
 }
 
 impl ReplaceNetworkAclEntryError {
-    pub fn from_body(body: &str) -> ReplaceNetworkAclEntryError {
+    pub fn from_body(body: &str, status: u16) -> ReplaceNetworkAclEntryError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -72705,7 +73123,9 @@ impl ReplaceNetworkAclEntryError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ReplaceNetworkAclEntryError::Unknown(String::from(body)),
             },
-            Err(_) => ReplaceNetworkAclEntryError::Unknown(body.to_string()),
+            Err(_) => {
+                ReplaceNetworkAclEntryError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -72771,7 +73191,7 @@ pub enum ReplaceRouteError {
 }
 
 impl ReplaceRouteError {
-    pub fn from_body(body: &str) -> ReplaceRouteError {
+    pub fn from_body(body: &str, status: u16) -> ReplaceRouteError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -72779,7 +73199,7 @@ impl ReplaceRouteError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ReplaceRouteError::Unknown(String::from(body)),
             },
-            Err(_) => ReplaceRouteError::Unknown(body.to_string()),
+            Err(_) => ReplaceRouteError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -72843,7 +73263,7 @@ pub enum ReplaceRouteTableAssociationError {
 }
 
 impl ReplaceRouteTableAssociationError {
-    pub fn from_body(body: &str) -> ReplaceRouteTableAssociationError {
+    pub fn from_body(body: &str, status: u16) -> ReplaceRouteTableAssociationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -72851,7 +73271,11 @@ impl ReplaceRouteTableAssociationError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ReplaceRouteTableAssociationError::Unknown(String::from(body)),
             },
-            Err(_) => ReplaceRouteTableAssociationError::Unknown(body.to_string()),
+            Err(_) => ReplaceRouteTableAssociationError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -72917,7 +73341,7 @@ pub enum ReportInstanceStatusError {
 }
 
 impl ReportInstanceStatusError {
-    pub fn from_body(body: &str) -> ReportInstanceStatusError {
+    pub fn from_body(body: &str, status: u16) -> ReportInstanceStatusError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -72925,7 +73349,9 @@ impl ReportInstanceStatusError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ReportInstanceStatusError::Unknown(String::from(body)),
             },
-            Err(_) => ReportInstanceStatusError::Unknown(body.to_string()),
+            Err(_) => {
+                ReportInstanceStatusError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -72991,7 +73417,7 @@ pub enum RequestSpotFleetError {
 }
 
 impl RequestSpotFleetError {
-    pub fn from_body(body: &str) -> RequestSpotFleetError {
+    pub fn from_body(body: &str, status: u16) -> RequestSpotFleetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -72999,7 +73425,7 @@ impl RequestSpotFleetError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => RequestSpotFleetError::Unknown(String::from(body)),
             },
-            Err(_) => RequestSpotFleetError::Unknown(body.to_string()),
+            Err(_) => RequestSpotFleetError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -73063,7 +73489,7 @@ pub enum RequestSpotInstancesError {
 }
 
 impl RequestSpotInstancesError {
-    pub fn from_body(body: &str) -> RequestSpotInstancesError {
+    pub fn from_body(body: &str, status: u16) -> RequestSpotInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -73071,7 +73497,9 @@ impl RequestSpotInstancesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => RequestSpotInstancesError::Unknown(String::from(body)),
             },
-            Err(_) => RequestSpotInstancesError::Unknown(body.to_string()),
+            Err(_) => {
+                RequestSpotInstancesError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -73137,7 +73565,7 @@ pub enum ResetFpgaImageAttributeError {
 }
 
 impl ResetFpgaImageAttributeError {
-    pub fn from_body(body: &str) -> ResetFpgaImageAttributeError {
+    pub fn from_body(body: &str, status: u16) -> ResetFpgaImageAttributeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -73145,7 +73573,9 @@ impl ResetFpgaImageAttributeError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ResetFpgaImageAttributeError::Unknown(String::from(body)),
             },
-            Err(_) => ResetFpgaImageAttributeError::Unknown(body.to_string()),
+            Err(_) => {
+                ResetFpgaImageAttributeError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -73211,7 +73641,7 @@ pub enum ResetImageAttributeError {
 }
 
 impl ResetImageAttributeError {
-    pub fn from_body(body: &str) -> ResetImageAttributeError {
+    pub fn from_body(body: &str, status: u16) -> ResetImageAttributeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -73219,7 +73649,7 @@ impl ResetImageAttributeError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ResetImageAttributeError::Unknown(String::from(body)),
             },
-            Err(_) => ResetImageAttributeError::Unknown(body.to_string()),
+            Err(_) => ResetImageAttributeError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -73285,7 +73715,7 @@ pub enum ResetInstanceAttributeError {
 }
 
 impl ResetInstanceAttributeError {
-    pub fn from_body(body: &str) -> ResetInstanceAttributeError {
+    pub fn from_body(body: &str, status: u16) -> ResetInstanceAttributeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -73293,7 +73723,9 @@ impl ResetInstanceAttributeError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ResetInstanceAttributeError::Unknown(String::from(body)),
             },
-            Err(_) => ResetInstanceAttributeError::Unknown(body.to_string()),
+            Err(_) => {
+                ResetInstanceAttributeError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -73359,7 +73791,7 @@ pub enum ResetNetworkInterfaceAttributeError {
 }
 
 impl ResetNetworkInterfaceAttributeError {
-    pub fn from_body(body: &str) -> ResetNetworkInterfaceAttributeError {
+    pub fn from_body(body: &str, status: u16) -> ResetNetworkInterfaceAttributeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -73367,7 +73799,11 @@ impl ResetNetworkInterfaceAttributeError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ResetNetworkInterfaceAttributeError::Unknown(String::from(body)),
             },
-            Err(_) => ResetNetworkInterfaceAttributeError::Unknown(body.to_string()),
+            Err(_) => ResetNetworkInterfaceAttributeError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -73433,7 +73869,7 @@ pub enum ResetSnapshotAttributeError {
 }
 
 impl ResetSnapshotAttributeError {
-    pub fn from_body(body: &str) -> ResetSnapshotAttributeError {
+    pub fn from_body(body: &str, status: u16) -> ResetSnapshotAttributeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -73441,7 +73877,9 @@ impl ResetSnapshotAttributeError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ResetSnapshotAttributeError::Unknown(String::from(body)),
             },
-            Err(_) => ResetSnapshotAttributeError::Unknown(body.to_string()),
+            Err(_) => {
+                ResetSnapshotAttributeError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -73507,7 +73945,7 @@ pub enum RestoreAddressToClassicError {
 }
 
 impl RestoreAddressToClassicError {
-    pub fn from_body(body: &str) -> RestoreAddressToClassicError {
+    pub fn from_body(body: &str, status: u16) -> RestoreAddressToClassicError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -73515,7 +73953,9 @@ impl RestoreAddressToClassicError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => RestoreAddressToClassicError::Unknown(String::from(body)),
             },
-            Err(_) => RestoreAddressToClassicError::Unknown(body.to_string()),
+            Err(_) => {
+                RestoreAddressToClassicError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -73581,7 +74021,7 @@ pub enum RevokeSecurityGroupEgressError {
 }
 
 impl RevokeSecurityGroupEgressError {
-    pub fn from_body(body: &str) -> RevokeSecurityGroupEgressError {
+    pub fn from_body(body: &str, status: u16) -> RevokeSecurityGroupEgressError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -73589,7 +74029,9 @@ impl RevokeSecurityGroupEgressError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => RevokeSecurityGroupEgressError::Unknown(String::from(body)),
             },
-            Err(_) => RevokeSecurityGroupEgressError::Unknown(body.to_string()),
+            Err(_) => {
+                RevokeSecurityGroupEgressError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -73655,7 +74097,7 @@ pub enum RevokeSecurityGroupIngressError {
 }
 
 impl RevokeSecurityGroupIngressError {
-    pub fn from_body(body: &str) -> RevokeSecurityGroupIngressError {
+    pub fn from_body(body: &str, status: u16) -> RevokeSecurityGroupIngressError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -73663,7 +74105,9 @@ impl RevokeSecurityGroupIngressError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => RevokeSecurityGroupIngressError::Unknown(String::from(body)),
             },
-            Err(_) => RevokeSecurityGroupIngressError::Unknown(body.to_string()),
+            Err(_) => {
+                RevokeSecurityGroupIngressError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -73729,7 +74173,7 @@ pub enum RunInstancesError {
 }
 
 impl RunInstancesError {
-    pub fn from_body(body: &str) -> RunInstancesError {
+    pub fn from_body(body: &str, status: u16) -> RunInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -73737,7 +74181,7 @@ impl RunInstancesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => RunInstancesError::Unknown(String::from(body)),
             },
-            Err(_) => RunInstancesError::Unknown(body.to_string()),
+            Err(_) => RunInstancesError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -73801,7 +74245,7 @@ pub enum RunScheduledInstancesError {
 }
 
 impl RunScheduledInstancesError {
-    pub fn from_body(body: &str) -> RunScheduledInstancesError {
+    pub fn from_body(body: &str, status: u16) -> RunScheduledInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -73809,7 +74253,9 @@ impl RunScheduledInstancesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => RunScheduledInstancesError::Unknown(String::from(body)),
             },
-            Err(_) => RunScheduledInstancesError::Unknown(body.to_string()),
+            Err(_) => {
+                RunScheduledInstancesError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -73875,7 +74321,7 @@ pub enum StartInstancesError {
 }
 
 impl StartInstancesError {
-    pub fn from_body(body: &str) -> StartInstancesError {
+    pub fn from_body(body: &str, status: u16) -> StartInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -73883,7 +74329,7 @@ impl StartInstancesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => StartInstancesError::Unknown(String::from(body)),
             },
-            Err(_) => StartInstancesError::Unknown(body.to_string()),
+            Err(_) => StartInstancesError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -73947,7 +74393,7 @@ pub enum StopInstancesError {
 }
 
 impl StopInstancesError {
-    pub fn from_body(body: &str) -> StopInstancesError {
+    pub fn from_body(body: &str, status: u16) -> StopInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -73955,7 +74401,7 @@ impl StopInstancesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => StopInstancesError::Unknown(String::from(body)),
             },
-            Err(_) => StopInstancesError::Unknown(body.to_string()),
+            Err(_) => StopInstancesError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -74019,7 +74465,7 @@ pub enum TerminateInstancesError {
 }
 
 impl TerminateInstancesError {
-    pub fn from_body(body: &str) -> TerminateInstancesError {
+    pub fn from_body(body: &str, status: u16) -> TerminateInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -74027,7 +74473,7 @@ impl TerminateInstancesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => TerminateInstancesError::Unknown(String::from(body)),
             },
-            Err(_) => TerminateInstancesError::Unknown(body.to_string()),
+            Err(_) => TerminateInstancesError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -74093,7 +74539,7 @@ pub enum UnassignIpv6AddressesError {
 }
 
 impl UnassignIpv6AddressesError {
-    pub fn from_body(body: &str) -> UnassignIpv6AddressesError {
+    pub fn from_body(body: &str, status: u16) -> UnassignIpv6AddressesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -74101,7 +74547,9 @@ impl UnassignIpv6AddressesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => UnassignIpv6AddressesError::Unknown(String::from(body)),
             },
-            Err(_) => UnassignIpv6AddressesError::Unknown(body.to_string()),
+            Err(_) => {
+                UnassignIpv6AddressesError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -74167,7 +74615,7 @@ pub enum UnassignPrivateIpAddressesError {
 }
 
 impl UnassignPrivateIpAddressesError {
-    pub fn from_body(body: &str) -> UnassignPrivateIpAddressesError {
+    pub fn from_body(body: &str, status: u16) -> UnassignPrivateIpAddressesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -74175,7 +74623,9 @@ impl UnassignPrivateIpAddressesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => UnassignPrivateIpAddressesError::Unknown(String::from(body)),
             },
-            Err(_) => UnassignPrivateIpAddressesError::Unknown(body.to_string()),
+            Err(_) => {
+                UnassignPrivateIpAddressesError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -74241,7 +74691,7 @@ pub enum UnmonitorInstancesError {
 }
 
 impl UnmonitorInstancesError {
-    pub fn from_body(body: &str) -> UnmonitorInstancesError {
+    pub fn from_body(body: &str, status: u16) -> UnmonitorInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -74249,7 +74699,7 @@ impl UnmonitorInstancesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => UnmonitorInstancesError::Unknown(String::from(body)),
             },
-            Err(_) => UnmonitorInstancesError::Unknown(body.to_string()),
+            Err(_) => UnmonitorInstancesError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -74315,7 +74765,7 @@ pub enum UpdateSecurityGroupRuleDescriptionsEgressError {
 }
 
 impl UpdateSecurityGroupRuleDescriptionsEgressError {
-    pub fn from_body(body: &str) -> UpdateSecurityGroupRuleDescriptionsEgressError {
+    pub fn from_body(body: &str, status: u16) -> UpdateSecurityGroupRuleDescriptionsEgressError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -74323,7 +74773,11 @@ impl UpdateSecurityGroupRuleDescriptionsEgressError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => UpdateSecurityGroupRuleDescriptionsEgressError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateSecurityGroupRuleDescriptionsEgressError::Unknown(body.to_string()),
+            Err(_) => UpdateSecurityGroupRuleDescriptionsEgressError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -74391,7 +74845,7 @@ pub enum UpdateSecurityGroupRuleDescriptionsIngressError {
 }
 
 impl UpdateSecurityGroupRuleDescriptionsIngressError {
-    pub fn from_body(body: &str) -> UpdateSecurityGroupRuleDescriptionsIngressError {
+    pub fn from_body(body: &str, status: u16) -> UpdateSecurityGroupRuleDescriptionsIngressError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -74399,7 +74853,11 @@ impl UpdateSecurityGroupRuleDescriptionsIngressError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => UpdateSecurityGroupRuleDescriptionsIngressError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateSecurityGroupRuleDescriptionsIngressError::Unknown(body.to_string()),
+            Err(_) => UpdateSecurityGroupRuleDescriptionsIngressError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 

--- a/rusoto/services/elasticache/src/generated.rs
+++ b/rusoto/services/elasticache/src/generated.rs
@@ -7996,7 +7996,7 @@ pub enum AddTagsToResourceError {
 }
 
 impl AddTagsToResourceError {
-    pub fn from_body(body: &str) -> AddTagsToResourceError {
+    pub fn from_body(body: &str, status: u16) -> AddTagsToResourceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -8018,7 +8018,7 @@ impl AddTagsToResourceError {
                 }
                 _ => AddTagsToResourceError::Unknown(String::from(body)),
             },
-            Err(_) => AddTagsToResourceError::Unknown(body.to_string()),
+            Err(_) => AddTagsToResourceError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -8097,7 +8097,7 @@ pub enum AuthorizeCacheSecurityGroupIngressError {
 }
 
 impl AuthorizeCacheSecurityGroupIngressError {
-    pub fn from_body(body: &str) -> AuthorizeCacheSecurityGroupIngressError {
+    pub fn from_body(body: &str, status: u16) -> AuthorizeCacheSecurityGroupIngressError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -8130,7 +8130,11 @@ impl AuthorizeCacheSecurityGroupIngressError {
                 }
                 _ => AuthorizeCacheSecurityGroupIngressError::Unknown(String::from(body)),
             },
-            Err(_) => AuthorizeCacheSecurityGroupIngressError::Unknown(body.to_string()),
+            Err(_) => AuthorizeCacheSecurityGroupIngressError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -8220,7 +8224,7 @@ pub enum CopySnapshotError {
 }
 
 impl CopySnapshotError {
-    pub fn from_body(body: &str) -> CopySnapshotError {
+    pub fn from_body(body: &str, status: u16) -> CopySnapshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -8246,7 +8250,7 @@ impl CopySnapshotError {
                 ),
                 _ => CopySnapshotError::Unknown(String::from(body)),
             },
-            Err(_) => CopySnapshotError::Unknown(body.to_string()),
+            Err(_) => CopySnapshotError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -8343,7 +8347,7 @@ pub enum CreateCacheClusterError {
 }
 
 impl CreateCacheClusterError {
-    pub fn from_body(body: &str) -> CreateCacheClusterError {
+    pub fn from_body(body: &str, status: u16) -> CreateCacheClusterError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -8419,7 +8423,7 @@ impl CreateCacheClusterError {
                 }
                 _ => CreateCacheClusterError::Unknown(String::from(body)),
             },
-            Err(_) => CreateCacheClusterError::Unknown(body.to_string()),
+            Err(_) => CreateCacheClusterError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -8508,7 +8512,7 @@ pub enum CreateCacheParameterGroupError {
 }
 
 impl CreateCacheParameterGroupError {
-    pub fn from_body(body: &str) -> CreateCacheParameterGroupError {
+    pub fn from_body(body: &str, status: u16) -> CreateCacheParameterGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -8539,7 +8543,9 @@ impl CreateCacheParameterGroupError {
                 ),
                 _ => CreateCacheParameterGroupError::Unknown(String::from(body)),
             },
-            Err(_) => CreateCacheParameterGroupError::Unknown(body.to_string()),
+            Err(_) => {
+                CreateCacheParameterGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -8623,7 +8629,7 @@ pub enum CreateCacheSecurityGroupError {
 }
 
 impl CreateCacheSecurityGroupError {
-    pub fn from_body(body: &str) -> CreateCacheSecurityGroupError {
+    pub fn from_body(body: &str, status: u16) -> CreateCacheSecurityGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -8649,7 +8655,9 @@ impl CreateCacheSecurityGroupError {
                 ),
                 _ => CreateCacheSecurityGroupError::Unknown(String::from(body)),
             },
-            Err(_) => CreateCacheSecurityGroupError::Unknown(body.to_string()),
+            Err(_) => {
+                CreateCacheSecurityGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -8726,7 +8734,7 @@ pub enum CreateCacheSubnetGroupError {
 }
 
 impl CreateCacheSubnetGroupError {
-    pub fn from_body(body: &str) -> CreateCacheSubnetGroupError {
+    pub fn from_body(body: &str, status: u16) -> CreateCacheSubnetGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -8752,7 +8760,9 @@ impl CreateCacheSubnetGroupError {
                 }
                 _ => CreateCacheSubnetGroupError::Unknown(String::from(body)),
             },
-            Err(_) => CreateCacheSubnetGroupError::Unknown(body.to_string()),
+            Err(_) => {
+                CreateCacheSubnetGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -8851,7 +8861,7 @@ pub enum CreateReplicationGroupError {
 }
 
 impl CreateReplicationGroupError {
-    pub fn from_body(body: &str) -> CreateReplicationGroupError {
+    pub fn from_body(body: &str, status: u16) -> CreateReplicationGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -8930,7 +8940,9 @@ impl CreateReplicationGroupError {
                 }
                 _ => CreateReplicationGroupError::Unknown(String::from(body)),
             },
-            Err(_) => CreateReplicationGroupError::Unknown(body.to_string()),
+            Err(_) => {
+                CreateReplicationGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -9030,7 +9042,7 @@ pub enum CreateSnapshotError {
 }
 
 impl CreateSnapshotError {
-    pub fn from_body(body: &str) -> CreateSnapshotError {
+    pub fn from_body(body: &str, status: u16) -> CreateSnapshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -9071,7 +9083,7 @@ impl CreateSnapshotError {
                 ),
                 _ => CreateSnapshotError::Unknown(String::from(body)),
             },
-            Err(_) => CreateSnapshotError::Unknown(body.to_string()),
+            Err(_) => CreateSnapshotError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -9157,7 +9169,7 @@ pub enum DeleteCacheClusterError {
 }
 
 impl DeleteCacheClusterError {
-    pub fn from_body(body: &str) -> DeleteCacheClusterError {
+    pub fn from_body(body: &str, status: u16) -> DeleteCacheClusterError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -9196,7 +9208,7 @@ impl DeleteCacheClusterError {
                 }
                 _ => DeleteCacheClusterError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteCacheClusterError::Unknown(body.to_string()),
+            Err(_) => DeleteCacheClusterError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -9276,7 +9288,7 @@ pub enum DeleteCacheParameterGroupError {
 }
 
 impl DeleteCacheParameterGroupError {
-    pub fn from_body(body: &str) -> DeleteCacheParameterGroupError {
+    pub fn from_body(body: &str, status: u16) -> DeleteCacheParameterGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -9302,7 +9314,9 @@ impl DeleteCacheParameterGroupError {
                 ),
                 _ => DeleteCacheParameterGroupError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteCacheParameterGroupError::Unknown(body.to_string()),
+            Err(_) => {
+                DeleteCacheParameterGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -9381,7 +9395,7 @@ pub enum DeleteCacheSecurityGroupError {
 }
 
 impl DeleteCacheSecurityGroupError {
-    pub fn from_body(body: &str) -> DeleteCacheSecurityGroupError {
+    pub fn from_body(body: &str, status: u16) -> DeleteCacheSecurityGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -9407,7 +9421,9 @@ impl DeleteCacheSecurityGroupError {
                 ),
                 _ => DeleteCacheSecurityGroupError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteCacheSecurityGroupError::Unknown(body.to_string()),
+            Err(_) => {
+                DeleteCacheSecurityGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -9480,7 +9496,7 @@ pub enum DeleteCacheSubnetGroupError {
 }
 
 impl DeleteCacheSubnetGroupError {
-    pub fn from_body(body: &str) -> DeleteCacheSubnetGroupError {
+    pub fn from_body(body: &str, status: u16) -> DeleteCacheSubnetGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -9496,7 +9512,9 @@ impl DeleteCacheSubnetGroupError {
                 }
                 _ => DeleteCacheSubnetGroupError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteCacheSubnetGroupError::Unknown(body.to_string()),
+            Err(_) => {
+                DeleteCacheSubnetGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -9577,7 +9595,7 @@ pub enum DeleteReplicationGroupError {
 }
 
 impl DeleteReplicationGroupError {
-    pub fn from_body(body: &str) -> DeleteReplicationGroupError {
+    pub fn from_body(body: &str, status: u16) -> DeleteReplicationGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -9618,7 +9636,9 @@ impl DeleteReplicationGroupError {
                 }
                 _ => DeleteReplicationGroupError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteReplicationGroupError::Unknown(body.to_string()),
+            Err(_) => {
+                DeleteReplicationGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -9698,7 +9718,7 @@ pub enum DeleteSnapshotError {
 }
 
 impl DeleteSnapshotError {
-    pub fn from_body(body: &str) -> DeleteSnapshotError {
+    pub fn from_body(body: &str, status: u16) -> DeleteSnapshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -9718,7 +9738,7 @@ impl DeleteSnapshotError {
                 }
                 _ => DeleteSnapshotError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteSnapshotError::Unknown(body.to_string()),
+            Err(_) => DeleteSnapshotError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -9791,7 +9811,7 @@ pub enum DescribeCacheClustersError {
 }
 
 impl DescribeCacheClustersError {
-    pub fn from_body(body: &str) -> DescribeCacheClustersError {
+    pub fn from_body(body: &str, status: u16) -> DescribeCacheClustersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -9810,7 +9830,9 @@ impl DescribeCacheClustersError {
                 ),
                 _ => DescribeCacheClustersError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeCacheClustersError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeCacheClustersError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -9878,7 +9900,7 @@ pub enum DescribeCacheEngineVersionsError {
 }
 
 impl DescribeCacheEngineVersionsError {
-    pub fn from_body(body: &str) -> DescribeCacheEngineVersionsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeCacheEngineVersionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -9886,7 +9908,11 @@ impl DescribeCacheEngineVersionsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeCacheEngineVersionsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeCacheEngineVersionsError::Unknown(body.to_string()),
+            Err(_) => DescribeCacheEngineVersionsError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -9957,7 +9983,7 @@ pub enum DescribeCacheParameterGroupsError {
 }
 
 impl DescribeCacheParameterGroupsError {
-    pub fn from_body(body: &str) -> DescribeCacheParameterGroupsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeCacheParameterGroupsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -9980,7 +10006,11 @@ impl DescribeCacheParameterGroupsError {
                 }
                 _ => DescribeCacheParameterGroupsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeCacheParameterGroupsError::Unknown(body.to_string()),
+            Err(_) => DescribeCacheParameterGroupsError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -10054,7 +10084,7 @@ pub enum DescribeCacheParametersError {
 }
 
 impl DescribeCacheParametersError {
-    pub fn from_body(body: &str) -> DescribeCacheParametersError {
+    pub fn from_body(body: &str, status: u16) -> DescribeCacheParametersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10075,7 +10105,9 @@ impl DescribeCacheParametersError {
                 ),
                 _ => DescribeCacheParametersError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeCacheParametersError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeCacheParametersError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -10149,7 +10181,7 @@ pub enum DescribeCacheSecurityGroupsError {
 }
 
 impl DescribeCacheSecurityGroupsError {
-    pub fn from_body(body: &str) -> DescribeCacheSecurityGroupsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeCacheSecurityGroupsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10170,7 +10202,11 @@ impl DescribeCacheSecurityGroupsError {
                 ),
                 _ => DescribeCacheSecurityGroupsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeCacheSecurityGroupsError::Unknown(body.to_string()),
+            Err(_) => DescribeCacheSecurityGroupsError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -10240,7 +10276,7 @@ pub enum DescribeCacheSubnetGroupsError {
 }
 
 impl DescribeCacheSubnetGroupsError {
-    pub fn from_body(body: &str) -> DescribeCacheSubnetGroupsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeCacheSubnetGroupsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10253,7 +10289,9 @@ impl DescribeCacheSubnetGroupsError {
                 }
                 _ => DescribeCacheSubnetGroupsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeCacheSubnetGroupsError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeCacheSubnetGroupsError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -10323,7 +10361,7 @@ pub enum DescribeEngineDefaultParametersError {
 }
 
 impl DescribeEngineDefaultParametersError {
-    pub fn from_body(body: &str) -> DescribeEngineDefaultParametersError {
+    pub fn from_body(body: &str, status: u16) -> DescribeEngineDefaultParametersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10341,7 +10379,11 @@ impl DescribeEngineDefaultParametersError {
                 }
                 _ => DescribeEngineDefaultParametersError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeEngineDefaultParametersError::Unknown(body.to_string()),
+            Err(_) => DescribeEngineDefaultParametersError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -10412,7 +10454,7 @@ pub enum DescribeEventsError {
 }
 
 impl DescribeEventsError {
-    pub fn from_body(body: &str) -> DescribeEventsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeEventsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10426,7 +10468,7 @@ impl DescribeEventsError {
                 }
                 _ => DescribeEventsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeEventsError::Unknown(body.to_string()),
+            Err(_) => DescribeEventsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -10497,7 +10539,7 @@ pub enum DescribeReplicationGroupsError {
 }
 
 impl DescribeReplicationGroupsError {
-    pub fn from_body(body: &str) -> DescribeReplicationGroupsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeReplicationGroupsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10518,7 +10560,9 @@ impl DescribeReplicationGroupsError {
                 }
                 _ => DescribeReplicationGroupsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeReplicationGroupsError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeReplicationGroupsError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -10592,7 +10636,7 @@ pub enum DescribeReservedCacheNodesError {
 }
 
 impl DescribeReservedCacheNodesError {
-    pub fn from_body(body: &str) -> DescribeReservedCacheNodesError {
+    pub fn from_body(body: &str, status: u16) -> DescribeReservedCacheNodesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10613,7 +10657,9 @@ impl DescribeReservedCacheNodesError {
                 }
                 _ => DescribeReservedCacheNodesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeReservedCacheNodesError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeReservedCacheNodesError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -10687,7 +10733,7 @@ pub enum DescribeReservedCacheNodesOfferingsError {
 }
 
 impl DescribeReservedCacheNodesOfferingsError {
-    pub fn from_body(body: &str) -> DescribeReservedCacheNodesOfferingsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeReservedCacheNodesOfferingsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10697,7 +10743,7 @@ impl DescribeReservedCacheNodesOfferingsError {
                                     "InvalidParameterCombination" => DescribeReservedCacheNodesOfferingsError::InvalidParameterCombination(String::from(parsed_error.message)),"InvalidParameterValue" => DescribeReservedCacheNodesOfferingsError::InvalidParameterValue(String::from(parsed_error.message)),"ReservedCacheNodesOfferingNotFound" => DescribeReservedCacheNodesOfferingsError::ReservedCacheNodesOfferingNotFoundFault(String::from(parsed_error.message)),_ => DescribeReservedCacheNodesOfferingsError::Unknown(String::from(body))
                                 }
                            },
-                           Err(_) => DescribeReservedCacheNodesOfferingsError::Unknown(body.to_string())
+                           Err(_) => DescribeReservedCacheNodesOfferingsError::Unknown(format!("{}:{}", body.to_string(), status))
                        }
     }
 
@@ -10777,7 +10823,7 @@ pub enum DescribeSnapshotsError {
 }
 
 impl DescribeSnapshotsError {
-    pub fn from_body(body: &str) -> DescribeSnapshotsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeSnapshotsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10799,7 +10845,7 @@ impl DescribeSnapshotsError {
                 ),
                 _ => DescribeSnapshotsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeSnapshotsError::Unknown(body.to_string()),
+            Err(_) => DescribeSnapshotsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -10876,7 +10922,7 @@ pub enum ListAllowedNodeTypeModificationsError {
 }
 
 impl ListAllowedNodeTypeModificationsError {
-    pub fn from_body(body: &str) -> ListAllowedNodeTypeModificationsError {
+    pub fn from_body(body: &str, status: u16) -> ListAllowedNodeTypeModificationsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10904,7 +10950,11 @@ impl ListAllowedNodeTypeModificationsError {
                 }
                 _ => ListAllowedNodeTypeModificationsError::Unknown(String::from(body)),
             },
-            Err(_) => ListAllowedNodeTypeModificationsError::Unknown(body.to_string()),
+            Err(_) => ListAllowedNodeTypeModificationsError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -10981,7 +11031,7 @@ pub enum ListTagsForResourceError {
 }
 
 impl ListTagsForResourceError {
-    pub fn from_body(body: &str) -> ListTagsForResourceError {
+    pub fn from_body(body: &str, status: u16) -> ListTagsForResourceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10998,7 +11048,7 @@ impl ListTagsForResourceError {
                 ),
                 _ => ListTagsForResourceError::Unknown(String::from(body)),
             },
-            Err(_) => ListTagsForResourceError::Unknown(body.to_string()),
+            Err(_) => ListTagsForResourceError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -11088,7 +11138,7 @@ pub enum ModifyCacheClusterError {
 }
 
 impl ModifyCacheClusterError {
-    pub fn from_body(body: &str) -> ModifyCacheClusterError {
+    pub fn from_body(body: &str, status: u16) -> ModifyCacheClusterError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11147,7 +11197,7 @@ impl ModifyCacheClusterError {
                 }
                 _ => ModifyCacheClusterError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyCacheClusterError::Unknown(body.to_string()),
+            Err(_) => ModifyCacheClusterError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -11231,7 +11281,7 @@ pub enum ModifyCacheParameterGroupError {
 }
 
 impl ModifyCacheParameterGroupError {
-    pub fn from_body(body: &str) -> ModifyCacheParameterGroupError {
+    pub fn from_body(body: &str, status: u16) -> ModifyCacheParameterGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11257,7 +11307,9 @@ impl ModifyCacheParameterGroupError {
                 ),
                 _ => ModifyCacheParameterGroupError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyCacheParameterGroupError::Unknown(body.to_string()),
+            Err(_) => {
+                ModifyCacheParameterGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -11336,7 +11388,7 @@ pub enum ModifyCacheSubnetGroupError {
 }
 
 impl ModifyCacheSubnetGroupError {
-    pub fn from_body(body: &str) -> ModifyCacheSubnetGroupError {
+    pub fn from_body(body: &str, status: u16) -> ModifyCacheSubnetGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11360,7 +11412,9 @@ impl ModifyCacheSubnetGroupError {
                 }
                 _ => ModifyCacheSubnetGroupError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyCacheSubnetGroupError::Unknown(body.to_string()),
+            Err(_) => {
+                ModifyCacheSubnetGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -11455,7 +11509,7 @@ pub enum ModifyReplicationGroupError {
 }
 
 impl ModifyReplicationGroupError {
-    pub fn from_body(body: &str) -> ModifyReplicationGroupError {
+    pub fn from_body(body: &str, status: u16) -> ModifyReplicationGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11524,7 +11578,9 @@ impl ModifyReplicationGroupError {
                 }
                 _ => ModifyReplicationGroupError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyReplicationGroupError::Unknown(body.to_string()),
+            Err(_) => {
+                ModifyReplicationGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -11620,7 +11676,7 @@ pub enum ModifyReplicationGroupShardConfigurationError {
 }
 
 impl ModifyReplicationGroupShardConfigurationError {
-    pub fn from_body(body: &str) -> ModifyReplicationGroupShardConfigurationError {
+    pub fn from_body(body: &str, status: u16) -> ModifyReplicationGroupShardConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11630,7 +11686,7 @@ impl ModifyReplicationGroupShardConfigurationError {
                                     "InsufficientCacheClusterCapacity" => ModifyReplicationGroupShardConfigurationError::InsufficientCacheClusterCapacityFault(String::from(parsed_error.message)),"InvalidCacheClusterState" => ModifyReplicationGroupShardConfigurationError::InvalidCacheClusterStateFault(String::from(parsed_error.message)),"InvalidParameterCombination" => ModifyReplicationGroupShardConfigurationError::InvalidParameterCombination(String::from(parsed_error.message)),"InvalidParameterValue" => ModifyReplicationGroupShardConfigurationError::InvalidParameterValue(String::from(parsed_error.message)),"InvalidReplicationGroupState" => ModifyReplicationGroupShardConfigurationError::InvalidReplicationGroupStateFault(String::from(parsed_error.message)),"InvalidVPCNetworkStateFault" => ModifyReplicationGroupShardConfigurationError::InvalidVPCNetworkStateFault(String::from(parsed_error.message)),"NodeGroupsPerReplicationGroupQuotaExceeded" => ModifyReplicationGroupShardConfigurationError::NodeGroupsPerReplicationGroupQuotaExceededFault(String::from(parsed_error.message)),"NodeQuotaForCustomerExceeded" => ModifyReplicationGroupShardConfigurationError::NodeQuotaForCustomerExceededFault(String::from(parsed_error.message)),"ReplicationGroupNotFoundFault" => ModifyReplicationGroupShardConfigurationError::ReplicationGroupNotFoundFault(String::from(parsed_error.message)),_ => ModifyReplicationGroupShardConfigurationError::Unknown(String::from(body))
                                 }
                            },
-                           Err(_) => ModifyReplicationGroupShardConfigurationError::Unknown(body.to_string())
+                           Err(_) => ModifyReplicationGroupShardConfigurationError::Unknown(format!("{}:{}", body.to_string(), status))
                        }
     }
 
@@ -11712,7 +11768,7 @@ pub enum PurchaseReservedCacheNodesOfferingError {
 }
 
 impl PurchaseReservedCacheNodesOfferingError {
-    pub fn from_body(body: &str) -> PurchaseReservedCacheNodesOfferingError {
+    pub fn from_body(body: &str, status: u16) -> PurchaseReservedCacheNodesOfferingError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11745,7 +11801,11 @@ impl PurchaseReservedCacheNodesOfferingError {
                 }
                 _ => PurchaseReservedCacheNodesOfferingError::Unknown(String::from(body)),
             },
-            Err(_) => PurchaseReservedCacheNodesOfferingError::Unknown(body.to_string()),
+            Err(_) => PurchaseReservedCacheNodesOfferingError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -11827,7 +11887,7 @@ pub enum RebootCacheClusterError {
 }
 
 impl RebootCacheClusterError {
-    pub fn from_body(body: &str) -> RebootCacheClusterError {
+    pub fn from_body(body: &str, status: u16) -> RebootCacheClusterError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11843,7 +11903,7 @@ impl RebootCacheClusterError {
                 }
                 _ => RebootCacheClusterError::Unknown(String::from(body)),
             },
-            Err(_) => RebootCacheClusterError::Unknown(body.to_string()),
+            Err(_) => RebootCacheClusterError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -11918,7 +11978,7 @@ pub enum RemoveTagsFromResourceError {
 }
 
 impl RemoveTagsFromResourceError {
-    pub fn from_body(body: &str) -> RemoveTagsFromResourceError {
+    pub fn from_body(body: &str, status: u16) -> RemoveTagsFromResourceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11938,7 +11998,9 @@ impl RemoveTagsFromResourceError {
                 )),
                 _ => RemoveTagsFromResourceError::Unknown(String::from(body)),
             },
-            Err(_) => RemoveTagsFromResourceError::Unknown(body.to_string()),
+            Err(_) => {
+                RemoveTagsFromResourceError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -12015,7 +12077,7 @@ pub enum ResetCacheParameterGroupError {
 }
 
 impl ResetCacheParameterGroupError {
-    pub fn from_body(body: &str) -> ResetCacheParameterGroupError {
+    pub fn from_body(body: &str, status: u16) -> ResetCacheParameterGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -12041,7 +12103,9 @@ impl ResetCacheParameterGroupError {
                 ),
                 _ => ResetCacheParameterGroupError::Unknown(String::from(body)),
             },
-            Err(_) => ResetCacheParameterGroupError::Unknown(body.to_string()),
+            Err(_) => {
+                ResetCacheParameterGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -12120,7 +12184,7 @@ pub enum RevokeCacheSecurityGroupIngressError {
 }
 
 impl RevokeCacheSecurityGroupIngressError {
-    pub fn from_body(body: &str) -> RevokeCacheSecurityGroupIngressError {
+    pub fn from_body(body: &str, status: u16) -> RevokeCacheSecurityGroupIngressError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -12153,7 +12217,11 @@ impl RevokeCacheSecurityGroupIngressError {
                 }
                 _ => RevokeCacheSecurityGroupIngressError::Unknown(String::from(body)),
             },
-            Err(_) => RevokeCacheSecurityGroupIngressError::Unknown(body.to_string()),
+            Err(_) => RevokeCacheSecurityGroupIngressError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -12243,7 +12311,7 @@ pub enum TestFailoverError {
 }
 
 impl TestFailoverError {
-    pub fn from_body(body: &str) -> TestFailoverError {
+    pub fn from_body(body: &str, status: u16) -> TestFailoverError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -12283,7 +12351,7 @@ impl TestFailoverError {
                 }
                 _ => TestFailoverError::Unknown(String::from(body)),
             },
-            Err(_) => TestFailoverError::Unknown(body.to_string()),
+            Err(_) => TestFailoverError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 

--- a/rusoto/services/elasticache/src/generated.rs
+++ b/rusoto/services/elasticache/src/generated.rs
@@ -8018,7 +8018,13 @@ impl AddTagsToResourceError {
                 }
                 _ => AddTagsToResourceError::Unknown(String::from(body)),
             },
-            Err(_) => AddTagsToResourceError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    AddTagsToResourceError::Unknown(format!("{}", status))
+                } else {
+                    AddTagsToResourceError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -8130,11 +8136,17 @@ impl AuthorizeCacheSecurityGroupIngressError {
                 }
                 _ => AuthorizeCacheSecurityGroupIngressError::Unknown(String::from(body)),
             },
-            Err(_) => AuthorizeCacheSecurityGroupIngressError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    AuthorizeCacheSecurityGroupIngressError::Unknown(format!("{}", status))
+                } else {
+                    AuthorizeCacheSecurityGroupIngressError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -8250,7 +8262,13 @@ impl CopySnapshotError {
                 ),
                 _ => CopySnapshotError::Unknown(String::from(body)),
             },
-            Err(_) => CopySnapshotError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CopySnapshotError::Unknown(format!("{}", status))
+                } else {
+                    CopySnapshotError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -8423,7 +8441,13 @@ impl CreateCacheClusterError {
                 }
                 _ => CreateCacheClusterError::Unknown(String::from(body)),
             },
-            Err(_) => CreateCacheClusterError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateCacheClusterError::Unknown(format!("{}", status))
+                } else {
+                    CreateCacheClusterError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -8544,7 +8568,15 @@ impl CreateCacheParameterGroupError {
                 _ => CreateCacheParameterGroupError::Unknown(String::from(body)),
             },
             Err(_) => {
-                CreateCacheParameterGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    CreateCacheParameterGroupError::Unknown(format!("{}", status))
+                } else {
+                    CreateCacheParameterGroupError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -8656,7 +8688,15 @@ impl CreateCacheSecurityGroupError {
                 _ => CreateCacheSecurityGroupError::Unknown(String::from(body)),
             },
             Err(_) => {
-                CreateCacheSecurityGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    CreateCacheSecurityGroupError::Unknown(format!("{}", status))
+                } else {
+                    CreateCacheSecurityGroupError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -8761,7 +8801,11 @@ impl CreateCacheSubnetGroupError {
                 _ => CreateCacheSubnetGroupError::Unknown(String::from(body)),
             },
             Err(_) => {
-                CreateCacheSubnetGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    CreateCacheSubnetGroupError::Unknown(format!("{}", status))
+                } else {
+                    CreateCacheSubnetGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -8941,7 +8985,11 @@ impl CreateReplicationGroupError {
                 _ => CreateReplicationGroupError::Unknown(String::from(body)),
             },
             Err(_) => {
-                CreateReplicationGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    CreateReplicationGroupError::Unknown(format!("{}", status))
+                } else {
+                    CreateReplicationGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -9083,7 +9131,13 @@ impl CreateSnapshotError {
                 ),
                 _ => CreateSnapshotError::Unknown(String::from(body)),
             },
-            Err(_) => CreateSnapshotError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateSnapshotError::Unknown(format!("{}", status))
+                } else {
+                    CreateSnapshotError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -9208,7 +9262,13 @@ impl DeleteCacheClusterError {
                 }
                 _ => DeleteCacheClusterError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteCacheClusterError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteCacheClusterError::Unknown(format!("{}", status))
+                } else {
+                    DeleteCacheClusterError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -9315,7 +9375,15 @@ impl DeleteCacheParameterGroupError {
                 _ => DeleteCacheParameterGroupError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DeleteCacheParameterGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DeleteCacheParameterGroupError::Unknown(format!("{}", status))
+                } else {
+                    DeleteCacheParameterGroupError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -9422,7 +9490,15 @@ impl DeleteCacheSecurityGroupError {
                 _ => DeleteCacheSecurityGroupError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DeleteCacheSecurityGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DeleteCacheSecurityGroupError::Unknown(format!("{}", status))
+                } else {
+                    DeleteCacheSecurityGroupError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -9513,7 +9589,11 @@ impl DeleteCacheSubnetGroupError {
                 _ => DeleteCacheSubnetGroupError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DeleteCacheSubnetGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DeleteCacheSubnetGroupError::Unknown(format!("{}", status))
+                } else {
+                    DeleteCacheSubnetGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -9637,7 +9717,11 @@ impl DeleteReplicationGroupError {
                 _ => DeleteReplicationGroupError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DeleteReplicationGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DeleteReplicationGroupError::Unknown(format!("{}", status))
+                } else {
+                    DeleteReplicationGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -9738,7 +9822,13 @@ impl DeleteSnapshotError {
                 }
                 _ => DeleteSnapshotError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteSnapshotError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteSnapshotError::Unknown(format!("{}", status))
+                } else {
+                    DeleteSnapshotError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -9831,7 +9921,11 @@ impl DescribeCacheClustersError {
                 _ => DescribeCacheClustersError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeCacheClustersError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeCacheClustersError::Unknown(format!("{}", status))
+                } else {
+                    DescribeCacheClustersError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -9908,11 +10002,17 @@ impl DescribeCacheEngineVersionsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeCacheEngineVersionsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeCacheEngineVersionsError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeCacheEngineVersionsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeCacheEngineVersionsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -10006,11 +10106,17 @@ impl DescribeCacheParameterGroupsError {
                 }
                 _ => DescribeCacheParameterGroupsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeCacheParameterGroupsError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeCacheParameterGroupsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeCacheParameterGroupsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -10106,7 +10212,15 @@ impl DescribeCacheParametersError {
                 _ => DescribeCacheParametersError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeCacheParametersError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeCacheParametersError::Unknown(format!("{}", status))
+                } else {
+                    DescribeCacheParametersError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -10202,11 +10316,17 @@ impl DescribeCacheSecurityGroupsError {
                 ),
                 _ => DescribeCacheSecurityGroupsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeCacheSecurityGroupsError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeCacheSecurityGroupsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeCacheSecurityGroupsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -10290,7 +10410,15 @@ impl DescribeCacheSubnetGroupsError {
                 _ => DescribeCacheSubnetGroupsError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeCacheSubnetGroupsError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeCacheSubnetGroupsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeCacheSubnetGroupsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -10379,11 +10507,17 @@ impl DescribeEngineDefaultParametersError {
                 }
                 _ => DescribeEngineDefaultParametersError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeEngineDefaultParametersError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeEngineDefaultParametersError::Unknown(format!("{}", status))
+                } else {
+                    DescribeEngineDefaultParametersError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -10468,7 +10602,13 @@ impl DescribeEventsError {
                 }
                 _ => DescribeEventsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeEventsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeEventsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeEventsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -10561,7 +10701,15 @@ impl DescribeReplicationGroupsError {
                 _ => DescribeReplicationGroupsError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeReplicationGroupsError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeReplicationGroupsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeReplicationGroupsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -10658,7 +10806,15 @@ impl DescribeReservedCacheNodesError {
                 _ => DescribeReservedCacheNodesError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeReservedCacheNodesError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeReservedCacheNodesError::Unknown(format!("{}", status))
+                } else {
+                    DescribeReservedCacheNodesError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -10743,7 +10899,13 @@ impl DescribeReservedCacheNodesOfferingsError {
                                     "InvalidParameterCombination" => DescribeReservedCacheNodesOfferingsError::InvalidParameterCombination(String::from(parsed_error.message)),"InvalidParameterValue" => DescribeReservedCacheNodesOfferingsError::InvalidParameterValue(String::from(parsed_error.message)),"ReservedCacheNodesOfferingNotFound" => DescribeReservedCacheNodesOfferingsError::ReservedCacheNodesOfferingNotFoundFault(String::from(parsed_error.message)),_ => DescribeReservedCacheNodesOfferingsError::Unknown(String::from(body))
                                 }
                            },
-                           Err(_) => DescribeReservedCacheNodesOfferingsError::Unknown(format!("{}:{}", body.to_string(), status))
+                           Err(_) => {
+                               if body.len() == 0 {
+                                   DescribeReservedCacheNodesOfferingsError::Unknown(format!("{}", status))
+                               } else {
+                                   DescribeReservedCacheNodesOfferingsError::Unknown(format!("{}:{}", body.to_string(), status))
+                               }
+                            }
                        }
     }
 
@@ -10845,7 +11007,13 @@ impl DescribeSnapshotsError {
                 ),
                 _ => DescribeSnapshotsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeSnapshotsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeSnapshotsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeSnapshotsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -10950,11 +11118,17 @@ impl ListAllowedNodeTypeModificationsError {
                 }
                 _ => ListAllowedNodeTypeModificationsError::Unknown(String::from(body)),
             },
-            Err(_) => ListAllowedNodeTypeModificationsError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    ListAllowedNodeTypeModificationsError::Unknown(format!("{}", status))
+                } else {
+                    ListAllowedNodeTypeModificationsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -11048,7 +11222,13 @@ impl ListTagsForResourceError {
                 ),
                 _ => ListTagsForResourceError::Unknown(String::from(body)),
             },
-            Err(_) => ListTagsForResourceError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ListTagsForResourceError::Unknown(format!("{}", status))
+                } else {
+                    ListTagsForResourceError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -11197,7 +11377,13 @@ impl ModifyCacheClusterError {
                 }
                 _ => ModifyCacheClusterError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyCacheClusterError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ModifyCacheClusterError::Unknown(format!("{}", status))
+                } else {
+                    ModifyCacheClusterError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -11308,7 +11494,15 @@ impl ModifyCacheParameterGroupError {
                 _ => ModifyCacheParameterGroupError::Unknown(String::from(body)),
             },
             Err(_) => {
-                ModifyCacheParameterGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    ModifyCacheParameterGroupError::Unknown(format!("{}", status))
+                } else {
+                    ModifyCacheParameterGroupError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -11413,7 +11607,11 @@ impl ModifyCacheSubnetGroupError {
                 _ => ModifyCacheSubnetGroupError::Unknown(String::from(body)),
             },
             Err(_) => {
-                ModifyCacheSubnetGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    ModifyCacheSubnetGroupError::Unknown(format!("{}", status))
+                } else {
+                    ModifyCacheSubnetGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -11579,7 +11777,11 @@ impl ModifyReplicationGroupError {
                 _ => ModifyReplicationGroupError::Unknown(String::from(body)),
             },
             Err(_) => {
-                ModifyReplicationGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    ModifyReplicationGroupError::Unknown(format!("{}", status))
+                } else {
+                    ModifyReplicationGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -11686,7 +11888,13 @@ impl ModifyReplicationGroupShardConfigurationError {
                                     "InsufficientCacheClusterCapacity" => ModifyReplicationGroupShardConfigurationError::InsufficientCacheClusterCapacityFault(String::from(parsed_error.message)),"InvalidCacheClusterState" => ModifyReplicationGroupShardConfigurationError::InvalidCacheClusterStateFault(String::from(parsed_error.message)),"InvalidParameterCombination" => ModifyReplicationGroupShardConfigurationError::InvalidParameterCombination(String::from(parsed_error.message)),"InvalidParameterValue" => ModifyReplicationGroupShardConfigurationError::InvalidParameterValue(String::from(parsed_error.message)),"InvalidReplicationGroupState" => ModifyReplicationGroupShardConfigurationError::InvalidReplicationGroupStateFault(String::from(parsed_error.message)),"InvalidVPCNetworkStateFault" => ModifyReplicationGroupShardConfigurationError::InvalidVPCNetworkStateFault(String::from(parsed_error.message)),"NodeGroupsPerReplicationGroupQuotaExceeded" => ModifyReplicationGroupShardConfigurationError::NodeGroupsPerReplicationGroupQuotaExceededFault(String::from(parsed_error.message)),"NodeQuotaForCustomerExceeded" => ModifyReplicationGroupShardConfigurationError::NodeQuotaForCustomerExceededFault(String::from(parsed_error.message)),"ReplicationGroupNotFoundFault" => ModifyReplicationGroupShardConfigurationError::ReplicationGroupNotFoundFault(String::from(parsed_error.message)),_ => ModifyReplicationGroupShardConfigurationError::Unknown(String::from(body))
                                 }
                            },
-                           Err(_) => ModifyReplicationGroupShardConfigurationError::Unknown(format!("{}:{}", body.to_string(), status))
+                           Err(_) => {
+                               if body.len() == 0 {
+                                   ModifyReplicationGroupShardConfigurationError::Unknown(format!("{}", status))
+                               } else {
+                                   ModifyReplicationGroupShardConfigurationError::Unknown(format!("{}:{}", body.to_string(), status))
+                               }
+                            }
                        }
     }
 
@@ -11801,11 +12009,17 @@ impl PurchaseReservedCacheNodesOfferingError {
                 }
                 _ => PurchaseReservedCacheNodesOfferingError::Unknown(String::from(body)),
             },
-            Err(_) => PurchaseReservedCacheNodesOfferingError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    PurchaseReservedCacheNodesOfferingError::Unknown(format!("{}", status))
+                } else {
+                    PurchaseReservedCacheNodesOfferingError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -11903,7 +12117,13 @@ impl RebootCacheClusterError {
                 }
                 _ => RebootCacheClusterError::Unknown(String::from(body)),
             },
-            Err(_) => RebootCacheClusterError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    RebootCacheClusterError::Unknown(format!("{}", status))
+                } else {
+                    RebootCacheClusterError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -11999,7 +12219,11 @@ impl RemoveTagsFromResourceError {
                 _ => RemoveTagsFromResourceError::Unknown(String::from(body)),
             },
             Err(_) => {
-                RemoveTagsFromResourceError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    RemoveTagsFromResourceError::Unknown(format!("{}", status))
+                } else {
+                    RemoveTagsFromResourceError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -12104,7 +12328,15 @@ impl ResetCacheParameterGroupError {
                 _ => ResetCacheParameterGroupError::Unknown(String::from(body)),
             },
             Err(_) => {
-                ResetCacheParameterGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    ResetCacheParameterGroupError::Unknown(format!("{}", status))
+                } else {
+                    ResetCacheParameterGroupError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -12217,11 +12449,17 @@ impl RevokeCacheSecurityGroupIngressError {
                 }
                 _ => RevokeCacheSecurityGroupIngressError::Unknown(String::from(body)),
             },
-            Err(_) => RevokeCacheSecurityGroupIngressError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    RevokeCacheSecurityGroupIngressError::Unknown(format!("{}", status))
+                } else {
+                    RevokeCacheSecurityGroupIngressError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -12351,7 +12589,13 @@ impl TestFailoverError {
                 }
                 _ => TestFailoverError::Unknown(String::from(body)),
             },
-            Err(_) => TestFailoverError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    TestFailoverError::Unknown(format!("{}", status))
+                } else {
+                    TestFailoverError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 

--- a/rusoto/services/elasticbeanstalk/src/generated.rs
+++ b/rusoto/services/elasticbeanstalk/src/generated.rs
@@ -9993,7 +9993,11 @@ impl AbortEnvironmentUpdateError {
                 _ => AbortEnvironmentUpdateError::Unknown(String::from(body)),
             },
             Err(_) => {
-                AbortEnvironmentUpdateError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    AbortEnvironmentUpdateError::Unknown(format!("{}", status))
+                } else {
+                    AbortEnvironmentUpdateError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -10082,11 +10086,17 @@ impl ApplyEnvironmentManagedActionError {
                 }
                 _ => ApplyEnvironmentManagedActionError::Unknown(String::from(body)),
             },
-            Err(_) => ApplyEnvironmentManagedActionError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    ApplyEnvironmentManagedActionError::Unknown(format!("{}", status))
+                } else {
+                    ApplyEnvironmentManagedActionError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -10162,7 +10172,11 @@ impl CheckDNSAvailabilityError {
                 _ => CheckDNSAvailabilityError::Unknown(String::from(body)),
             },
             Err(_) => {
-                CheckDNSAvailabilityError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    CheckDNSAvailabilityError::Unknown(format!("{}", status))
+                } else {
+                    CheckDNSAvailabilityError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -10248,7 +10262,13 @@ impl ComposeEnvironmentsError {
                 ),
                 _ => ComposeEnvironmentsError::Unknown(String::from(body)),
             },
-            Err(_) => ComposeEnvironmentsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ComposeEnvironmentsError::Unknown(format!("{}", status))
+                } else {
+                    ComposeEnvironmentsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -10328,7 +10348,13 @@ impl CreateApplicationError {
                 }
                 _ => CreateApplicationError::Unknown(String::from(body)),
             },
-            Err(_) => CreateApplicationError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateApplicationError::Unknown(format!("{}", status))
+                } else {
+                    CreateApplicationError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -10438,7 +10464,15 @@ impl CreateApplicationVersionError {
                 _ => CreateApplicationVersionError::Unknown(String::from(body)),
             },
             Err(_) => {
-                CreateApplicationVersionError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    CreateApplicationVersionError::Unknown(format!("{}", status))
+                } else {
+                    CreateApplicationVersionError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -10536,11 +10570,17 @@ impl CreateConfigurationTemplateError {
                 }
                 _ => CreateConfigurationTemplateError::Unknown(String::from(body)),
             },
-            Err(_) => CreateConfigurationTemplateError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateConfigurationTemplateError::Unknown(format!("{}", status))
+                } else {
+                    CreateConfigurationTemplateError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -10628,7 +10668,13 @@ impl CreateEnvironmentError {
                 }
                 _ => CreateEnvironmentError::Unknown(String::from(body)),
             },
-            Err(_) => CreateEnvironmentError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateEnvironmentError::Unknown(format!("{}", status))
+                } else {
+                    CreateEnvironmentError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -10723,7 +10769,11 @@ impl CreatePlatformVersionError {
                 _ => CreatePlatformVersionError::Unknown(String::from(body)),
             },
             Err(_) => {
-                CreatePlatformVersionError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    CreatePlatformVersionError::Unknown(format!("{}", status))
+                } else {
+                    CreatePlatformVersionError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -10820,7 +10870,11 @@ impl CreateStorageLocationError {
                 _ => CreateStorageLocationError::Unknown(String::from(body)),
             },
             Err(_) => {
-                CreateStorageLocationError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    CreateStorageLocationError::Unknown(format!("{}", status))
+                } else {
+                    CreateStorageLocationError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -10902,7 +10956,13 @@ impl DeleteApplicationError {
                 }
                 _ => DeleteApplicationError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteApplicationError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteApplicationError::Unknown(format!("{}", status))
+                } else {
+                    DeleteApplicationError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -11003,7 +11063,15 @@ impl DeleteApplicationVersionError {
                 _ => DeleteApplicationVersionError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DeleteApplicationVersionError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DeleteApplicationVersionError::Unknown(format!("{}", status))
+                } else {
+                    DeleteApplicationVersionError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -11088,11 +11156,17 @@ impl DeleteConfigurationTemplateError {
                 }
                 _ => DeleteConfigurationTemplateError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteConfigurationTemplateError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteConfigurationTemplateError::Unknown(format!("{}", status))
+                } else {
+                    DeleteConfigurationTemplateError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -11166,11 +11240,17 @@ impl DeleteEnvironmentConfigurationError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteEnvironmentConfigurationError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteEnvironmentConfigurationError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteEnvironmentConfigurationError::Unknown(format!("{}", status))
+                } else {
+                    DeleteEnvironmentConfigurationError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -11270,7 +11350,11 @@ impl DeletePlatformVersionError {
                 _ => DeletePlatformVersionError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DeletePlatformVersionError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DeletePlatformVersionError::Unknown(format!("{}", status))
+                } else {
+                    DeletePlatformVersionError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -11356,7 +11440,15 @@ impl DescribeAccountAttributesError {
                 _ => DescribeAccountAttributesError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeAccountAttributesError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeAccountAttributesError::Unknown(format!("{}", status))
+                } else {
+                    DescribeAccountAttributesError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -11431,11 +11523,17 @@ impl DescribeApplicationVersionsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeApplicationVersionsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeApplicationVersionsError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeApplicationVersionsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeApplicationVersionsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -11509,7 +11607,11 @@ impl DescribeApplicationsError {
                 _ => DescribeApplicationsError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeApplicationsError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeApplicationsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeApplicationsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -11588,11 +11690,17 @@ impl DescribeConfigurationOptionsError {
                 ),
                 _ => DescribeConfigurationOptionsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeConfigurationOptionsError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeConfigurationOptionsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeConfigurationOptionsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -11671,11 +11779,17 @@ impl DescribeConfigurationSettingsError {
                 ),
                 _ => DescribeConfigurationSettingsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeConfigurationSettingsError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeConfigurationSettingsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeConfigurationSettingsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -11762,7 +11876,15 @@ impl DescribeEnvironmentHealthError {
                 _ => DescribeEnvironmentHealthError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeEnvironmentHealthError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeEnvironmentHealthError::Unknown(format!("{}", status))
+                } else {
+                    DescribeEnvironmentHealthError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -11845,11 +11967,17 @@ impl DescribeEnvironmentManagedActionHistoryError {
                 }
                 _ => DescribeEnvironmentManagedActionHistoryError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeEnvironmentManagedActionHistoryError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeEnvironmentManagedActionHistoryError::Unknown(format!("{}", status))
+                } else {
+                    DescribeEnvironmentManagedActionHistoryError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -11932,11 +12060,17 @@ impl DescribeEnvironmentManagedActionsError {
                 }
                 _ => DescribeEnvironmentManagedActionsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeEnvironmentManagedActionsError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeEnvironmentManagedActionsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeEnvironmentManagedActionsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -12017,11 +12151,17 @@ impl DescribeEnvironmentResourcesError {
                 }
                 _ => DescribeEnvironmentResourcesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeEnvironmentResourcesError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeEnvironmentResourcesError::Unknown(format!("{}", status))
+                } else {
+                    DescribeEnvironmentResourcesError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -12096,7 +12236,11 @@ impl DescribeEnvironmentsError {
                 _ => DescribeEnvironmentsError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeEnvironmentsError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeEnvironmentsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeEnvironmentsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -12170,7 +12314,13 @@ impl DescribeEventsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeEventsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeEventsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeEventsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeEventsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -12254,7 +12404,15 @@ impl DescribeInstancesHealthError {
                 _ => DescribeInstancesHealthError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeInstancesHealthError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeInstancesHealthError::Unknown(format!("{}", status))
+                } else {
+                    DescribeInstancesHealthError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -12345,7 +12503,15 @@ impl DescribePlatformVersionError {
                 _ => DescribePlatformVersionError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribePlatformVersionError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribePlatformVersionError::Unknown(format!("{}", status))
+                } else {
+                    DescribePlatformVersionError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -12421,11 +12587,17 @@ impl ListAvailableSolutionStacksError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListAvailableSolutionStacksError::Unknown(String::from(body)),
             },
-            Err(_) => ListAvailableSolutionStacksError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    ListAvailableSolutionStacksError::Unknown(format!("{}", status))
+                } else {
+                    ListAvailableSolutionStacksError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -12513,7 +12685,11 @@ impl ListPlatformVersionsError {
                 _ => ListPlatformVersionsError::Unknown(String::from(body)),
             },
             Err(_) => {
-                ListPlatformVersionsError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    ListPlatformVersionsError::Unknown(format!("{}", status))
+                } else {
+                    ListPlatformVersionsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -12608,7 +12784,13 @@ impl ListTagsForResourceError {
                 }
                 _ => ListTagsForResourceError::Unknown(String::from(body)),
             },
-            Err(_) => ListTagsForResourceError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ListTagsForResourceError::Unknown(format!("{}", status))
+                } else {
+                    ListTagsForResourceError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -12691,7 +12873,13 @@ impl RebuildEnvironmentError {
                 }
                 _ => RebuildEnvironmentError::Unknown(String::from(body)),
             },
-            Err(_) => RebuildEnvironmentError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    RebuildEnvironmentError::Unknown(format!("{}", status))
+                } else {
+                    RebuildEnvironmentError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -12766,7 +12954,11 @@ impl RequestEnvironmentInfoError {
                 _ => RequestEnvironmentInfoError::Unknown(String::from(body)),
             },
             Err(_) => {
-                RequestEnvironmentInfoError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    RequestEnvironmentInfoError::Unknown(format!("{}", status))
+                } else {
+                    RequestEnvironmentInfoError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -12840,7 +13032,13 @@ impl RestartAppServerError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => RestartAppServerError::Unknown(String::from(body)),
             },
-            Err(_) => RestartAppServerError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    RestartAppServerError::Unknown(format!("{}", status))
+                } else {
+                    RestartAppServerError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -12912,7 +13110,15 @@ impl RetrieveEnvironmentInfoError {
                 _ => RetrieveEnvironmentInfoError::Unknown(String::from(body)),
             },
             Err(_) => {
-                RetrieveEnvironmentInfoError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    RetrieveEnvironmentInfoError::Unknown(format!("{}", status))
+                } else {
+                    RetrieveEnvironmentInfoError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -12987,7 +13193,11 @@ impl SwapEnvironmentCNAMEsError {
                 _ => SwapEnvironmentCNAMEsError::Unknown(String::from(body)),
             },
             Err(_) => {
-                SwapEnvironmentCNAMEsError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    SwapEnvironmentCNAMEsError::Unknown(format!("{}", status))
+                } else {
+                    SwapEnvironmentCNAMEsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -13069,7 +13279,11 @@ impl TerminateEnvironmentError {
                 _ => TerminateEnvironmentError::Unknown(String::from(body)),
             },
             Err(_) => {
-                TerminateEnvironmentError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    TerminateEnvironmentError::Unknown(format!("{}", status))
+                } else {
+                    TerminateEnvironmentError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -13144,7 +13358,13 @@ impl UpdateApplicationError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => UpdateApplicationError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateApplicationError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    UpdateApplicationError::Unknown(format!("{}", status))
+                } else {
+                    UpdateApplicationError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -13224,11 +13444,17 @@ impl UpdateApplicationResourceLifecycleError {
                 }
                 _ => UpdateApplicationResourceLifecycleError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateApplicationResourceLifecycleError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    UpdateApplicationResourceLifecycleError::Unknown(format!("{}", status))
+                } else {
+                    UpdateApplicationResourceLifecycleError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -13303,7 +13529,15 @@ impl UpdateApplicationVersionError {
                 _ => UpdateApplicationVersionError::Unknown(String::from(body)),
             },
             Err(_) => {
-                UpdateApplicationVersionError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    UpdateApplicationVersionError::Unknown(format!("{}", status))
+                } else {
+                    UpdateApplicationVersionError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -13389,11 +13623,17 @@ impl UpdateConfigurationTemplateError {
                 ),
                 _ => UpdateConfigurationTemplateError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateConfigurationTemplateError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    UpdateConfigurationTemplateError::Unknown(format!("{}", status))
+                } else {
+                    UpdateConfigurationTemplateError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -13480,7 +13720,13 @@ impl UpdateEnvironmentError {
                 }
                 _ => UpdateEnvironmentError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateEnvironmentError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    UpdateEnvironmentError::Unknown(format!("{}", status))
+                } else {
+                    UpdateEnvironmentError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -13585,7 +13831,11 @@ impl UpdateTagsForResourceError {
                 _ => UpdateTagsForResourceError::Unknown(String::from(body)),
             },
             Err(_) => {
-                UpdateTagsForResourceError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    UpdateTagsForResourceError::Unknown(format!("{}", status))
+                } else {
+                    UpdateTagsForResourceError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -13676,11 +13926,17 @@ impl ValidateConfigurationSettingsError {
                 ),
                 _ => ValidateConfigurationSettingsError::Unknown(String::from(body)),
             },
-            Err(_) => ValidateConfigurationSettingsError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    ValidateConfigurationSettingsError::Unknown(format!("{}", status))
+                } else {
+                    ValidateConfigurationSettingsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 

--- a/rusoto/services/elasticbeanstalk/src/generated.rs
+++ b/rusoto/services/elasticbeanstalk/src/generated.rs
@@ -9979,7 +9979,7 @@ pub enum AbortEnvironmentUpdateError {
 }
 
 impl AbortEnvironmentUpdateError {
-    pub fn from_body(body: &str) -> AbortEnvironmentUpdateError {
+    pub fn from_body(body: &str, status: u16) -> AbortEnvironmentUpdateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -9992,7 +9992,9 @@ impl AbortEnvironmentUpdateError {
                 }
                 _ => AbortEnvironmentUpdateError::Unknown(String::from(body)),
             },
-            Err(_) => AbortEnvironmentUpdateError::Unknown(body.to_string()),
+            Err(_) => {
+                AbortEnvironmentUpdateError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -10062,7 +10064,7 @@ pub enum ApplyEnvironmentManagedActionError {
 }
 
 impl ApplyEnvironmentManagedActionError {
-    pub fn from_body(body: &str) -> ApplyEnvironmentManagedActionError {
+    pub fn from_body(body: &str, status: u16) -> ApplyEnvironmentManagedActionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10080,7 +10082,11 @@ impl ApplyEnvironmentManagedActionError {
                 }
                 _ => ApplyEnvironmentManagedActionError::Unknown(String::from(body)),
             },
-            Err(_) => ApplyEnvironmentManagedActionError::Unknown(body.to_string()),
+            Err(_) => ApplyEnvironmentManagedActionError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -10147,7 +10153,7 @@ pub enum CheckDNSAvailabilityError {
 }
 
 impl CheckDNSAvailabilityError {
-    pub fn from_body(body: &str) -> CheckDNSAvailabilityError {
+    pub fn from_body(body: &str, status: u16) -> CheckDNSAvailabilityError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10155,7 +10161,9 @@ impl CheckDNSAvailabilityError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CheckDNSAvailabilityError::Unknown(String::from(body)),
             },
-            Err(_) => CheckDNSAvailabilityError::Unknown(body.to_string()),
+            Err(_) => {
+                CheckDNSAvailabilityError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -10224,7 +10232,7 @@ pub enum ComposeEnvironmentsError {
 }
 
 impl ComposeEnvironmentsError {
-    pub fn from_body(body: &str) -> ComposeEnvironmentsError {
+    pub fn from_body(body: &str, status: u16) -> ComposeEnvironmentsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10240,7 +10248,7 @@ impl ComposeEnvironmentsError {
                 ),
                 _ => ComposeEnvironmentsError::Unknown(String::from(body)),
             },
-            Err(_) => ComposeEnvironmentsError::Unknown(body.to_string()),
+            Err(_) => ComposeEnvironmentsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -10309,7 +10317,7 @@ pub enum CreateApplicationError {
 }
 
 impl CreateApplicationError {
-    pub fn from_body(body: &str) -> CreateApplicationError {
+    pub fn from_body(body: &str, status: u16) -> CreateApplicationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10320,7 +10328,7 @@ impl CreateApplicationError {
                 }
                 _ => CreateApplicationError::Unknown(String::from(body)),
             },
-            Err(_) => CreateApplicationError::Unknown(body.to_string()),
+            Err(_) => CreateApplicationError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -10396,7 +10404,7 @@ pub enum CreateApplicationVersionError {
 }
 
 impl CreateApplicationVersionError {
-    pub fn from_body(body: &str) -> CreateApplicationVersionError {
+    pub fn from_body(body: &str, status: u16) -> CreateApplicationVersionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10429,7 +10437,9 @@ impl CreateApplicationVersionError {
                 }
                 _ => CreateApplicationVersionError::Unknown(String::from(body)),
             },
-            Err(_) => CreateApplicationVersionError::Unknown(body.to_string()),
+            Err(_) => {
+                CreateApplicationVersionError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -10505,7 +10515,7 @@ pub enum CreateConfigurationTemplateError {
 }
 
 impl CreateConfigurationTemplateError {
-    pub fn from_body(body: &str) -> CreateConfigurationTemplateError {
+    pub fn from_body(body: &str, status: u16) -> CreateConfigurationTemplateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10526,7 +10536,11 @@ impl CreateConfigurationTemplateError {
                 }
                 _ => CreateConfigurationTemplateError::Unknown(String::from(body)),
             },
-            Err(_) => CreateConfigurationTemplateError::Unknown(body.to_string()),
+            Err(_) => CreateConfigurationTemplateError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -10598,7 +10612,7 @@ pub enum CreateEnvironmentError {
 }
 
 impl CreateEnvironmentError {
-    pub fn from_body(body: &str) -> CreateEnvironmentError {
+    pub fn from_body(body: &str, status: u16) -> CreateEnvironmentError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10614,7 +10628,7 @@ impl CreateEnvironmentError {
                 }
                 _ => CreateEnvironmentError::Unknown(String::from(body)),
             },
-            Err(_) => CreateEnvironmentError::Unknown(body.to_string()),
+            Err(_) => CreateEnvironmentError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -10687,7 +10701,7 @@ pub enum CreatePlatformVersionError {
 }
 
 impl CreatePlatformVersionError {
-    pub fn from_body(body: &str) -> CreatePlatformVersionError {
+    pub fn from_body(body: &str, status: u16) -> CreatePlatformVersionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10708,7 +10722,9 @@ impl CreatePlatformVersionError {
                 }
                 _ => CreatePlatformVersionError::Unknown(String::from(body)),
             },
-            Err(_) => CreatePlatformVersionError::Unknown(body.to_string()),
+            Err(_) => {
+                CreatePlatformVersionError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -10782,7 +10798,7 @@ pub enum CreateStorageLocationError {
 }
 
 impl CreateStorageLocationError {
-    pub fn from_body(body: &str) -> CreateStorageLocationError {
+    pub fn from_body(body: &str, status: u16) -> CreateStorageLocationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10803,7 +10819,9 @@ impl CreateStorageLocationError {
                 }
                 _ => CreateStorageLocationError::Unknown(String::from(body)),
             },
-            Err(_) => CreateStorageLocationError::Unknown(body.to_string()),
+            Err(_) => {
+                CreateStorageLocationError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -10873,7 +10891,7 @@ pub enum DeleteApplicationError {
 }
 
 impl DeleteApplicationError {
-    pub fn from_body(body: &str) -> DeleteApplicationError {
+    pub fn from_body(body: &str, status: u16) -> DeleteApplicationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10884,7 +10902,7 @@ impl DeleteApplicationError {
                 }
                 _ => DeleteApplicationError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteApplicationError::Unknown(body.to_string()),
+            Err(_) => DeleteApplicationError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -10958,7 +10976,7 @@ pub enum DeleteApplicationVersionError {
 }
 
 impl DeleteApplicationVersionError {
-    pub fn from_body(body: &str) -> DeleteApplicationVersionError {
+    pub fn from_body(body: &str, status: u16) -> DeleteApplicationVersionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10984,7 +11002,9 @@ impl DeleteApplicationVersionError {
                 }
                 _ => DeleteApplicationVersionError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteApplicationVersionError::Unknown(body.to_string()),
+            Err(_) => {
+                DeleteApplicationVersionError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -11055,7 +11075,7 @@ pub enum DeleteConfigurationTemplateError {
 }
 
 impl DeleteConfigurationTemplateError {
-    pub fn from_body(body: &str) -> DeleteConfigurationTemplateError {
+    pub fn from_body(body: &str, status: u16) -> DeleteConfigurationTemplateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11068,7 +11088,11 @@ impl DeleteConfigurationTemplateError {
                 }
                 _ => DeleteConfigurationTemplateError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteConfigurationTemplateError::Unknown(body.to_string()),
+            Err(_) => DeleteConfigurationTemplateError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -11134,7 +11158,7 @@ pub enum DeleteEnvironmentConfigurationError {
 }
 
 impl DeleteEnvironmentConfigurationError {
-    pub fn from_body(body: &str) -> DeleteEnvironmentConfigurationError {
+    pub fn from_body(body: &str, status: u16) -> DeleteEnvironmentConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11142,7 +11166,11 @@ impl DeleteEnvironmentConfigurationError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteEnvironmentConfigurationError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteEnvironmentConfigurationError::Unknown(body.to_string()),
+            Err(_) => DeleteEnvironmentConfigurationError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -11215,7 +11243,7 @@ pub enum DeletePlatformVersionError {
 }
 
 impl DeletePlatformVersionError {
-    pub fn from_body(body: &str) -> DeletePlatformVersionError {
+    pub fn from_body(body: &str, status: u16) -> DeletePlatformVersionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11241,7 +11269,9 @@ impl DeletePlatformVersionError {
                 }
                 _ => DeletePlatformVersionError::Unknown(String::from(body)),
             },
-            Err(_) => DeletePlatformVersionError::Unknown(body.to_string()),
+            Err(_) => {
+                DeletePlatformVersionError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -11312,7 +11342,7 @@ pub enum DescribeAccountAttributesError {
 }
 
 impl DescribeAccountAttributesError {
-    pub fn from_body(body: &str) -> DescribeAccountAttributesError {
+    pub fn from_body(body: &str, status: u16) -> DescribeAccountAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11325,7 +11355,9 @@ impl DescribeAccountAttributesError {
                 }
                 _ => DescribeAccountAttributesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeAccountAttributesError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeAccountAttributesError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -11391,7 +11423,7 @@ pub enum DescribeApplicationVersionsError {
 }
 
 impl DescribeApplicationVersionsError {
-    pub fn from_body(body: &str) -> DescribeApplicationVersionsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeApplicationVersionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11399,7 +11431,11 @@ impl DescribeApplicationVersionsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeApplicationVersionsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeApplicationVersionsError::Unknown(body.to_string()),
+            Err(_) => DescribeApplicationVersionsError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -11464,7 +11500,7 @@ pub enum DescribeApplicationsError {
 }
 
 impl DescribeApplicationsError {
-    pub fn from_body(body: &str) -> DescribeApplicationsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeApplicationsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11472,7 +11508,9 @@ impl DescribeApplicationsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeApplicationsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeApplicationsError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeApplicationsError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -11539,7 +11577,7 @@ pub enum DescribeConfigurationOptionsError {
 }
 
 impl DescribeConfigurationOptionsError {
-    pub fn from_body(body: &str) -> DescribeConfigurationOptionsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeConfigurationOptionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11550,7 +11588,11 @@ impl DescribeConfigurationOptionsError {
                 ),
                 _ => DescribeConfigurationOptionsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeConfigurationOptionsError::Unknown(body.to_string()),
+            Err(_) => DescribeConfigurationOptionsError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -11618,7 +11660,7 @@ pub enum DescribeConfigurationSettingsError {
 }
 
 impl DescribeConfigurationSettingsError {
-    pub fn from_body(body: &str) -> DescribeConfigurationSettingsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeConfigurationSettingsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11629,7 +11671,11 @@ impl DescribeConfigurationSettingsError {
                 ),
                 _ => DescribeConfigurationSettingsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeConfigurationSettingsError::Unknown(body.to_string()),
+            Err(_) => DescribeConfigurationSettingsError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -11699,7 +11745,7 @@ pub enum DescribeEnvironmentHealthError {
 }
 
 impl DescribeEnvironmentHealthError {
-    pub fn from_body(body: &str) -> DescribeEnvironmentHealthError {
+    pub fn from_body(body: &str, status: u16) -> DescribeEnvironmentHealthError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11715,7 +11761,9 @@ impl DescribeEnvironmentHealthError {
                 ),
                 _ => DescribeEnvironmentHealthError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeEnvironmentHealthError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeEnvironmentHealthError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -11784,7 +11832,7 @@ pub enum DescribeEnvironmentManagedActionHistoryError {
 }
 
 impl DescribeEnvironmentManagedActionHistoryError {
-    pub fn from_body(body: &str) -> DescribeEnvironmentManagedActionHistoryError {
+    pub fn from_body(body: &str, status: u16) -> DescribeEnvironmentManagedActionHistoryError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11797,7 +11845,11 @@ impl DescribeEnvironmentManagedActionHistoryError {
                 }
                 _ => DescribeEnvironmentManagedActionHistoryError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeEnvironmentManagedActionHistoryError::Unknown(body.to_string()),
+            Err(_) => DescribeEnvironmentManagedActionHistoryError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -11867,7 +11919,7 @@ pub enum DescribeEnvironmentManagedActionsError {
 }
 
 impl DescribeEnvironmentManagedActionsError {
-    pub fn from_body(body: &str) -> DescribeEnvironmentManagedActionsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeEnvironmentManagedActionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11880,7 +11932,11 @@ impl DescribeEnvironmentManagedActionsError {
                 }
                 _ => DescribeEnvironmentManagedActionsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeEnvironmentManagedActionsError::Unknown(body.to_string()),
+            Err(_) => DescribeEnvironmentManagedActionsError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -11948,7 +12004,7 @@ pub enum DescribeEnvironmentResourcesError {
 }
 
 impl DescribeEnvironmentResourcesError {
-    pub fn from_body(body: &str) -> DescribeEnvironmentResourcesError {
+    pub fn from_body(body: &str, status: u16) -> DescribeEnvironmentResourcesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11961,7 +12017,11 @@ impl DescribeEnvironmentResourcesError {
                 }
                 _ => DescribeEnvironmentResourcesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeEnvironmentResourcesError::Unknown(body.to_string()),
+            Err(_) => DescribeEnvironmentResourcesError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -12027,7 +12087,7 @@ pub enum DescribeEnvironmentsError {
 }
 
 impl DescribeEnvironmentsError {
-    pub fn from_body(body: &str) -> DescribeEnvironmentsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeEnvironmentsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -12035,7 +12095,9 @@ impl DescribeEnvironmentsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeEnvironmentsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeEnvironmentsError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeEnvironmentsError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -12100,7 +12162,7 @@ pub enum DescribeEventsError {
 }
 
 impl DescribeEventsError {
-    pub fn from_body(body: &str) -> DescribeEventsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeEventsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -12108,7 +12170,7 @@ impl DescribeEventsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeEventsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeEventsError::Unknown(body.to_string()),
+            Err(_) => DescribeEventsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -12175,7 +12237,7 @@ pub enum DescribeInstancesHealthError {
 }
 
 impl DescribeInstancesHealthError {
-    pub fn from_body(body: &str) -> DescribeInstancesHealthError {
+    pub fn from_body(body: &str, status: u16) -> DescribeInstancesHealthError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -12191,7 +12253,9 @@ impl DescribeInstancesHealthError {
                 }
                 _ => DescribeInstancesHealthError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeInstancesHealthError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeInstancesHealthError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -12262,7 +12326,7 @@ pub enum DescribePlatformVersionError {
 }
 
 impl DescribePlatformVersionError {
-    pub fn from_body(body: &str) -> DescribePlatformVersionError {
+    pub fn from_body(body: &str, status: u16) -> DescribePlatformVersionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -12280,7 +12344,9 @@ impl DescribePlatformVersionError {
                 }
                 _ => DescribePlatformVersionError::Unknown(String::from(body)),
             },
-            Err(_) => DescribePlatformVersionError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribePlatformVersionError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -12347,7 +12413,7 @@ pub enum ListAvailableSolutionStacksError {
 }
 
 impl ListAvailableSolutionStacksError {
-    pub fn from_body(body: &str) -> ListAvailableSolutionStacksError {
+    pub fn from_body(body: &str, status: u16) -> ListAvailableSolutionStacksError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -12355,7 +12421,11 @@ impl ListAvailableSolutionStacksError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListAvailableSolutionStacksError::Unknown(String::from(body)),
             },
-            Err(_) => ListAvailableSolutionStacksError::Unknown(body.to_string()),
+            Err(_) => ListAvailableSolutionStacksError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -12424,7 +12494,7 @@ pub enum ListPlatformVersionsError {
 }
 
 impl ListPlatformVersionsError {
-    pub fn from_body(body: &str) -> ListPlatformVersionsError {
+    pub fn from_body(body: &str, status: u16) -> ListPlatformVersionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -12442,7 +12512,9 @@ impl ListPlatformVersionsError {
                 }
                 _ => ListPlatformVersionsError::Unknown(String::from(body)),
             },
-            Err(_) => ListPlatformVersionsError::Unknown(body.to_string()),
+            Err(_) => {
+                ListPlatformVersionsError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -12515,7 +12587,7 @@ pub enum ListTagsForResourceError {
 }
 
 impl ListTagsForResourceError {
-    pub fn from_body(body: &str) -> ListTagsForResourceError {
+    pub fn from_body(body: &str, status: u16) -> ListTagsForResourceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -12536,7 +12608,7 @@ impl ListTagsForResourceError {
                 }
                 _ => ListTagsForResourceError::Unknown(String::from(body)),
             },
-            Err(_) => ListTagsForResourceError::Unknown(body.to_string()),
+            Err(_) => ListTagsForResourceError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -12606,7 +12678,7 @@ pub enum RebuildEnvironmentError {
 }
 
 impl RebuildEnvironmentError {
-    pub fn from_body(body: &str) -> RebuildEnvironmentError {
+    pub fn from_body(body: &str, status: u16) -> RebuildEnvironmentError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -12619,7 +12691,7 @@ impl RebuildEnvironmentError {
                 }
                 _ => RebuildEnvironmentError::Unknown(String::from(body)),
             },
-            Err(_) => RebuildEnvironmentError::Unknown(body.to_string()),
+            Err(_) => RebuildEnvironmentError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -12685,7 +12757,7 @@ pub enum RequestEnvironmentInfoError {
 }
 
 impl RequestEnvironmentInfoError {
-    pub fn from_body(body: &str) -> RequestEnvironmentInfoError {
+    pub fn from_body(body: &str, status: u16) -> RequestEnvironmentInfoError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -12693,7 +12765,9 @@ impl RequestEnvironmentInfoError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => RequestEnvironmentInfoError::Unknown(String::from(body)),
             },
-            Err(_) => RequestEnvironmentInfoError::Unknown(body.to_string()),
+            Err(_) => {
+                RequestEnvironmentInfoError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -12758,7 +12832,7 @@ pub enum RestartAppServerError {
 }
 
 impl RestartAppServerError {
-    pub fn from_body(body: &str) -> RestartAppServerError {
+    pub fn from_body(body: &str, status: u16) -> RestartAppServerError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -12766,7 +12840,7 @@ impl RestartAppServerError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => RestartAppServerError::Unknown(String::from(body)),
             },
-            Err(_) => RestartAppServerError::Unknown(body.to_string()),
+            Err(_) => RestartAppServerError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -12829,7 +12903,7 @@ pub enum RetrieveEnvironmentInfoError {
 }
 
 impl RetrieveEnvironmentInfoError {
-    pub fn from_body(body: &str) -> RetrieveEnvironmentInfoError {
+    pub fn from_body(body: &str, status: u16) -> RetrieveEnvironmentInfoError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -12837,7 +12911,9 @@ impl RetrieveEnvironmentInfoError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => RetrieveEnvironmentInfoError::Unknown(String::from(body)),
             },
-            Err(_) => RetrieveEnvironmentInfoError::Unknown(body.to_string()),
+            Err(_) => {
+                RetrieveEnvironmentInfoError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -12902,7 +12978,7 @@ pub enum SwapEnvironmentCNAMEsError {
 }
 
 impl SwapEnvironmentCNAMEsError {
-    pub fn from_body(body: &str) -> SwapEnvironmentCNAMEsError {
+    pub fn from_body(body: &str, status: u16) -> SwapEnvironmentCNAMEsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -12910,7 +12986,9 @@ impl SwapEnvironmentCNAMEsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => SwapEnvironmentCNAMEsError::Unknown(String::from(body)),
             },
-            Err(_) => SwapEnvironmentCNAMEsError::Unknown(body.to_string()),
+            Err(_) => {
+                SwapEnvironmentCNAMEsError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -12977,7 +13055,7 @@ pub enum TerminateEnvironmentError {
 }
 
 impl TerminateEnvironmentError {
-    pub fn from_body(body: &str) -> TerminateEnvironmentError {
+    pub fn from_body(body: &str, status: u16) -> TerminateEnvironmentError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -12990,7 +13068,9 @@ impl TerminateEnvironmentError {
                 }
                 _ => TerminateEnvironmentError::Unknown(String::from(body)),
             },
-            Err(_) => TerminateEnvironmentError::Unknown(body.to_string()),
+            Err(_) => {
+                TerminateEnvironmentError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -13056,7 +13136,7 @@ pub enum UpdateApplicationError {
 }
 
 impl UpdateApplicationError {
-    pub fn from_body(body: &str) -> UpdateApplicationError {
+    pub fn from_body(body: &str, status: u16) -> UpdateApplicationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -13064,7 +13144,7 @@ impl UpdateApplicationError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => UpdateApplicationError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateApplicationError::Unknown(body.to_string()),
+            Err(_) => UpdateApplicationError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -13131,7 +13211,7 @@ pub enum UpdateApplicationResourceLifecycleError {
 }
 
 impl UpdateApplicationResourceLifecycleError {
-    pub fn from_body(body: &str) -> UpdateApplicationResourceLifecycleError {
+    pub fn from_body(body: &str, status: u16) -> UpdateApplicationResourceLifecycleError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -13144,7 +13224,11 @@ impl UpdateApplicationResourceLifecycleError {
                 }
                 _ => UpdateApplicationResourceLifecycleError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateApplicationResourceLifecycleError::Unknown(body.to_string()),
+            Err(_) => UpdateApplicationResourceLifecycleError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -13210,7 +13294,7 @@ pub enum UpdateApplicationVersionError {
 }
 
 impl UpdateApplicationVersionError {
-    pub fn from_body(body: &str) -> UpdateApplicationVersionError {
+    pub fn from_body(body: &str, status: u16) -> UpdateApplicationVersionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -13218,7 +13302,9 @@ impl UpdateApplicationVersionError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => UpdateApplicationVersionError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateApplicationVersionError::Unknown(body.to_string()),
+            Err(_) => {
+                UpdateApplicationVersionError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -13287,7 +13373,7 @@ pub enum UpdateConfigurationTemplateError {
 }
 
 impl UpdateConfigurationTemplateError {
-    pub fn from_body(body: &str) -> UpdateConfigurationTemplateError {
+    pub fn from_body(body: &str, status: u16) -> UpdateConfigurationTemplateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -13303,7 +13389,11 @@ impl UpdateConfigurationTemplateError {
                 ),
                 _ => UpdateConfigurationTemplateError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateConfigurationTemplateError::Unknown(body.to_string()),
+            Err(_) => UpdateConfigurationTemplateError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -13374,7 +13464,7 @@ pub enum UpdateEnvironmentError {
 }
 
 impl UpdateEnvironmentError {
-    pub fn from_body(body: &str) -> UpdateEnvironmentError {
+    pub fn from_body(body: &str, status: u16) -> UpdateEnvironmentError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -13390,7 +13480,7 @@ impl UpdateEnvironmentError {
                 }
                 _ => UpdateEnvironmentError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateEnvironmentError::Unknown(body.to_string()),
+            Err(_) => UpdateEnvironmentError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -13467,7 +13557,7 @@ pub enum UpdateTagsForResourceError {
 }
 
 impl UpdateTagsForResourceError {
-    pub fn from_body(body: &str) -> UpdateTagsForResourceError {
+    pub fn from_body(body: &str, status: u16) -> UpdateTagsForResourceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -13494,7 +13584,9 @@ impl UpdateTagsForResourceError {
                 }
                 _ => UpdateTagsForResourceError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateTagsForResourceError::Unknown(body.to_string()),
+            Err(_) => {
+                UpdateTagsForResourceError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -13568,7 +13660,7 @@ pub enum ValidateConfigurationSettingsError {
 }
 
 impl ValidateConfigurationSettingsError {
-    pub fn from_body(body: &str) -> ValidateConfigurationSettingsError {
+    pub fn from_body(body: &str, status: u16) -> ValidateConfigurationSettingsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -13584,7 +13676,11 @@ impl ValidateConfigurationSettingsError {
                 ),
                 _ => ValidateConfigurationSettingsError::Unknown(String::from(body)),
             },
-            Err(_) => ValidateConfigurationSettingsError::Unknown(body.to_string()),
+            Err(_) => ValidateConfigurationSettingsError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 

--- a/rusoto/services/elb/src/generated.rs
+++ b/rusoto/services/elb/src/generated.rs
@@ -5522,7 +5522,7 @@ pub enum AddTagsError {
 }
 
 impl AddTagsError {
-    pub fn from_body(body: &str) -> AddTagsError {
+    pub fn from_body(body: &str, status: u16) -> AddTagsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -5537,7 +5537,7 @@ impl AddTagsError {
                 "TooManyTags" => AddTagsError::TooManyTags(String::from(parsed_error.message)),
                 _ => AddTagsError::Unknown(String::from(body)),
             },
-            Err(_) => AddTagsError::Unknown(body.to_string()),
+            Err(_) => AddTagsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -5609,7 +5609,7 @@ pub enum ApplySecurityGroupsToLoadBalancerError {
 }
 
 impl ApplySecurityGroupsToLoadBalancerError {
-    pub fn from_body(body: &str) -> ApplySecurityGroupsToLoadBalancerError {
+    pub fn from_body(body: &str, status: u16) -> ApplySecurityGroupsToLoadBalancerError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -5632,7 +5632,11 @@ impl ApplySecurityGroupsToLoadBalancerError {
                 }
                 _ => ApplySecurityGroupsToLoadBalancerError::Unknown(String::from(body)),
             },
-            Err(_) => ApplySecurityGroupsToLoadBalancerError::Unknown(body.to_string()),
+            Err(_) => ApplySecurityGroupsToLoadBalancerError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -5708,7 +5712,7 @@ pub enum AttachLoadBalancerToSubnetsError {
 }
 
 impl AttachLoadBalancerToSubnetsError {
-    pub fn from_body(body: &str) -> AttachLoadBalancerToSubnetsError {
+    pub fn from_body(body: &str, status: u16) -> AttachLoadBalancerToSubnetsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -5730,7 +5734,11 @@ impl AttachLoadBalancerToSubnetsError {
                 )),
                 _ => AttachLoadBalancerToSubnetsError::Unknown(String::from(body)),
             },
-            Err(_) => AttachLoadBalancerToSubnetsError::Unknown(body.to_string()),
+            Err(_) => AttachLoadBalancerToSubnetsError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -5801,7 +5809,7 @@ pub enum ConfigureHealthCheckError {
 }
 
 impl ConfigureHealthCheckError {
-    pub fn from_body(body: &str) -> ConfigureHealthCheckError {
+    pub fn from_body(body: &str, status: u16) -> ConfigureHealthCheckError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -5812,7 +5820,9 @@ impl ConfigureHealthCheckError {
                 ),
                 _ => ConfigureHealthCheckError::Unknown(String::from(body)),
             },
-            Err(_) => ConfigureHealthCheckError::Unknown(body.to_string()),
+            Err(_) => {
+                ConfigureHealthCheckError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -5886,7 +5896,7 @@ pub enum CreateAppCookieStickinessPolicyError {
 }
 
 impl CreateAppCookieStickinessPolicyError {
-    pub fn from_body(body: &str) -> CreateAppCookieStickinessPolicyError {
+    pub fn from_body(body: &str, status: u16) -> CreateAppCookieStickinessPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -5910,7 +5920,11 @@ impl CreateAppCookieStickinessPolicyError {
                 ),
                 _ => CreateAppCookieStickinessPolicyError::Unknown(String::from(body)),
             },
-            Err(_) => CreateAppCookieStickinessPolicyError::Unknown(body.to_string()),
+            Err(_) => CreateAppCookieStickinessPolicyError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -5987,7 +6001,7 @@ pub enum CreateLBCookieStickinessPolicyError {
 }
 
 impl CreateLBCookieStickinessPolicyError {
-    pub fn from_body(body: &str) -> CreateLBCookieStickinessPolicyError {
+    pub fn from_body(body: &str, status: u16) -> CreateLBCookieStickinessPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -6009,7 +6023,11 @@ impl CreateLBCookieStickinessPolicyError {
                 ),
                 _ => CreateLBCookieStickinessPolicyError::Unknown(String::from(body)),
             },
-            Err(_) => CreateLBCookieStickinessPolicyError::Unknown(body.to_string()),
+            Err(_) => CreateLBCookieStickinessPolicyError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -6102,7 +6120,7 @@ pub enum CreateLoadBalancerError {
 }
 
 impl CreateLoadBalancerError {
-    pub fn from_body(body: &str) -> CreateLoadBalancerError {
+    pub fn from_body(body: &str, status: u16) -> CreateLoadBalancerError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -6148,7 +6166,7 @@ impl CreateLoadBalancerError {
                 }
                 _ => CreateLoadBalancerError::Unknown(String::from(body)),
             },
-            Err(_) => CreateLoadBalancerError::Unknown(body.to_string()),
+            Err(_) => CreateLoadBalancerError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -6235,7 +6253,7 @@ pub enum CreateLoadBalancerListenersError {
 }
 
 impl CreateLoadBalancerListenersError {
-    pub fn from_body(body: &str) -> CreateLoadBalancerListenersError {
+    pub fn from_body(body: &str, status: u16) -> CreateLoadBalancerListenersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -6260,7 +6278,11 @@ impl CreateLoadBalancerListenersError {
                 ),
                 _ => CreateLoadBalancerListenersError::Unknown(String::from(body)),
             },
-            Err(_) => CreateLoadBalancerListenersError::Unknown(body.to_string()),
+            Err(_) => CreateLoadBalancerListenersError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -6340,7 +6362,7 @@ pub enum CreateLoadBalancerPolicyError {
 }
 
 impl CreateLoadBalancerPolicyError {
-    pub fn from_body(body: &str) -> CreateLoadBalancerPolicyError {
+    pub fn from_body(body: &str, status: u16) -> CreateLoadBalancerPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -6365,7 +6387,9 @@ impl CreateLoadBalancerPolicyError {
                 )),
                 _ => CreateLoadBalancerPolicyError::Unknown(String::from(body)),
             },
-            Err(_) => CreateLoadBalancerPolicyError::Unknown(body.to_string()),
+            Err(_) => {
+                CreateLoadBalancerPolicyError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -6435,7 +6459,7 @@ pub enum DeleteLoadBalancerError {
 }
 
 impl DeleteLoadBalancerError {
-    pub fn from_body(body: &str) -> DeleteLoadBalancerError {
+    pub fn from_body(body: &str, status: u16) -> DeleteLoadBalancerError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -6443,7 +6467,7 @@ impl DeleteLoadBalancerError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteLoadBalancerError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteLoadBalancerError::Unknown(body.to_string()),
+            Err(_) => DeleteLoadBalancerError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -6510,7 +6534,7 @@ pub enum DeleteLoadBalancerListenersError {
 }
 
 impl DeleteLoadBalancerListenersError {
-    pub fn from_body(body: &str) -> DeleteLoadBalancerListenersError {
+    pub fn from_body(body: &str, status: u16) -> DeleteLoadBalancerListenersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -6521,7 +6545,11 @@ impl DeleteLoadBalancerListenersError {
                 ),
                 _ => DeleteLoadBalancerListenersError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteLoadBalancerListenersError::Unknown(body.to_string()),
+            Err(_) => DeleteLoadBalancerListenersError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -6591,7 +6619,7 @@ pub enum DeleteLoadBalancerPolicyError {
 }
 
 impl DeleteLoadBalancerPolicyError {
-    pub fn from_body(body: &str) -> DeleteLoadBalancerPolicyError {
+    pub fn from_body(body: &str, status: u16) -> DeleteLoadBalancerPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -6607,7 +6635,9 @@ impl DeleteLoadBalancerPolicyError {
                 }
                 _ => DeleteLoadBalancerPolicyError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteLoadBalancerPolicyError::Unknown(body.to_string()),
+            Err(_) => {
+                DeleteLoadBalancerPolicyError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -6678,7 +6708,7 @@ pub enum DeregisterInstancesFromLoadBalancerError {
 }
 
 impl DeregisterInstancesFromLoadBalancerError {
-    pub fn from_body(body: &str) -> DeregisterInstancesFromLoadBalancerError {
+    pub fn from_body(body: &str, status: u16) -> DeregisterInstancesFromLoadBalancerError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -6694,7 +6724,11 @@ impl DeregisterInstancesFromLoadBalancerError {
                 ),
                 _ => DeregisterInstancesFromLoadBalancerError::Unknown(String::from(body)),
             },
-            Err(_) => DeregisterInstancesFromLoadBalancerError::Unknown(body.to_string()),
+            Err(_) => DeregisterInstancesFromLoadBalancerError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -6761,7 +6795,7 @@ pub enum DescribeAccountLimitsError {
 }
 
 impl DescribeAccountLimitsError {
-    pub fn from_body(body: &str) -> DescribeAccountLimitsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeAccountLimitsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -6769,7 +6803,9 @@ impl DescribeAccountLimitsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeAccountLimitsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeAccountLimitsError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeAccountLimitsError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -6838,7 +6874,7 @@ pub enum DescribeInstanceHealthError {
 }
 
 impl DescribeInstanceHealthError {
-    pub fn from_body(body: &str) -> DescribeInstanceHealthError {
+    pub fn from_body(body: &str, status: u16) -> DescribeInstanceHealthError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -6852,7 +6888,9 @@ impl DescribeInstanceHealthError {
                 }
                 _ => DescribeInstanceHealthError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeInstanceHealthError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeInstanceHealthError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -6923,7 +6961,7 @@ pub enum DescribeLoadBalancerAttributesError {
 }
 
 impl DescribeLoadBalancerAttributesError {
-    pub fn from_body(body: &str) -> DescribeLoadBalancerAttributesError {
+    pub fn from_body(body: &str, status: u16) -> DescribeLoadBalancerAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -6939,7 +6977,11 @@ impl DescribeLoadBalancerAttributesError {
                 }
                 _ => DescribeLoadBalancerAttributesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeLoadBalancerAttributesError::Unknown(body.to_string()),
+            Err(_) => DescribeLoadBalancerAttributesError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -7010,7 +7052,7 @@ pub enum DescribeLoadBalancerPoliciesError {
 }
 
 impl DescribeLoadBalancerPoliciesError {
-    pub fn from_body(body: &str) -> DescribeLoadBalancerPoliciesError {
+    pub fn from_body(body: &str, status: u16) -> DescribeLoadBalancerPoliciesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -7024,7 +7066,11 @@ impl DescribeLoadBalancerPoliciesError {
                 ),
                 _ => DescribeLoadBalancerPoliciesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeLoadBalancerPoliciesError::Unknown(body.to_string()),
+            Err(_) => DescribeLoadBalancerPoliciesError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -7093,7 +7139,7 @@ pub enum DescribeLoadBalancerPolicyTypesError {
 }
 
 impl DescribeLoadBalancerPolicyTypesError {
-    pub fn from_body(body: &str) -> DescribeLoadBalancerPolicyTypesError {
+    pub fn from_body(body: &str, status: u16) -> DescribeLoadBalancerPolicyTypesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -7104,7 +7150,11 @@ impl DescribeLoadBalancerPolicyTypesError {
                 ),
                 _ => DescribeLoadBalancerPolicyTypesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeLoadBalancerPolicyTypesError::Unknown(body.to_string()),
+            Err(_) => DescribeLoadBalancerPolicyTypesError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -7174,7 +7224,7 @@ pub enum DescribeLoadBalancersError {
 }
 
 impl DescribeLoadBalancersError {
-    pub fn from_body(body: &str) -> DescribeLoadBalancersError {
+    pub fn from_body(body: &str, status: u16) -> DescribeLoadBalancersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -7188,7 +7238,9 @@ impl DescribeLoadBalancersError {
                 ),
                 _ => DescribeLoadBalancersError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeLoadBalancersError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeLoadBalancersError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -7257,7 +7309,7 @@ pub enum DescribeTagsError {
 }
 
 impl DescribeTagsError {
-    pub fn from_body(body: &str) -> DescribeTagsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeTagsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -7268,7 +7320,7 @@ impl DescribeTagsError {
                 }
                 _ => DescribeTagsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeTagsError::Unknown(body.to_string()),
+            Err(_) => DescribeTagsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -7336,7 +7388,7 @@ pub enum DetachLoadBalancerFromSubnetsError {
 }
 
 impl DetachLoadBalancerFromSubnetsError {
-    pub fn from_body(body: &str) -> DetachLoadBalancerFromSubnetsError {
+    pub fn from_body(body: &str, status: u16) -> DetachLoadBalancerFromSubnetsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -7352,7 +7404,11 @@ impl DetachLoadBalancerFromSubnetsError {
                 }
                 _ => DetachLoadBalancerFromSubnetsError::Unknown(String::from(body)),
             },
-            Err(_) => DetachLoadBalancerFromSubnetsError::Unknown(body.to_string()),
+            Err(_) => DetachLoadBalancerFromSubnetsError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -7423,7 +7479,7 @@ pub enum DisableAvailabilityZonesForLoadBalancerError {
 }
 
 impl DisableAvailabilityZonesForLoadBalancerError {
-    pub fn from_body(body: &str) -> DisableAvailabilityZonesForLoadBalancerError {
+    pub fn from_body(body: &str, status: u16) -> DisableAvailabilityZonesForLoadBalancerError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -7441,7 +7497,11 @@ impl DisableAvailabilityZonesForLoadBalancerError {
                 }
                 _ => DisableAvailabilityZonesForLoadBalancerError::Unknown(String::from(body)),
             },
-            Err(_) => DisableAvailabilityZonesForLoadBalancerError::Unknown(body.to_string()),
+            Err(_) => DisableAvailabilityZonesForLoadBalancerError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -7512,7 +7572,7 @@ pub enum EnableAvailabilityZonesForLoadBalancerError {
 }
 
 impl EnableAvailabilityZonesForLoadBalancerError {
-    pub fn from_body(body: &str) -> EnableAvailabilityZonesForLoadBalancerError {
+    pub fn from_body(body: &str, status: u16) -> EnableAvailabilityZonesForLoadBalancerError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -7525,7 +7585,11 @@ impl EnableAvailabilityZonesForLoadBalancerError {
                 }
                 _ => EnableAvailabilityZonesForLoadBalancerError::Unknown(String::from(body)),
             },
-            Err(_) => EnableAvailabilityZonesForLoadBalancerError::Unknown(body.to_string()),
+            Err(_) => EnableAvailabilityZonesForLoadBalancerError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -7597,7 +7661,7 @@ pub enum ModifyLoadBalancerAttributesError {
 }
 
 impl ModifyLoadBalancerAttributesError {
-    pub fn from_body(body: &str) -> ModifyLoadBalancerAttributesError {
+    pub fn from_body(body: &str, status: u16) -> ModifyLoadBalancerAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -7618,7 +7682,11 @@ impl ModifyLoadBalancerAttributesError {
                 }
                 _ => ModifyLoadBalancerAttributesError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyLoadBalancerAttributesError::Unknown(body.to_string()),
+            Err(_) => ModifyLoadBalancerAttributesError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -7690,7 +7758,7 @@ pub enum RegisterInstancesWithLoadBalancerError {
 }
 
 impl RegisterInstancesWithLoadBalancerError {
-    pub fn from_body(body: &str) -> RegisterInstancesWithLoadBalancerError {
+    pub fn from_body(body: &str, status: u16) -> RegisterInstancesWithLoadBalancerError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -7706,7 +7774,11 @@ impl RegisterInstancesWithLoadBalancerError {
                 ),
                 _ => RegisterInstancesWithLoadBalancerError::Unknown(String::from(body)),
             },
-            Err(_) => RegisterInstancesWithLoadBalancerError::Unknown(body.to_string()),
+            Err(_) => RegisterInstancesWithLoadBalancerError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -7775,7 +7847,7 @@ pub enum RemoveTagsError {
 }
 
 impl RemoveTagsError {
-    pub fn from_body(body: &str) -> RemoveTagsError {
+    pub fn from_body(body: &str, status: u16) -> RemoveTagsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -7786,7 +7858,7 @@ impl RemoveTagsError {
                 }
                 _ => RemoveTagsError::Unknown(String::from(body)),
             },
-            Err(_) => RemoveTagsError::Unknown(body.to_string()),
+            Err(_) => RemoveTagsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -7860,7 +7932,7 @@ pub enum SetLoadBalancerListenerSSLCertificateError {
 }
 
 impl SetLoadBalancerListenerSSLCertificateError {
-    pub fn from_body(body: &str) -> SetLoadBalancerListenerSSLCertificateError {
+    pub fn from_body(body: &str, status: u16) -> SetLoadBalancerListenerSSLCertificateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -7891,7 +7963,11 @@ impl SetLoadBalancerListenerSSLCertificateError {
                 }
                 _ => SetLoadBalancerListenerSSLCertificateError::Unknown(String::from(body)),
             },
-            Err(_) => SetLoadBalancerListenerSSLCertificateError::Unknown(body.to_string()),
+            Err(_) => SetLoadBalancerListenerSSLCertificateError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -7969,7 +8045,7 @@ pub enum SetLoadBalancerPoliciesForBackendServerError {
 }
 
 impl SetLoadBalancerPoliciesForBackendServerError {
-    pub fn from_body(body: &str) -> SetLoadBalancerPoliciesForBackendServerError {
+    pub fn from_body(body: &str, status: u16) -> SetLoadBalancerPoliciesForBackendServerError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -7990,7 +8066,11 @@ impl SetLoadBalancerPoliciesForBackendServerError {
                 ),
                 _ => SetLoadBalancerPoliciesForBackendServerError::Unknown(String::from(body)),
             },
-            Err(_) => SetLoadBalancerPoliciesForBackendServerError::Unknown(body.to_string()),
+            Err(_) => SetLoadBalancerPoliciesForBackendServerError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -8068,7 +8148,7 @@ pub enum SetLoadBalancerPoliciesOfListenerError {
 }
 
 impl SetLoadBalancerPoliciesOfListenerError {
-    pub fn from_body(body: &str) -> SetLoadBalancerPoliciesOfListenerError {
+    pub fn from_body(body: &str, status: u16) -> SetLoadBalancerPoliciesOfListenerError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -8092,7 +8172,11 @@ impl SetLoadBalancerPoliciesOfListenerError {
                 ),
                 _ => SetLoadBalancerPoliciesOfListenerError::Unknown(String::from(body)),
             },
-            Err(_) => SetLoadBalancerPoliciesOfListenerError::Unknown(body.to_string()),
+            Err(_) => SetLoadBalancerPoliciesOfListenerError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 

--- a/rusoto/services/elb/src/generated.rs
+++ b/rusoto/services/elb/src/generated.rs
@@ -5537,7 +5537,13 @@ impl AddTagsError {
                 "TooManyTags" => AddTagsError::TooManyTags(String::from(parsed_error.message)),
                 _ => AddTagsError::Unknown(String::from(body)),
             },
-            Err(_) => AddTagsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    AddTagsError::Unknown(format!("{}", status))
+                } else {
+                    AddTagsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -5632,11 +5638,17 @@ impl ApplySecurityGroupsToLoadBalancerError {
                 }
                 _ => ApplySecurityGroupsToLoadBalancerError::Unknown(String::from(body)),
             },
-            Err(_) => ApplySecurityGroupsToLoadBalancerError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    ApplySecurityGroupsToLoadBalancerError::Unknown(format!("{}", status))
+                } else {
+                    ApplySecurityGroupsToLoadBalancerError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -5734,11 +5746,17 @@ impl AttachLoadBalancerToSubnetsError {
                 )),
                 _ => AttachLoadBalancerToSubnetsError::Unknown(String::from(body)),
             },
-            Err(_) => AttachLoadBalancerToSubnetsError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    AttachLoadBalancerToSubnetsError::Unknown(format!("{}", status))
+                } else {
+                    AttachLoadBalancerToSubnetsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -5821,7 +5839,11 @@ impl ConfigureHealthCheckError {
                 _ => ConfigureHealthCheckError::Unknown(String::from(body)),
             },
             Err(_) => {
-                ConfigureHealthCheckError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    ConfigureHealthCheckError::Unknown(format!("{}", status))
+                } else {
+                    ConfigureHealthCheckError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -5920,11 +5942,17 @@ impl CreateAppCookieStickinessPolicyError {
                 ),
                 _ => CreateAppCookieStickinessPolicyError::Unknown(String::from(body)),
             },
-            Err(_) => CreateAppCookieStickinessPolicyError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateAppCookieStickinessPolicyError::Unknown(format!("{}", status))
+                } else {
+                    CreateAppCookieStickinessPolicyError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -6023,11 +6051,17 @@ impl CreateLBCookieStickinessPolicyError {
                 ),
                 _ => CreateLBCookieStickinessPolicyError::Unknown(String::from(body)),
             },
-            Err(_) => CreateLBCookieStickinessPolicyError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateLBCookieStickinessPolicyError::Unknown(format!("{}", status))
+                } else {
+                    CreateLBCookieStickinessPolicyError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -6166,7 +6200,13 @@ impl CreateLoadBalancerError {
                 }
                 _ => CreateLoadBalancerError::Unknown(String::from(body)),
             },
-            Err(_) => CreateLoadBalancerError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateLoadBalancerError::Unknown(format!("{}", status))
+                } else {
+                    CreateLoadBalancerError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -6278,11 +6318,17 @@ impl CreateLoadBalancerListenersError {
                 ),
                 _ => CreateLoadBalancerListenersError::Unknown(String::from(body)),
             },
-            Err(_) => CreateLoadBalancerListenersError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateLoadBalancerListenersError::Unknown(format!("{}", status))
+                } else {
+                    CreateLoadBalancerListenersError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -6388,7 +6434,15 @@ impl CreateLoadBalancerPolicyError {
                 _ => CreateLoadBalancerPolicyError::Unknown(String::from(body)),
             },
             Err(_) => {
-                CreateLoadBalancerPolicyError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    CreateLoadBalancerPolicyError::Unknown(format!("{}", status))
+                } else {
+                    CreateLoadBalancerPolicyError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -6467,7 +6521,13 @@ impl DeleteLoadBalancerError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteLoadBalancerError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteLoadBalancerError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteLoadBalancerError::Unknown(format!("{}", status))
+                } else {
+                    DeleteLoadBalancerError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -6545,11 +6605,17 @@ impl DeleteLoadBalancerListenersError {
                 ),
                 _ => DeleteLoadBalancerListenersError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteLoadBalancerListenersError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteLoadBalancerListenersError::Unknown(format!("{}", status))
+                } else {
+                    DeleteLoadBalancerListenersError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -6636,7 +6702,15 @@ impl DeleteLoadBalancerPolicyError {
                 _ => DeleteLoadBalancerPolicyError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DeleteLoadBalancerPolicyError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DeleteLoadBalancerPolicyError::Unknown(format!("{}", status))
+                } else {
+                    DeleteLoadBalancerPolicyError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -6724,11 +6798,17 @@ impl DeregisterInstancesFromLoadBalancerError {
                 ),
                 _ => DeregisterInstancesFromLoadBalancerError::Unknown(String::from(body)),
             },
-            Err(_) => DeregisterInstancesFromLoadBalancerError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeregisterInstancesFromLoadBalancerError::Unknown(format!("{}", status))
+                } else {
+                    DeregisterInstancesFromLoadBalancerError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -6804,7 +6884,11 @@ impl DescribeAccountLimitsError {
                 _ => DescribeAccountLimitsError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeAccountLimitsError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeAccountLimitsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeAccountLimitsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -6889,7 +6973,11 @@ impl DescribeInstanceHealthError {
                 _ => DescribeInstanceHealthError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeInstanceHealthError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeInstanceHealthError::Unknown(format!("{}", status))
+                } else {
+                    DescribeInstanceHealthError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -6977,11 +7065,17 @@ impl DescribeLoadBalancerAttributesError {
                 }
                 _ => DescribeLoadBalancerAttributesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeLoadBalancerAttributesError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeLoadBalancerAttributesError::Unknown(format!("{}", status))
+                } else {
+                    DescribeLoadBalancerAttributesError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -7066,11 +7160,17 @@ impl DescribeLoadBalancerPoliciesError {
                 ),
                 _ => DescribeLoadBalancerPoliciesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeLoadBalancerPoliciesError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeLoadBalancerPoliciesError::Unknown(format!("{}", status))
+                } else {
+                    DescribeLoadBalancerPoliciesError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -7150,11 +7250,17 @@ impl DescribeLoadBalancerPolicyTypesError {
                 ),
                 _ => DescribeLoadBalancerPolicyTypesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeLoadBalancerPolicyTypesError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeLoadBalancerPolicyTypesError::Unknown(format!("{}", status))
+                } else {
+                    DescribeLoadBalancerPolicyTypesError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -7239,7 +7345,11 @@ impl DescribeLoadBalancersError {
                 _ => DescribeLoadBalancersError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeLoadBalancersError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeLoadBalancersError::Unknown(format!("{}", status))
+                } else {
+                    DescribeLoadBalancersError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -7320,7 +7430,13 @@ impl DescribeTagsError {
                 }
                 _ => DescribeTagsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeTagsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeTagsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeTagsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -7404,11 +7520,17 @@ impl DetachLoadBalancerFromSubnetsError {
                 }
                 _ => DetachLoadBalancerFromSubnetsError::Unknown(String::from(body)),
             },
-            Err(_) => DetachLoadBalancerFromSubnetsError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DetachLoadBalancerFromSubnetsError::Unknown(format!("{}", status))
+                } else {
+                    DetachLoadBalancerFromSubnetsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -7497,11 +7619,17 @@ impl DisableAvailabilityZonesForLoadBalancerError {
                 }
                 _ => DisableAvailabilityZonesForLoadBalancerError::Unknown(String::from(body)),
             },
-            Err(_) => DisableAvailabilityZonesForLoadBalancerError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DisableAvailabilityZonesForLoadBalancerError::Unknown(format!("{}", status))
+                } else {
+                    DisableAvailabilityZonesForLoadBalancerError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -7585,11 +7713,17 @@ impl EnableAvailabilityZonesForLoadBalancerError {
                 }
                 _ => EnableAvailabilityZonesForLoadBalancerError::Unknown(String::from(body)),
             },
-            Err(_) => EnableAvailabilityZonesForLoadBalancerError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    EnableAvailabilityZonesForLoadBalancerError::Unknown(format!("{}", status))
+                } else {
+                    EnableAvailabilityZonesForLoadBalancerError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -7682,11 +7816,17 @@ impl ModifyLoadBalancerAttributesError {
                 }
                 _ => ModifyLoadBalancerAttributesError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyLoadBalancerAttributesError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    ModifyLoadBalancerAttributesError::Unknown(format!("{}", status))
+                } else {
+                    ModifyLoadBalancerAttributesError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -7774,11 +7914,17 @@ impl RegisterInstancesWithLoadBalancerError {
                 ),
                 _ => RegisterInstancesWithLoadBalancerError::Unknown(String::from(body)),
             },
-            Err(_) => RegisterInstancesWithLoadBalancerError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    RegisterInstancesWithLoadBalancerError::Unknown(format!("{}", status))
+                } else {
+                    RegisterInstancesWithLoadBalancerError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -7858,7 +8004,13 @@ impl RemoveTagsError {
                 }
                 _ => RemoveTagsError::Unknown(String::from(body)),
             },
-            Err(_) => RemoveTagsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    RemoveTagsError::Unknown(format!("{}", status))
+                } else {
+                    RemoveTagsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -7963,11 +8115,17 @@ impl SetLoadBalancerListenerSSLCertificateError {
                 }
                 _ => SetLoadBalancerListenerSSLCertificateError::Unknown(String::from(body)),
             },
-            Err(_) => SetLoadBalancerListenerSSLCertificateError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    SetLoadBalancerListenerSSLCertificateError::Unknown(format!("{}", status))
+                } else {
+                    SetLoadBalancerListenerSSLCertificateError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -8066,11 +8224,17 @@ impl SetLoadBalancerPoliciesForBackendServerError {
                 ),
                 _ => SetLoadBalancerPoliciesForBackendServerError::Unknown(String::from(body)),
             },
-            Err(_) => SetLoadBalancerPoliciesForBackendServerError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    SetLoadBalancerPoliciesForBackendServerError::Unknown(format!("{}", status))
+                } else {
+                    SetLoadBalancerPoliciesForBackendServerError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -8172,11 +8336,17 @@ impl SetLoadBalancerPoliciesOfListenerError {
                 ),
                 _ => SetLoadBalancerPoliciesOfListenerError::Unknown(String::from(body)),
             },
-            Err(_) => SetLoadBalancerPoliciesOfListenerError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    SetLoadBalancerPoliciesOfListenerError::Unknown(format!("{}", status))
+                } else {
+                    SetLoadBalancerPoliciesOfListenerError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 

--- a/rusoto/services/elbv2/src/generated.rs
+++ b/rusoto/services/elbv2/src/generated.rs
@@ -7247,7 +7247,7 @@ pub enum AddListenerCertificatesError {
 }
 
 impl AddListenerCertificatesError {
-    pub fn from_body(body: &str) -> AddListenerCertificatesError {
+    pub fn from_body(body: &str, status: u16) -> AddListenerCertificatesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -7264,7 +7264,9 @@ impl AddListenerCertificatesError {
                 ),
                 _ => AddListenerCertificatesError::Unknown(String::from(body)),
             },
-            Err(_) => AddListenerCertificatesError::Unknown(body.to_string()),
+            Err(_) => {
+                AddListenerCertificatesError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -7340,7 +7342,7 @@ pub enum AddTagsError {
 }
 
 impl AddTagsError {
-    pub fn from_body(body: &str) -> AddTagsError {
+    pub fn from_body(body: &str, status: u16) -> AddTagsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -7358,7 +7360,7 @@ impl AddTagsError {
                 "TooManyTags" => AddTagsError::TooManyTags(String::from(parsed_error.message)),
                 _ => AddTagsError::Unknown(String::from(body)),
             },
-            Err(_) => AddTagsError::Unknown(body.to_string()),
+            Err(_) => AddTagsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -7455,7 +7457,7 @@ pub enum CreateListenerError {
 }
 
 impl CreateListenerError {
-    pub fn from_body(body: &str) -> CreateListenerError {
+    pub fn from_body(body: &str, status: u16) -> CreateListenerError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -7510,7 +7512,7 @@ impl CreateListenerError {
                 }
                 _ => CreateListenerError::Unknown(String::from(body)),
             },
-            Err(_) => CreateListenerError::Unknown(body.to_string()),
+            Err(_) => CreateListenerError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -7614,7 +7616,7 @@ pub enum CreateLoadBalancerError {
 }
 
 impl CreateLoadBalancerError {
-    pub fn from_body(body: &str) -> CreateLoadBalancerError {
+    pub fn from_body(body: &str, status: u16) -> CreateLoadBalancerError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -7665,7 +7667,7 @@ impl CreateLoadBalancerError {
                 }
                 _ => CreateLoadBalancerError::Unknown(String::from(body)),
             },
-            Err(_) => CreateLoadBalancerError::Unknown(body.to_string()),
+            Err(_) => CreateLoadBalancerError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -7769,7 +7771,7 @@ pub enum CreateRuleError {
 }
 
 impl CreateRuleError {
-    pub fn from_body(body: &str) -> CreateRuleError {
+    pub fn from_body(body: &str, status: u16) -> CreateRuleError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -7816,7 +7818,7 @@ impl CreateRuleError {
                 }
                 _ => CreateRuleError::Unknown(String::from(body)),
             },
-            Err(_) => CreateRuleError::Unknown(body.to_string()),
+            Err(_) => CreateRuleError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -7898,7 +7900,7 @@ pub enum CreateTargetGroupError {
 }
 
 impl CreateTargetGroupError {
-    pub fn from_body(body: &str) -> CreateTargetGroupError {
+    pub fn from_body(body: &str, status: u16) -> CreateTargetGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -7917,7 +7919,7 @@ impl CreateTargetGroupError {
                 }
                 _ => CreateTargetGroupError::Unknown(String::from(body)),
             },
-            Err(_) => CreateTargetGroupError::Unknown(body.to_string()),
+            Err(_) => CreateTargetGroupError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -7987,7 +7989,7 @@ pub enum DeleteListenerError {
 }
 
 impl DeleteListenerError {
-    pub fn from_body(body: &str) -> DeleteListenerError {
+    pub fn from_body(body: &str, status: u16) -> DeleteListenerError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -7998,7 +8000,7 @@ impl DeleteListenerError {
                 }
                 _ => DeleteListenerError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteListenerError::Unknown(body.to_string()),
+            Err(_) => DeleteListenerError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -8068,7 +8070,7 @@ pub enum DeleteLoadBalancerError {
 }
 
 impl DeleteLoadBalancerError {
-    pub fn from_body(body: &str) -> DeleteLoadBalancerError {
+    pub fn from_body(body: &str, status: u16) -> DeleteLoadBalancerError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -8085,7 +8087,7 @@ impl DeleteLoadBalancerError {
                 }
                 _ => DeleteLoadBalancerError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteLoadBalancerError::Unknown(body.to_string()),
+            Err(_) => DeleteLoadBalancerError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -8157,7 +8159,7 @@ pub enum DeleteRuleError {
 }
 
 impl DeleteRuleError {
-    pub fn from_body(body: &str) -> DeleteRuleError {
+    pub fn from_body(body: &str, status: u16) -> DeleteRuleError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -8169,7 +8171,7 @@ impl DeleteRuleError {
                 "RuleNotFound" => DeleteRuleError::RuleNotFound(String::from(parsed_error.message)),
                 _ => DeleteRuleError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteRuleError::Unknown(body.to_string()),
+            Err(_) => DeleteRuleError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -8236,7 +8238,7 @@ pub enum DeleteTargetGroupError {
 }
 
 impl DeleteTargetGroupError {
-    pub fn from_body(body: &str) -> DeleteTargetGroupError {
+    pub fn from_body(body: &str, status: u16) -> DeleteTargetGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -8247,7 +8249,7 @@ impl DeleteTargetGroupError {
                 }
                 _ => DeleteTargetGroupError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteTargetGroupError::Unknown(body.to_string()),
+            Err(_) => DeleteTargetGroupError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -8317,7 +8319,7 @@ pub enum DeregisterTargetsError {
 }
 
 impl DeregisterTargetsError {
-    pub fn from_body(body: &str) -> DeregisterTargetsError {
+    pub fn from_body(body: &str, status: u16) -> DeregisterTargetsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -8331,7 +8333,7 @@ impl DeregisterTargetsError {
                 }
                 _ => DeregisterTargetsError::Unknown(String::from(body)),
             },
-            Err(_) => DeregisterTargetsError::Unknown(body.to_string()),
+            Err(_) => DeregisterTargetsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -8398,7 +8400,7 @@ pub enum DescribeAccountLimitsError {
 }
 
 impl DescribeAccountLimitsError {
-    pub fn from_body(body: &str) -> DescribeAccountLimitsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeAccountLimitsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -8406,7 +8408,9 @@ impl DescribeAccountLimitsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeAccountLimitsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeAccountLimitsError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeAccountLimitsError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -8473,7 +8477,7 @@ pub enum DescribeListenerCertificatesError {
 }
 
 impl DescribeListenerCertificatesError {
-    pub fn from_body(body: &str) -> DescribeListenerCertificatesError {
+    pub fn from_body(body: &str, status: u16) -> DescribeListenerCertificatesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -8484,7 +8488,11 @@ impl DescribeListenerCertificatesError {
                 ),
                 _ => DescribeListenerCertificatesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeListenerCertificatesError::Unknown(body.to_string()),
+            Err(_) => DescribeListenerCertificatesError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -8556,7 +8564,7 @@ pub enum DescribeListenersError {
 }
 
 impl DescribeListenersError {
-    pub fn from_body(body: &str) -> DescribeListenersError {
+    pub fn from_body(body: &str, status: u16) -> DescribeListenersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -8573,7 +8581,7 @@ impl DescribeListenersError {
                 }
                 _ => DescribeListenersError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeListenersError::Unknown(body.to_string()),
+            Err(_) => DescribeListenersError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -8643,7 +8651,7 @@ pub enum DescribeLoadBalancerAttributesError {
 }
 
 impl DescribeLoadBalancerAttributesError {
-    pub fn from_body(body: &str) -> DescribeLoadBalancerAttributesError {
+    pub fn from_body(body: &str, status: u16) -> DescribeLoadBalancerAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -8656,7 +8664,11 @@ impl DescribeLoadBalancerAttributesError {
                 }
                 _ => DescribeLoadBalancerAttributesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeLoadBalancerAttributesError::Unknown(body.to_string()),
+            Err(_) => DescribeLoadBalancerAttributesError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -8724,7 +8736,7 @@ pub enum DescribeLoadBalancersError {
 }
 
 impl DescribeLoadBalancersError {
-    pub fn from_body(body: &str) -> DescribeLoadBalancersError {
+    pub fn from_body(body: &str, status: u16) -> DescribeLoadBalancersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -8735,7 +8747,9 @@ impl DescribeLoadBalancersError {
                 ),
                 _ => DescribeLoadBalancersError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeLoadBalancersError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeLoadBalancersError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -8807,7 +8821,7 @@ pub enum DescribeRulesError {
 }
 
 impl DescribeRulesError {
-    pub fn from_body(body: &str) -> DescribeRulesError {
+    pub fn from_body(body: &str, status: u16) -> DescribeRulesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -8824,7 +8838,7 @@ impl DescribeRulesError {
                 }
                 _ => DescribeRulesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeRulesError::Unknown(body.to_string()),
+            Err(_) => DescribeRulesError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -8892,7 +8906,7 @@ pub enum DescribeSSLPoliciesError {
 }
 
 impl DescribeSSLPoliciesError {
-    pub fn from_body(body: &str) -> DescribeSSLPoliciesError {
+    pub fn from_body(body: &str, status: u16) -> DescribeSSLPoliciesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -8903,7 +8917,7 @@ impl DescribeSSLPoliciesError {
                 }
                 _ => DescribeSSLPoliciesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeSSLPoliciesError::Unknown(body.to_string()),
+            Err(_) => DescribeSSLPoliciesError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -8977,7 +8991,7 @@ pub enum DescribeTagsError {
 }
 
 impl DescribeTagsError {
-    pub fn from_body(body: &str) -> DescribeTagsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeTagsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -8997,7 +9011,7 @@ impl DescribeTagsError {
                 }
                 _ => DescribeTagsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeTagsError::Unknown(body.to_string()),
+            Err(_) => DescribeTagsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -9066,7 +9080,7 @@ pub enum DescribeTargetGroupAttributesError {
 }
 
 impl DescribeTargetGroupAttributesError {
-    pub fn from_body(body: &str) -> DescribeTargetGroupAttributesError {
+    pub fn from_body(body: &str, status: u16) -> DescribeTargetGroupAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -9077,7 +9091,11 @@ impl DescribeTargetGroupAttributesError {
                 ),
                 _ => DescribeTargetGroupAttributesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeTargetGroupAttributesError::Unknown(body.to_string()),
+            Err(_) => DescribeTargetGroupAttributesError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -9147,7 +9165,7 @@ pub enum DescribeTargetGroupsError {
 }
 
 impl DescribeTargetGroupsError {
-    pub fn from_body(body: &str) -> DescribeTargetGroupsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeTargetGroupsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -9161,7 +9179,9 @@ impl DescribeTargetGroupsError {
                 ),
                 _ => DescribeTargetGroupsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeTargetGroupsError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeTargetGroupsError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -9234,7 +9254,7 @@ pub enum DescribeTargetHealthError {
 }
 
 impl DescribeTargetHealthError {
-    pub fn from_body(body: &str) -> DescribeTargetHealthError {
+    pub fn from_body(body: &str, status: u16) -> DescribeTargetHealthError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -9251,7 +9271,9 @@ impl DescribeTargetHealthError {
                 ),
                 _ => DescribeTargetHealthError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeTargetHealthError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeTargetHealthError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -9349,7 +9371,7 @@ pub enum ModifyListenerError {
 }
 
 impl ModifyListenerError {
-    pub fn from_body(body: &str) -> ModifyListenerError {
+    pub fn from_body(body: &str, status: u16) -> ModifyListenerError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -9404,7 +9426,7 @@ impl ModifyListenerError {
                 }
                 _ => ModifyListenerError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyListenerError::Unknown(body.to_string()),
+            Err(_) => ModifyListenerError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -9486,7 +9508,7 @@ pub enum ModifyLoadBalancerAttributesError {
 }
 
 impl ModifyLoadBalancerAttributesError {
-    pub fn from_body(body: &str) -> ModifyLoadBalancerAttributesError {
+    pub fn from_body(body: &str, status: u16) -> ModifyLoadBalancerAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -9502,7 +9524,11 @@ impl ModifyLoadBalancerAttributesError {
                 ),
                 _ => ModifyLoadBalancerAttributesError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyLoadBalancerAttributesError::Unknown(body.to_string()),
+            Err(_) => ModifyLoadBalancerAttributesError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -9589,7 +9615,7 @@ pub enum ModifyRuleError {
 }
 
 impl ModifyRuleError {
-    pub fn from_body(body: &str) -> ModifyRuleError {
+    pub fn from_body(body: &str, status: u16) -> ModifyRuleError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -9627,7 +9653,7 @@ impl ModifyRuleError {
                 }
                 _ => ModifyRuleError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyRuleError::Unknown(body.to_string()),
+            Err(_) => ModifyRuleError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -9704,7 +9730,7 @@ pub enum ModifyTargetGroupError {
 }
 
 impl ModifyTargetGroupError {
-    pub fn from_body(body: &str) -> ModifyTargetGroupError {
+    pub fn from_body(body: &str, status: u16) -> ModifyTargetGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -9720,7 +9746,7 @@ impl ModifyTargetGroupError {
                 }
                 _ => ModifyTargetGroupError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyTargetGroupError::Unknown(body.to_string()),
+            Err(_) => ModifyTargetGroupError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -9791,7 +9817,7 @@ pub enum ModifyTargetGroupAttributesError {
 }
 
 impl ModifyTargetGroupAttributesError {
-    pub fn from_body(body: &str) -> ModifyTargetGroupAttributesError {
+    pub fn from_body(body: &str, status: u16) -> ModifyTargetGroupAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -9807,7 +9833,11 @@ impl ModifyTargetGroupAttributesError {
                 ),
                 _ => ModifyTargetGroupAttributesError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyTargetGroupAttributesError::Unknown(body.to_string()),
+            Err(_) => ModifyTargetGroupAttributesError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -9882,7 +9912,7 @@ pub enum RegisterTargetsError {
 }
 
 impl RegisterTargetsError {
-    pub fn from_body(body: &str) -> RegisterTargetsError {
+    pub fn from_body(body: &str, status: u16) -> RegisterTargetsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -9904,7 +9934,7 @@ impl RegisterTargetsError {
                 }
                 _ => RegisterTargetsError::Unknown(String::from(body)),
             },
-            Err(_) => RegisterTargetsError::Unknown(body.to_string()),
+            Err(_) => RegisterTargetsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -9975,7 +10005,7 @@ pub enum RemoveListenerCertificatesError {
 }
 
 impl RemoveListenerCertificatesError {
-    pub fn from_body(body: &str) -> RemoveListenerCertificatesError {
+    pub fn from_body(body: &str, status: u16) -> RemoveListenerCertificatesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -9989,7 +10019,9 @@ impl RemoveListenerCertificatesError {
                 ),
                 _ => RemoveListenerCertificatesError::Unknown(String::from(body)),
             },
-            Err(_) => RemoveListenerCertificatesError::Unknown(body.to_string()),
+            Err(_) => {
+                RemoveListenerCertificatesError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -10066,7 +10098,7 @@ pub enum RemoveTagsError {
 }
 
 impl RemoveTagsError {
-    pub fn from_body(body: &str) -> RemoveTagsError {
+    pub fn from_body(body: &str, status: u16) -> RemoveTagsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10085,7 +10117,7 @@ impl RemoveTagsError {
                 "TooManyTags" => RemoveTagsError::TooManyTags(String::from(parsed_error.message)),
                 _ => RemoveTagsError::Unknown(String::from(body)),
             },
-            Err(_) => RemoveTagsError::Unknown(body.to_string()),
+            Err(_) => RemoveTagsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -10159,7 +10191,7 @@ pub enum SetIpAddressTypeError {
 }
 
 impl SetIpAddressTypeError {
-    pub fn from_body(body: &str) -> SetIpAddressTypeError {
+    pub fn from_body(body: &str, status: u16) -> SetIpAddressTypeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10178,7 +10210,7 @@ impl SetIpAddressTypeError {
                 }
                 _ => SetIpAddressTypeError::Unknown(String::from(body)),
             },
-            Err(_) => SetIpAddressTypeError::Unknown(body.to_string()),
+            Err(_) => SetIpAddressTypeError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -10250,7 +10282,7 @@ pub enum SetRulePrioritiesError {
 }
 
 impl SetRulePrioritiesError {
-    pub fn from_body(body: &str) -> SetRulePrioritiesError {
+    pub fn from_body(body: &str, status: u16) -> SetRulePrioritiesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10267,7 +10299,7 @@ impl SetRulePrioritiesError {
                 }
                 _ => SetRulePrioritiesError::Unknown(String::from(body)),
             },
-            Err(_) => SetRulePrioritiesError::Unknown(body.to_string()),
+            Err(_) => SetRulePrioritiesError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -10341,7 +10373,7 @@ pub enum SetSecurityGroupsError {
 }
 
 impl SetSecurityGroupsError {
-    pub fn from_body(body: &str) -> SetSecurityGroupsError {
+    pub fn from_body(body: &str, status: u16) -> SetSecurityGroupsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10360,7 +10392,7 @@ impl SetSecurityGroupsError {
                 }
                 _ => SetSecurityGroupsError::Unknown(String::from(body)),
             },
-            Err(_) => SetSecurityGroupsError::Unknown(body.to_string()),
+            Err(_) => SetSecurityGroupsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -10440,7 +10472,7 @@ pub enum SetSubnetsError {
 }
 
 impl SetSubnetsError {
-    pub fn from_body(body: &str) -> SetSubnetsError {
+    pub fn from_body(body: &str, status: u16) -> SetSubnetsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10466,7 +10498,7 @@ impl SetSubnetsError {
                 }
                 _ => SetSubnetsError::Unknown(String::from(body)),
             },
-            Err(_) => SetSubnetsError::Unknown(body.to_string()),
+            Err(_) => SetSubnetsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 

--- a/rusoto/services/elbv2/src/generated.rs
+++ b/rusoto/services/elbv2/src/generated.rs
@@ -7265,7 +7265,15 @@ impl AddListenerCertificatesError {
                 _ => AddListenerCertificatesError::Unknown(String::from(body)),
             },
             Err(_) => {
-                AddListenerCertificatesError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    AddListenerCertificatesError::Unknown(format!("{}", status))
+                } else {
+                    AddListenerCertificatesError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -7360,7 +7368,13 @@ impl AddTagsError {
                 "TooManyTags" => AddTagsError::TooManyTags(String::from(parsed_error.message)),
                 _ => AddTagsError::Unknown(String::from(body)),
             },
-            Err(_) => AddTagsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    AddTagsError::Unknown(format!("{}", status))
+                } else {
+                    AddTagsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -7512,7 +7526,13 @@ impl CreateListenerError {
                 }
                 _ => CreateListenerError::Unknown(String::from(body)),
             },
-            Err(_) => CreateListenerError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateListenerError::Unknown(format!("{}", status))
+                } else {
+                    CreateListenerError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -7667,7 +7687,13 @@ impl CreateLoadBalancerError {
                 }
                 _ => CreateLoadBalancerError::Unknown(String::from(body)),
             },
-            Err(_) => CreateLoadBalancerError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateLoadBalancerError::Unknown(format!("{}", status))
+                } else {
+                    CreateLoadBalancerError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -7818,7 +7844,13 @@ impl CreateRuleError {
                 }
                 _ => CreateRuleError::Unknown(String::from(body)),
             },
-            Err(_) => CreateRuleError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateRuleError::Unknown(format!("{}", status))
+                } else {
+                    CreateRuleError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -7919,7 +7951,13 @@ impl CreateTargetGroupError {
                 }
                 _ => CreateTargetGroupError::Unknown(String::from(body)),
             },
-            Err(_) => CreateTargetGroupError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateTargetGroupError::Unknown(format!("{}", status))
+                } else {
+                    CreateTargetGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -8000,7 +8038,13 @@ impl DeleteListenerError {
                 }
                 _ => DeleteListenerError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteListenerError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteListenerError::Unknown(format!("{}", status))
+                } else {
+                    DeleteListenerError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -8087,7 +8131,13 @@ impl DeleteLoadBalancerError {
                 }
                 _ => DeleteLoadBalancerError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteLoadBalancerError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteLoadBalancerError::Unknown(format!("{}", status))
+                } else {
+                    DeleteLoadBalancerError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -8171,7 +8221,13 @@ impl DeleteRuleError {
                 "RuleNotFound" => DeleteRuleError::RuleNotFound(String::from(parsed_error.message)),
                 _ => DeleteRuleError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteRuleError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteRuleError::Unknown(format!("{}", status))
+                } else {
+                    DeleteRuleError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -8249,7 +8305,13 @@ impl DeleteTargetGroupError {
                 }
                 _ => DeleteTargetGroupError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteTargetGroupError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteTargetGroupError::Unknown(format!("{}", status))
+                } else {
+                    DeleteTargetGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -8333,7 +8395,13 @@ impl DeregisterTargetsError {
                 }
                 _ => DeregisterTargetsError::Unknown(String::from(body)),
             },
-            Err(_) => DeregisterTargetsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeregisterTargetsError::Unknown(format!("{}", status))
+                } else {
+                    DeregisterTargetsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -8409,7 +8477,11 @@ impl DescribeAccountLimitsError {
                 _ => DescribeAccountLimitsError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeAccountLimitsError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeAccountLimitsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeAccountLimitsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -8488,11 +8560,17 @@ impl DescribeListenerCertificatesError {
                 ),
                 _ => DescribeListenerCertificatesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeListenerCertificatesError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeListenerCertificatesError::Unknown(format!("{}", status))
+                } else {
+                    DescribeListenerCertificatesError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -8581,7 +8659,13 @@ impl DescribeListenersError {
                 }
                 _ => DescribeListenersError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeListenersError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeListenersError::Unknown(format!("{}", status))
+                } else {
+                    DescribeListenersError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -8664,11 +8748,17 @@ impl DescribeLoadBalancerAttributesError {
                 }
                 _ => DescribeLoadBalancerAttributesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeLoadBalancerAttributesError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeLoadBalancerAttributesError::Unknown(format!("{}", status))
+                } else {
+                    DescribeLoadBalancerAttributesError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -8748,7 +8838,11 @@ impl DescribeLoadBalancersError {
                 _ => DescribeLoadBalancersError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeLoadBalancersError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeLoadBalancersError::Unknown(format!("{}", status))
+                } else {
+                    DescribeLoadBalancersError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -8838,7 +8932,13 @@ impl DescribeRulesError {
                 }
                 _ => DescribeRulesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeRulesError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeRulesError::Unknown(format!("{}", status))
+                } else {
+                    DescribeRulesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -8917,7 +9017,13 @@ impl DescribeSSLPoliciesError {
                 }
                 _ => DescribeSSLPoliciesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeSSLPoliciesError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeSSLPoliciesError::Unknown(format!("{}", status))
+                } else {
+                    DescribeSSLPoliciesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -9011,7 +9117,13 @@ impl DescribeTagsError {
                 }
                 _ => DescribeTagsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeTagsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeTagsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeTagsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -9091,11 +9203,17 @@ impl DescribeTargetGroupAttributesError {
                 ),
                 _ => DescribeTargetGroupAttributesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeTargetGroupAttributesError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeTargetGroupAttributesError::Unknown(format!("{}", status))
+                } else {
+                    DescribeTargetGroupAttributesError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -9180,7 +9298,11 @@ impl DescribeTargetGroupsError {
                 _ => DescribeTargetGroupsError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeTargetGroupsError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeTargetGroupsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeTargetGroupsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -9272,7 +9394,11 @@ impl DescribeTargetHealthError {
                 _ => DescribeTargetHealthError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeTargetHealthError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeTargetHealthError::Unknown(format!("{}", status))
+                } else {
+                    DescribeTargetHealthError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -9426,7 +9552,13 @@ impl ModifyListenerError {
                 }
                 _ => ModifyListenerError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyListenerError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ModifyListenerError::Unknown(format!("{}", status))
+                } else {
+                    ModifyListenerError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -9524,11 +9656,17 @@ impl ModifyLoadBalancerAttributesError {
                 ),
                 _ => ModifyLoadBalancerAttributesError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyLoadBalancerAttributesError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    ModifyLoadBalancerAttributesError::Unknown(format!("{}", status))
+                } else {
+                    ModifyLoadBalancerAttributesError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -9653,7 +9791,13 @@ impl ModifyRuleError {
                 }
                 _ => ModifyRuleError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyRuleError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ModifyRuleError::Unknown(format!("{}", status))
+                } else {
+                    ModifyRuleError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -9746,7 +9890,13 @@ impl ModifyTargetGroupError {
                 }
                 _ => ModifyTargetGroupError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyTargetGroupError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ModifyTargetGroupError::Unknown(format!("{}", status))
+                } else {
+                    ModifyTargetGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -9833,11 +9983,17 @@ impl ModifyTargetGroupAttributesError {
                 ),
                 _ => ModifyTargetGroupAttributesError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyTargetGroupAttributesError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    ModifyTargetGroupAttributesError::Unknown(format!("{}", status))
+                } else {
+                    ModifyTargetGroupAttributesError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -9934,7 +10090,13 @@ impl RegisterTargetsError {
                 }
                 _ => RegisterTargetsError::Unknown(String::from(body)),
             },
-            Err(_) => RegisterTargetsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    RegisterTargetsError::Unknown(format!("{}", status))
+                } else {
+                    RegisterTargetsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -10020,7 +10182,15 @@ impl RemoveListenerCertificatesError {
                 _ => RemoveListenerCertificatesError::Unknown(String::from(body)),
             },
             Err(_) => {
-                RemoveListenerCertificatesError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    RemoveListenerCertificatesError::Unknown(format!("{}", status))
+                } else {
+                    RemoveListenerCertificatesError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -10117,7 +10287,13 @@ impl RemoveTagsError {
                 "TooManyTags" => RemoveTagsError::TooManyTags(String::from(parsed_error.message)),
                 _ => RemoveTagsError::Unknown(String::from(body)),
             },
-            Err(_) => RemoveTagsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    RemoveTagsError::Unknown(format!("{}", status))
+                } else {
+                    RemoveTagsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -10210,7 +10386,13 @@ impl SetIpAddressTypeError {
                 }
                 _ => SetIpAddressTypeError::Unknown(String::from(body)),
             },
-            Err(_) => SetIpAddressTypeError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    SetIpAddressTypeError::Unknown(format!("{}", status))
+                } else {
+                    SetIpAddressTypeError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -10299,7 +10481,13 @@ impl SetRulePrioritiesError {
                 }
                 _ => SetRulePrioritiesError::Unknown(String::from(body)),
             },
-            Err(_) => SetRulePrioritiesError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    SetRulePrioritiesError::Unknown(format!("{}", status))
+                } else {
+                    SetRulePrioritiesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -10392,7 +10580,13 @@ impl SetSecurityGroupsError {
                 }
                 _ => SetSecurityGroupsError::Unknown(String::from(body)),
             },
-            Err(_) => SetSecurityGroupsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    SetSecurityGroupsError::Unknown(format!("{}", status))
+                } else {
+                    SetSecurityGroupsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -10498,7 +10692,13 @@ impl SetSubnetsError {
                 }
                 _ => SetSubnetsError::Unknown(String::from(body)),
             },
-            Err(_) => SetSubnetsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    SetSubnetsError::Unknown(format!("{}", status))
+                } else {
+                    SetSubnetsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 

--- a/rusoto/services/iam/src/generated.rs
+++ b/rusoto/services/iam/src/generated.rs
@@ -12780,7 +12780,7 @@ pub enum AddClientIDToOpenIDConnectProviderError {
 }
 
 impl AddClientIDToOpenIDConnectProviderError {
-    pub fn from_body(body: &str) -> AddClientIDToOpenIDConnectProviderError {
+    pub fn from_body(body: &str, status: u16) -> AddClientIDToOpenIDConnectProviderError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -12800,7 +12800,11 @@ impl AddClientIDToOpenIDConnectProviderError {
                 ),
                 _ => AddClientIDToOpenIDConnectProviderError::Unknown(String::from(body)),
             },
-            Err(_) => AddClientIDToOpenIDConnectProviderError::Unknown(body.to_string()),
+            Err(_) => AddClientIDToOpenIDConnectProviderError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -12879,7 +12883,7 @@ pub enum AddRoleToInstanceProfileError {
 }
 
 impl AddRoleToInstanceProfileError {
-    pub fn from_body(body: &str) -> AddRoleToInstanceProfileError {
+    pub fn from_body(body: &str, status: u16) -> AddRoleToInstanceProfileError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -12902,7 +12906,9 @@ impl AddRoleToInstanceProfileError {
                 ),
                 _ => AddRoleToInstanceProfileError::Unknown(String::from(body)),
             },
-            Err(_) => AddRoleToInstanceProfileError::Unknown(body.to_string()),
+            Err(_) => {
+                AddRoleToInstanceProfileError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -12978,7 +12984,7 @@ pub enum AddUserToGroupError {
 }
 
 impl AddUserToGroupError {
-    pub fn from_body(body: &str) -> AddUserToGroupError {
+    pub fn from_body(body: &str, status: u16) -> AddUserToGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -12995,7 +13001,7 @@ impl AddUserToGroupError {
                 }
                 _ => AddUserToGroupError::Unknown(String::from(body)),
             },
-            Err(_) => AddUserToGroupError::Unknown(body.to_string()),
+            Err(_) => AddUserToGroupError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -13071,7 +13077,7 @@ pub enum AttachGroupPolicyError {
 }
 
 impl AttachGroupPolicyError {
-    pub fn from_body(body: &str) -> AttachGroupPolicyError {
+    pub fn from_body(body: &str, status: u16) -> AttachGroupPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -13094,7 +13100,7 @@ impl AttachGroupPolicyError {
                 }
                 _ => AttachGroupPolicyError::Unknown(String::from(body)),
             },
-            Err(_) => AttachGroupPolicyError::Unknown(body.to_string()),
+            Err(_) => AttachGroupPolicyError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -13176,7 +13182,7 @@ pub enum AttachRolePolicyError {
 }
 
 impl AttachRolePolicyError {
-    pub fn from_body(body: &str) -> AttachRolePolicyError {
+    pub fn from_body(body: &str, status: u16) -> AttachRolePolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -13202,7 +13208,7 @@ impl AttachRolePolicyError {
                 }
                 _ => AttachRolePolicyError::Unknown(String::from(body)),
             },
-            Err(_) => AttachRolePolicyError::Unknown(body.to_string()),
+            Err(_) => AttachRolePolicyError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -13281,7 +13287,7 @@ pub enum AttachUserPolicyError {
 }
 
 impl AttachUserPolicyError {
-    pub fn from_body(body: &str) -> AttachUserPolicyError {
+    pub fn from_body(body: &str, status: u16) -> AttachUserPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -13304,7 +13310,7 @@ impl AttachUserPolicyError {
                 }
                 _ => AttachUserPolicyError::Unknown(String::from(body)),
             },
-            Err(_) => AttachUserPolicyError::Unknown(body.to_string()),
+            Err(_) => AttachUserPolicyError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -13384,7 +13390,7 @@ pub enum ChangePasswordError {
 }
 
 impl ChangePasswordError {
-    pub fn from_body(body: &str) -> ChangePasswordError {
+    pub fn from_body(body: &str, status: u16) -> ChangePasswordError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -13412,7 +13418,7 @@ impl ChangePasswordError {
                 }
                 _ => ChangePasswordError::Unknown(String::from(body)),
             },
-            Err(_) => ChangePasswordError::Unknown(body.to_string()),
+            Err(_) => ChangePasswordError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -13487,7 +13493,7 @@ pub enum CreateAccessKeyError {
 }
 
 impl CreateAccessKeyError {
-    pub fn from_body(body: &str) -> CreateAccessKeyError {
+    pub fn from_body(body: &str, status: u16) -> CreateAccessKeyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -13504,7 +13510,7 @@ impl CreateAccessKeyError {
                 }
                 _ => CreateAccessKeyError::Unknown(String::from(body)),
             },
-            Err(_) => CreateAccessKeyError::Unknown(body.to_string()),
+            Err(_) => CreateAccessKeyError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -13576,7 +13582,7 @@ pub enum CreateAccountAliasError {
 }
 
 impl CreateAccountAliasError {
-    pub fn from_body(body: &str) -> CreateAccountAliasError {
+    pub fn from_body(body: &str, status: u16) -> CreateAccountAliasError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -13593,7 +13599,7 @@ impl CreateAccountAliasError {
                 }
                 _ => CreateAccountAliasError::Unknown(String::from(body)),
             },
-            Err(_) => CreateAccountAliasError::Unknown(body.to_string()),
+            Err(_) => CreateAccountAliasError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -13669,7 +13675,7 @@ pub enum CreateGroupError {
 }
 
 impl CreateGroupError {
-    pub fn from_body(body: &str) -> CreateGroupError {
+    pub fn from_body(body: &str, status: u16) -> CreateGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -13689,7 +13695,7 @@ impl CreateGroupError {
                 }
                 _ => CreateGroupError::Unknown(String::from(body)),
             },
-            Err(_) => CreateGroupError::Unknown(body.to_string()),
+            Err(_) => CreateGroupError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -13762,7 +13768,7 @@ pub enum CreateInstanceProfileError {
 }
 
 impl CreateInstanceProfileError {
-    pub fn from_body(body: &str) -> CreateInstanceProfileError {
+    pub fn from_body(body: &str, status: u16) -> CreateInstanceProfileError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -13779,7 +13785,9 @@ impl CreateInstanceProfileError {
                 }
                 _ => CreateInstanceProfileError::Unknown(String::from(body)),
             },
-            Err(_) => CreateInstanceProfileError::Unknown(body.to_string()),
+            Err(_) => {
+                CreateInstanceProfileError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -13857,7 +13865,7 @@ pub enum CreateLoginProfileError {
 }
 
 impl CreateLoginProfileError {
-    pub fn from_body(body: &str) -> CreateLoginProfileError {
+    pub fn from_body(body: &str, status: u16) -> CreateLoginProfileError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -13880,7 +13888,7 @@ impl CreateLoginProfileError {
                 }
                 _ => CreateLoginProfileError::Unknown(String::from(body)),
             },
-            Err(_) => CreateLoginProfileError::Unknown(body.to_string()),
+            Err(_) => CreateLoginProfileError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -13958,7 +13966,7 @@ pub enum CreateOpenIDConnectProviderError {
 }
 
 impl CreateOpenIDConnectProviderError {
-    pub fn from_body(body: &str) -> CreateOpenIDConnectProviderError {
+    pub fn from_body(body: &str, status: u16) -> CreateOpenIDConnectProviderError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -13978,7 +13986,11 @@ impl CreateOpenIDConnectProviderError {
                 )),
                 _ => CreateOpenIDConnectProviderError::Unknown(String::from(body)),
             },
-            Err(_) => CreateOpenIDConnectProviderError::Unknown(body.to_string()),
+            Err(_) => CreateOpenIDConnectProviderError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -14057,7 +14069,7 @@ pub enum CreatePolicyError {
 }
 
 impl CreatePolicyError {
-    pub fn from_body(body: &str) -> CreatePolicyError {
+    pub fn from_body(body: &str, status: u16) -> CreatePolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -14080,7 +14092,7 @@ impl CreatePolicyError {
                 }
                 _ => CreatePolicyError::Unknown(String::from(body)),
             },
-            Err(_) => CreatePolicyError::Unknown(body.to_string()),
+            Err(_) => CreatePolicyError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -14158,7 +14170,7 @@ pub enum CreatePolicyVersionError {
 }
 
 impl CreatePolicyVersionError {
-    pub fn from_body(body: &str) -> CreatePolicyVersionError {
+    pub fn from_body(body: &str, status: u16) -> CreatePolicyVersionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -14181,7 +14193,7 @@ impl CreatePolicyVersionError {
                 }
                 _ => CreatePolicyVersionError::Unknown(String::from(body)),
             },
-            Err(_) => CreatePolicyVersionError::Unknown(body.to_string()),
+            Err(_) => CreatePolicyVersionError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -14261,7 +14273,7 @@ pub enum CreateRoleError {
 }
 
 impl CreateRoleError {
-    pub fn from_body(body: &str) -> CreateRoleError {
+    pub fn from_body(body: &str, status: u16) -> CreateRoleError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -14282,7 +14294,7 @@ impl CreateRoleError {
                 }
                 _ => CreateRoleError::Unknown(String::from(body)),
             },
-            Err(_) => CreateRoleError::Unknown(body.to_string()),
+            Err(_) => CreateRoleError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -14358,7 +14370,7 @@ pub enum CreateSAMLProviderError {
 }
 
 impl CreateSAMLProviderError {
-    pub fn from_body(body: &str) -> CreateSAMLProviderError {
+    pub fn from_body(body: &str, status: u16) -> CreateSAMLProviderError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -14378,7 +14390,7 @@ impl CreateSAMLProviderError {
                 }
                 _ => CreateSAMLProviderError::Unknown(String::from(body)),
             },
-            Err(_) => CreateSAMLProviderError::Unknown(body.to_string()),
+            Err(_) => CreateSAMLProviderError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -14455,7 +14467,7 @@ pub enum CreateServiceLinkedRoleError {
 }
 
 impl CreateServiceLinkedRoleError {
-    pub fn from_body(body: &str) -> CreateServiceLinkedRoleError {
+    pub fn from_body(body: &str, status: u16) -> CreateServiceLinkedRoleError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -14475,7 +14487,9 @@ impl CreateServiceLinkedRoleError {
                 }
                 _ => CreateServiceLinkedRoleError::Unknown(String::from(body)),
             },
-            Err(_) => CreateServiceLinkedRoleError::Unknown(body.to_string()),
+            Err(_) => {
+                CreateServiceLinkedRoleError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -14550,7 +14564,7 @@ pub enum CreateServiceSpecificCredentialError {
 }
 
 impl CreateServiceSpecificCredentialError {
-    pub fn from_body(body: &str) -> CreateServiceSpecificCredentialError {
+    pub fn from_body(body: &str, status: u16) -> CreateServiceSpecificCredentialError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -14567,7 +14581,11 @@ impl CreateServiceSpecificCredentialError {
                 ),
                 _ => CreateServiceSpecificCredentialError::Unknown(String::from(body)),
             },
-            Err(_) => CreateServiceSpecificCredentialError::Unknown(body.to_string()),
+            Err(_) => CreateServiceSpecificCredentialError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -14643,7 +14661,7 @@ pub enum CreateUserError {
 }
 
 impl CreateUserError {
-    pub fn from_body(body: &str) -> CreateUserError {
+    pub fn from_body(body: &str, status: u16) -> CreateUserError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -14661,7 +14679,7 @@ impl CreateUserError {
                 }
                 _ => CreateUserError::Unknown(String::from(body)),
             },
-            Err(_) => CreateUserError::Unknown(body.to_string()),
+            Err(_) => CreateUserError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -14734,7 +14752,7 @@ pub enum CreateVirtualMFADeviceError {
 }
 
 impl CreateVirtualMFADeviceError {
-    pub fn from_body(body: &str) -> CreateVirtualMFADeviceError {
+    pub fn from_body(body: &str, status: u16) -> CreateVirtualMFADeviceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -14751,7 +14769,9 @@ impl CreateVirtualMFADeviceError {
                 }
                 _ => CreateVirtualMFADeviceError::Unknown(String::from(body)),
             },
-            Err(_) => CreateVirtualMFADeviceError::Unknown(body.to_string()),
+            Err(_) => {
+                CreateVirtualMFADeviceError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -14827,7 +14847,7 @@ pub enum DeactivateMFADeviceError {
 }
 
 impl DeactivateMFADeviceError {
-    pub fn from_body(body: &str) -> DeactivateMFADeviceError {
+    pub fn from_body(body: &str, status: u16) -> DeactivateMFADeviceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -14849,7 +14869,7 @@ impl DeactivateMFADeviceError {
                 }
                 _ => DeactivateMFADeviceError::Unknown(String::from(body)),
             },
-            Err(_) => DeactivateMFADeviceError::Unknown(body.to_string()),
+            Err(_) => DeactivateMFADeviceError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -14924,7 +14944,7 @@ pub enum DeleteAccessKeyError {
 }
 
 impl DeleteAccessKeyError {
-    pub fn from_body(body: &str) -> DeleteAccessKeyError {
+    pub fn from_body(body: &str, status: u16) -> DeleteAccessKeyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -14941,7 +14961,7 @@ impl DeleteAccessKeyError {
                 }
                 _ => DeleteAccessKeyError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteAccessKeyError::Unknown(body.to_string()),
+            Err(_) => DeleteAccessKeyError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -15013,7 +15033,7 @@ pub enum DeleteAccountAliasError {
 }
 
 impl DeleteAccountAliasError {
-    pub fn from_body(body: &str) -> DeleteAccountAliasError {
+    pub fn from_body(body: &str, status: u16) -> DeleteAccountAliasError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -15030,7 +15050,7 @@ impl DeleteAccountAliasError {
                 }
                 _ => DeleteAccountAliasError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteAccountAliasError::Unknown(body.to_string()),
+            Err(_) => DeleteAccountAliasError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -15104,7 +15124,7 @@ pub enum DeleteAccountPasswordPolicyError {
 }
 
 impl DeleteAccountPasswordPolicyError {
-    pub fn from_body(body: &str) -> DeleteAccountPasswordPolicyError {
+    pub fn from_body(body: &str, status: u16) -> DeleteAccountPasswordPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -15121,7 +15141,11 @@ impl DeleteAccountPasswordPolicyError {
                 )),
                 _ => DeleteAccountPasswordPolicyError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteAccountPasswordPolicyError::Unknown(body.to_string()),
+            Err(_) => DeleteAccountPasswordPolicyError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -15197,7 +15221,7 @@ pub enum DeleteGroupError {
 }
 
 impl DeleteGroupError {
-    pub fn from_body(body: &str) -> DeleteGroupError {
+    pub fn from_body(body: &str, status: u16) -> DeleteGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -15217,7 +15241,7 @@ impl DeleteGroupError {
                 }
                 _ => DeleteGroupError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteGroupError::Unknown(body.to_string()),
+            Err(_) => DeleteGroupError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -15290,7 +15314,7 @@ pub enum DeleteGroupPolicyError {
 }
 
 impl DeleteGroupPolicyError {
-    pub fn from_body(body: &str) -> DeleteGroupPolicyError {
+    pub fn from_body(body: &str, status: u16) -> DeleteGroupPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -15307,7 +15331,7 @@ impl DeleteGroupPolicyError {
                 }
                 _ => DeleteGroupPolicyError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteGroupPolicyError::Unknown(body.to_string()),
+            Err(_) => DeleteGroupPolicyError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -15383,7 +15407,7 @@ pub enum DeleteInstanceProfileError {
 }
 
 impl DeleteInstanceProfileError {
-    pub fn from_body(body: &str) -> DeleteInstanceProfileError {
+    pub fn from_body(body: &str, status: u16) -> DeleteInstanceProfileError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -15403,7 +15427,9 @@ impl DeleteInstanceProfileError {
                 }
                 _ => DeleteInstanceProfileError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteInstanceProfileError::Unknown(body.to_string()),
+            Err(_) => {
+                DeleteInstanceProfileError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -15480,7 +15506,7 @@ pub enum DeleteLoginProfileError {
 }
 
 impl DeleteLoginProfileError {
-    pub fn from_body(body: &str) -> DeleteLoginProfileError {
+    pub fn from_body(body: &str, status: u16) -> DeleteLoginProfileError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -15502,7 +15528,7 @@ impl DeleteLoginProfileError {
                 }
                 _ => DeleteLoginProfileError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteLoginProfileError::Unknown(body.to_string()),
+            Err(_) => DeleteLoginProfileError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -15577,7 +15603,7 @@ pub enum DeleteOpenIDConnectProviderError {
 }
 
 impl DeleteOpenIDConnectProviderError {
-    pub fn from_body(body: &str) -> DeleteOpenIDConnectProviderError {
+    pub fn from_body(body: &str, status: u16) -> DeleteOpenIDConnectProviderError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -15594,7 +15620,11 @@ impl DeleteOpenIDConnectProviderError {
                 )),
                 _ => DeleteOpenIDConnectProviderError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteOpenIDConnectProviderError::Unknown(body.to_string()),
+            Err(_) => DeleteOpenIDConnectProviderError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -15672,7 +15702,7 @@ pub enum DeletePolicyError {
 }
 
 impl DeletePolicyError {
-    pub fn from_body(body: &str) -> DeletePolicyError {
+    pub fn from_body(body: &str, status: u16) -> DeletePolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -15695,7 +15725,7 @@ impl DeletePolicyError {
                 }
                 _ => DeletePolicyError::Unknown(String::from(body)),
             },
-            Err(_) => DeletePolicyError::Unknown(body.to_string()),
+            Err(_) => DeletePolicyError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -15773,7 +15803,7 @@ pub enum DeletePolicyVersionError {
 }
 
 impl DeletePolicyVersionError {
-    pub fn from_body(body: &str) -> DeletePolicyVersionError {
+    pub fn from_body(body: &str, status: u16) -> DeletePolicyVersionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -15796,7 +15826,7 @@ impl DeletePolicyVersionError {
                 }
                 _ => DeletePolicyVersionError::Unknown(String::from(body)),
             },
-            Err(_) => DeletePolicyVersionError::Unknown(body.to_string()),
+            Err(_) => DeletePolicyVersionError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -15876,7 +15906,7 @@ pub enum DeleteRoleError {
 }
 
 impl DeleteRoleError {
-    pub fn from_body(body: &str) -> DeleteRoleError {
+    pub fn from_body(body: &str, status: u16) -> DeleteRoleError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -15897,7 +15927,7 @@ impl DeleteRoleError {
                 }
                 _ => DeleteRoleError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteRoleError::Unknown(body.to_string()),
+            Err(_) => DeleteRoleError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -15971,7 +16001,7 @@ pub enum DeleteRolePermissionsBoundaryError {
 }
 
 impl DeleteRolePermissionsBoundaryError {
-    pub fn from_body(body: &str) -> DeleteRolePermissionsBoundaryError {
+    pub fn from_body(body: &str, status: u16) -> DeleteRolePermissionsBoundaryError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -15988,7 +16018,11 @@ impl DeleteRolePermissionsBoundaryError {
                 ),
                 _ => DeleteRolePermissionsBoundaryError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteRolePermissionsBoundaryError::Unknown(body.to_string()),
+            Err(_) => DeleteRolePermissionsBoundaryError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -16064,7 +16098,7 @@ pub enum DeleteRolePolicyError {
 }
 
 impl DeleteRolePolicyError {
-    pub fn from_body(body: &str) -> DeleteRolePolicyError {
+    pub fn from_body(body: &str, status: u16) -> DeleteRolePolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -16084,7 +16118,7 @@ impl DeleteRolePolicyError {
                 }
                 _ => DeleteRolePolicyError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteRolePolicyError::Unknown(body.to_string()),
+            Err(_) => DeleteRolePolicyError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -16159,7 +16193,7 @@ pub enum DeleteSAMLProviderError {
 }
 
 impl DeleteSAMLProviderError {
-    pub fn from_body(body: &str) -> DeleteSAMLProviderError {
+    pub fn from_body(body: &str, status: u16) -> DeleteSAMLProviderError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -16179,7 +16213,7 @@ impl DeleteSAMLProviderError {
                 }
                 _ => DeleteSAMLProviderError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteSAMLProviderError::Unknown(body.to_string()),
+            Err(_) => DeleteSAMLProviderError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -16250,7 +16284,7 @@ pub enum DeleteSSHPublicKeyError {
 }
 
 impl DeleteSSHPublicKeyError {
-    pub fn from_body(body: &str) -> DeleteSSHPublicKeyError {
+    pub fn from_body(body: &str, status: u16) -> DeleteSSHPublicKeyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -16261,7 +16295,7 @@ impl DeleteSSHPublicKeyError {
                 }
                 _ => DeleteSSHPublicKeyError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteSSHPublicKeyError::Unknown(body.to_string()),
+            Err(_) => DeleteSSHPublicKeyError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -16335,7 +16369,7 @@ pub enum DeleteServerCertificateError {
 }
 
 impl DeleteServerCertificateError {
-    pub fn from_body(body: &str) -> DeleteServerCertificateError {
+    pub fn from_body(body: &str, status: u16) -> DeleteServerCertificateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -16355,7 +16389,9 @@ impl DeleteServerCertificateError {
                 }
                 _ => DeleteServerCertificateError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteServerCertificateError::Unknown(body.to_string()),
+            Err(_) => {
+                DeleteServerCertificateError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -16430,7 +16466,7 @@ pub enum DeleteServiceLinkedRoleError {
 }
 
 impl DeleteServiceLinkedRoleError {
-    pub fn from_body(body: &str) -> DeleteServiceLinkedRoleError {
+    pub fn from_body(body: &str, status: u16) -> DeleteServiceLinkedRoleError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -16447,7 +16483,9 @@ impl DeleteServiceLinkedRoleError {
                 }
                 _ => DeleteServiceLinkedRoleError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteServiceLinkedRoleError::Unknown(body.to_string()),
+            Err(_) => {
+                DeleteServiceLinkedRoleError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -16517,7 +16555,7 @@ pub enum DeleteServiceSpecificCredentialError {
 }
 
 impl DeleteServiceSpecificCredentialError {
-    pub fn from_body(body: &str) -> DeleteServiceSpecificCredentialError {
+    pub fn from_body(body: &str, status: u16) -> DeleteServiceSpecificCredentialError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -16528,7 +16566,11 @@ impl DeleteServiceSpecificCredentialError {
                 )),
                 _ => DeleteServiceSpecificCredentialError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteServiceSpecificCredentialError::Unknown(body.to_string()),
+            Err(_) => DeleteServiceSpecificCredentialError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -16600,7 +16642,7 @@ pub enum DeleteSigningCertificateError {
 }
 
 impl DeleteSigningCertificateError {
-    pub fn from_body(body: &str) -> DeleteSigningCertificateError {
+    pub fn from_body(body: &str, status: u16) -> DeleteSigningCertificateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -16617,7 +16659,9 @@ impl DeleteSigningCertificateError {
                 )),
                 _ => DeleteSigningCertificateError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteSigningCertificateError::Unknown(body.to_string()),
+            Err(_) => {
+                DeleteSigningCertificateError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -16693,7 +16737,7 @@ pub enum DeleteUserError {
 }
 
 impl DeleteUserError {
-    pub fn from_body(body: &str) -> DeleteUserError {
+    pub fn from_body(body: &str, status: u16) -> DeleteUserError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -16711,7 +16755,7 @@ impl DeleteUserError {
                 }
                 _ => DeleteUserError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteUserError::Unknown(body.to_string()),
+            Err(_) => DeleteUserError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -16782,7 +16826,7 @@ pub enum DeleteUserPermissionsBoundaryError {
 }
 
 impl DeleteUserPermissionsBoundaryError {
-    pub fn from_body(body: &str) -> DeleteUserPermissionsBoundaryError {
+    pub fn from_body(body: &str, status: u16) -> DeleteUserPermissionsBoundaryError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -16796,7 +16840,11 @@ impl DeleteUserPermissionsBoundaryError {
                 ),
                 _ => DeleteUserPermissionsBoundaryError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteUserPermissionsBoundaryError::Unknown(body.to_string()),
+            Err(_) => DeleteUserPermissionsBoundaryError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -16869,7 +16917,7 @@ pub enum DeleteUserPolicyError {
 }
 
 impl DeleteUserPolicyError {
-    pub fn from_body(body: &str) -> DeleteUserPolicyError {
+    pub fn from_body(body: &str, status: u16) -> DeleteUserPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -16886,7 +16934,7 @@ impl DeleteUserPolicyError {
                 }
                 _ => DeleteUserPolicyError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteUserPolicyError::Unknown(body.to_string()),
+            Err(_) => DeleteUserPolicyError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -16960,7 +17008,7 @@ pub enum DeleteVirtualMFADeviceError {
 }
 
 impl DeleteVirtualMFADeviceError {
-    pub fn from_body(body: &str) -> DeleteVirtualMFADeviceError {
+    pub fn from_body(body: &str, status: u16) -> DeleteVirtualMFADeviceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -16980,7 +17028,9 @@ impl DeleteVirtualMFADeviceError {
                 }
                 _ => DeleteVirtualMFADeviceError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteVirtualMFADeviceError::Unknown(body.to_string()),
+            Err(_) => {
+                DeleteVirtualMFADeviceError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -17057,7 +17107,7 @@ pub enum DetachGroupPolicyError {
 }
 
 impl DetachGroupPolicyError {
-    pub fn from_body(body: &str) -> DetachGroupPolicyError {
+    pub fn from_body(body: &str, status: u16) -> DetachGroupPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -17077,7 +17127,7 @@ impl DetachGroupPolicyError {
                 }
                 _ => DetachGroupPolicyError::Unknown(String::from(body)),
             },
-            Err(_) => DetachGroupPolicyError::Unknown(body.to_string()),
+            Err(_) => DetachGroupPolicyError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -17156,7 +17206,7 @@ pub enum DetachRolePolicyError {
 }
 
 impl DetachRolePolicyError {
-    pub fn from_body(body: &str) -> DetachRolePolicyError {
+    pub fn from_body(body: &str, status: u16) -> DetachRolePolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -17179,7 +17229,7 @@ impl DetachRolePolicyError {
                 }
                 _ => DetachRolePolicyError::Unknown(String::from(body)),
             },
-            Err(_) => DetachRolePolicyError::Unknown(body.to_string()),
+            Err(_) => DetachRolePolicyError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -17255,7 +17305,7 @@ pub enum DetachUserPolicyError {
 }
 
 impl DetachUserPolicyError {
-    pub fn from_body(body: &str) -> DetachUserPolicyError {
+    pub fn from_body(body: &str, status: u16) -> DetachUserPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -17275,7 +17325,7 @@ impl DetachUserPolicyError {
                 }
                 _ => DetachUserPolicyError::Unknown(String::from(body)),
             },
-            Err(_) => DetachUserPolicyError::Unknown(body.to_string()),
+            Err(_) => DetachUserPolicyError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -17354,7 +17404,7 @@ pub enum EnableMFADeviceError {
 }
 
 impl EnableMFADeviceError {
-    pub fn from_body(body: &str) -> EnableMFADeviceError {
+    pub fn from_body(body: &str, status: u16) -> EnableMFADeviceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -17382,7 +17432,7 @@ impl EnableMFADeviceError {
                 }
                 _ => EnableMFADeviceError::Unknown(String::from(body)),
             },
-            Err(_) => EnableMFADeviceError::Unknown(body.to_string()),
+            Err(_) => EnableMFADeviceError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -17455,7 +17505,7 @@ pub enum GenerateCredentialReportError {
 }
 
 impl GenerateCredentialReportError {
-    pub fn from_body(body: &str) -> GenerateCredentialReportError {
+    pub fn from_body(body: &str, status: u16) -> GenerateCredentialReportError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -17469,7 +17519,9 @@ impl GenerateCredentialReportError {
                 )),
                 _ => GenerateCredentialReportError::Unknown(String::from(body)),
             },
-            Err(_) => GenerateCredentialReportError::Unknown(body.to_string()),
+            Err(_) => {
+                GenerateCredentialReportError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -17538,7 +17590,7 @@ pub enum GetAccessKeyLastUsedError {
 }
 
 impl GetAccessKeyLastUsedError {
-    pub fn from_body(body: &str) -> GetAccessKeyLastUsedError {
+    pub fn from_body(body: &str, status: u16) -> GetAccessKeyLastUsedError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -17549,7 +17601,9 @@ impl GetAccessKeyLastUsedError {
                 }
                 _ => GetAccessKeyLastUsedError::Unknown(String::from(body)),
             },
-            Err(_) => GetAccessKeyLastUsedError::Unknown(body.to_string()),
+            Err(_) => {
+                GetAccessKeyLastUsedError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -17617,7 +17671,7 @@ pub enum GetAccountAuthorizationDetailsError {
 }
 
 impl GetAccountAuthorizationDetailsError {
-    pub fn from_body(body: &str) -> GetAccountAuthorizationDetailsError {
+    pub fn from_body(body: &str, status: u16) -> GetAccountAuthorizationDetailsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -17628,7 +17682,11 @@ impl GetAccountAuthorizationDetailsError {
                 ),
                 _ => GetAccountAuthorizationDetailsError::Unknown(String::from(body)),
             },
-            Err(_) => GetAccountAuthorizationDetailsError::Unknown(body.to_string()),
+            Err(_) => GetAccountAuthorizationDetailsError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -17698,7 +17756,7 @@ pub enum GetAccountPasswordPolicyError {
 }
 
 impl GetAccountPasswordPolicyError {
-    pub fn from_body(body: &str) -> GetAccountPasswordPolicyError {
+    pub fn from_body(body: &str, status: u16) -> GetAccountPasswordPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -17712,7 +17770,9 @@ impl GetAccountPasswordPolicyError {
                 )),
                 _ => GetAccountPasswordPolicyError::Unknown(String::from(body)),
             },
-            Err(_) => GetAccountPasswordPolicyError::Unknown(body.to_string()),
+            Err(_) => {
+                GetAccountPasswordPolicyError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -17781,7 +17841,7 @@ pub enum GetAccountSummaryError {
 }
 
 impl GetAccountSummaryError {
-    pub fn from_body(body: &str) -> GetAccountSummaryError {
+    pub fn from_body(body: &str, status: u16) -> GetAccountSummaryError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -17792,7 +17852,7 @@ impl GetAccountSummaryError {
                 }
                 _ => GetAccountSummaryError::Unknown(String::from(body)),
             },
-            Err(_) => GetAccountSummaryError::Unknown(body.to_string()),
+            Err(_) => GetAccountSummaryError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -17860,7 +17920,7 @@ pub enum GetContextKeysForCustomPolicyError {
 }
 
 impl GetContextKeysForCustomPolicyError {
-    pub fn from_body(body: &str) -> GetContextKeysForCustomPolicyError {
+    pub fn from_body(body: &str, status: u16) -> GetContextKeysForCustomPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -17871,7 +17931,11 @@ impl GetContextKeysForCustomPolicyError {
                 )),
                 _ => GetContextKeysForCustomPolicyError::Unknown(String::from(body)),
             },
-            Err(_) => GetContextKeysForCustomPolicyError::Unknown(body.to_string()),
+            Err(_) => GetContextKeysForCustomPolicyError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -17941,7 +18005,7 @@ pub enum GetContextKeysForPrincipalPolicyError {
 }
 
 impl GetContextKeysForPrincipalPolicyError {
-    pub fn from_body(body: &str) -> GetContextKeysForPrincipalPolicyError {
+    pub fn from_body(body: &str, status: u16) -> GetContextKeysForPrincipalPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -17955,7 +18019,11 @@ impl GetContextKeysForPrincipalPolicyError {
                 ),
                 _ => GetContextKeysForPrincipalPolicyError::Unknown(String::from(body)),
             },
-            Err(_) => GetContextKeysForPrincipalPolicyError::Unknown(body.to_string()),
+            Err(_) => GetContextKeysForPrincipalPolicyError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -18030,7 +18098,7 @@ pub enum GetCredentialReportError {
 }
 
 impl GetCredentialReportError {
-    pub fn from_body(body: &str) -> GetCredentialReportError {
+    pub fn from_body(body: &str, status: u16) -> GetCredentialReportError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -18050,7 +18118,7 @@ impl GetCredentialReportError {
                 }
                 _ => GetCredentialReportError::Unknown(String::from(body)),
             },
-            Err(_) => GetCredentialReportError::Unknown(body.to_string()),
+            Err(_) => GetCredentialReportError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -18123,7 +18191,7 @@ pub enum GetGroupError {
 }
 
 impl GetGroupError {
-    pub fn from_body(body: &str) -> GetGroupError {
+    pub fn from_body(body: &str, status: u16) -> GetGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -18135,7 +18203,7 @@ impl GetGroupError {
                 }
                 _ => GetGroupError::Unknown(String::from(body)),
             },
-            Err(_) => GetGroupError::Unknown(body.to_string()),
+            Err(_) => GetGroupError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -18204,7 +18272,7 @@ pub enum GetGroupPolicyError {
 }
 
 impl GetGroupPolicyError {
-    pub fn from_body(body: &str) -> GetGroupPolicyError {
+    pub fn from_body(body: &str, status: u16) -> GetGroupPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -18218,7 +18286,7 @@ impl GetGroupPolicyError {
                 }
                 _ => GetGroupPolicyError::Unknown(String::from(body)),
             },
-            Err(_) => GetGroupPolicyError::Unknown(body.to_string()),
+            Err(_) => GetGroupPolicyError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -18287,7 +18355,7 @@ pub enum GetInstanceProfileError {
 }
 
 impl GetInstanceProfileError {
-    pub fn from_body(body: &str) -> GetInstanceProfileError {
+    pub fn from_body(body: &str, status: u16) -> GetInstanceProfileError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -18301,7 +18369,7 @@ impl GetInstanceProfileError {
                 }
                 _ => GetInstanceProfileError::Unknown(String::from(body)),
             },
-            Err(_) => GetInstanceProfileError::Unknown(body.to_string()),
+            Err(_) => GetInstanceProfileError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -18372,7 +18440,7 @@ pub enum GetLoginProfileError {
 }
 
 impl GetLoginProfileError {
-    pub fn from_body(body: &str) -> GetLoginProfileError {
+    pub fn from_body(body: &str, status: u16) -> GetLoginProfileError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -18386,7 +18454,7 @@ impl GetLoginProfileError {
                 }
                 _ => GetLoginProfileError::Unknown(String::from(body)),
             },
-            Err(_) => GetLoginProfileError::Unknown(body.to_string()),
+            Err(_) => GetLoginProfileError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -18457,7 +18525,7 @@ pub enum GetOpenIDConnectProviderError {
 }
 
 impl GetOpenIDConnectProviderError {
-    pub fn from_body(body: &str) -> GetOpenIDConnectProviderError {
+    pub fn from_body(body: &str, status: u16) -> GetOpenIDConnectProviderError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -18474,7 +18542,9 @@ impl GetOpenIDConnectProviderError {
                 )),
                 _ => GetOpenIDConnectProviderError::Unknown(String::from(body)),
             },
-            Err(_) => GetOpenIDConnectProviderError::Unknown(body.to_string()),
+            Err(_) => {
+                GetOpenIDConnectProviderError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -18548,7 +18618,7 @@ pub enum GetPolicyError {
 }
 
 impl GetPolicyError {
-    pub fn from_body(body: &str) -> GetPolicyError {
+    pub fn from_body(body: &str, status: u16) -> GetPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -18561,7 +18631,7 @@ impl GetPolicyError {
                 }
                 _ => GetPolicyError::Unknown(String::from(body)),
             },
-            Err(_) => GetPolicyError::Unknown(body.to_string()),
+            Err(_) => GetPolicyError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -18633,7 +18703,7 @@ pub enum GetPolicyVersionError {
 }
 
 impl GetPolicyVersionError {
-    pub fn from_body(body: &str) -> GetPolicyVersionError {
+    pub fn from_body(body: &str, status: u16) -> GetPolicyVersionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -18650,7 +18720,7 @@ impl GetPolicyVersionError {
                 }
                 _ => GetPolicyVersionError::Unknown(String::from(body)),
             },
-            Err(_) => GetPolicyVersionError::Unknown(body.to_string()),
+            Err(_) => GetPolicyVersionError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -18720,7 +18790,7 @@ pub enum GetRoleError {
 }
 
 impl GetRoleError {
-    pub fn from_body(body: &str) -> GetRoleError {
+    pub fn from_body(body: &str, status: u16) -> GetRoleError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -18732,7 +18802,7 @@ impl GetRoleError {
                 }
                 _ => GetRoleError::Unknown(String::from(body)),
             },
-            Err(_) => GetRoleError::Unknown(body.to_string()),
+            Err(_) => GetRoleError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -18801,7 +18871,7 @@ pub enum GetRolePolicyError {
 }
 
 impl GetRolePolicyError {
-    pub fn from_body(body: &str) -> GetRolePolicyError {
+    pub fn from_body(body: &str, status: u16) -> GetRolePolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -18815,7 +18885,7 @@ impl GetRolePolicyError {
                 }
                 _ => GetRolePolicyError::Unknown(String::from(body)),
             },
-            Err(_) => GetRolePolicyError::Unknown(body.to_string()),
+            Err(_) => GetRolePolicyError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -18886,7 +18956,7 @@ pub enum GetSAMLProviderError {
 }
 
 impl GetSAMLProviderError {
-    pub fn from_body(body: &str) -> GetSAMLProviderError {
+    pub fn from_body(body: &str, status: u16) -> GetSAMLProviderError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -18903,7 +18973,7 @@ impl GetSAMLProviderError {
                 }
                 _ => GetSAMLProviderError::Unknown(String::from(body)),
             },
-            Err(_) => GetSAMLProviderError::Unknown(body.to_string()),
+            Err(_) => GetSAMLProviderError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -18973,7 +19043,7 @@ pub enum GetSSHPublicKeyError {
 }
 
 impl GetSSHPublicKeyError {
-    pub fn from_body(body: &str) -> GetSSHPublicKeyError {
+    pub fn from_body(body: &str, status: u16) -> GetSSHPublicKeyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -18989,7 +19059,7 @@ impl GetSSHPublicKeyError {
                 }
                 _ => GetSSHPublicKeyError::Unknown(String::from(body)),
             },
-            Err(_) => GetSSHPublicKeyError::Unknown(body.to_string()),
+            Err(_) => GetSSHPublicKeyError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -19058,7 +19128,7 @@ pub enum GetServerCertificateError {
 }
 
 impl GetServerCertificateError {
-    pub fn from_body(body: &str) -> GetServerCertificateError {
+    pub fn from_body(body: &str, status: u16) -> GetServerCertificateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -19072,7 +19142,9 @@ impl GetServerCertificateError {
                 }
                 _ => GetServerCertificateError::Unknown(String::from(body)),
             },
-            Err(_) => GetServerCertificateError::Unknown(body.to_string()),
+            Err(_) => {
+                GetServerCertificateError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -19145,7 +19217,7 @@ pub enum GetServiceLinkedRoleDeletionStatusError {
 }
 
 impl GetServiceLinkedRoleDeletionStatusError {
-    pub fn from_body(body: &str) -> GetServiceLinkedRoleDeletionStatusError {
+    pub fn from_body(body: &str, status: u16) -> GetServiceLinkedRoleDeletionStatusError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -19162,7 +19234,11 @@ impl GetServiceLinkedRoleDeletionStatusError {
                 ),
                 _ => GetServiceLinkedRoleDeletionStatusError::Unknown(String::from(body)),
             },
-            Err(_) => GetServiceLinkedRoleDeletionStatusError::Unknown(body.to_string()),
+            Err(_) => GetServiceLinkedRoleDeletionStatusError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -19234,7 +19310,7 @@ pub enum GetUserError {
 }
 
 impl GetUserError {
-    pub fn from_body(body: &str) -> GetUserError {
+    pub fn from_body(body: &str, status: u16) -> GetUserError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -19246,7 +19322,7 @@ impl GetUserError {
                 }
                 _ => GetUserError::Unknown(String::from(body)),
             },
-            Err(_) => GetUserError::Unknown(body.to_string()),
+            Err(_) => GetUserError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -19315,7 +19391,7 @@ pub enum GetUserPolicyError {
 }
 
 impl GetUserPolicyError {
-    pub fn from_body(body: &str) -> GetUserPolicyError {
+    pub fn from_body(body: &str, status: u16) -> GetUserPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -19329,7 +19405,7 @@ impl GetUserPolicyError {
                 }
                 _ => GetUserPolicyError::Unknown(String::from(body)),
             },
-            Err(_) => GetUserPolicyError::Unknown(body.to_string()),
+            Err(_) => GetUserPolicyError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -19398,7 +19474,7 @@ pub enum ListAccessKeysError {
 }
 
 impl ListAccessKeysError {
-    pub fn from_body(body: &str) -> ListAccessKeysError {
+    pub fn from_body(body: &str, status: u16) -> ListAccessKeysError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -19412,7 +19488,7 @@ impl ListAccessKeysError {
                 }
                 _ => ListAccessKeysError::Unknown(String::from(body)),
             },
-            Err(_) => ListAccessKeysError::Unknown(body.to_string()),
+            Err(_) => ListAccessKeysError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -19479,7 +19555,7 @@ pub enum ListAccountAliasesError {
 }
 
 impl ListAccountAliasesError {
-    pub fn from_body(body: &str) -> ListAccountAliasesError {
+    pub fn from_body(body: &str, status: u16) -> ListAccountAliasesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -19490,7 +19566,7 @@ impl ListAccountAliasesError {
                 }
                 _ => ListAccountAliasesError::Unknown(String::from(body)),
             },
-            Err(_) => ListAccountAliasesError::Unknown(body.to_string()),
+            Err(_) => ListAccountAliasesError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -19562,7 +19638,7 @@ pub enum ListAttachedGroupPoliciesError {
 }
 
 impl ListAttachedGroupPoliciesError {
-    pub fn from_body(body: &str) -> ListAttachedGroupPoliciesError {
+    pub fn from_body(body: &str, status: u16) -> ListAttachedGroupPoliciesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -19579,7 +19655,9 @@ impl ListAttachedGroupPoliciesError {
                 )),
                 _ => ListAttachedGroupPoliciesError::Unknown(String::from(body)),
             },
-            Err(_) => ListAttachedGroupPoliciesError::Unknown(body.to_string()),
+            Err(_) => {
+                ListAttachedGroupPoliciesError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -19653,7 +19731,7 @@ pub enum ListAttachedRolePoliciesError {
 }
 
 impl ListAttachedRolePoliciesError {
-    pub fn from_body(body: &str) -> ListAttachedRolePoliciesError {
+    pub fn from_body(body: &str, status: u16) -> ListAttachedRolePoliciesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -19670,7 +19748,9 @@ impl ListAttachedRolePoliciesError {
                 )),
                 _ => ListAttachedRolePoliciesError::Unknown(String::from(body)),
             },
-            Err(_) => ListAttachedRolePoliciesError::Unknown(body.to_string()),
+            Err(_) => {
+                ListAttachedRolePoliciesError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -19744,7 +19824,7 @@ pub enum ListAttachedUserPoliciesError {
 }
 
 impl ListAttachedUserPoliciesError {
-    pub fn from_body(body: &str) -> ListAttachedUserPoliciesError {
+    pub fn from_body(body: &str, status: u16) -> ListAttachedUserPoliciesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -19761,7 +19841,9 @@ impl ListAttachedUserPoliciesError {
                 )),
                 _ => ListAttachedUserPoliciesError::Unknown(String::from(body)),
             },
-            Err(_) => ListAttachedUserPoliciesError::Unknown(body.to_string()),
+            Err(_) => {
+                ListAttachedUserPoliciesError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -19835,7 +19917,7 @@ pub enum ListEntitiesForPolicyError {
 }
 
 impl ListEntitiesForPolicyError {
-    pub fn from_body(body: &str) -> ListEntitiesForPolicyError {
+    pub fn from_body(body: &str, status: u16) -> ListEntitiesForPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -19852,7 +19934,9 @@ impl ListEntitiesForPolicyError {
                 }
                 _ => ListEntitiesForPolicyError::Unknown(String::from(body)),
             },
-            Err(_) => ListEntitiesForPolicyError::Unknown(body.to_string()),
+            Err(_) => {
+                ListEntitiesForPolicyError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -19924,7 +20008,7 @@ pub enum ListGroupPoliciesError {
 }
 
 impl ListGroupPoliciesError {
-    pub fn from_body(body: &str) -> ListGroupPoliciesError {
+    pub fn from_body(body: &str, status: u16) -> ListGroupPoliciesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -19938,7 +20022,7 @@ impl ListGroupPoliciesError {
                 }
                 _ => ListGroupPoliciesError::Unknown(String::from(body)),
             },
-            Err(_) => ListGroupPoliciesError::Unknown(body.to_string()),
+            Err(_) => ListGroupPoliciesError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -20007,7 +20091,7 @@ pub enum ListGroupsError {
 }
 
 impl ListGroupsError {
-    pub fn from_body(body: &str) -> ListGroupsError {
+    pub fn from_body(body: &str, status: u16) -> ListGroupsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -20018,7 +20102,7 @@ impl ListGroupsError {
                 }
                 _ => ListGroupsError::Unknown(String::from(body)),
             },
-            Err(_) => ListGroupsError::Unknown(body.to_string()),
+            Err(_) => ListGroupsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -20086,7 +20170,7 @@ pub enum ListGroupsForUserError {
 }
 
 impl ListGroupsForUserError {
-    pub fn from_body(body: &str) -> ListGroupsForUserError {
+    pub fn from_body(body: &str, status: u16) -> ListGroupsForUserError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -20100,7 +20184,7 @@ impl ListGroupsForUserError {
                 }
                 _ => ListGroupsForUserError::Unknown(String::from(body)),
             },
-            Err(_) => ListGroupsForUserError::Unknown(body.to_string()),
+            Err(_) => ListGroupsForUserError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -20169,7 +20253,7 @@ pub enum ListInstanceProfilesError {
 }
 
 impl ListInstanceProfilesError {
-    pub fn from_body(body: &str) -> ListInstanceProfilesError {
+    pub fn from_body(body: &str, status: u16) -> ListInstanceProfilesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -20180,7 +20264,9 @@ impl ListInstanceProfilesError {
                 }
                 _ => ListInstanceProfilesError::Unknown(String::from(body)),
             },
-            Err(_) => ListInstanceProfilesError::Unknown(body.to_string()),
+            Err(_) => {
+                ListInstanceProfilesError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -20250,7 +20336,7 @@ pub enum ListInstanceProfilesForRoleError {
 }
 
 impl ListInstanceProfilesForRoleError {
-    pub fn from_body(body: &str) -> ListInstanceProfilesForRoleError {
+    pub fn from_body(body: &str, status: u16) -> ListInstanceProfilesForRoleError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -20264,7 +20350,11 @@ impl ListInstanceProfilesForRoleError {
                 )),
                 _ => ListInstanceProfilesForRoleError::Unknown(String::from(body)),
             },
-            Err(_) => ListInstanceProfilesForRoleError::Unknown(body.to_string()),
+            Err(_) => ListInstanceProfilesForRoleError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -20335,7 +20425,7 @@ pub enum ListMFADevicesError {
 }
 
 impl ListMFADevicesError {
-    pub fn from_body(body: &str) -> ListMFADevicesError {
+    pub fn from_body(body: &str, status: u16) -> ListMFADevicesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -20349,7 +20439,7 @@ impl ListMFADevicesError {
                 }
                 _ => ListMFADevicesError::Unknown(String::from(body)),
             },
-            Err(_) => ListMFADevicesError::Unknown(body.to_string()),
+            Err(_) => ListMFADevicesError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -20416,7 +20506,7 @@ pub enum ListOpenIDConnectProvidersError {
 }
 
 impl ListOpenIDConnectProvidersError {
-    pub fn from_body(body: &str) -> ListOpenIDConnectProvidersError {
+    pub fn from_body(body: &str, status: u16) -> ListOpenIDConnectProvidersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -20427,7 +20517,9 @@ impl ListOpenIDConnectProvidersError {
                 )),
                 _ => ListOpenIDConnectProvidersError::Unknown(String::from(body)),
             },
-            Err(_) => ListOpenIDConnectProvidersError::Unknown(body.to_string()),
+            Err(_) => {
+                ListOpenIDConnectProvidersError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -20495,7 +20587,7 @@ pub enum ListPoliciesError {
 }
 
 impl ListPoliciesError {
-    pub fn from_body(body: &str) -> ListPoliciesError {
+    pub fn from_body(body: &str, status: u16) -> ListPoliciesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -20506,7 +20598,7 @@ impl ListPoliciesError {
                 }
                 _ => ListPoliciesError::Unknown(String::from(body)),
             },
-            Err(_) => ListPoliciesError::Unknown(body.to_string()),
+            Err(_) => ListPoliciesError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -20576,7 +20668,7 @@ pub enum ListPolicyVersionsError {
 }
 
 impl ListPolicyVersionsError {
-    pub fn from_body(body: &str) -> ListPolicyVersionsError {
+    pub fn from_body(body: &str, status: u16) -> ListPolicyVersionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -20593,7 +20685,7 @@ impl ListPolicyVersionsError {
                 }
                 _ => ListPolicyVersionsError::Unknown(String::from(body)),
             },
-            Err(_) => ListPolicyVersionsError::Unknown(body.to_string()),
+            Err(_) => ListPolicyVersionsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -20665,7 +20757,7 @@ pub enum ListRolePoliciesError {
 }
 
 impl ListRolePoliciesError {
-    pub fn from_body(body: &str) -> ListRolePoliciesError {
+    pub fn from_body(body: &str, status: u16) -> ListRolePoliciesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -20679,7 +20771,7 @@ impl ListRolePoliciesError {
                 }
                 _ => ListRolePoliciesError::Unknown(String::from(body)),
             },
-            Err(_) => ListRolePoliciesError::Unknown(body.to_string()),
+            Err(_) => ListRolePoliciesError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -20746,7 +20838,7 @@ pub enum ListRolesError {
 }
 
 impl ListRolesError {
-    pub fn from_body(body: &str) -> ListRolesError {
+    pub fn from_body(body: &str, status: u16) -> ListRolesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -20757,7 +20849,7 @@ impl ListRolesError {
                 }
                 _ => ListRolesError::Unknown(String::from(body)),
             },
-            Err(_) => ListRolesError::Unknown(body.to_string()),
+            Err(_) => ListRolesError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -20823,7 +20915,7 @@ pub enum ListSAMLProvidersError {
 }
 
 impl ListSAMLProvidersError {
-    pub fn from_body(body: &str) -> ListSAMLProvidersError {
+    pub fn from_body(body: &str, status: u16) -> ListSAMLProvidersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -20834,7 +20926,7 @@ impl ListSAMLProvidersError {
                 }
                 _ => ListSAMLProvidersError::Unknown(String::from(body)),
             },
-            Err(_) => ListSAMLProvidersError::Unknown(body.to_string()),
+            Err(_) => ListSAMLProvidersError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -20902,7 +20994,7 @@ pub enum ListSSHPublicKeysError {
 }
 
 impl ListSSHPublicKeysError {
-    pub fn from_body(body: &str) -> ListSSHPublicKeysError {
+    pub fn from_body(body: &str, status: u16) -> ListSSHPublicKeysError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -20913,7 +21005,7 @@ impl ListSSHPublicKeysError {
                 }
                 _ => ListSSHPublicKeysError::Unknown(String::from(body)),
             },
-            Err(_) => ListSSHPublicKeysError::Unknown(body.to_string()),
+            Err(_) => ListSSHPublicKeysError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -20981,7 +21073,7 @@ pub enum ListServerCertificatesError {
 }
 
 impl ListServerCertificatesError {
-    pub fn from_body(body: &str) -> ListServerCertificatesError {
+    pub fn from_body(body: &str, status: u16) -> ListServerCertificatesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -20992,7 +21084,9 @@ impl ListServerCertificatesError {
                 }
                 _ => ListServerCertificatesError::Unknown(String::from(body)),
             },
-            Err(_) => ListServerCertificatesError::Unknown(body.to_string()),
+            Err(_) => {
+                ListServerCertificatesError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -21062,7 +21156,7 @@ pub enum ListServiceSpecificCredentialsError {
 }
 
 impl ListServiceSpecificCredentialsError {
-    pub fn from_body(body: &str) -> ListServiceSpecificCredentialsError {
+    pub fn from_body(body: &str, status: u16) -> ListServiceSpecificCredentialsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -21076,7 +21170,11 @@ impl ListServiceSpecificCredentialsError {
                 ),
                 _ => ListServiceSpecificCredentialsError::Unknown(String::from(body)),
             },
-            Err(_) => ListServiceSpecificCredentialsError::Unknown(body.to_string()),
+            Err(_) => ListServiceSpecificCredentialsError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -21147,7 +21245,7 @@ pub enum ListSigningCertificatesError {
 }
 
 impl ListSigningCertificatesError {
-    pub fn from_body(body: &str) -> ListSigningCertificatesError {
+    pub fn from_body(body: &str, status: u16) -> ListSigningCertificatesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -21161,7 +21259,9 @@ impl ListSigningCertificatesError {
                 }
                 _ => ListSigningCertificatesError::Unknown(String::from(body)),
             },
-            Err(_) => ListSigningCertificatesError::Unknown(body.to_string()),
+            Err(_) => {
+                ListSigningCertificatesError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -21232,7 +21332,7 @@ pub enum ListUserPoliciesError {
 }
 
 impl ListUserPoliciesError {
-    pub fn from_body(body: &str) -> ListUserPoliciesError {
+    pub fn from_body(body: &str, status: u16) -> ListUserPoliciesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -21246,7 +21346,7 @@ impl ListUserPoliciesError {
                 }
                 _ => ListUserPoliciesError::Unknown(String::from(body)),
             },
-            Err(_) => ListUserPoliciesError::Unknown(body.to_string()),
+            Err(_) => ListUserPoliciesError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -21313,7 +21413,7 @@ pub enum ListUsersError {
 }
 
 impl ListUsersError {
-    pub fn from_body(body: &str) -> ListUsersError {
+    pub fn from_body(body: &str, status: u16) -> ListUsersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -21324,7 +21424,7 @@ impl ListUsersError {
                 }
                 _ => ListUsersError::Unknown(String::from(body)),
             },
-            Err(_) => ListUsersError::Unknown(body.to_string()),
+            Err(_) => ListUsersError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -21388,7 +21488,7 @@ pub enum ListVirtualMFADevicesError {
 }
 
 impl ListVirtualMFADevicesError {
-    pub fn from_body(body: &str) -> ListVirtualMFADevicesError {
+    pub fn from_body(body: &str, status: u16) -> ListVirtualMFADevicesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -21396,7 +21496,9 @@ impl ListVirtualMFADevicesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListVirtualMFADevicesError::Unknown(String::from(body)),
             },
-            Err(_) => ListVirtualMFADevicesError::Unknown(body.to_string()),
+            Err(_) => {
+                ListVirtualMFADevicesError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -21469,7 +21571,7 @@ pub enum PutGroupPolicyError {
 }
 
 impl PutGroupPolicyError {
-    pub fn from_body(body: &str) -> PutGroupPolicyError {
+    pub fn from_body(body: &str, status: u16) -> PutGroupPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -21489,7 +21591,7 @@ impl PutGroupPolicyError {
                 }
                 _ => PutGroupPolicyError::Unknown(String::from(body)),
             },
-            Err(_) => PutGroupPolicyError::Unknown(body.to_string()),
+            Err(_) => PutGroupPolicyError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -21566,7 +21668,7 @@ pub enum PutRolePermissionsBoundaryError {
 }
 
 impl PutRolePermissionsBoundaryError {
-    pub fn from_body(body: &str) -> PutRolePermissionsBoundaryError {
+    pub fn from_body(body: &str, status: u16) -> PutRolePermissionsBoundaryError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -21589,7 +21691,9 @@ impl PutRolePermissionsBoundaryError {
                 ),
                 _ => PutRolePermissionsBoundaryError::Unknown(String::from(body)),
             },
-            Err(_) => PutRolePermissionsBoundaryError::Unknown(body.to_string()),
+            Err(_) => {
+                PutRolePermissionsBoundaryError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -21669,7 +21773,7 @@ pub enum PutRolePolicyError {
 }
 
 impl PutRolePolicyError {
-    pub fn from_body(body: &str) -> PutRolePolicyError {
+    pub fn from_body(body: &str, status: u16) -> PutRolePolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -21692,7 +21796,7 @@ impl PutRolePolicyError {
                 }
                 _ => PutRolePolicyError::Unknown(String::from(body)),
             },
-            Err(_) => PutRolePolicyError::Unknown(body.to_string()),
+            Err(_) => PutRolePolicyError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -21768,7 +21872,7 @@ pub enum PutUserPermissionsBoundaryError {
 }
 
 impl PutUserPermissionsBoundaryError {
-    pub fn from_body(body: &str) -> PutUserPermissionsBoundaryError {
+    pub fn from_body(body: &str, status: u16) -> PutUserPermissionsBoundaryError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -21788,7 +21892,9 @@ impl PutUserPermissionsBoundaryError {
                 )),
                 _ => PutUserPermissionsBoundaryError::Unknown(String::from(body)),
             },
-            Err(_) => PutUserPermissionsBoundaryError::Unknown(body.to_string()),
+            Err(_) => {
+                PutUserPermissionsBoundaryError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -21865,7 +21971,7 @@ pub enum PutUserPolicyError {
 }
 
 impl PutUserPolicyError {
-    pub fn from_body(body: &str) -> PutUserPolicyError {
+    pub fn from_body(body: &str, status: u16) -> PutUserPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -21885,7 +21991,7 @@ impl PutUserPolicyError {
                 }
                 _ => PutUserPolicyError::Unknown(String::from(body)),
             },
-            Err(_) => PutUserPolicyError::Unknown(body.to_string()),
+            Err(_) => PutUserPolicyError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -21958,7 +22064,7 @@ pub enum RemoveClientIDFromOpenIDConnectProviderError {
 }
 
 impl RemoveClientIDFromOpenIDConnectProviderError {
-    pub fn from_body(body: &str) -> RemoveClientIDFromOpenIDConnectProviderError {
+    pub fn from_body(body: &str, status: u16) -> RemoveClientIDFromOpenIDConnectProviderError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -21975,7 +22081,11 @@ impl RemoveClientIDFromOpenIDConnectProviderError {
                 ),
                 _ => RemoveClientIDFromOpenIDConnectProviderError::Unknown(String::from(body)),
             },
-            Err(_) => RemoveClientIDFromOpenIDConnectProviderError::Unknown(body.to_string()),
+            Err(_) => RemoveClientIDFromOpenIDConnectProviderError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -22051,7 +22161,7 @@ pub enum RemoveRoleFromInstanceProfileError {
 }
 
 impl RemoveRoleFromInstanceProfileError {
-    pub fn from_body(body: &str) -> RemoveRoleFromInstanceProfileError {
+    pub fn from_body(body: &str, status: u16) -> RemoveRoleFromInstanceProfileError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -22071,7 +22181,11 @@ impl RemoveRoleFromInstanceProfileError {
                 ),
                 _ => RemoveRoleFromInstanceProfileError::Unknown(String::from(body)),
             },
-            Err(_) => RemoveRoleFromInstanceProfileError::Unknown(body.to_string()),
+            Err(_) => RemoveRoleFromInstanceProfileError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -22146,7 +22260,7 @@ pub enum RemoveUserFromGroupError {
 }
 
 impl RemoveUserFromGroupError {
-    pub fn from_body(body: &str) -> RemoveUserFromGroupError {
+    pub fn from_body(body: &str, status: u16) -> RemoveUserFromGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -22163,7 +22277,7 @@ impl RemoveUserFromGroupError {
                 }
                 _ => RemoveUserFromGroupError::Unknown(String::from(body)),
             },
-            Err(_) => RemoveUserFromGroupError::Unknown(body.to_string()),
+            Err(_) => RemoveUserFromGroupError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -22233,7 +22347,7 @@ pub enum ResetServiceSpecificCredentialError {
 }
 
 impl ResetServiceSpecificCredentialError {
-    pub fn from_body(body: &str) -> ResetServiceSpecificCredentialError {
+    pub fn from_body(body: &str, status: u16) -> ResetServiceSpecificCredentialError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -22244,7 +22358,11 @@ impl ResetServiceSpecificCredentialError {
                 )),
                 _ => ResetServiceSpecificCredentialError::Unknown(String::from(body)),
             },
-            Err(_) => ResetServiceSpecificCredentialError::Unknown(body.to_string()),
+            Err(_) => ResetServiceSpecificCredentialError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -22318,7 +22436,7 @@ pub enum ResyncMFADeviceError {
 }
 
 impl ResyncMFADeviceError {
-    pub fn from_body(body: &str) -> ResyncMFADeviceError {
+    pub fn from_body(body: &str, status: u16) -> ResyncMFADeviceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -22338,7 +22456,7 @@ impl ResyncMFADeviceError {
                 }
                 _ => ResyncMFADeviceError::Unknown(String::from(body)),
             },
-            Err(_) => ResyncMFADeviceError::Unknown(body.to_string()),
+            Err(_) => ResyncMFADeviceError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -22413,7 +22531,7 @@ pub enum SetDefaultPolicyVersionError {
 }
 
 impl SetDefaultPolicyVersionError {
-    pub fn from_body(body: &str) -> SetDefaultPolicyVersionError {
+    pub fn from_body(body: &str, status: u16) -> SetDefaultPolicyVersionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -22433,7 +22551,9 @@ impl SetDefaultPolicyVersionError {
                 }
                 _ => SetDefaultPolicyVersionError::Unknown(String::from(body)),
             },
-            Err(_) => SetDefaultPolicyVersionError::Unknown(body.to_string()),
+            Err(_) => {
+                SetDefaultPolicyVersionError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -22506,7 +22626,7 @@ pub enum SimulateCustomPolicyError {
 }
 
 impl SimulateCustomPolicyError {
-    pub fn from_body(body: &str) -> SimulateCustomPolicyError {
+    pub fn from_body(body: &str, status: u16) -> SimulateCustomPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -22520,7 +22640,9 @@ impl SimulateCustomPolicyError {
                 }
                 _ => SimulateCustomPolicyError::Unknown(String::from(body)),
             },
-            Err(_) => SimulateCustomPolicyError::Unknown(body.to_string()),
+            Err(_) => {
+                SimulateCustomPolicyError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -22593,7 +22715,7 @@ pub enum SimulatePrincipalPolicyError {
 }
 
 impl SimulatePrincipalPolicyError {
-    pub fn from_body(body: &str) -> SimulatePrincipalPolicyError {
+    pub fn from_body(body: &str, status: u16) -> SimulatePrincipalPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -22610,7 +22732,9 @@ impl SimulatePrincipalPolicyError {
                 )),
                 _ => SimulatePrincipalPolicyError::Unknown(String::from(body)),
             },
-            Err(_) => SimulatePrincipalPolicyError::Unknown(body.to_string()),
+            Err(_) => {
+                SimulatePrincipalPolicyError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -22684,7 +22808,7 @@ pub enum UpdateAccessKeyError {
 }
 
 impl UpdateAccessKeyError {
-    pub fn from_body(body: &str) -> UpdateAccessKeyError {
+    pub fn from_body(body: &str, status: u16) -> UpdateAccessKeyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -22701,7 +22825,7 @@ impl UpdateAccessKeyError {
                 }
                 _ => UpdateAccessKeyError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateAccessKeyError::Unknown(body.to_string()),
+            Err(_) => UpdateAccessKeyError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -22775,7 +22899,7 @@ pub enum UpdateAccountPasswordPolicyError {
 }
 
 impl UpdateAccountPasswordPolicyError {
-    pub fn from_body(body: &str) -> UpdateAccountPasswordPolicyError {
+    pub fn from_body(body: &str, status: u16) -> UpdateAccountPasswordPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -22797,7 +22921,11 @@ impl UpdateAccountPasswordPolicyError {
                 )),
                 _ => UpdateAccountPasswordPolicyError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateAccountPasswordPolicyError::Unknown(body.to_string()),
+            Err(_) => UpdateAccountPasswordPolicyError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -22876,7 +23004,7 @@ pub enum UpdateAssumeRolePolicyError {
 }
 
 impl UpdateAssumeRolePolicyError {
-    pub fn from_body(body: &str) -> UpdateAssumeRolePolicyError {
+    pub fn from_body(body: &str, status: u16) -> UpdateAssumeRolePolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -22899,7 +23027,9 @@ impl UpdateAssumeRolePolicyError {
                 ),
                 _ => UpdateAssumeRolePolicyError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateAssumeRolePolicyError::Unknown(body.to_string()),
+            Err(_) => {
+                UpdateAssumeRolePolicyError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -22977,7 +23107,7 @@ pub enum UpdateGroupError {
 }
 
 impl UpdateGroupError {
-    pub fn from_body(body: &str) -> UpdateGroupError {
+    pub fn from_body(body: &str, status: u16) -> UpdateGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -22997,7 +23127,7 @@ impl UpdateGroupError {
                 }
                 _ => UpdateGroupError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateGroupError::Unknown(body.to_string()),
+            Err(_) => UpdateGroupError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -23074,7 +23204,7 @@ pub enum UpdateLoginProfileError {
 }
 
 impl UpdateLoginProfileError {
-    pub fn from_body(body: &str) -> UpdateLoginProfileError {
+    pub fn from_body(body: &str, status: u16) -> UpdateLoginProfileError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -23099,7 +23229,7 @@ impl UpdateLoginProfileError {
                 }
                 _ => UpdateLoginProfileError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateLoginProfileError::Unknown(body.to_string()),
+            Err(_) => UpdateLoginProfileError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -23175,7 +23305,7 @@ pub enum UpdateOpenIDConnectProviderThumbprintError {
 }
 
 impl UpdateOpenIDConnectProviderThumbprintError {
-    pub fn from_body(body: &str) -> UpdateOpenIDConnectProviderThumbprintError {
+    pub fn from_body(body: &str, status: u16) -> UpdateOpenIDConnectProviderThumbprintError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -23192,7 +23322,11 @@ impl UpdateOpenIDConnectProviderThumbprintError {
                 ),
                 _ => UpdateOpenIDConnectProviderThumbprintError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateOpenIDConnectProviderThumbprintError::Unknown(body.to_string()),
+            Err(_) => UpdateOpenIDConnectProviderThumbprintError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -23266,7 +23400,7 @@ pub enum UpdateRoleError {
 }
 
 impl UpdateRoleError {
-    pub fn from_body(body: &str) -> UpdateRoleError {
+    pub fn from_body(body: &str, status: u16) -> UpdateRoleError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -23281,7 +23415,7 @@ impl UpdateRoleError {
                 }
                 _ => UpdateRoleError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateRoleError::Unknown(body.to_string()),
+            Err(_) => UpdateRoleError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -23353,7 +23487,7 @@ pub enum UpdateRoleDescriptionError {
 }
 
 impl UpdateRoleDescriptionError {
-    pub fn from_body(body: &str) -> UpdateRoleDescriptionError {
+    pub fn from_body(body: &str, status: u16) -> UpdateRoleDescriptionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -23370,7 +23504,9 @@ impl UpdateRoleDescriptionError {
                 ),
                 _ => UpdateRoleDescriptionError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateRoleDescriptionError::Unknown(body.to_string()),
+            Err(_) => {
+                UpdateRoleDescriptionError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -23446,7 +23582,7 @@ pub enum UpdateSAMLProviderError {
 }
 
 impl UpdateSAMLProviderError {
-    pub fn from_body(body: &str) -> UpdateSAMLProviderError {
+    pub fn from_body(body: &str, status: u16) -> UpdateSAMLProviderError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -23466,7 +23602,7 @@ impl UpdateSAMLProviderError {
                 }
                 _ => UpdateSAMLProviderError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateSAMLProviderError::Unknown(body.to_string()),
+            Err(_) => UpdateSAMLProviderError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -23537,7 +23673,7 @@ pub enum UpdateSSHPublicKeyError {
 }
 
 impl UpdateSSHPublicKeyError {
-    pub fn from_body(body: &str) -> UpdateSSHPublicKeyError {
+    pub fn from_body(body: &str, status: u16) -> UpdateSSHPublicKeyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -23548,7 +23684,7 @@ impl UpdateSSHPublicKeyError {
                 }
                 _ => UpdateSSHPublicKeyError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateSSHPublicKeyError::Unknown(body.to_string()),
+            Err(_) => UpdateSSHPublicKeyError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -23622,7 +23758,7 @@ pub enum UpdateServerCertificateError {
 }
 
 impl UpdateServerCertificateError {
-    pub fn from_body(body: &str) -> UpdateServerCertificateError {
+    pub fn from_body(body: &str, status: u16) -> UpdateServerCertificateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -23642,7 +23778,9 @@ impl UpdateServerCertificateError {
                 }
                 _ => UpdateServerCertificateError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateServerCertificateError::Unknown(body.to_string()),
+            Err(_) => {
+                UpdateServerCertificateError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -23713,7 +23851,7 @@ pub enum UpdateServiceSpecificCredentialError {
 }
 
 impl UpdateServiceSpecificCredentialError {
-    pub fn from_body(body: &str) -> UpdateServiceSpecificCredentialError {
+    pub fn from_body(body: &str, status: u16) -> UpdateServiceSpecificCredentialError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -23724,7 +23862,11 @@ impl UpdateServiceSpecificCredentialError {
                 )),
                 _ => UpdateServiceSpecificCredentialError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateServiceSpecificCredentialError::Unknown(body.to_string()),
+            Err(_) => UpdateServiceSpecificCredentialError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -23796,7 +23938,7 @@ pub enum UpdateSigningCertificateError {
 }
 
 impl UpdateSigningCertificateError {
-    pub fn from_body(body: &str) -> UpdateSigningCertificateError {
+    pub fn from_body(body: &str, status: u16) -> UpdateSigningCertificateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -23813,7 +23955,9 @@ impl UpdateSigningCertificateError {
                 )),
                 _ => UpdateSigningCertificateError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateSigningCertificateError::Unknown(body.to_string()),
+            Err(_) => {
+                UpdateSigningCertificateError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -23891,7 +24035,7 @@ pub enum UpdateUserError {
 }
 
 impl UpdateUserError {
-    pub fn from_body(body: &str) -> UpdateUserError {
+    pub fn from_body(body: &str, status: u16) -> UpdateUserError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -23912,7 +24056,7 @@ impl UpdateUserError {
                 }
                 _ => UpdateUserError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateUserError::Unknown(body.to_string()),
+            Err(_) => UpdateUserError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -23990,7 +24134,7 @@ pub enum UploadSSHPublicKeyError {
 }
 
 impl UploadSSHPublicKeyError {
-    pub fn from_body(body: &str) -> UploadSSHPublicKeyError {
+    pub fn from_body(body: &str, status: u16) -> UploadSSHPublicKeyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -24015,7 +24159,7 @@ impl UploadSSHPublicKeyError {
                 }
                 _ => UploadSSHPublicKeyError::Unknown(String::from(body)),
             },
-            Err(_) => UploadSSHPublicKeyError::Unknown(body.to_string()),
+            Err(_) => UploadSSHPublicKeyError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -24095,7 +24239,7 @@ pub enum UploadServerCertificateError {
 }
 
 impl UploadServerCertificateError {
-    pub fn from_body(body: &str) -> UploadServerCertificateError {
+    pub fn from_body(body: &str, status: u16) -> UploadServerCertificateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -24118,7 +24262,9 @@ impl UploadServerCertificateError {
                 }
                 _ => UploadServerCertificateError::Unknown(String::from(body)),
             },
-            Err(_) => UploadServerCertificateError::Unknown(body.to_string()),
+            Err(_) => {
+                UploadServerCertificateError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -24202,7 +24348,7 @@ pub enum UploadSigningCertificateError {
 }
 
 impl UploadSigningCertificateError {
-    pub fn from_body(body: &str) -> UploadSigningCertificateError {
+    pub fn from_body(body: &str, status: u16) -> UploadSigningCertificateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -24231,7 +24377,9 @@ impl UploadSigningCertificateError {
                 )),
                 _ => UploadSigningCertificateError::Unknown(String::from(body)),
             },
-            Err(_) => UploadSigningCertificateError::Unknown(body.to_string()),
+            Err(_) => {
+                UploadSigningCertificateError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 

--- a/rusoto/services/iam/src/generated.rs
+++ b/rusoto/services/iam/src/generated.rs
@@ -12800,11 +12800,17 @@ impl AddClientIDToOpenIDConnectProviderError {
                 ),
                 _ => AddClientIDToOpenIDConnectProviderError::Unknown(String::from(body)),
             },
-            Err(_) => AddClientIDToOpenIDConnectProviderError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    AddClientIDToOpenIDConnectProviderError::Unknown(format!("{}", status))
+                } else {
+                    AddClientIDToOpenIDConnectProviderError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -12907,7 +12913,15 @@ impl AddRoleToInstanceProfileError {
                 _ => AddRoleToInstanceProfileError::Unknown(String::from(body)),
             },
             Err(_) => {
-                AddRoleToInstanceProfileError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    AddRoleToInstanceProfileError::Unknown(format!("{}", status))
+                } else {
+                    AddRoleToInstanceProfileError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -13001,7 +13015,13 @@ impl AddUserToGroupError {
                 }
                 _ => AddUserToGroupError::Unknown(String::from(body)),
             },
-            Err(_) => AddUserToGroupError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    AddUserToGroupError::Unknown(format!("{}", status))
+                } else {
+                    AddUserToGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -13100,7 +13120,13 @@ impl AttachGroupPolicyError {
                 }
                 _ => AttachGroupPolicyError::Unknown(String::from(body)),
             },
-            Err(_) => AttachGroupPolicyError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    AttachGroupPolicyError::Unknown(format!("{}", status))
+                } else {
+                    AttachGroupPolicyError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -13208,7 +13234,13 @@ impl AttachRolePolicyError {
                 }
                 _ => AttachRolePolicyError::Unknown(String::from(body)),
             },
-            Err(_) => AttachRolePolicyError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    AttachRolePolicyError::Unknown(format!("{}", status))
+                } else {
+                    AttachRolePolicyError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -13310,7 +13342,13 @@ impl AttachUserPolicyError {
                 }
                 _ => AttachUserPolicyError::Unknown(String::from(body)),
             },
-            Err(_) => AttachUserPolicyError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    AttachUserPolicyError::Unknown(format!("{}", status))
+                } else {
+                    AttachUserPolicyError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -13418,7 +13456,13 @@ impl ChangePasswordError {
                 }
                 _ => ChangePasswordError::Unknown(String::from(body)),
             },
-            Err(_) => ChangePasswordError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ChangePasswordError::Unknown(format!("{}", status))
+                } else {
+                    ChangePasswordError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -13510,7 +13554,13 @@ impl CreateAccessKeyError {
                 }
                 _ => CreateAccessKeyError::Unknown(String::from(body)),
             },
-            Err(_) => CreateAccessKeyError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateAccessKeyError::Unknown(format!("{}", status))
+                } else {
+                    CreateAccessKeyError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -13599,7 +13649,13 @@ impl CreateAccountAliasError {
                 }
                 _ => CreateAccountAliasError::Unknown(String::from(body)),
             },
-            Err(_) => CreateAccountAliasError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateAccountAliasError::Unknown(format!("{}", status))
+                } else {
+                    CreateAccountAliasError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -13695,7 +13751,13 @@ impl CreateGroupError {
                 }
                 _ => CreateGroupError::Unknown(String::from(body)),
             },
-            Err(_) => CreateGroupError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateGroupError::Unknown(format!("{}", status))
+                } else {
+                    CreateGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -13786,7 +13848,11 @@ impl CreateInstanceProfileError {
                 _ => CreateInstanceProfileError::Unknown(String::from(body)),
             },
             Err(_) => {
-                CreateInstanceProfileError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    CreateInstanceProfileError::Unknown(format!("{}", status))
+                } else {
+                    CreateInstanceProfileError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -13888,7 +13954,13 @@ impl CreateLoginProfileError {
                 }
                 _ => CreateLoginProfileError::Unknown(String::from(body)),
             },
-            Err(_) => CreateLoginProfileError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateLoginProfileError::Unknown(format!("{}", status))
+                } else {
+                    CreateLoginProfileError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -13986,11 +14058,17 @@ impl CreateOpenIDConnectProviderError {
                 )),
                 _ => CreateOpenIDConnectProviderError::Unknown(String::from(body)),
             },
-            Err(_) => CreateOpenIDConnectProviderError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateOpenIDConnectProviderError::Unknown(format!("{}", status))
+                } else {
+                    CreateOpenIDConnectProviderError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -14092,7 +14170,13 @@ impl CreatePolicyError {
                 }
                 _ => CreatePolicyError::Unknown(String::from(body)),
             },
-            Err(_) => CreatePolicyError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreatePolicyError::Unknown(format!("{}", status))
+                } else {
+                    CreatePolicyError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -14193,7 +14277,13 @@ impl CreatePolicyVersionError {
                 }
                 _ => CreatePolicyVersionError::Unknown(String::from(body)),
             },
-            Err(_) => CreatePolicyVersionError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreatePolicyVersionError::Unknown(format!("{}", status))
+                } else {
+                    CreatePolicyVersionError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -14294,7 +14384,13 @@ impl CreateRoleError {
                 }
                 _ => CreateRoleError::Unknown(String::from(body)),
             },
-            Err(_) => CreateRoleError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateRoleError::Unknown(format!("{}", status))
+                } else {
+                    CreateRoleError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -14390,7 +14486,13 @@ impl CreateSAMLProviderError {
                 }
                 _ => CreateSAMLProviderError::Unknown(String::from(body)),
             },
-            Err(_) => CreateSAMLProviderError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateSAMLProviderError::Unknown(format!("{}", status))
+                } else {
+                    CreateSAMLProviderError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -14488,7 +14590,15 @@ impl CreateServiceLinkedRoleError {
                 _ => CreateServiceLinkedRoleError::Unknown(String::from(body)),
             },
             Err(_) => {
-                CreateServiceLinkedRoleError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    CreateServiceLinkedRoleError::Unknown(format!("{}", status))
+                } else {
+                    CreateServiceLinkedRoleError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -14581,11 +14691,17 @@ impl CreateServiceSpecificCredentialError {
                 ),
                 _ => CreateServiceSpecificCredentialError::Unknown(String::from(body)),
             },
-            Err(_) => CreateServiceSpecificCredentialError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateServiceSpecificCredentialError::Unknown(format!("{}", status))
+                } else {
+                    CreateServiceSpecificCredentialError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -14679,7 +14795,13 @@ impl CreateUserError {
                 }
                 _ => CreateUserError::Unknown(String::from(body)),
             },
-            Err(_) => CreateUserError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateUserError::Unknown(format!("{}", status))
+                } else {
+                    CreateUserError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -14770,7 +14892,11 @@ impl CreateVirtualMFADeviceError {
                 _ => CreateVirtualMFADeviceError::Unknown(String::from(body)),
             },
             Err(_) => {
-                CreateVirtualMFADeviceError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    CreateVirtualMFADeviceError::Unknown(format!("{}", status))
+                } else {
+                    CreateVirtualMFADeviceError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -14869,7 +14995,13 @@ impl DeactivateMFADeviceError {
                 }
                 _ => DeactivateMFADeviceError::Unknown(String::from(body)),
             },
-            Err(_) => DeactivateMFADeviceError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeactivateMFADeviceError::Unknown(format!("{}", status))
+                } else {
+                    DeactivateMFADeviceError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -14961,7 +15093,13 @@ impl DeleteAccessKeyError {
                 }
                 _ => DeleteAccessKeyError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteAccessKeyError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteAccessKeyError::Unknown(format!("{}", status))
+                } else {
+                    DeleteAccessKeyError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -15050,7 +15188,13 @@ impl DeleteAccountAliasError {
                 }
                 _ => DeleteAccountAliasError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteAccountAliasError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteAccountAliasError::Unknown(format!("{}", status))
+                } else {
+                    DeleteAccountAliasError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -15141,11 +15285,17 @@ impl DeleteAccountPasswordPolicyError {
                 )),
                 _ => DeleteAccountPasswordPolicyError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteAccountPasswordPolicyError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteAccountPasswordPolicyError::Unknown(format!("{}", status))
+                } else {
+                    DeleteAccountPasswordPolicyError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -15241,7 +15391,13 @@ impl DeleteGroupError {
                 }
                 _ => DeleteGroupError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteGroupError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteGroupError::Unknown(format!("{}", status))
+                } else {
+                    DeleteGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -15331,7 +15487,13 @@ impl DeleteGroupPolicyError {
                 }
                 _ => DeleteGroupPolicyError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteGroupPolicyError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteGroupPolicyError::Unknown(format!("{}", status))
+                } else {
+                    DeleteGroupPolicyError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -15428,7 +15590,11 @@ impl DeleteInstanceProfileError {
                 _ => DeleteInstanceProfileError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DeleteInstanceProfileError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DeleteInstanceProfileError::Unknown(format!("{}", status))
+                } else {
+                    DeleteInstanceProfileError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -15528,7 +15694,13 @@ impl DeleteLoginProfileError {
                 }
                 _ => DeleteLoginProfileError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteLoginProfileError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteLoginProfileError::Unknown(format!("{}", status))
+                } else {
+                    DeleteLoginProfileError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -15620,11 +15792,17 @@ impl DeleteOpenIDConnectProviderError {
                 )),
                 _ => DeleteOpenIDConnectProviderError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteOpenIDConnectProviderError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteOpenIDConnectProviderError::Unknown(format!("{}", status))
+                } else {
+                    DeleteOpenIDConnectProviderError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -15725,7 +15903,13 @@ impl DeletePolicyError {
                 }
                 _ => DeletePolicyError::Unknown(String::from(body)),
             },
-            Err(_) => DeletePolicyError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeletePolicyError::Unknown(format!("{}", status))
+                } else {
+                    DeletePolicyError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -15826,7 +16010,13 @@ impl DeletePolicyVersionError {
                 }
                 _ => DeletePolicyVersionError::Unknown(String::from(body)),
             },
-            Err(_) => DeletePolicyVersionError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeletePolicyVersionError::Unknown(format!("{}", status))
+                } else {
+                    DeletePolicyVersionError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -15927,7 +16117,13 @@ impl DeleteRoleError {
                 }
                 _ => DeleteRoleError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteRoleError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteRoleError::Unknown(format!("{}", status))
+                } else {
+                    DeleteRoleError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -16018,11 +16214,17 @@ impl DeleteRolePermissionsBoundaryError {
                 ),
                 _ => DeleteRolePermissionsBoundaryError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteRolePermissionsBoundaryError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteRolePermissionsBoundaryError::Unknown(format!("{}", status))
+                } else {
+                    DeleteRolePermissionsBoundaryError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -16118,7 +16320,13 @@ impl DeleteRolePolicyError {
                 }
                 _ => DeleteRolePolicyError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteRolePolicyError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteRolePolicyError::Unknown(format!("{}", status))
+                } else {
+                    DeleteRolePolicyError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -16213,7 +16421,13 @@ impl DeleteSAMLProviderError {
                 }
                 _ => DeleteSAMLProviderError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteSAMLProviderError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteSAMLProviderError::Unknown(format!("{}", status))
+                } else {
+                    DeleteSAMLProviderError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -16295,7 +16509,13 @@ impl DeleteSSHPublicKeyError {
                 }
                 _ => DeleteSSHPublicKeyError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteSSHPublicKeyError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteSSHPublicKeyError::Unknown(format!("{}", status))
+                } else {
+                    DeleteSSHPublicKeyError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -16390,7 +16610,15 @@ impl DeleteServerCertificateError {
                 _ => DeleteServerCertificateError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DeleteServerCertificateError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DeleteServerCertificateError::Unknown(format!("{}", status))
+                } else {
+                    DeleteServerCertificateError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -16484,7 +16712,15 @@ impl DeleteServiceLinkedRoleError {
                 _ => DeleteServiceLinkedRoleError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DeleteServiceLinkedRoleError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DeleteServiceLinkedRoleError::Unknown(format!("{}", status))
+                } else {
+                    DeleteServiceLinkedRoleError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -16566,11 +16802,17 @@ impl DeleteServiceSpecificCredentialError {
                 )),
                 _ => DeleteServiceSpecificCredentialError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteServiceSpecificCredentialError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteServiceSpecificCredentialError::Unknown(format!("{}", status))
+                } else {
+                    DeleteServiceSpecificCredentialError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -16660,7 +16902,15 @@ impl DeleteSigningCertificateError {
                 _ => DeleteSigningCertificateError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DeleteSigningCertificateError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DeleteSigningCertificateError::Unknown(format!("{}", status))
+                } else {
+                    DeleteSigningCertificateError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -16755,7 +17005,13 @@ impl DeleteUserError {
                 }
                 _ => DeleteUserError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteUserError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteUserError::Unknown(format!("{}", status))
+                } else {
+                    DeleteUserError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -16840,11 +17096,17 @@ impl DeleteUserPermissionsBoundaryError {
                 ),
                 _ => DeleteUserPermissionsBoundaryError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteUserPermissionsBoundaryError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteUserPermissionsBoundaryError::Unknown(format!("{}", status))
+                } else {
+                    DeleteUserPermissionsBoundaryError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -16934,7 +17196,13 @@ impl DeleteUserPolicyError {
                 }
                 _ => DeleteUserPolicyError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteUserPolicyError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteUserPolicyError::Unknown(format!("{}", status))
+                } else {
+                    DeleteUserPolicyError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -17029,7 +17297,11 @@ impl DeleteVirtualMFADeviceError {
                 _ => DeleteVirtualMFADeviceError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DeleteVirtualMFADeviceError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DeleteVirtualMFADeviceError::Unknown(format!("{}", status))
+                } else {
+                    DeleteVirtualMFADeviceError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -17127,7 +17399,13 @@ impl DetachGroupPolicyError {
                 }
                 _ => DetachGroupPolicyError::Unknown(String::from(body)),
             },
-            Err(_) => DetachGroupPolicyError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DetachGroupPolicyError::Unknown(format!("{}", status))
+                } else {
+                    DetachGroupPolicyError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -17229,7 +17507,13 @@ impl DetachRolePolicyError {
                 }
                 _ => DetachRolePolicyError::Unknown(String::from(body)),
             },
-            Err(_) => DetachRolePolicyError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DetachRolePolicyError::Unknown(format!("{}", status))
+                } else {
+                    DetachRolePolicyError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -17325,7 +17609,13 @@ impl DetachUserPolicyError {
                 }
                 _ => DetachUserPolicyError::Unknown(String::from(body)),
             },
-            Err(_) => DetachUserPolicyError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DetachUserPolicyError::Unknown(format!("{}", status))
+                } else {
+                    DetachUserPolicyError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -17432,7 +17722,13 @@ impl EnableMFADeviceError {
                 }
                 _ => EnableMFADeviceError::Unknown(String::from(body)),
             },
-            Err(_) => EnableMFADeviceError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    EnableMFADeviceError::Unknown(format!("{}", status))
+                } else {
+                    EnableMFADeviceError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -17520,7 +17816,15 @@ impl GenerateCredentialReportError {
                 _ => GenerateCredentialReportError::Unknown(String::from(body)),
             },
             Err(_) => {
-                GenerateCredentialReportError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    GenerateCredentialReportError::Unknown(format!("{}", status))
+                } else {
+                    GenerateCredentialReportError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -17602,7 +17906,11 @@ impl GetAccessKeyLastUsedError {
                 _ => GetAccessKeyLastUsedError::Unknown(String::from(body)),
             },
             Err(_) => {
-                GetAccessKeyLastUsedError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    GetAccessKeyLastUsedError::Unknown(format!("{}", status))
+                } else {
+                    GetAccessKeyLastUsedError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -17682,11 +17990,17 @@ impl GetAccountAuthorizationDetailsError {
                 ),
                 _ => GetAccountAuthorizationDetailsError::Unknown(String::from(body)),
             },
-            Err(_) => GetAccountAuthorizationDetailsError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetAccountAuthorizationDetailsError::Unknown(format!("{}", status))
+                } else {
+                    GetAccountAuthorizationDetailsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -17771,7 +18085,15 @@ impl GetAccountPasswordPolicyError {
                 _ => GetAccountPasswordPolicyError::Unknown(String::from(body)),
             },
             Err(_) => {
-                GetAccountPasswordPolicyError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    GetAccountPasswordPolicyError::Unknown(format!("{}", status))
+                } else {
+                    GetAccountPasswordPolicyError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -17852,7 +18174,13 @@ impl GetAccountSummaryError {
                 }
                 _ => GetAccountSummaryError::Unknown(String::from(body)),
             },
-            Err(_) => GetAccountSummaryError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetAccountSummaryError::Unknown(format!("{}", status))
+                } else {
+                    GetAccountSummaryError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -17931,11 +18259,17 @@ impl GetContextKeysForCustomPolicyError {
                 )),
                 _ => GetContextKeysForCustomPolicyError::Unknown(String::from(body)),
             },
-            Err(_) => GetContextKeysForCustomPolicyError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetContextKeysForCustomPolicyError::Unknown(format!("{}", status))
+                } else {
+                    GetContextKeysForCustomPolicyError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -18019,11 +18353,17 @@ impl GetContextKeysForPrincipalPolicyError {
                 ),
                 _ => GetContextKeysForPrincipalPolicyError::Unknown(String::from(body)),
             },
-            Err(_) => GetContextKeysForPrincipalPolicyError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetContextKeysForPrincipalPolicyError::Unknown(format!("{}", status))
+                } else {
+                    GetContextKeysForPrincipalPolicyError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -18118,7 +18458,13 @@ impl GetCredentialReportError {
                 }
                 _ => GetCredentialReportError::Unknown(String::from(body)),
             },
-            Err(_) => GetCredentialReportError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetCredentialReportError::Unknown(format!("{}", status))
+                } else {
+                    GetCredentialReportError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -18203,7 +18549,13 @@ impl GetGroupError {
                 }
                 _ => GetGroupError::Unknown(String::from(body)),
             },
-            Err(_) => GetGroupError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetGroupError::Unknown(format!("{}", status))
+                } else {
+                    GetGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -18286,7 +18638,13 @@ impl GetGroupPolicyError {
                 }
                 _ => GetGroupPolicyError::Unknown(String::from(body)),
             },
-            Err(_) => GetGroupPolicyError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetGroupPolicyError::Unknown(format!("{}", status))
+                } else {
+                    GetGroupPolicyError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -18369,7 +18727,13 @@ impl GetInstanceProfileError {
                 }
                 _ => GetInstanceProfileError::Unknown(String::from(body)),
             },
-            Err(_) => GetInstanceProfileError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetInstanceProfileError::Unknown(format!("{}", status))
+                } else {
+                    GetInstanceProfileError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -18454,7 +18818,13 @@ impl GetLoginProfileError {
                 }
                 _ => GetLoginProfileError::Unknown(String::from(body)),
             },
-            Err(_) => GetLoginProfileError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetLoginProfileError::Unknown(format!("{}", status))
+                } else {
+                    GetLoginProfileError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -18543,7 +18913,15 @@ impl GetOpenIDConnectProviderError {
                 _ => GetOpenIDConnectProviderError::Unknown(String::from(body)),
             },
             Err(_) => {
-                GetOpenIDConnectProviderError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    GetOpenIDConnectProviderError::Unknown(format!("{}", status))
+                } else {
+                    GetOpenIDConnectProviderError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -18631,7 +19009,13 @@ impl GetPolicyError {
                 }
                 _ => GetPolicyError::Unknown(String::from(body)),
             },
-            Err(_) => GetPolicyError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetPolicyError::Unknown(format!("{}", status))
+                } else {
+                    GetPolicyError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -18720,7 +19104,13 @@ impl GetPolicyVersionError {
                 }
                 _ => GetPolicyVersionError::Unknown(String::from(body)),
             },
-            Err(_) => GetPolicyVersionError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetPolicyVersionError::Unknown(format!("{}", status))
+                } else {
+                    GetPolicyVersionError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -18802,7 +19192,13 @@ impl GetRoleError {
                 }
                 _ => GetRoleError::Unknown(String::from(body)),
             },
-            Err(_) => GetRoleError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetRoleError::Unknown(format!("{}", status))
+                } else {
+                    GetRoleError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -18885,7 +19281,13 @@ impl GetRolePolicyError {
                 }
                 _ => GetRolePolicyError::Unknown(String::from(body)),
             },
-            Err(_) => GetRolePolicyError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetRolePolicyError::Unknown(format!("{}", status))
+                } else {
+                    GetRolePolicyError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -18973,7 +19375,13 @@ impl GetSAMLProviderError {
                 }
                 _ => GetSAMLProviderError::Unknown(String::from(body)),
             },
-            Err(_) => GetSAMLProviderError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetSAMLProviderError::Unknown(format!("{}", status))
+                } else {
+                    GetSAMLProviderError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -19059,7 +19467,13 @@ impl GetSSHPublicKeyError {
                 }
                 _ => GetSSHPublicKeyError::Unknown(String::from(body)),
             },
-            Err(_) => GetSSHPublicKeyError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetSSHPublicKeyError::Unknown(format!("{}", status))
+                } else {
+                    GetSSHPublicKeyError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -19143,7 +19557,11 @@ impl GetServerCertificateError {
                 _ => GetServerCertificateError::Unknown(String::from(body)),
             },
             Err(_) => {
-                GetServerCertificateError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    GetServerCertificateError::Unknown(format!("{}", status))
+                } else {
+                    GetServerCertificateError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -19234,11 +19652,17 @@ impl GetServiceLinkedRoleDeletionStatusError {
                 ),
                 _ => GetServiceLinkedRoleDeletionStatusError::Unknown(String::from(body)),
             },
-            Err(_) => GetServiceLinkedRoleDeletionStatusError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetServiceLinkedRoleDeletionStatusError::Unknown(format!("{}", status))
+                } else {
+                    GetServiceLinkedRoleDeletionStatusError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -19322,7 +19746,13 @@ impl GetUserError {
                 }
                 _ => GetUserError::Unknown(String::from(body)),
             },
-            Err(_) => GetUserError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetUserError::Unknown(format!("{}", status))
+                } else {
+                    GetUserError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -19405,7 +19835,13 @@ impl GetUserPolicyError {
                 }
                 _ => GetUserPolicyError::Unknown(String::from(body)),
             },
-            Err(_) => GetUserPolicyError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetUserPolicyError::Unknown(format!("{}", status))
+                } else {
+                    GetUserPolicyError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -19488,7 +19924,13 @@ impl ListAccessKeysError {
                 }
                 _ => ListAccessKeysError::Unknown(String::from(body)),
             },
-            Err(_) => ListAccessKeysError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ListAccessKeysError::Unknown(format!("{}", status))
+                } else {
+                    ListAccessKeysError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -19566,7 +20008,13 @@ impl ListAccountAliasesError {
                 }
                 _ => ListAccountAliasesError::Unknown(String::from(body)),
             },
-            Err(_) => ListAccountAliasesError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ListAccountAliasesError::Unknown(format!("{}", status))
+                } else {
+                    ListAccountAliasesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -19656,7 +20104,15 @@ impl ListAttachedGroupPoliciesError {
                 _ => ListAttachedGroupPoliciesError::Unknown(String::from(body)),
             },
             Err(_) => {
-                ListAttachedGroupPoliciesError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    ListAttachedGroupPoliciesError::Unknown(format!("{}", status))
+                } else {
+                    ListAttachedGroupPoliciesError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -19749,7 +20205,15 @@ impl ListAttachedRolePoliciesError {
                 _ => ListAttachedRolePoliciesError::Unknown(String::from(body)),
             },
             Err(_) => {
-                ListAttachedRolePoliciesError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    ListAttachedRolePoliciesError::Unknown(format!("{}", status))
+                } else {
+                    ListAttachedRolePoliciesError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -19842,7 +20306,15 @@ impl ListAttachedUserPoliciesError {
                 _ => ListAttachedUserPoliciesError::Unknown(String::from(body)),
             },
             Err(_) => {
-                ListAttachedUserPoliciesError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    ListAttachedUserPoliciesError::Unknown(format!("{}", status))
+                } else {
+                    ListAttachedUserPoliciesError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -19935,7 +20407,11 @@ impl ListEntitiesForPolicyError {
                 _ => ListEntitiesForPolicyError::Unknown(String::from(body)),
             },
             Err(_) => {
-                ListEntitiesForPolicyError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    ListEntitiesForPolicyError::Unknown(format!("{}", status))
+                } else {
+                    ListEntitiesForPolicyError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -20022,7 +20498,13 @@ impl ListGroupPoliciesError {
                 }
                 _ => ListGroupPoliciesError::Unknown(String::from(body)),
             },
-            Err(_) => ListGroupPoliciesError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ListGroupPoliciesError::Unknown(format!("{}", status))
+                } else {
+                    ListGroupPoliciesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -20102,7 +20584,13 @@ impl ListGroupsError {
                 }
                 _ => ListGroupsError::Unknown(String::from(body)),
             },
-            Err(_) => ListGroupsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ListGroupsError::Unknown(format!("{}", status))
+                } else {
+                    ListGroupsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -20184,7 +20672,13 @@ impl ListGroupsForUserError {
                 }
                 _ => ListGroupsForUserError::Unknown(String::from(body)),
             },
-            Err(_) => ListGroupsForUserError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ListGroupsForUserError::Unknown(format!("{}", status))
+                } else {
+                    ListGroupsForUserError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -20265,7 +20759,11 @@ impl ListInstanceProfilesError {
                 _ => ListInstanceProfilesError::Unknown(String::from(body)),
             },
             Err(_) => {
-                ListInstanceProfilesError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    ListInstanceProfilesError::Unknown(format!("{}", status))
+                } else {
+                    ListInstanceProfilesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -20350,11 +20848,17 @@ impl ListInstanceProfilesForRoleError {
                 )),
                 _ => ListInstanceProfilesForRoleError::Unknown(String::from(body)),
             },
-            Err(_) => ListInstanceProfilesForRoleError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    ListInstanceProfilesForRoleError::Unknown(format!("{}", status))
+                } else {
+                    ListInstanceProfilesForRoleError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -20439,7 +20943,13 @@ impl ListMFADevicesError {
                 }
                 _ => ListMFADevicesError::Unknown(String::from(body)),
             },
-            Err(_) => ListMFADevicesError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ListMFADevicesError::Unknown(format!("{}", status))
+                } else {
+                    ListMFADevicesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -20518,7 +21028,15 @@ impl ListOpenIDConnectProvidersError {
                 _ => ListOpenIDConnectProvidersError::Unknown(String::from(body)),
             },
             Err(_) => {
-                ListOpenIDConnectProvidersError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    ListOpenIDConnectProvidersError::Unknown(format!("{}", status))
+                } else {
+                    ListOpenIDConnectProvidersError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -20598,7 +21116,13 @@ impl ListPoliciesError {
                 }
                 _ => ListPoliciesError::Unknown(String::from(body)),
             },
-            Err(_) => ListPoliciesError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ListPoliciesError::Unknown(format!("{}", status))
+                } else {
+                    ListPoliciesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -20685,7 +21209,13 @@ impl ListPolicyVersionsError {
                 }
                 _ => ListPolicyVersionsError::Unknown(String::from(body)),
             },
-            Err(_) => ListPolicyVersionsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ListPolicyVersionsError::Unknown(format!("{}", status))
+                } else {
+                    ListPolicyVersionsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -20771,7 +21301,13 @@ impl ListRolePoliciesError {
                 }
                 _ => ListRolePoliciesError::Unknown(String::from(body)),
             },
-            Err(_) => ListRolePoliciesError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ListRolePoliciesError::Unknown(format!("{}", status))
+                } else {
+                    ListRolePoliciesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -20849,7 +21385,13 @@ impl ListRolesError {
                 }
                 _ => ListRolesError::Unknown(String::from(body)),
             },
-            Err(_) => ListRolesError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ListRolesError::Unknown(format!("{}", status))
+                } else {
+                    ListRolesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -20926,7 +21468,13 @@ impl ListSAMLProvidersError {
                 }
                 _ => ListSAMLProvidersError::Unknown(String::from(body)),
             },
-            Err(_) => ListSAMLProvidersError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ListSAMLProvidersError::Unknown(format!("{}", status))
+                } else {
+                    ListSAMLProvidersError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -21005,7 +21553,13 @@ impl ListSSHPublicKeysError {
                 }
                 _ => ListSSHPublicKeysError::Unknown(String::from(body)),
             },
-            Err(_) => ListSSHPublicKeysError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ListSSHPublicKeysError::Unknown(format!("{}", status))
+                } else {
+                    ListSSHPublicKeysError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -21085,7 +21639,11 @@ impl ListServerCertificatesError {
                 _ => ListServerCertificatesError::Unknown(String::from(body)),
             },
             Err(_) => {
-                ListServerCertificatesError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    ListServerCertificatesError::Unknown(format!("{}", status))
+                } else {
+                    ListServerCertificatesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -21170,11 +21728,17 @@ impl ListServiceSpecificCredentialsError {
                 ),
                 _ => ListServiceSpecificCredentialsError::Unknown(String::from(body)),
             },
-            Err(_) => ListServiceSpecificCredentialsError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    ListServiceSpecificCredentialsError::Unknown(format!("{}", status))
+                } else {
+                    ListServiceSpecificCredentialsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -21260,7 +21824,15 @@ impl ListSigningCertificatesError {
                 _ => ListSigningCertificatesError::Unknown(String::from(body)),
             },
             Err(_) => {
-                ListSigningCertificatesError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    ListSigningCertificatesError::Unknown(format!("{}", status))
+                } else {
+                    ListSigningCertificatesError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -21346,7 +21918,13 @@ impl ListUserPoliciesError {
                 }
                 _ => ListUserPoliciesError::Unknown(String::from(body)),
             },
-            Err(_) => ListUserPoliciesError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ListUserPoliciesError::Unknown(format!("{}", status))
+                } else {
+                    ListUserPoliciesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -21424,7 +22002,13 @@ impl ListUsersError {
                 }
                 _ => ListUsersError::Unknown(String::from(body)),
             },
-            Err(_) => ListUsersError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ListUsersError::Unknown(format!("{}", status))
+                } else {
+                    ListUsersError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -21497,7 +22081,11 @@ impl ListVirtualMFADevicesError {
                 _ => ListVirtualMFADevicesError::Unknown(String::from(body)),
             },
             Err(_) => {
-                ListVirtualMFADevicesError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    ListVirtualMFADevicesError::Unknown(format!("{}", status))
+                } else {
+                    ListVirtualMFADevicesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -21591,7 +22179,13 @@ impl PutGroupPolicyError {
                 }
                 _ => PutGroupPolicyError::Unknown(String::from(body)),
             },
-            Err(_) => PutGroupPolicyError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    PutGroupPolicyError::Unknown(format!("{}", status))
+                } else {
+                    PutGroupPolicyError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -21692,7 +22286,15 @@ impl PutRolePermissionsBoundaryError {
                 _ => PutRolePermissionsBoundaryError::Unknown(String::from(body)),
             },
             Err(_) => {
-                PutRolePermissionsBoundaryError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    PutRolePermissionsBoundaryError::Unknown(format!("{}", status))
+                } else {
+                    PutRolePermissionsBoundaryError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -21796,7 +22398,13 @@ impl PutRolePolicyError {
                 }
                 _ => PutRolePolicyError::Unknown(String::from(body)),
             },
-            Err(_) => PutRolePolicyError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    PutRolePolicyError::Unknown(format!("{}", status))
+                } else {
+                    PutRolePolicyError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -21893,7 +22501,15 @@ impl PutUserPermissionsBoundaryError {
                 _ => PutUserPermissionsBoundaryError::Unknown(String::from(body)),
             },
             Err(_) => {
-                PutUserPermissionsBoundaryError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    PutUserPermissionsBoundaryError::Unknown(format!("{}", status))
+                } else {
+                    PutUserPermissionsBoundaryError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -21991,7 +22607,13 @@ impl PutUserPolicyError {
                 }
                 _ => PutUserPolicyError::Unknown(String::from(body)),
             },
-            Err(_) => PutUserPolicyError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    PutUserPolicyError::Unknown(format!("{}", status))
+                } else {
+                    PutUserPolicyError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -22081,11 +22703,17 @@ impl RemoveClientIDFromOpenIDConnectProviderError {
                 ),
                 _ => RemoveClientIDFromOpenIDConnectProviderError::Unknown(String::from(body)),
             },
-            Err(_) => RemoveClientIDFromOpenIDConnectProviderError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    RemoveClientIDFromOpenIDConnectProviderError::Unknown(format!("{}", status))
+                } else {
+                    RemoveClientIDFromOpenIDConnectProviderError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -22181,11 +22809,17 @@ impl RemoveRoleFromInstanceProfileError {
                 ),
                 _ => RemoveRoleFromInstanceProfileError::Unknown(String::from(body)),
             },
-            Err(_) => RemoveRoleFromInstanceProfileError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    RemoveRoleFromInstanceProfileError::Unknown(format!("{}", status))
+                } else {
+                    RemoveRoleFromInstanceProfileError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -22277,7 +22911,13 @@ impl RemoveUserFromGroupError {
                 }
                 _ => RemoveUserFromGroupError::Unknown(String::from(body)),
             },
-            Err(_) => RemoveUserFromGroupError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    RemoveUserFromGroupError::Unknown(format!("{}", status))
+                } else {
+                    RemoveUserFromGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -22358,11 +22998,17 @@ impl ResetServiceSpecificCredentialError {
                 )),
                 _ => ResetServiceSpecificCredentialError::Unknown(String::from(body)),
             },
-            Err(_) => ResetServiceSpecificCredentialError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    ResetServiceSpecificCredentialError::Unknown(format!("{}", status))
+                } else {
+                    ResetServiceSpecificCredentialError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -22456,7 +23102,13 @@ impl ResyncMFADeviceError {
                 }
                 _ => ResyncMFADeviceError::Unknown(String::from(body)),
             },
-            Err(_) => ResyncMFADeviceError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ResyncMFADeviceError::Unknown(format!("{}", status))
+                } else {
+                    ResyncMFADeviceError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -22552,7 +23204,15 @@ impl SetDefaultPolicyVersionError {
                 _ => SetDefaultPolicyVersionError::Unknown(String::from(body)),
             },
             Err(_) => {
-                SetDefaultPolicyVersionError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    SetDefaultPolicyVersionError::Unknown(format!("{}", status))
+                } else {
+                    SetDefaultPolicyVersionError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -22641,7 +23301,11 @@ impl SimulateCustomPolicyError {
                 _ => SimulateCustomPolicyError::Unknown(String::from(body)),
             },
             Err(_) => {
-                SimulateCustomPolicyError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    SimulateCustomPolicyError::Unknown(format!("{}", status))
+                } else {
+                    SimulateCustomPolicyError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -22733,7 +23397,15 @@ impl SimulatePrincipalPolicyError {
                 _ => SimulatePrincipalPolicyError::Unknown(String::from(body)),
             },
             Err(_) => {
-                SimulatePrincipalPolicyError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    SimulatePrincipalPolicyError::Unknown(format!("{}", status))
+                } else {
+                    SimulatePrincipalPolicyError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -22825,7 +23497,13 @@ impl UpdateAccessKeyError {
                 }
                 _ => UpdateAccessKeyError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateAccessKeyError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    UpdateAccessKeyError::Unknown(format!("{}", status))
+                } else {
+                    UpdateAccessKeyError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -22921,11 +23599,17 @@ impl UpdateAccountPasswordPolicyError {
                 )),
                 _ => UpdateAccountPasswordPolicyError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateAccountPasswordPolicyError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    UpdateAccountPasswordPolicyError::Unknown(format!("{}", status))
+                } else {
+                    UpdateAccountPasswordPolicyError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -23028,7 +23712,11 @@ impl UpdateAssumeRolePolicyError {
                 _ => UpdateAssumeRolePolicyError::Unknown(String::from(body)),
             },
             Err(_) => {
-                UpdateAssumeRolePolicyError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    UpdateAssumeRolePolicyError::Unknown(format!("{}", status))
+                } else {
+                    UpdateAssumeRolePolicyError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -23127,7 +23815,13 @@ impl UpdateGroupError {
                 }
                 _ => UpdateGroupError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateGroupError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    UpdateGroupError::Unknown(format!("{}", status))
+                } else {
+                    UpdateGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -23229,7 +23923,13 @@ impl UpdateLoginProfileError {
                 }
                 _ => UpdateLoginProfileError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateLoginProfileError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    UpdateLoginProfileError::Unknown(format!("{}", status))
+                } else {
+                    UpdateLoginProfileError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -23322,11 +24022,17 @@ impl UpdateOpenIDConnectProviderThumbprintError {
                 ),
                 _ => UpdateOpenIDConnectProviderThumbprintError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateOpenIDConnectProviderThumbprintError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    UpdateOpenIDConnectProviderThumbprintError::Unknown(format!("{}", status))
+                } else {
+                    UpdateOpenIDConnectProviderThumbprintError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -23415,7 +24121,13 @@ impl UpdateRoleError {
                 }
                 _ => UpdateRoleError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateRoleError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    UpdateRoleError::Unknown(format!("{}", status))
+                } else {
+                    UpdateRoleError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -23505,7 +24217,11 @@ impl UpdateRoleDescriptionError {
                 _ => UpdateRoleDescriptionError::Unknown(String::from(body)),
             },
             Err(_) => {
-                UpdateRoleDescriptionError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    UpdateRoleDescriptionError::Unknown(format!("{}", status))
+                } else {
+                    UpdateRoleDescriptionError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -23602,7 +24318,13 @@ impl UpdateSAMLProviderError {
                 }
                 _ => UpdateSAMLProviderError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateSAMLProviderError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    UpdateSAMLProviderError::Unknown(format!("{}", status))
+                } else {
+                    UpdateSAMLProviderError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -23684,7 +24406,13 @@ impl UpdateSSHPublicKeyError {
                 }
                 _ => UpdateSSHPublicKeyError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateSSHPublicKeyError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    UpdateSSHPublicKeyError::Unknown(format!("{}", status))
+                } else {
+                    UpdateSSHPublicKeyError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -23779,7 +24507,15 @@ impl UpdateServerCertificateError {
                 _ => UpdateServerCertificateError::Unknown(String::from(body)),
             },
             Err(_) => {
-                UpdateServerCertificateError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    UpdateServerCertificateError::Unknown(format!("{}", status))
+                } else {
+                    UpdateServerCertificateError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -23862,11 +24598,17 @@ impl UpdateServiceSpecificCredentialError {
                 )),
                 _ => UpdateServiceSpecificCredentialError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateServiceSpecificCredentialError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    UpdateServiceSpecificCredentialError::Unknown(format!("{}", status))
+                } else {
+                    UpdateServiceSpecificCredentialError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -23956,7 +24698,15 @@ impl UpdateSigningCertificateError {
                 _ => UpdateSigningCertificateError::Unknown(String::from(body)),
             },
             Err(_) => {
-                UpdateSigningCertificateError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    UpdateSigningCertificateError::Unknown(format!("{}", status))
+                } else {
+                    UpdateSigningCertificateError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -24056,7 +24806,13 @@ impl UpdateUserError {
                 }
                 _ => UpdateUserError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateUserError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    UpdateUserError::Unknown(format!("{}", status))
+                } else {
+                    UpdateUserError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -24159,7 +24915,13 @@ impl UploadSSHPublicKeyError {
                 }
                 _ => UploadSSHPublicKeyError::Unknown(String::from(body)),
             },
-            Err(_) => UploadSSHPublicKeyError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    UploadSSHPublicKeyError::Unknown(format!("{}", status))
+                } else {
+                    UploadSSHPublicKeyError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -24263,7 +25025,15 @@ impl UploadServerCertificateError {
                 _ => UploadServerCertificateError::Unknown(String::from(body)),
             },
             Err(_) => {
-                UploadServerCertificateError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    UploadServerCertificateError::Unknown(format!("{}", status))
+                } else {
+                    UploadServerCertificateError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -24378,7 +25148,15 @@ impl UploadSigningCertificateError {
                 _ => UploadSigningCertificateError::Unknown(String::from(body)),
             },
             Err(_) => {
-                UploadSigningCertificateError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    UploadSigningCertificateError::Unknown(format!("{}", status))
+                } else {
+                    UploadSigningCertificateError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }

--- a/rusoto/services/importexport/src/generated.rs
+++ b/rusoto/services/importexport/src/generated.rs
@@ -1212,7 +1212,7 @@ pub enum CancelJobError {
 }
 
 impl CancelJobError {
-    pub fn from_body(body: &str) -> CancelJobError {
+    pub fn from_body(body: &str, status: u16) -> CancelJobError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -1238,7 +1238,7 @@ impl CancelJobError {
                 }
                 _ => CancelJobError::Unknown(String::from(body)),
             },
-            Err(_) => CancelJobError::Unknown(body.to_string()),
+            Err(_) => CancelJobError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -1339,7 +1339,7 @@ pub enum CreateJobError {
 }
 
 impl CreateJobError {
-    pub fn from_body(body: &str) -> CreateJobError {
+    pub fn from_body(body: &str, status: u16) -> CreateJobError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -1395,7 +1395,7 @@ impl CreateJobError {
                 }
                 _ => CreateJobError::Unknown(String::from(body)),
             },
-            Err(_) => CreateJobError::Unknown(body.to_string()),
+            Err(_) => CreateJobError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -1488,7 +1488,7 @@ pub enum GetShippingLabelError {
 }
 
 impl GetShippingLabelError {
-    pub fn from_body(body: &str) -> GetShippingLabelError {
+    pub fn from_body(body: &str, status: u16) -> GetShippingLabelError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -1517,7 +1517,7 @@ impl GetShippingLabelError {
                 }
                 _ => GetShippingLabelError::Unknown(String::from(body)),
             },
-            Err(_) => GetShippingLabelError::Unknown(body.to_string()),
+            Err(_) => GetShippingLabelError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -1597,7 +1597,7 @@ pub enum GetStatusError {
 }
 
 impl GetStatusError {
-    pub fn from_body(body: &str) -> GetStatusError {
+    pub fn from_body(body: &str, status: u16) -> GetStatusError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -1620,7 +1620,7 @@ impl GetStatusError {
                 }
                 _ => GetStatusError::Unknown(String::from(body)),
             },
-            Err(_) => GetStatusError::Unknown(body.to_string()),
+            Err(_) => GetStatusError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -1694,7 +1694,7 @@ pub enum ListJobsError {
 }
 
 impl ListJobsError {
-    pub fn from_body(body: &str) -> ListJobsError {
+    pub fn from_body(body: &str, status: u16) -> ListJobsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -1711,7 +1711,7 @@ impl ListJobsError {
                 }
                 _ => ListJobsError::Unknown(String::from(body)),
             },
-            Err(_) => ListJobsError::Unknown(body.to_string()),
+            Err(_) => ListJobsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -1813,7 +1813,7 @@ pub enum UpdateJobError {
 }
 
 impl UpdateJobError {
-    pub fn from_body(body: &str) -> UpdateJobError {
+    pub fn from_body(body: &str, status: u16) -> UpdateJobError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -1875,7 +1875,7 @@ impl UpdateJobError {
                 }
                 _ => UpdateJobError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateJobError::Unknown(body.to_string()),
+            Err(_) => UpdateJobError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 

--- a/rusoto/services/importexport/src/generated.rs
+++ b/rusoto/services/importexport/src/generated.rs
@@ -1238,7 +1238,13 @@ impl CancelJobError {
                 }
                 _ => CancelJobError::Unknown(String::from(body)),
             },
-            Err(_) => CancelJobError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CancelJobError::Unknown(format!("{}", status))
+                } else {
+                    CancelJobError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -1395,7 +1401,13 @@ impl CreateJobError {
                 }
                 _ => CreateJobError::Unknown(String::from(body)),
             },
-            Err(_) => CreateJobError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateJobError::Unknown(format!("{}", status))
+                } else {
+                    CreateJobError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -1517,7 +1529,13 @@ impl GetShippingLabelError {
                 }
                 _ => GetShippingLabelError::Unknown(String::from(body)),
             },
-            Err(_) => GetShippingLabelError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetShippingLabelError::Unknown(format!("{}", status))
+                } else {
+                    GetShippingLabelError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -1620,7 +1638,13 @@ impl GetStatusError {
                 }
                 _ => GetStatusError::Unknown(String::from(body)),
             },
-            Err(_) => GetStatusError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetStatusError::Unknown(format!("{}", status))
+                } else {
+                    GetStatusError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -1711,7 +1735,13 @@ impl ListJobsError {
                 }
                 _ => ListJobsError::Unknown(String::from(body)),
             },
-            Err(_) => ListJobsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ListJobsError::Unknown(format!("{}", status))
+                } else {
+                    ListJobsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -1875,7 +1905,13 @@ impl UpdateJobError {
                 }
                 _ => UpdateJobError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateJobError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    UpdateJobError::Unknown(format!("{}", status))
+                } else {
+                    UpdateJobError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 

--- a/rusoto/services/neptune/src/generated.rs
+++ b/rusoto/services/neptune/src/generated.rs
@@ -11031,7 +11031,7 @@ pub enum AddRoleToDBClusterError {
 }
 
 impl AddRoleToDBClusterError {
-    pub fn from_body(body: &str) -> AddRoleToDBClusterError {
+    pub fn from_body(body: &str, status: u16) -> AddRoleToDBClusterError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11057,7 +11057,7 @@ impl AddRoleToDBClusterError {
                 }
                 _ => AddRoleToDBClusterError::Unknown(String::from(body)),
             },
-            Err(_) => AddRoleToDBClusterError::Unknown(body.to_string()),
+            Err(_) => AddRoleToDBClusterError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -11129,7 +11129,7 @@ pub enum AddSourceIdentifierToSubscriptionError {
 }
 
 impl AddSourceIdentifierToSubscriptionError {
-    pub fn from_body(body: &str) -> AddSourceIdentifierToSubscriptionError {
+    pub fn from_body(body: &str, status: u16) -> AddSourceIdentifierToSubscriptionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11145,7 +11145,11 @@ impl AddSourceIdentifierToSubscriptionError {
                 }
                 _ => AddSourceIdentifierToSubscriptionError::Unknown(String::from(body)),
             },
-            Err(_) => AddSourceIdentifierToSubscriptionError::Unknown(body.to_string()),
+            Err(_) => AddSourceIdentifierToSubscriptionError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -11218,7 +11222,7 @@ pub enum AddTagsToResourceError {
 }
 
 impl AddTagsToResourceError {
-    pub fn from_body(body: &str) -> AddTagsToResourceError {
+    pub fn from_body(body: &str, status: u16) -> AddTagsToResourceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11235,7 +11239,7 @@ impl AddTagsToResourceError {
                 ),
                 _ => AddTagsToResourceError::Unknown(String::from(body)),
             },
-            Err(_) => AddTagsToResourceError::Unknown(body.to_string()),
+            Err(_) => AddTagsToResourceError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -11305,7 +11309,7 @@ pub enum ApplyPendingMaintenanceActionError {
 }
 
 impl ApplyPendingMaintenanceActionError {
-    pub fn from_body(body: &str) -> ApplyPendingMaintenanceActionError {
+    pub fn from_body(body: &str, status: u16) -> ApplyPendingMaintenanceActionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11318,7 +11322,11 @@ impl ApplyPendingMaintenanceActionError {
                 }
                 _ => ApplyPendingMaintenanceActionError::Unknown(String::from(body)),
             },
-            Err(_) => ApplyPendingMaintenanceActionError::Unknown(body.to_string()),
+            Err(_) => ApplyPendingMaintenanceActionError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -11390,7 +11398,7 @@ pub enum CopyDBClusterParameterGroupError {
 }
 
 impl CopyDBClusterParameterGroupError {
-    pub fn from_body(body: &str) -> CopyDBClusterParameterGroupError {
+    pub fn from_body(body: &str, status: u16) -> CopyDBClusterParameterGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11413,7 +11421,11 @@ impl CopyDBClusterParameterGroupError {
                 }
                 _ => CopyDBClusterParameterGroupError::Unknown(String::from(body)),
             },
-            Err(_) => CopyDBClusterParameterGroupError::Unknown(body.to_string()),
+            Err(_) => CopyDBClusterParameterGroupError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -11497,7 +11509,7 @@ pub enum CopyDBClusterSnapshotError {
 }
 
 impl CopyDBClusterSnapshotError {
-    pub fn from_body(body: &str) -> CopyDBClusterSnapshotError {
+    pub fn from_body(body: &str, status: u16) -> CopyDBClusterSnapshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11531,7 +11543,9 @@ impl CopyDBClusterSnapshotError {
                 ),
                 _ => CopyDBClusterSnapshotError::Unknown(String::from(body)),
             },
-            Err(_) => CopyDBClusterSnapshotError::Unknown(body.to_string()),
+            Err(_) => {
+                CopyDBClusterSnapshotError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -11608,7 +11622,7 @@ pub enum CopyDBParameterGroupError {
 }
 
 impl CopyDBParameterGroupError {
-    pub fn from_body(body: &str) -> CopyDBParameterGroupError {
+    pub fn from_body(body: &str, status: u16) -> CopyDBParameterGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11631,7 +11645,9 @@ impl CopyDBParameterGroupError {
                 }
                 _ => CopyDBParameterGroupError::Unknown(String::from(body)),
             },
-            Err(_) => CopyDBParameterGroupError::Unknown(body.to_string()),
+            Err(_) => {
+                CopyDBParameterGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -11729,7 +11745,7 @@ pub enum CreateDBClusterError {
 }
 
 impl CreateDBClusterError {
-    pub fn from_body(body: &str) -> CreateDBClusterError {
+    pub fn from_body(body: &str, status: u16) -> CreateDBClusterError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11790,7 +11806,7 @@ impl CreateDBClusterError {
                 ),
                 _ => CreateDBClusterError::Unknown(String::from(body)),
             },
-            Err(_) => CreateDBClusterError::Unknown(body.to_string()),
+            Err(_) => CreateDBClusterError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -11872,7 +11888,7 @@ pub enum CreateDBClusterParameterGroupError {
 }
 
 impl CreateDBClusterParameterGroupError {
-    pub fn from_body(body: &str) -> CreateDBClusterParameterGroupError {
+    pub fn from_body(body: &str, status: u16) -> CreateDBClusterParameterGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11890,7 +11906,11 @@ impl CreateDBClusterParameterGroupError {
                 }
                 _ => CreateDBClusterParameterGroupError::Unknown(String::from(body)),
             },
-            Err(_) => CreateDBClusterParameterGroupError::Unknown(body.to_string()),
+            Err(_) => CreateDBClusterParameterGroupError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -11971,7 +11991,7 @@ pub enum CreateDBClusterSnapshotError {
 }
 
 impl CreateDBClusterSnapshotError {
-    pub fn from_body(body: &str) -> CreateDBClusterSnapshotError {
+    pub fn from_body(body: &str, status: u16) -> CreateDBClusterSnapshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -12002,7 +12022,9 @@ impl CreateDBClusterSnapshotError {
                 }
                 _ => CreateDBClusterSnapshotError::Unknown(String::from(body)),
             },
-            Err(_) => CreateDBClusterSnapshotError::Unknown(body.to_string()),
+            Err(_) => {
+                CreateDBClusterSnapshotError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -12108,7 +12130,7 @@ pub enum CreateDBInstanceError {
 }
 
 impl CreateDBInstanceError {
-    pub fn from_body(body: &str) -> CreateDBInstanceError {
+    pub fn from_body(body: &str, status: u16) -> CreateDBInstanceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -12178,7 +12200,7 @@ impl CreateDBInstanceError {
                 ),
                 _ => CreateDBInstanceError::Unknown(String::from(body)),
             },
-            Err(_) => CreateDBInstanceError::Unknown(body.to_string()),
+            Err(_) => CreateDBInstanceError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -12263,7 +12285,7 @@ pub enum CreateDBParameterGroupError {
 }
 
 impl CreateDBParameterGroupError {
-    pub fn from_body(body: &str) -> CreateDBParameterGroupError {
+    pub fn from_body(body: &str, status: u16) -> CreateDBParameterGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -12281,7 +12303,9 @@ impl CreateDBParameterGroupError {
                 }
                 _ => CreateDBParameterGroupError::Unknown(String::from(body)),
             },
-            Err(_) => CreateDBParameterGroupError::Unknown(body.to_string()),
+            Err(_) => {
+                CreateDBParameterGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -12358,7 +12382,7 @@ pub enum CreateDBSubnetGroupError {
 }
 
 impl CreateDBSubnetGroupError {
-    pub fn from_body(body: &str) -> CreateDBSubnetGroupError {
+    pub fn from_body(body: &str, status: u16) -> CreateDBSubnetGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -12389,7 +12413,7 @@ impl CreateDBSubnetGroupError {
                 }
                 _ => CreateDBSubnetGroupError::Unknown(String::from(body)),
             },
-            Err(_) => CreateDBSubnetGroupError::Unknown(body.to_string()),
+            Err(_) => CreateDBSubnetGroupError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -12472,7 +12496,7 @@ pub enum CreateEventSubscriptionError {
 }
 
 impl CreateEventSubscriptionError {
-    pub fn from_body(body: &str) -> CreateEventSubscriptionError {
+    pub fn from_body(body: &str, status: u16) -> CreateEventSubscriptionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -12507,7 +12531,9 @@ impl CreateEventSubscriptionError {
                 }
                 _ => CreateEventSubscriptionError::Unknown(String::from(body)),
             },
-            Err(_) => CreateEventSubscriptionError::Unknown(body.to_string()),
+            Err(_) => {
+                CreateEventSubscriptionError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -12589,7 +12615,7 @@ pub enum DeleteDBClusterError {
 }
 
 impl DeleteDBClusterError {
-    pub fn from_body(body: &str) -> DeleteDBClusterError {
+    pub fn from_body(body: &str, status: u16) -> DeleteDBClusterError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -12616,7 +12642,7 @@ impl DeleteDBClusterError {
                 ),
                 _ => DeleteDBClusterError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteDBClusterError::Unknown(body.to_string()),
+            Err(_) => DeleteDBClusterError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -12688,7 +12714,7 @@ pub enum DeleteDBClusterParameterGroupError {
 }
 
 impl DeleteDBClusterParameterGroupError {
-    pub fn from_body(body: &str) -> DeleteDBClusterParameterGroupError {
+    pub fn from_body(body: &str, status: u16) -> DeleteDBClusterParameterGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -12706,7 +12732,11 @@ impl DeleteDBClusterParameterGroupError {
                 }
                 _ => DeleteDBClusterParameterGroupError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteDBClusterParameterGroupError::Unknown(body.to_string()),
+            Err(_) => DeleteDBClusterParameterGroupError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -12779,7 +12809,7 @@ pub enum DeleteDBClusterSnapshotError {
 }
 
 impl DeleteDBClusterSnapshotError {
-    pub fn from_body(body: &str) -> DeleteDBClusterSnapshotError {
+    pub fn from_body(body: &str, status: u16) -> DeleteDBClusterSnapshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -12797,7 +12827,9 @@ impl DeleteDBClusterSnapshotError {
                 }
                 _ => DeleteDBClusterSnapshotError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteDBClusterSnapshotError::Unknown(body.to_string()),
+            Err(_) => {
+                DeleteDBClusterSnapshotError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -12874,7 +12906,7 @@ pub enum DeleteDBInstanceError {
 }
 
 impl DeleteDBInstanceError {
-    pub fn from_body(body: &str) -> DeleteDBInstanceError {
+    pub fn from_body(body: &str, status: u16) -> DeleteDBInstanceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -12897,7 +12929,7 @@ impl DeleteDBInstanceError {
                 ),
                 _ => DeleteDBInstanceError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteDBInstanceError::Unknown(body.to_string()),
+            Err(_) => DeleteDBInstanceError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -12969,7 +13001,7 @@ pub enum DeleteDBParameterGroupError {
 }
 
 impl DeleteDBParameterGroupError {
-    pub fn from_body(body: &str) -> DeleteDBParameterGroupError {
+    pub fn from_body(body: &str, status: u16) -> DeleteDBParameterGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -12987,7 +13019,9 @@ impl DeleteDBParameterGroupError {
                 }
                 _ => DeleteDBParameterGroupError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteDBParameterGroupError::Unknown(body.to_string()),
+            Err(_) => {
+                DeleteDBParameterGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -13060,7 +13094,7 @@ pub enum DeleteDBSubnetGroupError {
 }
 
 impl DeleteDBSubnetGroupError {
-    pub fn from_body(body: &str) -> DeleteDBSubnetGroupError {
+    pub fn from_body(body: &str, status: u16) -> DeleteDBSubnetGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -13081,7 +13115,7 @@ impl DeleteDBSubnetGroupError {
                 ),
                 _ => DeleteDBSubnetGroupError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteDBSubnetGroupError::Unknown(body.to_string()),
+            Err(_) => DeleteDBSubnetGroupError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -13152,7 +13186,7 @@ pub enum DeleteEventSubscriptionError {
 }
 
 impl DeleteEventSubscriptionError {
-    pub fn from_body(body: &str) -> DeleteEventSubscriptionError {
+    pub fn from_body(body: &str, status: u16) -> DeleteEventSubscriptionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -13168,7 +13202,9 @@ impl DeleteEventSubscriptionError {
                 ),
                 _ => DeleteEventSubscriptionError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteEventSubscriptionError::Unknown(body.to_string()),
+            Err(_) => {
+                DeleteEventSubscriptionError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -13237,7 +13273,7 @@ pub enum DescribeDBClusterParameterGroupsError {
 }
 
 impl DescribeDBClusterParameterGroupsError {
-    pub fn from_body(body: &str) -> DescribeDBClusterParameterGroupsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeDBClusterParameterGroupsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -13250,7 +13286,11 @@ impl DescribeDBClusterParameterGroupsError {
                 }
                 _ => DescribeDBClusterParameterGroupsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeDBClusterParameterGroupsError::Unknown(body.to_string()),
+            Err(_) => DescribeDBClusterParameterGroupsError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -13320,7 +13360,7 @@ pub enum DescribeDBClusterParametersError {
 }
 
 impl DescribeDBClusterParametersError {
-    pub fn from_body(body: &str) -> DescribeDBClusterParametersError {
+    pub fn from_body(body: &str, status: u16) -> DescribeDBClusterParametersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -13333,7 +13373,11 @@ impl DescribeDBClusterParametersError {
                 }
                 _ => DescribeDBClusterParametersError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeDBClusterParametersError::Unknown(body.to_string()),
+            Err(_) => DescribeDBClusterParametersError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -13401,7 +13445,7 @@ pub enum DescribeDBClusterSnapshotAttributesError {
 }
 
 impl DescribeDBClusterSnapshotAttributesError {
-    pub fn from_body(body: &str) -> DescribeDBClusterSnapshotAttributesError {
+    pub fn from_body(body: &str, status: u16) -> DescribeDBClusterSnapshotAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -13414,7 +13458,11 @@ impl DescribeDBClusterSnapshotAttributesError {
                 }
                 _ => DescribeDBClusterSnapshotAttributesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeDBClusterSnapshotAttributesError::Unknown(body.to_string()),
+            Err(_) => DescribeDBClusterSnapshotAttributesError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -13484,7 +13532,7 @@ pub enum DescribeDBClusterSnapshotsError {
 }
 
 impl DescribeDBClusterSnapshotsError {
-    pub fn from_body(body: &str) -> DescribeDBClusterSnapshotsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeDBClusterSnapshotsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -13497,7 +13545,9 @@ impl DescribeDBClusterSnapshotsError {
                 }
                 _ => DescribeDBClusterSnapshotsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeDBClusterSnapshotsError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeDBClusterSnapshotsError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -13565,7 +13615,7 @@ pub enum DescribeDBClustersError {
 }
 
 impl DescribeDBClustersError {
-    pub fn from_body(body: &str) -> DescribeDBClustersError {
+    pub fn from_body(body: &str, status: u16) -> DescribeDBClustersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -13576,7 +13626,7 @@ impl DescribeDBClustersError {
                 ),
                 _ => DescribeDBClustersError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeDBClustersError::Unknown(body.to_string()),
+            Err(_) => DescribeDBClustersError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -13642,7 +13692,7 @@ pub enum DescribeDBEngineVersionsError {
 }
 
 impl DescribeDBEngineVersionsError {
-    pub fn from_body(body: &str) -> DescribeDBEngineVersionsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeDBEngineVersionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -13650,7 +13700,9 @@ impl DescribeDBEngineVersionsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeDBEngineVersionsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeDBEngineVersionsError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeDBEngineVersionsError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -13717,7 +13769,7 @@ pub enum DescribeDBInstancesError {
 }
 
 impl DescribeDBInstancesError {
-    pub fn from_body(body: &str) -> DescribeDBInstancesError {
+    pub fn from_body(body: &str, status: u16) -> DescribeDBInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -13728,7 +13780,7 @@ impl DescribeDBInstancesError {
                 ),
                 _ => DescribeDBInstancesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeDBInstancesError::Unknown(body.to_string()),
+            Err(_) => DescribeDBInstancesError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -13796,7 +13848,7 @@ pub enum DescribeDBParameterGroupsError {
 }
 
 impl DescribeDBParameterGroupsError {
-    pub fn from_body(body: &str) -> DescribeDBParameterGroupsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeDBParameterGroupsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -13809,7 +13861,9 @@ impl DescribeDBParameterGroupsError {
                 }
                 _ => DescribeDBParameterGroupsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeDBParameterGroupsError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeDBParameterGroupsError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -13877,7 +13931,7 @@ pub enum DescribeDBParametersError {
 }
 
 impl DescribeDBParametersError {
-    pub fn from_body(body: &str) -> DescribeDBParametersError {
+    pub fn from_body(body: &str, status: u16) -> DescribeDBParametersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -13890,7 +13944,9 @@ impl DescribeDBParametersError {
                 }
                 _ => DescribeDBParametersError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeDBParametersError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeDBParametersError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -13958,7 +14014,7 @@ pub enum DescribeDBSubnetGroupsError {
 }
 
 impl DescribeDBSubnetGroupsError {
-    pub fn from_body(body: &str) -> DescribeDBSubnetGroupsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeDBSubnetGroupsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -13971,7 +14027,9 @@ impl DescribeDBSubnetGroupsError {
                 }
                 _ => DescribeDBSubnetGroupsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeDBSubnetGroupsError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeDBSubnetGroupsError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -14037,7 +14095,7 @@ pub enum DescribeEngineDefaultClusterParametersError {
 }
 
 impl DescribeEngineDefaultClusterParametersError {
-    pub fn from_body(body: &str) -> DescribeEngineDefaultClusterParametersError {
+    pub fn from_body(body: &str, status: u16) -> DescribeEngineDefaultClusterParametersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -14045,7 +14103,11 @@ impl DescribeEngineDefaultClusterParametersError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeEngineDefaultClusterParametersError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeEngineDefaultClusterParametersError::Unknown(body.to_string()),
+            Err(_) => DescribeEngineDefaultClusterParametersError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -14110,7 +14172,7 @@ pub enum DescribeEngineDefaultParametersError {
 }
 
 impl DescribeEngineDefaultParametersError {
-    pub fn from_body(body: &str) -> DescribeEngineDefaultParametersError {
+    pub fn from_body(body: &str, status: u16) -> DescribeEngineDefaultParametersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -14118,7 +14180,11 @@ impl DescribeEngineDefaultParametersError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeEngineDefaultParametersError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeEngineDefaultParametersError::Unknown(body.to_string()),
+            Err(_) => DescribeEngineDefaultParametersError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -14183,7 +14249,7 @@ pub enum DescribeEventCategoriesError {
 }
 
 impl DescribeEventCategoriesError {
-    pub fn from_body(body: &str) -> DescribeEventCategoriesError {
+    pub fn from_body(body: &str, status: u16) -> DescribeEventCategoriesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -14191,7 +14257,9 @@ impl DescribeEventCategoriesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeEventCategoriesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeEventCategoriesError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeEventCategoriesError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -14257,7 +14325,7 @@ pub enum DescribeEventSubscriptionsError {
 }
 
 impl DescribeEventSubscriptionsError {
-    pub fn from_body(body: &str) -> DescribeEventSubscriptionsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeEventSubscriptionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -14270,7 +14338,9 @@ impl DescribeEventSubscriptionsError {
                 }
                 _ => DescribeEventSubscriptionsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeEventSubscriptionsError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeEventSubscriptionsError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -14336,7 +14406,7 @@ pub enum DescribeEventsError {
 }
 
 impl DescribeEventsError {
-    pub fn from_body(body: &str) -> DescribeEventsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeEventsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -14344,7 +14414,7 @@ impl DescribeEventsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeEventsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeEventsError::Unknown(body.to_string()),
+            Err(_) => DescribeEventsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -14407,7 +14477,7 @@ pub enum DescribeOrderableDBInstanceOptionsError {
 }
 
 impl DescribeOrderableDBInstanceOptionsError {
-    pub fn from_body(body: &str) -> DescribeOrderableDBInstanceOptionsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeOrderableDBInstanceOptionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -14415,7 +14485,11 @@ impl DescribeOrderableDBInstanceOptionsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeOrderableDBInstanceOptionsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeOrderableDBInstanceOptionsError::Unknown(body.to_string()),
+            Err(_) => DescribeOrderableDBInstanceOptionsError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -14482,7 +14556,7 @@ pub enum DescribePendingMaintenanceActionsError {
 }
 
 impl DescribePendingMaintenanceActionsError {
-    pub fn from_body(body: &str) -> DescribePendingMaintenanceActionsError {
+    pub fn from_body(body: &str, status: u16) -> DescribePendingMaintenanceActionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -14495,7 +14569,11 @@ impl DescribePendingMaintenanceActionsError {
                 }
                 _ => DescribePendingMaintenanceActionsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribePendingMaintenanceActionsError::Unknown(body.to_string()),
+            Err(_) => DescribePendingMaintenanceActionsError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -14565,7 +14643,7 @@ pub enum DescribeValidDBInstanceModificationsError {
 }
 
 impl DescribeValidDBInstanceModificationsError {
-    pub fn from_body(body: &str) -> DescribeValidDBInstanceModificationsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeValidDBInstanceModificationsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -14583,7 +14661,11 @@ impl DescribeValidDBInstanceModificationsError {
                 }
                 _ => DescribeValidDBInstanceModificationsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeValidDBInstanceModificationsError::Unknown(body.to_string()),
+            Err(_) => DescribeValidDBInstanceModificationsError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -14658,7 +14740,7 @@ pub enum FailoverDBClusterError {
 }
 
 impl FailoverDBClusterError {
-    pub fn from_body(body: &str) -> FailoverDBClusterError {
+    pub fn from_body(body: &str, status: u16) -> FailoverDBClusterError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -14675,7 +14757,7 @@ impl FailoverDBClusterError {
                 ),
                 _ => FailoverDBClusterError::Unknown(String::from(body)),
             },
-            Err(_) => FailoverDBClusterError::Unknown(body.to_string()),
+            Err(_) => FailoverDBClusterError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -14749,7 +14831,7 @@ pub enum ListTagsForResourceError {
 }
 
 impl ListTagsForResourceError {
-    pub fn from_body(body: &str) -> ListTagsForResourceError {
+    pub fn from_body(body: &str, status: u16) -> ListTagsForResourceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -14766,7 +14848,7 @@ impl ListTagsForResourceError {
                 ),
                 _ => ListTagsForResourceError::Unknown(String::from(body)),
             },
-            Err(_) => ListTagsForResourceError::Unknown(body.to_string()),
+            Err(_) => ListTagsForResourceError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -14856,7 +14938,7 @@ pub enum ModifyDBClusterError {
 }
 
 impl ModifyDBClusterError {
-    pub fn from_body(body: &str) -> ModifyDBClusterError {
+    pub fn from_body(body: &str, status: u16) -> ModifyDBClusterError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -14903,7 +14985,7 @@ impl ModifyDBClusterError {
                 ),
                 _ => ModifyDBClusterError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyDBClusterError::Unknown(body.to_string()),
+            Err(_) => ModifyDBClusterError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -14981,7 +15063,7 @@ pub enum ModifyDBClusterParameterGroupError {
 }
 
 impl ModifyDBClusterParameterGroupError {
-    pub fn from_body(body: &str) -> ModifyDBClusterParameterGroupError {
+    pub fn from_body(body: &str, status: u16) -> ModifyDBClusterParameterGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -14999,7 +15081,11 @@ impl ModifyDBClusterParameterGroupError {
                 }
                 _ => ModifyDBClusterParameterGroupError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyDBClusterParameterGroupError::Unknown(body.to_string()),
+            Err(_) => ModifyDBClusterParameterGroupError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -15074,7 +15160,7 @@ pub enum ModifyDBClusterSnapshotAttributeError {
 }
 
 impl ModifyDBClusterSnapshotAttributeError {
-    pub fn from_body(body: &str) -> ModifyDBClusterSnapshotAttributeError {
+    pub fn from_body(body: &str, status: u16) -> ModifyDBClusterSnapshotAttributeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -15097,7 +15183,11 @@ impl ModifyDBClusterSnapshotAttributeError {
                 }
                 _ => ModifyDBClusterSnapshotAttributeError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyDBClusterSnapshotAttributeError::Unknown(body.to_string()),
+            Err(_) => ModifyDBClusterSnapshotAttributeError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -15203,7 +15293,7 @@ pub enum ModifyDBInstanceError {
 }
 
 impl ModifyDBInstanceError {
-    pub fn from_body(body: &str) -> ModifyDBInstanceError {
+    pub fn from_body(body: &str, status: u16) -> ModifyDBInstanceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -15269,7 +15359,7 @@ impl ModifyDBInstanceError {
                 ),
                 _ => ModifyDBInstanceError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyDBInstanceError::Unknown(body.to_string()),
+            Err(_) => ModifyDBInstanceError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -15352,7 +15442,7 @@ pub enum ModifyDBParameterGroupError {
 }
 
 impl ModifyDBParameterGroupError {
-    pub fn from_body(body: &str) -> ModifyDBParameterGroupError {
+    pub fn from_body(body: &str, status: u16) -> ModifyDBParameterGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -15370,7 +15460,9 @@ impl ModifyDBParameterGroupError {
                 }
                 _ => ModifyDBParameterGroupError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyDBParameterGroupError::Unknown(body.to_string()),
+            Err(_) => {
+                ModifyDBParameterGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -15447,7 +15539,7 @@ pub enum ModifyDBSubnetGroupError {
 }
 
 impl ModifyDBSubnetGroupError {
-    pub fn from_body(body: &str) -> ModifyDBSubnetGroupError {
+    pub fn from_body(body: &str, status: u16) -> ModifyDBSubnetGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -15476,7 +15568,7 @@ impl ModifyDBSubnetGroupError {
                 }
                 _ => ModifyDBSubnetGroupError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyDBSubnetGroupError::Unknown(body.to_string()),
+            Err(_) => ModifyDBSubnetGroupError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -15557,7 +15649,7 @@ pub enum ModifyEventSubscriptionError {
 }
 
 impl ModifyEventSubscriptionError {
-    pub fn from_body(body: &str) -> ModifyEventSubscriptionError {
+    pub fn from_body(body: &str, status: u16) -> ModifyEventSubscriptionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -15587,7 +15679,9 @@ impl ModifyEventSubscriptionError {
                 ),
                 _ => ModifyEventSubscriptionError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyEventSubscriptionError::Unknown(body.to_string()),
+            Err(_) => {
+                ModifyEventSubscriptionError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -15662,7 +15756,7 @@ pub enum PromoteReadReplicaDBClusterError {
 }
 
 impl PromoteReadReplicaDBClusterError {
-    pub fn from_body(body: &str) -> PromoteReadReplicaDBClusterError {
+    pub fn from_body(body: &str, status: u16) -> PromoteReadReplicaDBClusterError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -15680,7 +15774,11 @@ impl PromoteReadReplicaDBClusterError {
                 }
                 _ => PromoteReadReplicaDBClusterError::Unknown(String::from(body)),
             },
-            Err(_) => PromoteReadReplicaDBClusterError::Unknown(body.to_string()),
+            Err(_) => PromoteReadReplicaDBClusterError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -15751,7 +15849,7 @@ pub enum RebootDBInstanceError {
 }
 
 impl RebootDBInstanceError {
-    pub fn from_body(body: &str) -> RebootDBInstanceError {
+    pub fn from_body(body: &str, status: u16) -> RebootDBInstanceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -15765,7 +15863,7 @@ impl RebootDBInstanceError {
                 ),
                 _ => RebootDBInstanceError::Unknown(String::from(body)),
             },
-            Err(_) => RebootDBInstanceError::Unknown(body.to_string()),
+            Err(_) => RebootDBInstanceError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -15836,7 +15934,7 @@ pub enum RemoveRoleFromDBClusterError {
 }
 
 impl RemoveRoleFromDBClusterError {
-    pub fn from_body(body: &str) -> RemoveRoleFromDBClusterError {
+    pub fn from_body(body: &str, status: u16) -> RemoveRoleFromDBClusterError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -15857,7 +15955,9 @@ impl RemoveRoleFromDBClusterError {
                 }
                 _ => RemoveRoleFromDBClusterError::Unknown(String::from(body)),
             },
-            Err(_) => RemoveRoleFromDBClusterError::Unknown(body.to_string()),
+            Err(_) => {
+                RemoveRoleFromDBClusterError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -15928,7 +16028,7 @@ pub enum RemoveSourceIdentifierFromSubscriptionError {
 }
 
 impl RemoveSourceIdentifierFromSubscriptionError {
-    pub fn from_body(body: &str) -> RemoveSourceIdentifierFromSubscriptionError {
+    pub fn from_body(body: &str, status: u16) -> RemoveSourceIdentifierFromSubscriptionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -15946,7 +16046,11 @@ impl RemoveSourceIdentifierFromSubscriptionError {
                 }
                 _ => RemoveSourceIdentifierFromSubscriptionError::Unknown(String::from(body)),
             },
-            Err(_) => RemoveSourceIdentifierFromSubscriptionError::Unknown(body.to_string()),
+            Err(_) => RemoveSourceIdentifierFromSubscriptionError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -16021,7 +16125,7 @@ pub enum RemoveTagsFromResourceError {
 }
 
 impl RemoveTagsFromResourceError {
-    pub fn from_body(body: &str) -> RemoveTagsFromResourceError {
+    pub fn from_body(body: &str, status: u16) -> RemoveTagsFromResourceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -16038,7 +16142,9 @@ impl RemoveTagsFromResourceError {
                 ),
                 _ => RemoveTagsFromResourceError::Unknown(String::from(body)),
             },
-            Err(_) => RemoveTagsFromResourceError::Unknown(body.to_string()),
+            Err(_) => {
+                RemoveTagsFromResourceError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -16110,7 +16216,7 @@ pub enum ResetDBClusterParameterGroupError {
 }
 
 impl ResetDBClusterParameterGroupError {
-    pub fn from_body(body: &str) -> ResetDBClusterParameterGroupError {
+    pub fn from_body(body: &str, status: u16) -> ResetDBClusterParameterGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -16128,7 +16234,11 @@ impl ResetDBClusterParameterGroupError {
                 }
                 _ => ResetDBClusterParameterGroupError::Unknown(String::from(body)),
             },
-            Err(_) => ResetDBClusterParameterGroupError::Unknown(body.to_string()),
+            Err(_) => ResetDBClusterParameterGroupError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -16201,7 +16311,7 @@ pub enum ResetDBParameterGroupError {
 }
 
 impl ResetDBParameterGroupError {
-    pub fn from_body(body: &str) -> ResetDBParameterGroupError {
+    pub fn from_body(body: &str, status: u16) -> ResetDBParameterGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -16219,7 +16329,9 @@ impl ResetDBParameterGroupError {
                 }
                 _ => ResetDBParameterGroupError::Unknown(String::from(body)),
             },
-            Err(_) => ResetDBParameterGroupError::Unknown(body.to_string()),
+            Err(_) => {
+                ResetDBParameterGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -16316,7 +16428,7 @@ pub enum RestoreDBClusterFromSnapshotError {
 }
 
 impl RestoreDBClusterFromSnapshotError {
-    pub fn from_body(body: &str) -> RestoreDBClusterFromSnapshotError {
+    pub fn from_body(body: &str, status: u16) -> RestoreDBClusterFromSnapshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -16393,7 +16505,11 @@ impl RestoreDBClusterFromSnapshotError {
                 }
                 _ => RestoreDBClusterFromSnapshotError::Unknown(String::from(body)),
             },
-            Err(_) => RestoreDBClusterFromSnapshotError::Unknown(body.to_string()),
+            Err(_) => RestoreDBClusterFromSnapshotError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -16511,7 +16627,7 @@ pub enum RestoreDBClusterToPointInTimeError {
 }
 
 impl RestoreDBClusterToPointInTimeError {
-    pub fn from_body(body: &str) -> RestoreDBClusterToPointInTimeError {
+    pub fn from_body(body: &str, status: u16) -> RestoreDBClusterToPointInTimeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -16595,7 +16711,11 @@ impl RestoreDBClusterToPointInTimeError {
                 }
                 _ => RestoreDBClusterToPointInTimeError::Unknown(String::from(body)),
             },
-            Err(_) => RestoreDBClusterToPointInTimeError::Unknown(body.to_string()),
+            Err(_) => RestoreDBClusterToPointInTimeError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 

--- a/rusoto/services/neptune/src/generated.rs
+++ b/rusoto/services/neptune/src/generated.rs
@@ -11057,7 +11057,13 @@ impl AddRoleToDBClusterError {
                 }
                 _ => AddRoleToDBClusterError::Unknown(String::from(body)),
             },
-            Err(_) => AddRoleToDBClusterError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    AddRoleToDBClusterError::Unknown(format!("{}", status))
+                } else {
+                    AddRoleToDBClusterError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -11145,11 +11151,17 @@ impl AddSourceIdentifierToSubscriptionError {
                 }
                 _ => AddSourceIdentifierToSubscriptionError::Unknown(String::from(body)),
             },
-            Err(_) => AddSourceIdentifierToSubscriptionError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    AddSourceIdentifierToSubscriptionError::Unknown(format!("{}", status))
+                } else {
+                    AddSourceIdentifierToSubscriptionError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -11239,7 +11251,13 @@ impl AddTagsToResourceError {
                 ),
                 _ => AddTagsToResourceError::Unknown(String::from(body)),
             },
-            Err(_) => AddTagsToResourceError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    AddTagsToResourceError::Unknown(format!("{}", status))
+                } else {
+                    AddTagsToResourceError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -11322,11 +11340,17 @@ impl ApplyPendingMaintenanceActionError {
                 }
                 _ => ApplyPendingMaintenanceActionError::Unknown(String::from(body)),
             },
-            Err(_) => ApplyPendingMaintenanceActionError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    ApplyPendingMaintenanceActionError::Unknown(format!("{}", status))
+                } else {
+                    ApplyPendingMaintenanceActionError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -11421,11 +11445,17 @@ impl CopyDBClusterParameterGroupError {
                 }
                 _ => CopyDBClusterParameterGroupError::Unknown(String::from(body)),
             },
-            Err(_) => CopyDBClusterParameterGroupError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    CopyDBClusterParameterGroupError::Unknown(format!("{}", status))
+                } else {
+                    CopyDBClusterParameterGroupError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -11544,7 +11574,11 @@ impl CopyDBClusterSnapshotError {
                 _ => CopyDBClusterSnapshotError::Unknown(String::from(body)),
             },
             Err(_) => {
-                CopyDBClusterSnapshotError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    CopyDBClusterSnapshotError::Unknown(format!("{}", status))
+                } else {
+                    CopyDBClusterSnapshotError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -11646,7 +11680,11 @@ impl CopyDBParameterGroupError {
                 _ => CopyDBParameterGroupError::Unknown(String::from(body)),
             },
             Err(_) => {
-                CopyDBParameterGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    CopyDBParameterGroupError::Unknown(format!("{}", status))
+                } else {
+                    CopyDBParameterGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -11806,7 +11844,13 @@ impl CreateDBClusterError {
                 ),
                 _ => CreateDBClusterError::Unknown(String::from(body)),
             },
-            Err(_) => CreateDBClusterError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateDBClusterError::Unknown(format!("{}", status))
+                } else {
+                    CreateDBClusterError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -11906,11 +11950,17 @@ impl CreateDBClusterParameterGroupError {
                 }
                 _ => CreateDBClusterParameterGroupError::Unknown(String::from(body)),
             },
-            Err(_) => CreateDBClusterParameterGroupError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateDBClusterParameterGroupError::Unknown(format!("{}", status))
+                } else {
+                    CreateDBClusterParameterGroupError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -12023,7 +12073,15 @@ impl CreateDBClusterSnapshotError {
                 _ => CreateDBClusterSnapshotError::Unknown(String::from(body)),
             },
             Err(_) => {
-                CreateDBClusterSnapshotError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    CreateDBClusterSnapshotError::Unknown(format!("{}", status))
+                } else {
+                    CreateDBClusterSnapshotError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -12200,7 +12258,13 @@ impl CreateDBInstanceError {
                 ),
                 _ => CreateDBInstanceError::Unknown(String::from(body)),
             },
-            Err(_) => CreateDBInstanceError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateDBInstanceError::Unknown(format!("{}", status))
+                } else {
+                    CreateDBInstanceError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -12304,7 +12368,11 @@ impl CreateDBParameterGroupError {
                 _ => CreateDBParameterGroupError::Unknown(String::from(body)),
             },
             Err(_) => {
-                CreateDBParameterGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    CreateDBParameterGroupError::Unknown(format!("{}", status))
+                } else {
+                    CreateDBParameterGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -12413,7 +12481,13 @@ impl CreateDBSubnetGroupError {
                 }
                 _ => CreateDBSubnetGroupError::Unknown(String::from(body)),
             },
-            Err(_) => CreateDBSubnetGroupError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateDBSubnetGroupError::Unknown(format!("{}", status))
+                } else {
+                    CreateDBSubnetGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -12532,7 +12606,15 @@ impl CreateEventSubscriptionError {
                 _ => CreateEventSubscriptionError::Unknown(String::from(body)),
             },
             Err(_) => {
-                CreateEventSubscriptionError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    CreateEventSubscriptionError::Unknown(format!("{}", status))
+                } else {
+                    CreateEventSubscriptionError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -12642,7 +12724,13 @@ impl DeleteDBClusterError {
                 ),
                 _ => DeleteDBClusterError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteDBClusterError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteDBClusterError::Unknown(format!("{}", status))
+                } else {
+                    DeleteDBClusterError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -12732,11 +12820,17 @@ impl DeleteDBClusterParameterGroupError {
                 }
                 _ => DeleteDBClusterParameterGroupError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteDBClusterParameterGroupError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteDBClusterParameterGroupError::Unknown(format!("{}", status))
+                } else {
+                    DeleteDBClusterParameterGroupError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -12828,7 +12922,15 @@ impl DeleteDBClusterSnapshotError {
                 _ => DeleteDBClusterSnapshotError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DeleteDBClusterSnapshotError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DeleteDBClusterSnapshotError::Unknown(format!("{}", status))
+                } else {
+                    DeleteDBClusterSnapshotError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -12929,7 +13031,13 @@ impl DeleteDBInstanceError {
                 ),
                 _ => DeleteDBInstanceError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteDBInstanceError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteDBInstanceError::Unknown(format!("{}", status))
+                } else {
+                    DeleteDBInstanceError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -13020,7 +13128,11 @@ impl DeleteDBParameterGroupError {
                 _ => DeleteDBParameterGroupError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DeleteDBParameterGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DeleteDBParameterGroupError::Unknown(format!("{}", status))
+                } else {
+                    DeleteDBParameterGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -13115,7 +13227,13 @@ impl DeleteDBSubnetGroupError {
                 ),
                 _ => DeleteDBSubnetGroupError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteDBSubnetGroupError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteDBSubnetGroupError::Unknown(format!("{}", status))
+                } else {
+                    DeleteDBSubnetGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -13203,7 +13321,15 @@ impl DeleteEventSubscriptionError {
                 _ => DeleteEventSubscriptionError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DeleteEventSubscriptionError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DeleteEventSubscriptionError::Unknown(format!("{}", status))
+                } else {
+                    DeleteEventSubscriptionError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -13286,11 +13412,17 @@ impl DescribeDBClusterParameterGroupsError {
                 }
                 _ => DescribeDBClusterParameterGroupsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeDBClusterParameterGroupsError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeDBClusterParameterGroupsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeDBClusterParameterGroupsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -13373,11 +13505,17 @@ impl DescribeDBClusterParametersError {
                 }
                 _ => DescribeDBClusterParametersError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeDBClusterParametersError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeDBClusterParametersError::Unknown(format!("{}", status))
+                } else {
+                    DescribeDBClusterParametersError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -13458,11 +13596,17 @@ impl DescribeDBClusterSnapshotAttributesError {
                 }
                 _ => DescribeDBClusterSnapshotAttributesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeDBClusterSnapshotAttributesError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeDBClusterSnapshotAttributesError::Unknown(format!("{}", status))
+                } else {
+                    DescribeDBClusterSnapshotAttributesError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -13546,7 +13690,15 @@ impl DescribeDBClusterSnapshotsError {
                 _ => DescribeDBClusterSnapshotsError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeDBClusterSnapshotsError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeDBClusterSnapshotsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeDBClusterSnapshotsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -13626,7 +13778,13 @@ impl DescribeDBClustersError {
                 ),
                 _ => DescribeDBClustersError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeDBClustersError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeDBClustersError::Unknown(format!("{}", status))
+                } else {
+                    DescribeDBClustersError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -13701,7 +13859,15 @@ impl DescribeDBEngineVersionsError {
                 _ => DescribeDBEngineVersionsError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeDBEngineVersionsError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeDBEngineVersionsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeDBEngineVersionsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -13780,7 +13946,13 @@ impl DescribeDBInstancesError {
                 ),
                 _ => DescribeDBInstancesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeDBInstancesError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeDBInstancesError::Unknown(format!("{}", status))
+                } else {
+                    DescribeDBInstancesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -13862,7 +14034,15 @@ impl DescribeDBParameterGroupsError {
                 _ => DescribeDBParameterGroupsError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeDBParameterGroupsError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeDBParameterGroupsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeDBParameterGroupsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -13945,7 +14125,11 @@ impl DescribeDBParametersError {
                 _ => DescribeDBParametersError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeDBParametersError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeDBParametersError::Unknown(format!("{}", status))
+                } else {
+                    DescribeDBParametersError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -14028,7 +14212,11 @@ impl DescribeDBSubnetGroupsError {
                 _ => DescribeDBSubnetGroupsError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeDBSubnetGroupsError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeDBSubnetGroupsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeDBSubnetGroupsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -14103,11 +14291,17 @@ impl DescribeEngineDefaultClusterParametersError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeEngineDefaultClusterParametersError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeEngineDefaultClusterParametersError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeEngineDefaultClusterParametersError::Unknown(format!("{}", status))
+                } else {
+                    DescribeEngineDefaultClusterParametersError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -14180,11 +14374,17 @@ impl DescribeEngineDefaultParametersError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeEngineDefaultParametersError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeEngineDefaultParametersError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeEngineDefaultParametersError::Unknown(format!("{}", status))
+                } else {
+                    DescribeEngineDefaultParametersError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -14258,7 +14458,15 @@ impl DescribeEventCategoriesError {
                 _ => DescribeEventCategoriesError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeEventCategoriesError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeEventCategoriesError::Unknown(format!("{}", status))
+                } else {
+                    DescribeEventCategoriesError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -14339,7 +14547,15 @@ impl DescribeEventSubscriptionsError {
                 _ => DescribeEventSubscriptionsError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeEventSubscriptionsError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeEventSubscriptionsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeEventSubscriptionsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -14414,7 +14630,13 @@ impl DescribeEventsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeEventsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeEventsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeEventsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeEventsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -14485,11 +14707,17 @@ impl DescribeOrderableDBInstanceOptionsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeOrderableDBInstanceOptionsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeOrderableDBInstanceOptionsError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeOrderableDBInstanceOptionsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeOrderableDBInstanceOptionsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -14569,11 +14797,17 @@ impl DescribePendingMaintenanceActionsError {
                 }
                 _ => DescribePendingMaintenanceActionsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribePendingMaintenanceActionsError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribePendingMaintenanceActionsError::Unknown(format!("{}", status))
+                } else {
+                    DescribePendingMaintenanceActionsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -14661,11 +14895,17 @@ impl DescribeValidDBInstanceModificationsError {
                 }
                 _ => DescribeValidDBInstanceModificationsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeValidDBInstanceModificationsError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeValidDBInstanceModificationsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeValidDBInstanceModificationsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -14757,7 +14997,13 @@ impl FailoverDBClusterError {
                 ),
                 _ => FailoverDBClusterError::Unknown(String::from(body)),
             },
-            Err(_) => FailoverDBClusterError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    FailoverDBClusterError::Unknown(format!("{}", status))
+                } else {
+                    FailoverDBClusterError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -14848,7 +15094,13 @@ impl ListTagsForResourceError {
                 ),
                 _ => ListTagsForResourceError::Unknown(String::from(body)),
             },
-            Err(_) => ListTagsForResourceError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ListTagsForResourceError::Unknown(format!("{}", status))
+                } else {
+                    ListTagsForResourceError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -14985,7 +15237,13 @@ impl ModifyDBClusterError {
                 ),
                 _ => ModifyDBClusterError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyDBClusterError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ModifyDBClusterError::Unknown(format!("{}", status))
+                } else {
+                    ModifyDBClusterError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -15081,11 +15339,17 @@ impl ModifyDBClusterParameterGroupError {
                 }
                 _ => ModifyDBClusterParameterGroupError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyDBClusterParameterGroupError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    ModifyDBClusterParameterGroupError::Unknown(format!("{}", status))
+                } else {
+                    ModifyDBClusterParameterGroupError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -15183,11 +15447,17 @@ impl ModifyDBClusterSnapshotAttributeError {
                 }
                 _ => ModifyDBClusterSnapshotAttributeError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyDBClusterSnapshotAttributeError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    ModifyDBClusterSnapshotAttributeError::Unknown(format!("{}", status))
+                } else {
+                    ModifyDBClusterSnapshotAttributeError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -15359,7 +15629,13 @@ impl ModifyDBInstanceError {
                 ),
                 _ => ModifyDBInstanceError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyDBInstanceError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ModifyDBInstanceError::Unknown(format!("{}", status))
+                } else {
+                    ModifyDBInstanceError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -15461,7 +15737,11 @@ impl ModifyDBParameterGroupError {
                 _ => ModifyDBParameterGroupError::Unknown(String::from(body)),
             },
             Err(_) => {
-                ModifyDBParameterGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    ModifyDBParameterGroupError::Unknown(format!("{}", status))
+                } else {
+                    ModifyDBParameterGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -15568,7 +15848,13 @@ impl ModifyDBSubnetGroupError {
                 }
                 _ => ModifyDBSubnetGroupError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyDBSubnetGroupError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ModifyDBSubnetGroupError::Unknown(format!("{}", status))
+                } else {
+                    ModifyDBSubnetGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -15680,7 +15966,15 @@ impl ModifyEventSubscriptionError {
                 _ => ModifyEventSubscriptionError::Unknown(String::from(body)),
             },
             Err(_) => {
-                ModifyEventSubscriptionError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    ModifyEventSubscriptionError::Unknown(format!("{}", status))
+                } else {
+                    ModifyEventSubscriptionError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -15774,11 +16068,17 @@ impl PromoteReadReplicaDBClusterError {
                 }
                 _ => PromoteReadReplicaDBClusterError::Unknown(String::from(body)),
             },
-            Err(_) => PromoteReadReplicaDBClusterError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    PromoteReadReplicaDBClusterError::Unknown(format!("{}", status))
+                } else {
+                    PromoteReadReplicaDBClusterError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -15863,7 +16163,13 @@ impl RebootDBInstanceError {
                 ),
                 _ => RebootDBInstanceError::Unknown(String::from(body)),
             },
-            Err(_) => RebootDBInstanceError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    RebootDBInstanceError::Unknown(format!("{}", status))
+                } else {
+                    RebootDBInstanceError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -15956,7 +16262,15 @@ impl RemoveRoleFromDBClusterError {
                 _ => RemoveRoleFromDBClusterError::Unknown(String::from(body)),
             },
             Err(_) => {
-                RemoveRoleFromDBClusterError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    RemoveRoleFromDBClusterError::Unknown(format!("{}", status))
+                } else {
+                    RemoveRoleFromDBClusterError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -16046,11 +16360,17 @@ impl RemoveSourceIdentifierFromSubscriptionError {
                 }
                 _ => RemoveSourceIdentifierFromSubscriptionError::Unknown(String::from(body)),
             },
-            Err(_) => RemoveSourceIdentifierFromSubscriptionError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    RemoveSourceIdentifierFromSubscriptionError::Unknown(format!("{}", status))
+                } else {
+                    RemoveSourceIdentifierFromSubscriptionError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -16143,7 +16463,11 @@ impl RemoveTagsFromResourceError {
                 _ => RemoveTagsFromResourceError::Unknown(String::from(body)),
             },
             Err(_) => {
-                RemoveTagsFromResourceError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    RemoveTagsFromResourceError::Unknown(format!("{}", status))
+                } else {
+                    RemoveTagsFromResourceError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -16234,11 +16558,17 @@ impl ResetDBClusterParameterGroupError {
                 }
                 _ => ResetDBClusterParameterGroupError::Unknown(String::from(body)),
             },
-            Err(_) => ResetDBClusterParameterGroupError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    ResetDBClusterParameterGroupError::Unknown(format!("{}", status))
+                } else {
+                    ResetDBClusterParameterGroupError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -16330,7 +16660,11 @@ impl ResetDBParameterGroupError {
                 _ => ResetDBParameterGroupError::Unknown(String::from(body)),
             },
             Err(_) => {
-                ResetDBParameterGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    ResetDBParameterGroupError::Unknown(format!("{}", status))
+                } else {
+                    ResetDBParameterGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -16505,11 +16839,17 @@ impl RestoreDBClusterFromSnapshotError {
                 }
                 _ => RestoreDBClusterFromSnapshotError::Unknown(String::from(body)),
             },
-            Err(_) => RestoreDBClusterFromSnapshotError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    RestoreDBClusterFromSnapshotError::Unknown(format!("{}", status))
+                } else {
+                    RestoreDBClusterFromSnapshotError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -16711,11 +17051,17 @@ impl RestoreDBClusterToPointInTimeError {
                 }
                 _ => RestoreDBClusterToPointInTimeError::Unknown(String::from(body)),
             },
-            Err(_) => RestoreDBClusterToPointInTimeError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    RestoreDBClusterToPointInTimeError::Unknown(format!("{}", status))
+                } else {
+                    RestoreDBClusterToPointInTimeError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 

--- a/rusoto/services/rds/src/generated.rs
+++ b/rusoto/services/rds/src/generated.rs
@@ -18340,7 +18340,7 @@ pub enum AddRoleToDBClusterError {
 }
 
 impl AddRoleToDBClusterError {
-    pub fn from_body(body: &str) -> AddRoleToDBClusterError {
+    pub fn from_body(body: &str, status: u16) -> AddRoleToDBClusterError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -18366,7 +18366,7 @@ impl AddRoleToDBClusterError {
                 }
                 _ => AddRoleToDBClusterError::Unknown(String::from(body)),
             },
-            Err(_) => AddRoleToDBClusterError::Unknown(body.to_string()),
+            Err(_) => AddRoleToDBClusterError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -18439,7 +18439,7 @@ pub enum AddSourceIdentifierToSubscriptionError {
 }
 
 impl AddSourceIdentifierToSubscriptionError {
-    pub fn from_body(body: &str) -> AddSourceIdentifierToSubscriptionError {
+    pub fn from_body(body: &str, status: u16) -> AddSourceIdentifierToSubscriptionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -18455,7 +18455,11 @@ impl AddSourceIdentifierToSubscriptionError {
                 }
                 _ => AddSourceIdentifierToSubscriptionError::Unknown(String::from(body)),
             },
-            Err(_) => AddSourceIdentifierToSubscriptionError::Unknown(body.to_string()),
+            Err(_) => AddSourceIdentifierToSubscriptionError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -18528,7 +18532,7 @@ pub enum AddTagsToResourceError {
 }
 
 impl AddTagsToResourceError {
-    pub fn from_body(body: &str) -> AddTagsToResourceError {
+    pub fn from_body(body: &str, status: u16) -> AddTagsToResourceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -18545,7 +18549,7 @@ impl AddTagsToResourceError {
                 ),
                 _ => AddTagsToResourceError::Unknown(String::from(body)),
             },
-            Err(_) => AddTagsToResourceError::Unknown(body.to_string()),
+            Err(_) => AddTagsToResourceError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -18615,7 +18619,7 @@ pub enum ApplyPendingMaintenanceActionError {
 }
 
 impl ApplyPendingMaintenanceActionError {
-    pub fn from_body(body: &str) -> ApplyPendingMaintenanceActionError {
+    pub fn from_body(body: &str, status: u16) -> ApplyPendingMaintenanceActionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -18628,7 +18632,11 @@ impl ApplyPendingMaintenanceActionError {
                 }
                 _ => ApplyPendingMaintenanceActionError::Unknown(String::from(body)),
             },
-            Err(_) => ApplyPendingMaintenanceActionError::Unknown(body.to_string()),
+            Err(_) => ApplyPendingMaintenanceActionError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -18702,7 +18710,7 @@ pub enum AuthorizeDBSecurityGroupIngressError {
 }
 
 impl AuthorizeDBSecurityGroupIngressError {
-    pub fn from_body(body: &str) -> AuthorizeDBSecurityGroupIngressError {
+    pub fn from_body(body: &str, status: u16) -> AuthorizeDBSecurityGroupIngressError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -18730,7 +18738,11 @@ impl AuthorizeDBSecurityGroupIngressError {
                 }
                 _ => AuthorizeDBSecurityGroupIngressError::Unknown(String::from(body)),
             },
-            Err(_) => AuthorizeDBSecurityGroupIngressError::Unknown(body.to_string()),
+            Err(_) => AuthorizeDBSecurityGroupIngressError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -18809,7 +18821,7 @@ pub enum BacktrackDBClusterError {
 }
 
 impl BacktrackDBClusterError {
-    pub fn from_body(body: &str) -> BacktrackDBClusterError {
+    pub fn from_body(body: &str, status: u16) -> BacktrackDBClusterError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -18825,7 +18837,7 @@ impl BacktrackDBClusterError {
                 }
                 _ => BacktrackDBClusterError::Unknown(String::from(body)),
             },
-            Err(_) => BacktrackDBClusterError::Unknown(body.to_string()),
+            Err(_) => BacktrackDBClusterError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -18898,7 +18910,7 @@ pub enum CopyDBClusterParameterGroupError {
 }
 
 impl CopyDBClusterParameterGroupError {
-    pub fn from_body(body: &str) -> CopyDBClusterParameterGroupError {
+    pub fn from_body(body: &str, status: u16) -> CopyDBClusterParameterGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -18921,7 +18933,11 @@ impl CopyDBClusterParameterGroupError {
                 }
                 _ => CopyDBClusterParameterGroupError::Unknown(String::from(body)),
             },
-            Err(_) => CopyDBClusterParameterGroupError::Unknown(body.to_string()),
+            Err(_) => CopyDBClusterParameterGroupError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -19005,7 +19021,7 @@ pub enum CopyDBClusterSnapshotError {
 }
 
 impl CopyDBClusterSnapshotError {
-    pub fn from_body(body: &str) -> CopyDBClusterSnapshotError {
+    pub fn from_body(body: &str, status: u16) -> CopyDBClusterSnapshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -19039,7 +19055,9 @@ impl CopyDBClusterSnapshotError {
                 ),
                 _ => CopyDBClusterSnapshotError::Unknown(String::from(body)),
             },
-            Err(_) => CopyDBClusterSnapshotError::Unknown(body.to_string()),
+            Err(_) => {
+                CopyDBClusterSnapshotError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -19116,7 +19134,7 @@ pub enum CopyDBParameterGroupError {
 }
 
 impl CopyDBParameterGroupError {
-    pub fn from_body(body: &str) -> CopyDBParameterGroupError {
+    pub fn from_body(body: &str, status: u16) -> CopyDBParameterGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -19139,7 +19157,9 @@ impl CopyDBParameterGroupError {
                 }
                 _ => CopyDBParameterGroupError::Unknown(String::from(body)),
             },
-            Err(_) => CopyDBParameterGroupError::Unknown(body.to_string()),
+            Err(_) => {
+                CopyDBParameterGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -19217,7 +19237,7 @@ pub enum CopyDBSnapshotError {
 }
 
 impl CopyDBSnapshotError {
-    pub fn from_body(body: &str) -> CopyDBSnapshotError {
+    pub fn from_body(body: &str, status: u16) -> CopyDBSnapshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -19240,7 +19260,7 @@ impl CopyDBSnapshotError {
                 ),
                 _ => CopyDBSnapshotError::Unknown(String::from(body)),
             },
-            Err(_) => CopyDBSnapshotError::Unknown(body.to_string()),
+            Err(_) => CopyDBSnapshotError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -19314,7 +19334,7 @@ pub enum CopyOptionGroupError {
 }
 
 impl CopyOptionGroupError {
-    pub fn from_body(body: &str) -> CopyOptionGroupError {
+    pub fn from_body(body: &str, status: u16) -> CopyOptionGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -19335,7 +19355,7 @@ impl CopyOptionGroupError {
                 }
                 _ => CopyOptionGroupError::Unknown(String::from(body)),
             },
-            Err(_) => CopyOptionGroupError::Unknown(body.to_string()),
+            Err(_) => CopyOptionGroupError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -19431,7 +19451,7 @@ pub enum CreateDBClusterError {
 }
 
 impl CreateDBClusterError {
-    pub fn from_body(body: &str) -> CreateDBClusterError {
+    pub fn from_body(body: &str, status: u16) -> CreateDBClusterError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -19492,7 +19512,7 @@ impl CreateDBClusterError {
                 ),
                 _ => CreateDBClusterError::Unknown(String::from(body)),
             },
-            Err(_) => CreateDBClusterError::Unknown(body.to_string()),
+            Err(_) => CreateDBClusterError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -19574,7 +19594,7 @@ pub enum CreateDBClusterParameterGroupError {
 }
 
 impl CreateDBClusterParameterGroupError {
-    pub fn from_body(body: &str) -> CreateDBClusterParameterGroupError {
+    pub fn from_body(body: &str, status: u16) -> CreateDBClusterParameterGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -19592,7 +19612,11 @@ impl CreateDBClusterParameterGroupError {
                 }
                 _ => CreateDBClusterParameterGroupError::Unknown(String::from(body)),
             },
-            Err(_) => CreateDBClusterParameterGroupError::Unknown(body.to_string()),
+            Err(_) => CreateDBClusterParameterGroupError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -19673,7 +19697,7 @@ pub enum CreateDBClusterSnapshotError {
 }
 
 impl CreateDBClusterSnapshotError {
-    pub fn from_body(body: &str) -> CreateDBClusterSnapshotError {
+    pub fn from_body(body: &str, status: u16) -> CreateDBClusterSnapshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -19704,7 +19728,9 @@ impl CreateDBClusterSnapshotError {
                 }
                 _ => CreateDBClusterSnapshotError::Unknown(String::from(body)),
             },
-            Err(_) => CreateDBClusterSnapshotError::Unknown(body.to_string()),
+            Err(_) => {
+                CreateDBClusterSnapshotError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -19810,7 +19836,7 @@ pub enum CreateDBInstanceError {
 }
 
 impl CreateDBInstanceError {
-    pub fn from_body(body: &str) -> CreateDBInstanceError {
+    pub fn from_body(body: &str, status: u16) -> CreateDBInstanceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -19880,7 +19906,7 @@ impl CreateDBInstanceError {
                 ),
                 _ => CreateDBInstanceError::Unknown(String::from(body)),
             },
-            Err(_) => CreateDBInstanceError::Unknown(body.to_string()),
+            Err(_) => CreateDBInstanceError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -19997,7 +20023,7 @@ pub enum CreateDBInstanceReadReplicaError {
 }
 
 impl CreateDBInstanceReadReplicaError {
-    pub fn from_body(body: &str) -> CreateDBInstanceReadReplicaError {
+    pub fn from_body(body: &str, status: u16) -> CreateDBInstanceReadReplicaError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -20091,7 +20117,11 @@ impl CreateDBInstanceReadReplicaError {
                 }
                 _ => CreateDBInstanceReadReplicaError::Unknown(String::from(body)),
             },
-            Err(_) => CreateDBInstanceReadReplicaError::Unknown(body.to_string()),
+            Err(_) => CreateDBInstanceReadReplicaError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -20184,7 +20214,7 @@ pub enum CreateDBParameterGroupError {
 }
 
 impl CreateDBParameterGroupError {
-    pub fn from_body(body: &str) -> CreateDBParameterGroupError {
+    pub fn from_body(body: &str, status: u16) -> CreateDBParameterGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -20202,7 +20232,9 @@ impl CreateDBParameterGroupError {
                 }
                 _ => CreateDBParameterGroupError::Unknown(String::from(body)),
             },
-            Err(_) => CreateDBParameterGroupError::Unknown(body.to_string()),
+            Err(_) => {
+                CreateDBParameterGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -20275,7 +20307,7 @@ pub enum CreateDBSecurityGroupError {
 }
 
 impl CreateDBSecurityGroupError {
-    pub fn from_body(body: &str) -> CreateDBSecurityGroupError {
+    pub fn from_body(body: &str, status: u16) -> CreateDBSecurityGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -20298,7 +20330,9 @@ impl CreateDBSecurityGroupError {
                 }
                 _ => CreateDBSecurityGroupError::Unknown(String::from(body)),
             },
-            Err(_) => CreateDBSecurityGroupError::Unknown(body.to_string()),
+            Err(_) => {
+                CreateDBSecurityGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -20374,7 +20408,7 @@ pub enum CreateDBSnapshotError {
 }
 
 impl CreateDBSnapshotError {
-    pub fn from_body(body: &str) -> CreateDBSnapshotError {
+    pub fn from_body(body: &str, status: u16) -> CreateDBSnapshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -20394,7 +20428,7 @@ impl CreateDBSnapshotError {
                 ),
                 _ => CreateDBSnapshotError::Unknown(String::from(body)),
             },
-            Err(_) => CreateDBSnapshotError::Unknown(body.to_string()),
+            Err(_) => CreateDBSnapshotError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -20471,7 +20505,7 @@ pub enum CreateDBSubnetGroupError {
 }
 
 impl CreateDBSubnetGroupError {
-    pub fn from_body(body: &str) -> CreateDBSubnetGroupError {
+    pub fn from_body(body: &str, status: u16) -> CreateDBSubnetGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -20502,7 +20536,7 @@ impl CreateDBSubnetGroupError {
                 }
                 _ => CreateDBSubnetGroupError::Unknown(String::from(body)),
             },
-            Err(_) => CreateDBSubnetGroupError::Unknown(body.to_string()),
+            Err(_) => CreateDBSubnetGroupError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -20586,7 +20620,7 @@ pub enum CreateEventSubscriptionError {
 }
 
 impl CreateEventSubscriptionError {
-    pub fn from_body(body: &str) -> CreateEventSubscriptionError {
+    pub fn from_body(body: &str, status: u16) -> CreateEventSubscriptionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -20621,7 +20655,9 @@ impl CreateEventSubscriptionError {
                 }
                 _ => CreateEventSubscriptionError::Unknown(String::from(body)),
             },
-            Err(_) => CreateEventSubscriptionError::Unknown(body.to_string()),
+            Err(_) => {
+                CreateEventSubscriptionError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -20697,7 +20733,7 @@ pub enum CreateOptionGroupError {
 }
 
 impl CreateOptionGroupError {
-    pub fn from_body(body: &str) -> CreateOptionGroupError {
+    pub fn from_body(body: &str, status: u16) -> CreateOptionGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -20715,7 +20751,7 @@ impl CreateOptionGroupError {
                 }
                 _ => CreateOptionGroupError::Unknown(String::from(body)),
             },
-            Err(_) => CreateOptionGroupError::Unknown(body.to_string()),
+            Err(_) => CreateOptionGroupError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -20792,7 +20828,7 @@ pub enum DeleteDBClusterError {
 }
 
 impl DeleteDBClusterError {
-    pub fn from_body(body: &str) -> DeleteDBClusterError {
+    pub fn from_body(body: &str, status: u16) -> DeleteDBClusterError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -20819,7 +20855,7 @@ impl DeleteDBClusterError {
                 ),
                 _ => DeleteDBClusterError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteDBClusterError::Unknown(body.to_string()),
+            Err(_) => DeleteDBClusterError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -20891,7 +20927,7 @@ pub enum DeleteDBClusterParameterGroupError {
 }
 
 impl DeleteDBClusterParameterGroupError {
-    pub fn from_body(body: &str) -> DeleteDBClusterParameterGroupError {
+    pub fn from_body(body: &str, status: u16) -> DeleteDBClusterParameterGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -20909,7 +20945,11 @@ impl DeleteDBClusterParameterGroupError {
                 }
                 _ => DeleteDBClusterParameterGroupError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteDBClusterParameterGroupError::Unknown(body.to_string()),
+            Err(_) => DeleteDBClusterParameterGroupError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -20982,7 +21022,7 @@ pub enum DeleteDBClusterSnapshotError {
 }
 
 impl DeleteDBClusterSnapshotError {
-    pub fn from_body(body: &str) -> DeleteDBClusterSnapshotError {
+    pub fn from_body(body: &str, status: u16) -> DeleteDBClusterSnapshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -21000,7 +21040,9 @@ impl DeleteDBClusterSnapshotError {
                 }
                 _ => DeleteDBClusterSnapshotError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteDBClusterSnapshotError::Unknown(body.to_string()),
+            Err(_) => {
+                DeleteDBClusterSnapshotError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -21077,7 +21119,7 @@ pub enum DeleteDBInstanceError {
 }
 
 impl DeleteDBInstanceError {
-    pub fn from_body(body: &str) -> DeleteDBInstanceError {
+    pub fn from_body(body: &str, status: u16) -> DeleteDBInstanceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -21100,7 +21142,7 @@ impl DeleteDBInstanceError {
                 ),
                 _ => DeleteDBInstanceError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteDBInstanceError::Unknown(body.to_string()),
+            Err(_) => DeleteDBInstanceError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -21172,7 +21214,7 @@ pub enum DeleteDBParameterGroupError {
 }
 
 impl DeleteDBParameterGroupError {
-    pub fn from_body(body: &str) -> DeleteDBParameterGroupError {
+    pub fn from_body(body: &str, status: u16) -> DeleteDBParameterGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -21190,7 +21232,9 @@ impl DeleteDBParameterGroupError {
                 }
                 _ => DeleteDBParameterGroupError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteDBParameterGroupError::Unknown(body.to_string()),
+            Err(_) => {
+                DeleteDBParameterGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -21261,7 +21305,7 @@ pub enum DeleteDBSecurityGroupError {
 }
 
 impl DeleteDBSecurityGroupError {
-    pub fn from_body(body: &str) -> DeleteDBSecurityGroupError {
+    pub fn from_body(body: &str, status: u16) -> DeleteDBSecurityGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -21279,7 +21323,9 @@ impl DeleteDBSecurityGroupError {
                 }
                 _ => DeleteDBSecurityGroupError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteDBSecurityGroupError::Unknown(body.to_string()),
+            Err(_) => {
+                DeleteDBSecurityGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -21350,7 +21396,7 @@ pub enum DeleteDBSnapshotError {
 }
 
 impl DeleteDBSnapshotError {
-    pub fn from_body(body: &str) -> DeleteDBSnapshotError {
+    pub fn from_body(body: &str, status: u16) -> DeleteDBSnapshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -21364,7 +21410,7 @@ impl DeleteDBSnapshotError {
                 ),
                 _ => DeleteDBSnapshotError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteDBSnapshotError::Unknown(body.to_string()),
+            Err(_) => DeleteDBSnapshotError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -21435,7 +21481,7 @@ pub enum DeleteDBSubnetGroupError {
 }
 
 impl DeleteDBSubnetGroupError {
-    pub fn from_body(body: &str) -> DeleteDBSubnetGroupError {
+    pub fn from_body(body: &str, status: u16) -> DeleteDBSubnetGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -21456,7 +21502,7 @@ impl DeleteDBSubnetGroupError {
                 ),
                 _ => DeleteDBSubnetGroupError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteDBSubnetGroupError::Unknown(body.to_string()),
+            Err(_) => DeleteDBSubnetGroupError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -21528,7 +21574,7 @@ pub enum DeleteEventSubscriptionError {
 }
 
 impl DeleteEventSubscriptionError {
-    pub fn from_body(body: &str) -> DeleteEventSubscriptionError {
+    pub fn from_body(body: &str, status: u16) -> DeleteEventSubscriptionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -21544,7 +21590,9 @@ impl DeleteEventSubscriptionError {
                 ),
                 _ => DeleteEventSubscriptionError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteEventSubscriptionError::Unknown(body.to_string()),
+            Err(_) => {
+                DeleteEventSubscriptionError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -21615,7 +21663,7 @@ pub enum DeleteOptionGroupError {
 }
 
 impl DeleteOptionGroupError {
-    pub fn from_body(body: &str) -> DeleteOptionGroupError {
+    pub fn from_body(body: &str, status: u16) -> DeleteOptionGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -21631,7 +21679,7 @@ impl DeleteOptionGroupError {
                 ),
                 _ => DeleteOptionGroupError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteOptionGroupError::Unknown(body.to_string()),
+            Err(_) => DeleteOptionGroupError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -21698,7 +21746,7 @@ pub enum DescribeAccountAttributesError {
 }
 
 impl DescribeAccountAttributesError {
-    pub fn from_body(body: &str) -> DescribeAccountAttributesError {
+    pub fn from_body(body: &str, status: u16) -> DescribeAccountAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -21706,7 +21754,9 @@ impl DescribeAccountAttributesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeAccountAttributesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeAccountAttributesError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeAccountAttributesError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -21773,7 +21823,7 @@ pub enum DescribeCertificatesError {
 }
 
 impl DescribeCertificatesError {
-    pub fn from_body(body: &str) -> DescribeCertificatesError {
+    pub fn from_body(body: &str, status: u16) -> DescribeCertificatesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -21784,7 +21834,9 @@ impl DescribeCertificatesError {
                 ),
                 _ => DescribeCertificatesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeCertificatesError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeCertificatesError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -21854,7 +21906,7 @@ pub enum DescribeDBClusterBacktracksError {
 }
 
 impl DescribeDBClusterBacktracksError {
-    pub fn from_body(body: &str) -> DescribeDBClusterBacktracksError {
+    pub fn from_body(body: &str, status: u16) -> DescribeDBClusterBacktracksError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -21872,7 +21924,11 @@ impl DescribeDBClusterBacktracksError {
                 }
                 _ => DescribeDBClusterBacktracksError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeDBClusterBacktracksError::Unknown(body.to_string()),
+            Err(_) => DescribeDBClusterBacktracksError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -21941,7 +21997,7 @@ pub enum DescribeDBClusterParameterGroupsError {
 }
 
 impl DescribeDBClusterParameterGroupsError {
-    pub fn from_body(body: &str) -> DescribeDBClusterParameterGroupsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeDBClusterParameterGroupsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -21954,7 +22010,11 @@ impl DescribeDBClusterParameterGroupsError {
                 }
                 _ => DescribeDBClusterParameterGroupsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeDBClusterParameterGroupsError::Unknown(body.to_string()),
+            Err(_) => DescribeDBClusterParameterGroupsError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -22024,7 +22084,7 @@ pub enum DescribeDBClusterParametersError {
 }
 
 impl DescribeDBClusterParametersError {
-    pub fn from_body(body: &str) -> DescribeDBClusterParametersError {
+    pub fn from_body(body: &str, status: u16) -> DescribeDBClusterParametersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -22037,7 +22097,11 @@ impl DescribeDBClusterParametersError {
                 }
                 _ => DescribeDBClusterParametersError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeDBClusterParametersError::Unknown(body.to_string()),
+            Err(_) => DescribeDBClusterParametersError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -22105,7 +22169,7 @@ pub enum DescribeDBClusterSnapshotAttributesError {
 }
 
 impl DescribeDBClusterSnapshotAttributesError {
-    pub fn from_body(body: &str) -> DescribeDBClusterSnapshotAttributesError {
+    pub fn from_body(body: &str, status: u16) -> DescribeDBClusterSnapshotAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -22118,7 +22182,11 @@ impl DescribeDBClusterSnapshotAttributesError {
                 }
                 _ => DescribeDBClusterSnapshotAttributesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeDBClusterSnapshotAttributesError::Unknown(body.to_string()),
+            Err(_) => DescribeDBClusterSnapshotAttributesError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -22188,7 +22256,7 @@ pub enum DescribeDBClusterSnapshotsError {
 }
 
 impl DescribeDBClusterSnapshotsError {
-    pub fn from_body(body: &str) -> DescribeDBClusterSnapshotsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeDBClusterSnapshotsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -22201,7 +22269,9 @@ impl DescribeDBClusterSnapshotsError {
                 }
                 _ => DescribeDBClusterSnapshotsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeDBClusterSnapshotsError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeDBClusterSnapshotsError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -22269,7 +22339,7 @@ pub enum DescribeDBClustersError {
 }
 
 impl DescribeDBClustersError {
-    pub fn from_body(body: &str) -> DescribeDBClustersError {
+    pub fn from_body(body: &str, status: u16) -> DescribeDBClustersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -22280,7 +22350,7 @@ impl DescribeDBClustersError {
                 ),
                 _ => DescribeDBClustersError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeDBClustersError::Unknown(body.to_string()),
+            Err(_) => DescribeDBClustersError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -22346,7 +22416,7 @@ pub enum DescribeDBEngineVersionsError {
 }
 
 impl DescribeDBEngineVersionsError {
-    pub fn from_body(body: &str) -> DescribeDBEngineVersionsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeDBEngineVersionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -22354,7 +22424,9 @@ impl DescribeDBEngineVersionsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeDBEngineVersionsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeDBEngineVersionsError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeDBEngineVersionsError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -22421,7 +22493,7 @@ pub enum DescribeDBInstancesError {
 }
 
 impl DescribeDBInstancesError {
-    pub fn from_body(body: &str) -> DescribeDBInstancesError {
+    pub fn from_body(body: &str, status: u16) -> DescribeDBInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -22432,7 +22504,7 @@ impl DescribeDBInstancesError {
                 ),
                 _ => DescribeDBInstancesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeDBInstancesError::Unknown(body.to_string()),
+            Err(_) => DescribeDBInstancesError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -22500,7 +22572,7 @@ pub enum DescribeDBLogFilesError {
 }
 
 impl DescribeDBLogFilesError {
-    pub fn from_body(body: &str) -> DescribeDBLogFilesError {
+    pub fn from_body(body: &str, status: u16) -> DescribeDBLogFilesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -22511,7 +22583,7 @@ impl DescribeDBLogFilesError {
                 ),
                 _ => DescribeDBLogFilesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeDBLogFilesError::Unknown(body.to_string()),
+            Err(_) => DescribeDBLogFilesError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -22579,7 +22651,7 @@ pub enum DescribeDBParameterGroupsError {
 }
 
 impl DescribeDBParameterGroupsError {
-    pub fn from_body(body: &str) -> DescribeDBParameterGroupsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeDBParameterGroupsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -22592,7 +22664,9 @@ impl DescribeDBParameterGroupsError {
                 }
                 _ => DescribeDBParameterGroupsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeDBParameterGroupsError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeDBParameterGroupsError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -22660,7 +22734,7 @@ pub enum DescribeDBParametersError {
 }
 
 impl DescribeDBParametersError {
-    pub fn from_body(body: &str) -> DescribeDBParametersError {
+    pub fn from_body(body: &str, status: u16) -> DescribeDBParametersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -22673,7 +22747,9 @@ impl DescribeDBParametersError {
                 }
                 _ => DescribeDBParametersError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeDBParametersError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeDBParametersError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -22741,7 +22817,7 @@ pub enum DescribeDBSecurityGroupsError {
 }
 
 impl DescribeDBSecurityGroupsError {
-    pub fn from_body(body: &str) -> DescribeDBSecurityGroupsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeDBSecurityGroupsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -22754,7 +22830,9 @@ impl DescribeDBSecurityGroupsError {
                 }
                 _ => DescribeDBSecurityGroupsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeDBSecurityGroupsError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeDBSecurityGroupsError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -22822,7 +22900,7 @@ pub enum DescribeDBSnapshotAttributesError {
 }
 
 impl DescribeDBSnapshotAttributesError {
-    pub fn from_body(body: &str) -> DescribeDBSnapshotAttributesError {
+    pub fn from_body(body: &str, status: u16) -> DescribeDBSnapshotAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -22833,7 +22911,11 @@ impl DescribeDBSnapshotAttributesError {
                 ),
                 _ => DescribeDBSnapshotAttributesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeDBSnapshotAttributesError::Unknown(body.to_string()),
+            Err(_) => DescribeDBSnapshotAttributesError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -22901,7 +22983,7 @@ pub enum DescribeDBSnapshotsError {
 }
 
 impl DescribeDBSnapshotsError {
-    pub fn from_body(body: &str) -> DescribeDBSnapshotsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeDBSnapshotsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -22912,7 +22994,7 @@ impl DescribeDBSnapshotsError {
                 ),
                 _ => DescribeDBSnapshotsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeDBSnapshotsError::Unknown(body.to_string()),
+            Err(_) => DescribeDBSnapshotsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -22980,7 +23062,7 @@ pub enum DescribeDBSubnetGroupsError {
 }
 
 impl DescribeDBSubnetGroupsError {
-    pub fn from_body(body: &str) -> DescribeDBSubnetGroupsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeDBSubnetGroupsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -22993,7 +23075,9 @@ impl DescribeDBSubnetGroupsError {
                 }
                 _ => DescribeDBSubnetGroupsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeDBSubnetGroupsError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeDBSubnetGroupsError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -23059,7 +23143,7 @@ pub enum DescribeEngineDefaultClusterParametersError {
 }
 
 impl DescribeEngineDefaultClusterParametersError {
-    pub fn from_body(body: &str) -> DescribeEngineDefaultClusterParametersError {
+    pub fn from_body(body: &str, status: u16) -> DescribeEngineDefaultClusterParametersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -23067,7 +23151,11 @@ impl DescribeEngineDefaultClusterParametersError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeEngineDefaultClusterParametersError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeEngineDefaultClusterParametersError::Unknown(body.to_string()),
+            Err(_) => DescribeEngineDefaultClusterParametersError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -23132,7 +23220,7 @@ pub enum DescribeEngineDefaultParametersError {
 }
 
 impl DescribeEngineDefaultParametersError {
-    pub fn from_body(body: &str) -> DescribeEngineDefaultParametersError {
+    pub fn from_body(body: &str, status: u16) -> DescribeEngineDefaultParametersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -23140,7 +23228,11 @@ impl DescribeEngineDefaultParametersError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeEngineDefaultParametersError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeEngineDefaultParametersError::Unknown(body.to_string()),
+            Err(_) => DescribeEngineDefaultParametersError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -23205,7 +23297,7 @@ pub enum DescribeEventCategoriesError {
 }
 
 impl DescribeEventCategoriesError {
-    pub fn from_body(body: &str) -> DescribeEventCategoriesError {
+    pub fn from_body(body: &str, status: u16) -> DescribeEventCategoriesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -23213,7 +23305,9 @@ impl DescribeEventCategoriesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeEventCategoriesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeEventCategoriesError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeEventCategoriesError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -23280,7 +23374,7 @@ pub enum DescribeEventSubscriptionsError {
 }
 
 impl DescribeEventSubscriptionsError {
-    pub fn from_body(body: &str) -> DescribeEventSubscriptionsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeEventSubscriptionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -23293,7 +23387,9 @@ impl DescribeEventSubscriptionsError {
                 }
                 _ => DescribeEventSubscriptionsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeEventSubscriptionsError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeEventSubscriptionsError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -23359,7 +23455,7 @@ pub enum DescribeEventsError {
 }
 
 impl DescribeEventsError {
-    pub fn from_body(body: &str) -> DescribeEventsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeEventsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -23367,7 +23463,7 @@ impl DescribeEventsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeEventsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeEventsError::Unknown(body.to_string()),
+            Err(_) => DescribeEventsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -23430,7 +23526,7 @@ pub enum DescribeOptionGroupOptionsError {
 }
 
 impl DescribeOptionGroupOptionsError {
-    pub fn from_body(body: &str) -> DescribeOptionGroupOptionsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeOptionGroupOptionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -23438,7 +23534,9 @@ impl DescribeOptionGroupOptionsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeOptionGroupOptionsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeOptionGroupOptionsError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeOptionGroupOptionsError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -23505,7 +23603,7 @@ pub enum DescribeOptionGroupsError {
 }
 
 impl DescribeOptionGroupsError {
-    pub fn from_body(body: &str) -> DescribeOptionGroupsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeOptionGroupsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -23516,7 +23614,9 @@ impl DescribeOptionGroupsError {
                 ),
                 _ => DescribeOptionGroupsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeOptionGroupsError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeOptionGroupsError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -23582,7 +23682,7 @@ pub enum DescribeOrderableDBInstanceOptionsError {
 }
 
 impl DescribeOrderableDBInstanceOptionsError {
-    pub fn from_body(body: &str) -> DescribeOrderableDBInstanceOptionsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeOrderableDBInstanceOptionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -23590,7 +23690,11 @@ impl DescribeOrderableDBInstanceOptionsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeOrderableDBInstanceOptionsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeOrderableDBInstanceOptionsError::Unknown(body.to_string()),
+            Err(_) => DescribeOrderableDBInstanceOptionsError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -23657,7 +23761,7 @@ pub enum DescribePendingMaintenanceActionsError {
 }
 
 impl DescribePendingMaintenanceActionsError {
-    pub fn from_body(body: &str) -> DescribePendingMaintenanceActionsError {
+    pub fn from_body(body: &str, status: u16) -> DescribePendingMaintenanceActionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -23670,7 +23774,11 @@ impl DescribePendingMaintenanceActionsError {
                 }
                 _ => DescribePendingMaintenanceActionsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribePendingMaintenanceActionsError::Unknown(body.to_string()),
+            Err(_) => DescribePendingMaintenanceActionsError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -23738,7 +23846,7 @@ pub enum DescribeReservedDBInstancesError {
 }
 
 impl DescribeReservedDBInstancesError {
-    pub fn from_body(body: &str) -> DescribeReservedDBInstancesError {
+    pub fn from_body(body: &str, status: u16) -> DescribeReservedDBInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -23751,7 +23859,11 @@ impl DescribeReservedDBInstancesError {
                 }
                 _ => DescribeReservedDBInstancesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeReservedDBInstancesError::Unknown(body.to_string()),
+            Err(_) => DescribeReservedDBInstancesError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -23819,7 +23931,7 @@ pub enum DescribeReservedDBInstancesOfferingsError {
 }
 
 impl DescribeReservedDBInstancesOfferingsError {
-    pub fn from_body(body: &str) -> DescribeReservedDBInstancesOfferingsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeReservedDBInstancesOfferingsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -23829,7 +23941,7 @@ impl DescribeReservedDBInstancesOfferingsError {
                                     "ReservedDBInstancesOfferingNotFound" => DescribeReservedDBInstancesOfferingsError::ReservedDBInstancesOfferingNotFoundFault(String::from(parsed_error.message)),_ => DescribeReservedDBInstancesOfferingsError::Unknown(String::from(body))
                                 }
                            },
-                           Err(_) => DescribeReservedDBInstancesOfferingsError::Unknown(body.to_string())
+                           Err(_) => DescribeReservedDBInstancesOfferingsError::Unknown(format!("{}:{}", body.to_string(), status))
                        }
     }
 
@@ -23897,7 +24009,7 @@ pub enum DescribeSourceRegionsError {
 }
 
 impl DescribeSourceRegionsError {
-    pub fn from_body(body: &str) -> DescribeSourceRegionsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeSourceRegionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -23905,7 +24017,9 @@ impl DescribeSourceRegionsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeSourceRegionsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeSourceRegionsError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeSourceRegionsError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -23974,7 +24088,7 @@ pub enum DescribeValidDBInstanceModificationsError {
 }
 
 impl DescribeValidDBInstanceModificationsError {
-    pub fn from_body(body: &str) -> DescribeValidDBInstanceModificationsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeValidDBInstanceModificationsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -23992,7 +24106,11 @@ impl DescribeValidDBInstanceModificationsError {
                 }
                 _ => DescribeValidDBInstanceModificationsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeValidDBInstanceModificationsError::Unknown(body.to_string()),
+            Err(_) => DescribeValidDBInstanceModificationsError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -24065,7 +24183,7 @@ pub enum DownloadDBLogFilePortionError {
 }
 
 impl DownloadDBLogFilePortionError {
-    pub fn from_body(body: &str) -> DownloadDBLogFilePortionError {
+    pub fn from_body(body: &str, status: u16) -> DownloadDBLogFilePortionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -24079,7 +24197,9 @@ impl DownloadDBLogFilePortionError {
                 ),
                 _ => DownloadDBLogFilePortionError::Unknown(String::from(body)),
             },
-            Err(_) => DownloadDBLogFilePortionError::Unknown(body.to_string()),
+            Err(_) => {
+                DownloadDBLogFilePortionError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -24152,7 +24272,7 @@ pub enum FailoverDBClusterError {
 }
 
 impl FailoverDBClusterError {
-    pub fn from_body(body: &str) -> FailoverDBClusterError {
+    pub fn from_body(body: &str, status: u16) -> FailoverDBClusterError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -24169,7 +24289,7 @@ impl FailoverDBClusterError {
                 ),
                 _ => FailoverDBClusterError::Unknown(String::from(body)),
             },
-            Err(_) => FailoverDBClusterError::Unknown(body.to_string()),
+            Err(_) => FailoverDBClusterError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -24243,7 +24363,7 @@ pub enum ListTagsForResourceError {
 }
 
 impl ListTagsForResourceError {
-    pub fn from_body(body: &str) -> ListTagsForResourceError {
+    pub fn from_body(body: &str, status: u16) -> ListTagsForResourceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -24260,7 +24380,7 @@ impl ListTagsForResourceError {
                 ),
                 _ => ListTagsForResourceError::Unknown(String::from(body)),
             },
-            Err(_) => ListTagsForResourceError::Unknown(body.to_string()),
+            Err(_) => ListTagsForResourceError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -24350,7 +24470,7 @@ pub enum ModifyDBClusterError {
 }
 
 impl ModifyDBClusterError {
-    pub fn from_body(body: &str) -> ModifyDBClusterError {
+    pub fn from_body(body: &str, status: u16) -> ModifyDBClusterError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -24397,7 +24517,7 @@ impl ModifyDBClusterError {
                 ),
                 _ => ModifyDBClusterError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyDBClusterError::Unknown(body.to_string()),
+            Err(_) => ModifyDBClusterError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -24475,7 +24595,7 @@ pub enum ModifyDBClusterParameterGroupError {
 }
 
 impl ModifyDBClusterParameterGroupError {
-    pub fn from_body(body: &str) -> ModifyDBClusterParameterGroupError {
+    pub fn from_body(body: &str, status: u16) -> ModifyDBClusterParameterGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -24493,7 +24613,11 @@ impl ModifyDBClusterParameterGroupError {
                 }
                 _ => ModifyDBClusterParameterGroupError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyDBClusterParameterGroupError::Unknown(body.to_string()),
+            Err(_) => ModifyDBClusterParameterGroupError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -24568,7 +24692,7 @@ pub enum ModifyDBClusterSnapshotAttributeError {
 }
 
 impl ModifyDBClusterSnapshotAttributeError {
-    pub fn from_body(body: &str) -> ModifyDBClusterSnapshotAttributeError {
+    pub fn from_body(body: &str, status: u16) -> ModifyDBClusterSnapshotAttributeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -24591,7 +24715,11 @@ impl ModifyDBClusterSnapshotAttributeError {
                 }
                 _ => ModifyDBClusterSnapshotAttributeError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyDBClusterSnapshotAttributeError::Unknown(body.to_string()),
+            Err(_) => ModifyDBClusterSnapshotAttributeError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -24697,7 +24825,7 @@ pub enum ModifyDBInstanceError {
 }
 
 impl ModifyDBInstanceError {
-    pub fn from_body(body: &str) -> ModifyDBInstanceError {
+    pub fn from_body(body: &str, status: u16) -> ModifyDBInstanceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -24763,7 +24891,7 @@ impl ModifyDBInstanceError {
                 ),
                 _ => ModifyDBInstanceError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyDBInstanceError::Unknown(body.to_string()),
+            Err(_) => ModifyDBInstanceError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -24846,7 +24974,7 @@ pub enum ModifyDBParameterGroupError {
 }
 
 impl ModifyDBParameterGroupError {
-    pub fn from_body(body: &str) -> ModifyDBParameterGroupError {
+    pub fn from_body(body: &str, status: u16) -> ModifyDBParameterGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -24864,7 +24992,9 @@ impl ModifyDBParameterGroupError {
                 }
                 _ => ModifyDBParameterGroupError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyDBParameterGroupError::Unknown(body.to_string()),
+            Err(_) => {
+                ModifyDBParameterGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -24933,7 +25063,7 @@ pub enum ModifyDBSnapshotError {
 }
 
 impl ModifyDBSnapshotError {
-    pub fn from_body(body: &str) -> ModifyDBSnapshotError {
+    pub fn from_body(body: &str, status: u16) -> ModifyDBSnapshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -24944,7 +25074,7 @@ impl ModifyDBSnapshotError {
                 ),
                 _ => ModifyDBSnapshotError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyDBSnapshotError::Unknown(body.to_string()),
+            Err(_) => ModifyDBSnapshotError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -25014,7 +25144,7 @@ pub enum ModifyDBSnapshotAttributeError {
 }
 
 impl ModifyDBSnapshotAttributeError {
-    pub fn from_body(body: &str) -> ModifyDBSnapshotAttributeError {
+    pub fn from_body(body: &str, status: u16) -> ModifyDBSnapshotAttributeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -25035,7 +25165,9 @@ impl ModifyDBSnapshotAttributeError {
                 }
                 _ => ModifyDBSnapshotAttributeError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyDBSnapshotAttributeError::Unknown(body.to_string()),
+            Err(_) => {
+                ModifyDBSnapshotAttributeError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -25113,7 +25245,7 @@ pub enum ModifyDBSubnetGroupError {
 }
 
 impl ModifyDBSubnetGroupError {
-    pub fn from_body(body: &str) -> ModifyDBSubnetGroupError {
+    pub fn from_body(body: &str, status: u16) -> ModifyDBSubnetGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -25142,7 +25274,7 @@ impl ModifyDBSubnetGroupError {
                 }
                 _ => ModifyDBSubnetGroupError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyDBSubnetGroupError::Unknown(body.to_string()),
+            Err(_) => ModifyDBSubnetGroupError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -25224,7 +25356,7 @@ pub enum ModifyEventSubscriptionError {
 }
 
 impl ModifyEventSubscriptionError {
-    pub fn from_body(body: &str) -> ModifyEventSubscriptionError {
+    pub fn from_body(body: &str, status: u16) -> ModifyEventSubscriptionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -25254,7 +25386,9 @@ impl ModifyEventSubscriptionError {
                 ),
                 _ => ModifyEventSubscriptionError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyEventSubscriptionError::Unknown(body.to_string()),
+            Err(_) => {
+                ModifyEventSubscriptionError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -25329,7 +25463,7 @@ pub enum ModifyOptionGroupError {
 }
 
 impl ModifyOptionGroupError {
-    pub fn from_body(body: &str) -> ModifyOptionGroupError {
+    pub fn from_body(body: &str, status: u16) -> ModifyOptionGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -25345,7 +25479,7 @@ impl ModifyOptionGroupError {
                 ),
                 _ => ModifyOptionGroupError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyOptionGroupError::Unknown(body.to_string()),
+            Err(_) => ModifyOptionGroupError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -25416,7 +25550,7 @@ pub enum PromoteReadReplicaError {
 }
 
 impl PromoteReadReplicaError {
-    pub fn from_body(body: &str) -> PromoteReadReplicaError {
+    pub fn from_body(body: &str, status: u16) -> PromoteReadReplicaError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -25430,7 +25564,7 @@ impl PromoteReadReplicaError {
                 ),
                 _ => PromoteReadReplicaError::Unknown(String::from(body)),
             },
-            Err(_) => PromoteReadReplicaError::Unknown(body.to_string()),
+            Err(_) => PromoteReadReplicaError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -25501,7 +25635,7 @@ pub enum PromoteReadReplicaDBClusterError {
 }
 
 impl PromoteReadReplicaDBClusterError {
-    pub fn from_body(body: &str) -> PromoteReadReplicaDBClusterError {
+    pub fn from_body(body: &str, status: u16) -> PromoteReadReplicaDBClusterError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -25519,7 +25653,11 @@ impl PromoteReadReplicaDBClusterError {
                 }
                 _ => PromoteReadReplicaDBClusterError::Unknown(String::from(body)),
             },
-            Err(_) => PromoteReadReplicaDBClusterError::Unknown(body.to_string()),
+            Err(_) => PromoteReadReplicaDBClusterError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -25592,7 +25730,7 @@ pub enum PurchaseReservedDBInstancesOfferingError {
 }
 
 impl PurchaseReservedDBInstancesOfferingError {
-    pub fn from_body(body: &str) -> PurchaseReservedDBInstancesOfferingError {
+    pub fn from_body(body: &str, status: u16) -> PurchaseReservedDBInstancesOfferingError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -25602,7 +25740,7 @@ impl PurchaseReservedDBInstancesOfferingError {
                                     "ReservedDBInstanceAlreadyExists" => PurchaseReservedDBInstancesOfferingError::ReservedDBInstanceAlreadyExistsFault(String::from(parsed_error.message)),"ReservedDBInstanceQuotaExceeded" => PurchaseReservedDBInstancesOfferingError::ReservedDBInstanceQuotaExceededFault(String::from(parsed_error.message)),"ReservedDBInstancesOfferingNotFound" => PurchaseReservedDBInstancesOfferingError::ReservedDBInstancesOfferingNotFoundFault(String::from(parsed_error.message)),_ => PurchaseReservedDBInstancesOfferingError::Unknown(String::from(body))
                                 }
                            },
-                           Err(_) => PurchaseReservedDBInstancesOfferingError::Unknown(body.to_string())
+                           Err(_) => PurchaseReservedDBInstancesOfferingError::Unknown(format!("{}:{}", body.to_string(), status))
                        }
     }
 
@@ -25680,7 +25818,7 @@ pub enum RebootDBInstanceError {
 }
 
 impl RebootDBInstanceError {
-    pub fn from_body(body: &str) -> RebootDBInstanceError {
+    pub fn from_body(body: &str, status: u16) -> RebootDBInstanceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -25694,7 +25832,7 @@ impl RebootDBInstanceError {
                 ),
                 _ => RebootDBInstanceError::Unknown(String::from(body)),
             },
-            Err(_) => RebootDBInstanceError::Unknown(body.to_string()),
+            Err(_) => RebootDBInstanceError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -25765,7 +25903,7 @@ pub enum RemoveRoleFromDBClusterError {
 }
 
 impl RemoveRoleFromDBClusterError {
-    pub fn from_body(body: &str) -> RemoveRoleFromDBClusterError {
+    pub fn from_body(body: &str, status: u16) -> RemoveRoleFromDBClusterError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -25786,7 +25924,9 @@ impl RemoveRoleFromDBClusterError {
                 }
                 _ => RemoveRoleFromDBClusterError::Unknown(String::from(body)),
             },
-            Err(_) => RemoveRoleFromDBClusterError::Unknown(body.to_string()),
+            Err(_) => {
+                RemoveRoleFromDBClusterError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -25858,7 +25998,7 @@ pub enum RemoveSourceIdentifierFromSubscriptionError {
 }
 
 impl RemoveSourceIdentifierFromSubscriptionError {
-    pub fn from_body(body: &str) -> RemoveSourceIdentifierFromSubscriptionError {
+    pub fn from_body(body: &str, status: u16) -> RemoveSourceIdentifierFromSubscriptionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -25876,7 +26016,11 @@ impl RemoveSourceIdentifierFromSubscriptionError {
                 }
                 _ => RemoveSourceIdentifierFromSubscriptionError::Unknown(String::from(body)),
             },
-            Err(_) => RemoveSourceIdentifierFromSubscriptionError::Unknown(body.to_string()),
+            Err(_) => RemoveSourceIdentifierFromSubscriptionError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -25951,7 +26095,7 @@ pub enum RemoveTagsFromResourceError {
 }
 
 impl RemoveTagsFromResourceError {
-    pub fn from_body(body: &str) -> RemoveTagsFromResourceError {
+    pub fn from_body(body: &str, status: u16) -> RemoveTagsFromResourceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -25968,7 +26112,9 @@ impl RemoveTagsFromResourceError {
                 ),
                 _ => RemoveTagsFromResourceError::Unknown(String::from(body)),
             },
-            Err(_) => RemoveTagsFromResourceError::Unknown(body.to_string()),
+            Err(_) => {
+                RemoveTagsFromResourceError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -26040,7 +26186,7 @@ pub enum ResetDBClusterParameterGroupError {
 }
 
 impl ResetDBClusterParameterGroupError {
-    pub fn from_body(body: &str) -> ResetDBClusterParameterGroupError {
+    pub fn from_body(body: &str, status: u16) -> ResetDBClusterParameterGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -26058,7 +26204,11 @@ impl ResetDBClusterParameterGroupError {
                 }
                 _ => ResetDBClusterParameterGroupError::Unknown(String::from(body)),
             },
-            Err(_) => ResetDBClusterParameterGroupError::Unknown(body.to_string()),
+            Err(_) => ResetDBClusterParameterGroupError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -26131,7 +26281,7 @@ pub enum ResetDBParameterGroupError {
 }
 
 impl ResetDBParameterGroupError {
-    pub fn from_body(body: &str) -> ResetDBParameterGroupError {
+    pub fn from_body(body: &str, status: u16) -> ResetDBParameterGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -26149,7 +26299,9 @@ impl ResetDBParameterGroupError {
                 }
                 _ => ResetDBParameterGroupError::Unknown(String::from(body)),
             },
-            Err(_) => ResetDBParameterGroupError::Unknown(body.to_string()),
+            Err(_) => {
+                ResetDBParameterGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -26242,7 +26394,7 @@ pub enum RestoreDBClusterFromS3Error {
 }
 
 impl RestoreDBClusterFromS3Error {
-    pub fn from_body(body: &str) -> RestoreDBClusterFromS3Error {
+    pub fn from_body(body: &str, status: u16) -> RestoreDBClusterFromS3Error {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -26307,7 +26459,9 @@ impl RestoreDBClusterFromS3Error {
                 ),
                 _ => RestoreDBClusterFromS3Error::Unknown(String::from(body)),
             },
-            Err(_) => RestoreDBClusterFromS3Error::Unknown(body.to_string()),
+            Err(_) => {
+                RestoreDBClusterFromS3Error::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -26419,7 +26573,7 @@ pub enum RestoreDBClusterFromSnapshotError {
 }
 
 impl RestoreDBClusterFromSnapshotError {
-    pub fn from_body(body: &str) -> RestoreDBClusterFromSnapshotError {
+    pub fn from_body(body: &str, status: u16) -> RestoreDBClusterFromSnapshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -26501,7 +26655,11 @@ impl RestoreDBClusterFromSnapshotError {
                 }
                 _ => RestoreDBClusterFromSnapshotError::Unknown(String::from(body)),
             },
-            Err(_) => RestoreDBClusterFromSnapshotError::Unknown(body.to_string()),
+            Err(_) => RestoreDBClusterFromSnapshotError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -26624,7 +26782,7 @@ pub enum RestoreDBClusterToPointInTimeError {
 }
 
 impl RestoreDBClusterToPointInTimeError {
-    pub fn from_body(body: &str) -> RestoreDBClusterToPointInTimeError {
+    pub fn from_body(body: &str, status: u16) -> RestoreDBClusterToPointInTimeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -26713,7 +26871,11 @@ impl RestoreDBClusterToPointInTimeError {
                 }
                 _ => RestoreDBClusterToPointInTimeError::Unknown(String::from(body)),
             },
-            Err(_) => RestoreDBClusterToPointInTimeError::Unknown(body.to_string()),
+            Err(_) => RestoreDBClusterToPointInTimeError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -26841,7 +27003,7 @@ pub enum RestoreDBInstanceFromDBSnapshotError {
 }
 
 impl RestoreDBInstanceFromDBSnapshotError {
-    pub fn from_body(body: &str) -> RestoreDBInstanceFromDBSnapshotError {
+    pub fn from_body(body: &str, status: u16) -> RestoreDBInstanceFromDBSnapshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -26938,7 +27100,11 @@ impl RestoreDBInstanceFromDBSnapshotError {
                 }
                 _ => RestoreDBInstanceFromDBSnapshotError::Unknown(String::from(body)),
             },
-            Err(_) => RestoreDBInstanceFromDBSnapshotError::Unknown(body.to_string()),
+            Err(_) => RestoreDBInstanceFromDBSnapshotError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -27060,7 +27226,7 @@ pub enum RestoreDBInstanceFromS3Error {
 }
 
 impl RestoreDBInstanceFromS3Error {
-    pub fn from_body(body: &str) -> RestoreDBInstanceFromS3Error {
+    pub fn from_body(body: &str, status: u16) -> RestoreDBInstanceFromS3Error {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -27142,7 +27308,9 @@ impl RestoreDBInstanceFromS3Error {
                 }
                 _ => RestoreDBInstanceFromS3Error::Unknown(String::from(body)),
             },
-            Err(_) => RestoreDBInstanceFromS3Error::Unknown(body.to_string()),
+            Err(_) => {
+                RestoreDBInstanceFromS3Error::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -27263,7 +27431,7 @@ pub enum RestoreDBInstanceToPointInTimeError {
 }
 
 impl RestoreDBInstanceToPointInTimeError {
-    pub fn from_body(body: &str) -> RestoreDBInstanceToPointInTimeError {
+    pub fn from_body(body: &str, status: u16) -> RestoreDBInstanceToPointInTimeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -27365,7 +27533,11 @@ impl RestoreDBInstanceToPointInTimeError {
                 }
                 _ => RestoreDBInstanceToPointInTimeError::Unknown(String::from(body)),
             },
-            Err(_) => RestoreDBInstanceToPointInTimeError::Unknown(body.to_string()),
+            Err(_) => RestoreDBInstanceToPointInTimeError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -27464,7 +27636,7 @@ pub enum RevokeDBSecurityGroupIngressError {
 }
 
 impl RevokeDBSecurityGroupIngressError {
-    pub fn from_body(body: &str) -> RevokeDBSecurityGroupIngressError {
+    pub fn from_body(body: &str, status: u16) -> RevokeDBSecurityGroupIngressError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -27487,7 +27659,11 @@ impl RevokeDBSecurityGroupIngressError {
                 }
                 _ => RevokeDBSecurityGroupIngressError::Unknown(String::from(body)),
             },
-            Err(_) => RevokeDBSecurityGroupIngressError::Unknown(body.to_string()),
+            Err(_) => RevokeDBSecurityGroupIngressError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -27577,7 +27753,7 @@ pub enum StartDBInstanceError {
 }
 
 impl StartDBInstanceError {
-    pub fn from_body(body: &str) -> StartDBInstanceError {
+    pub fn from_body(body: &str, status: u16) -> StartDBInstanceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -27622,7 +27798,7 @@ impl StartDBInstanceError {
                 ),
                 _ => StartDBInstanceError::Unknown(String::from(body)),
             },
-            Err(_) => StartDBInstanceError::Unknown(body.to_string()),
+            Err(_) => StartDBInstanceError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -27706,7 +27882,7 @@ pub enum StopDBInstanceError {
 }
 
 impl StopDBInstanceError {
-    pub fn from_body(body: &str) -> StopDBInstanceError {
+    pub fn from_body(body: &str, status: u16) -> StopDBInstanceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -27729,7 +27905,7 @@ impl StopDBInstanceError {
                 ),
                 _ => StopDBInstanceError::Unknown(String::from(body)),
             },
-            Err(_) => StopDBInstanceError::Unknown(body.to_string()),
+            Err(_) => StopDBInstanceError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 

--- a/rusoto/services/rds/src/generated.rs
+++ b/rusoto/services/rds/src/generated.rs
@@ -18366,7 +18366,13 @@ impl AddRoleToDBClusterError {
                 }
                 _ => AddRoleToDBClusterError::Unknown(String::from(body)),
             },
-            Err(_) => AddRoleToDBClusterError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    AddRoleToDBClusterError::Unknown(format!("{}", status))
+                } else {
+                    AddRoleToDBClusterError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -18455,11 +18461,17 @@ impl AddSourceIdentifierToSubscriptionError {
                 }
                 _ => AddSourceIdentifierToSubscriptionError::Unknown(String::from(body)),
             },
-            Err(_) => AddSourceIdentifierToSubscriptionError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    AddSourceIdentifierToSubscriptionError::Unknown(format!("{}", status))
+                } else {
+                    AddSourceIdentifierToSubscriptionError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -18549,7 +18561,13 @@ impl AddTagsToResourceError {
                 ),
                 _ => AddTagsToResourceError::Unknown(String::from(body)),
             },
-            Err(_) => AddTagsToResourceError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    AddTagsToResourceError::Unknown(format!("{}", status))
+                } else {
+                    AddTagsToResourceError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -18632,11 +18650,17 @@ impl ApplyPendingMaintenanceActionError {
                 }
                 _ => ApplyPendingMaintenanceActionError::Unknown(String::from(body)),
             },
-            Err(_) => ApplyPendingMaintenanceActionError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    ApplyPendingMaintenanceActionError::Unknown(format!("{}", status))
+                } else {
+                    ApplyPendingMaintenanceActionError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -18738,11 +18762,17 @@ impl AuthorizeDBSecurityGroupIngressError {
                 }
                 _ => AuthorizeDBSecurityGroupIngressError::Unknown(String::from(body)),
             },
-            Err(_) => AuthorizeDBSecurityGroupIngressError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    AuthorizeDBSecurityGroupIngressError::Unknown(format!("{}", status))
+                } else {
+                    AuthorizeDBSecurityGroupIngressError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -18837,7 +18867,13 @@ impl BacktrackDBClusterError {
                 }
                 _ => BacktrackDBClusterError::Unknown(String::from(body)),
             },
-            Err(_) => BacktrackDBClusterError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    BacktrackDBClusterError::Unknown(format!("{}", status))
+                } else {
+                    BacktrackDBClusterError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -18933,11 +18969,17 @@ impl CopyDBClusterParameterGroupError {
                 }
                 _ => CopyDBClusterParameterGroupError::Unknown(String::from(body)),
             },
-            Err(_) => CopyDBClusterParameterGroupError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    CopyDBClusterParameterGroupError::Unknown(format!("{}", status))
+                } else {
+                    CopyDBClusterParameterGroupError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -19056,7 +19098,11 @@ impl CopyDBClusterSnapshotError {
                 _ => CopyDBClusterSnapshotError::Unknown(String::from(body)),
             },
             Err(_) => {
-                CopyDBClusterSnapshotError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    CopyDBClusterSnapshotError::Unknown(format!("{}", status))
+                } else {
+                    CopyDBClusterSnapshotError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -19158,7 +19204,11 @@ impl CopyDBParameterGroupError {
                 _ => CopyDBParameterGroupError::Unknown(String::from(body)),
             },
             Err(_) => {
-                CopyDBParameterGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    CopyDBParameterGroupError::Unknown(format!("{}", status))
+                } else {
+                    CopyDBParameterGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -19260,7 +19310,13 @@ impl CopyDBSnapshotError {
                 ),
                 _ => CopyDBSnapshotError::Unknown(String::from(body)),
             },
-            Err(_) => CopyDBSnapshotError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CopyDBSnapshotError::Unknown(format!("{}", status))
+                } else {
+                    CopyDBSnapshotError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -19355,7 +19411,13 @@ impl CopyOptionGroupError {
                 }
                 _ => CopyOptionGroupError::Unknown(String::from(body)),
             },
-            Err(_) => CopyOptionGroupError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CopyOptionGroupError::Unknown(format!("{}", status))
+                } else {
+                    CopyOptionGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -19512,7 +19574,13 @@ impl CreateDBClusterError {
                 ),
                 _ => CreateDBClusterError::Unknown(String::from(body)),
             },
-            Err(_) => CreateDBClusterError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateDBClusterError::Unknown(format!("{}", status))
+                } else {
+                    CreateDBClusterError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -19612,11 +19680,17 @@ impl CreateDBClusterParameterGroupError {
                 }
                 _ => CreateDBClusterParameterGroupError::Unknown(String::from(body)),
             },
-            Err(_) => CreateDBClusterParameterGroupError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateDBClusterParameterGroupError::Unknown(format!("{}", status))
+                } else {
+                    CreateDBClusterParameterGroupError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -19729,7 +19803,15 @@ impl CreateDBClusterSnapshotError {
                 _ => CreateDBClusterSnapshotError::Unknown(String::from(body)),
             },
             Err(_) => {
-                CreateDBClusterSnapshotError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    CreateDBClusterSnapshotError::Unknown(format!("{}", status))
+                } else {
+                    CreateDBClusterSnapshotError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -19906,7 +19988,13 @@ impl CreateDBInstanceError {
                 ),
                 _ => CreateDBInstanceError::Unknown(String::from(body)),
             },
-            Err(_) => CreateDBInstanceError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateDBInstanceError::Unknown(format!("{}", status))
+                } else {
+                    CreateDBInstanceError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -20117,11 +20205,17 @@ impl CreateDBInstanceReadReplicaError {
                 }
                 _ => CreateDBInstanceReadReplicaError::Unknown(String::from(body)),
             },
-            Err(_) => CreateDBInstanceReadReplicaError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateDBInstanceReadReplicaError::Unknown(format!("{}", status))
+                } else {
+                    CreateDBInstanceReadReplicaError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -20233,7 +20327,11 @@ impl CreateDBParameterGroupError {
                 _ => CreateDBParameterGroupError::Unknown(String::from(body)),
             },
             Err(_) => {
-                CreateDBParameterGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    CreateDBParameterGroupError::Unknown(format!("{}", status))
+                } else {
+                    CreateDBParameterGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -20331,7 +20429,11 @@ impl CreateDBSecurityGroupError {
                 _ => CreateDBSecurityGroupError::Unknown(String::from(body)),
             },
             Err(_) => {
-                CreateDBSecurityGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    CreateDBSecurityGroupError::Unknown(format!("{}", status))
+                } else {
+                    CreateDBSecurityGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -20428,7 +20530,13 @@ impl CreateDBSnapshotError {
                 ),
                 _ => CreateDBSnapshotError::Unknown(String::from(body)),
             },
-            Err(_) => CreateDBSnapshotError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateDBSnapshotError::Unknown(format!("{}", status))
+                } else {
+                    CreateDBSnapshotError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -20536,7 +20644,13 @@ impl CreateDBSubnetGroupError {
                 }
                 _ => CreateDBSubnetGroupError::Unknown(String::from(body)),
             },
-            Err(_) => CreateDBSubnetGroupError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateDBSubnetGroupError::Unknown(format!("{}", status))
+                } else {
+                    CreateDBSubnetGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -20656,7 +20770,15 @@ impl CreateEventSubscriptionError {
                 _ => CreateEventSubscriptionError::Unknown(String::from(body)),
             },
             Err(_) => {
-                CreateEventSubscriptionError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    CreateEventSubscriptionError::Unknown(format!("{}", status))
+                } else {
+                    CreateEventSubscriptionError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -20751,7 +20873,13 @@ impl CreateOptionGroupError {
                 }
                 _ => CreateOptionGroupError::Unknown(String::from(body)),
             },
-            Err(_) => CreateOptionGroupError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateOptionGroupError::Unknown(format!("{}", status))
+                } else {
+                    CreateOptionGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -20855,7 +20983,13 @@ impl DeleteDBClusterError {
                 ),
                 _ => DeleteDBClusterError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteDBClusterError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteDBClusterError::Unknown(format!("{}", status))
+                } else {
+                    DeleteDBClusterError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -20945,11 +21079,17 @@ impl DeleteDBClusterParameterGroupError {
                 }
                 _ => DeleteDBClusterParameterGroupError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteDBClusterParameterGroupError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteDBClusterParameterGroupError::Unknown(format!("{}", status))
+                } else {
+                    DeleteDBClusterParameterGroupError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -21041,7 +21181,15 @@ impl DeleteDBClusterSnapshotError {
                 _ => DeleteDBClusterSnapshotError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DeleteDBClusterSnapshotError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DeleteDBClusterSnapshotError::Unknown(format!("{}", status))
+                } else {
+                    DeleteDBClusterSnapshotError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -21142,7 +21290,13 @@ impl DeleteDBInstanceError {
                 ),
                 _ => DeleteDBInstanceError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteDBInstanceError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteDBInstanceError::Unknown(format!("{}", status))
+                } else {
+                    DeleteDBInstanceError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -21233,7 +21387,11 @@ impl DeleteDBParameterGroupError {
                 _ => DeleteDBParameterGroupError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DeleteDBParameterGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DeleteDBParameterGroupError::Unknown(format!("{}", status))
+                } else {
+                    DeleteDBParameterGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -21324,7 +21482,11 @@ impl DeleteDBSecurityGroupError {
                 _ => DeleteDBSecurityGroupError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DeleteDBSecurityGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DeleteDBSecurityGroupError::Unknown(format!("{}", status))
+                } else {
+                    DeleteDBSecurityGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -21410,7 +21572,13 @@ impl DeleteDBSnapshotError {
                 ),
                 _ => DeleteDBSnapshotError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteDBSnapshotError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteDBSnapshotError::Unknown(format!("{}", status))
+                } else {
+                    DeleteDBSnapshotError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -21502,7 +21670,13 @@ impl DeleteDBSubnetGroupError {
                 ),
                 _ => DeleteDBSubnetGroupError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteDBSubnetGroupError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteDBSubnetGroupError::Unknown(format!("{}", status))
+                } else {
+                    DeleteDBSubnetGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -21591,7 +21765,15 @@ impl DeleteEventSubscriptionError {
                 _ => DeleteEventSubscriptionError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DeleteEventSubscriptionError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DeleteEventSubscriptionError::Unknown(format!("{}", status))
+                } else {
+                    DeleteEventSubscriptionError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -21679,7 +21861,13 @@ impl DeleteOptionGroupError {
                 ),
                 _ => DeleteOptionGroupError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteOptionGroupError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteOptionGroupError::Unknown(format!("{}", status))
+                } else {
+                    DeleteOptionGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -21755,7 +21943,15 @@ impl DescribeAccountAttributesError {
                 _ => DescribeAccountAttributesError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeAccountAttributesError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeAccountAttributesError::Unknown(format!("{}", status))
+                } else {
+                    DescribeAccountAttributesError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -21835,7 +22031,11 @@ impl DescribeCertificatesError {
                 _ => DescribeCertificatesError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeCertificatesError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeCertificatesError::Unknown(format!("{}", status))
+                } else {
+                    DescribeCertificatesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -21924,11 +22124,17 @@ impl DescribeDBClusterBacktracksError {
                 }
                 _ => DescribeDBClusterBacktracksError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeDBClusterBacktracksError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeDBClusterBacktracksError::Unknown(format!("{}", status))
+                } else {
+                    DescribeDBClusterBacktracksError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -22010,11 +22216,17 @@ impl DescribeDBClusterParameterGroupsError {
                 }
                 _ => DescribeDBClusterParameterGroupsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeDBClusterParameterGroupsError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeDBClusterParameterGroupsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeDBClusterParameterGroupsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -22097,11 +22309,17 @@ impl DescribeDBClusterParametersError {
                 }
                 _ => DescribeDBClusterParametersError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeDBClusterParametersError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeDBClusterParametersError::Unknown(format!("{}", status))
+                } else {
+                    DescribeDBClusterParametersError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -22182,11 +22400,17 @@ impl DescribeDBClusterSnapshotAttributesError {
                 }
                 _ => DescribeDBClusterSnapshotAttributesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeDBClusterSnapshotAttributesError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeDBClusterSnapshotAttributesError::Unknown(format!("{}", status))
+                } else {
+                    DescribeDBClusterSnapshotAttributesError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -22270,7 +22494,15 @@ impl DescribeDBClusterSnapshotsError {
                 _ => DescribeDBClusterSnapshotsError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeDBClusterSnapshotsError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeDBClusterSnapshotsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeDBClusterSnapshotsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -22350,7 +22582,13 @@ impl DescribeDBClustersError {
                 ),
                 _ => DescribeDBClustersError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeDBClustersError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeDBClustersError::Unknown(format!("{}", status))
+                } else {
+                    DescribeDBClustersError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -22425,7 +22663,15 @@ impl DescribeDBEngineVersionsError {
                 _ => DescribeDBEngineVersionsError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeDBEngineVersionsError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeDBEngineVersionsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeDBEngineVersionsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -22504,7 +22750,13 @@ impl DescribeDBInstancesError {
                 ),
                 _ => DescribeDBInstancesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeDBInstancesError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeDBInstancesError::Unknown(format!("{}", status))
+                } else {
+                    DescribeDBInstancesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -22583,7 +22835,13 @@ impl DescribeDBLogFilesError {
                 ),
                 _ => DescribeDBLogFilesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeDBLogFilesError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeDBLogFilesError::Unknown(format!("{}", status))
+                } else {
+                    DescribeDBLogFilesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -22665,7 +22923,15 @@ impl DescribeDBParameterGroupsError {
                 _ => DescribeDBParameterGroupsError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeDBParameterGroupsError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeDBParameterGroupsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeDBParameterGroupsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -22748,7 +23014,11 @@ impl DescribeDBParametersError {
                 _ => DescribeDBParametersError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeDBParametersError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeDBParametersError::Unknown(format!("{}", status))
+                } else {
+                    DescribeDBParametersError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -22831,7 +23101,15 @@ impl DescribeDBSecurityGroupsError {
                 _ => DescribeDBSecurityGroupsError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeDBSecurityGroupsError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeDBSecurityGroupsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeDBSecurityGroupsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -22911,11 +23189,17 @@ impl DescribeDBSnapshotAttributesError {
                 ),
                 _ => DescribeDBSnapshotAttributesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeDBSnapshotAttributesError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeDBSnapshotAttributesError::Unknown(format!("{}", status))
+                } else {
+                    DescribeDBSnapshotAttributesError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -22994,7 +23278,13 @@ impl DescribeDBSnapshotsError {
                 ),
                 _ => DescribeDBSnapshotsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeDBSnapshotsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeDBSnapshotsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeDBSnapshotsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -23076,7 +23366,11 @@ impl DescribeDBSubnetGroupsError {
                 _ => DescribeDBSubnetGroupsError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeDBSubnetGroupsError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeDBSubnetGroupsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeDBSubnetGroupsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -23151,11 +23445,17 @@ impl DescribeEngineDefaultClusterParametersError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeEngineDefaultClusterParametersError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeEngineDefaultClusterParametersError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeEngineDefaultClusterParametersError::Unknown(format!("{}", status))
+                } else {
+                    DescribeEngineDefaultClusterParametersError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -23228,11 +23528,17 @@ impl DescribeEngineDefaultParametersError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeEngineDefaultParametersError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeEngineDefaultParametersError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeEngineDefaultParametersError::Unknown(format!("{}", status))
+                } else {
+                    DescribeEngineDefaultParametersError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -23306,7 +23612,15 @@ impl DescribeEventCategoriesError {
                 _ => DescribeEventCategoriesError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeEventCategoriesError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeEventCategoriesError::Unknown(format!("{}", status))
+                } else {
+                    DescribeEventCategoriesError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -23388,7 +23702,15 @@ impl DescribeEventSubscriptionsError {
                 _ => DescribeEventSubscriptionsError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeEventSubscriptionsError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeEventSubscriptionsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeEventSubscriptionsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -23463,7 +23785,13 @@ impl DescribeEventsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeEventsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeEventsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeEventsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeEventsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -23535,7 +23863,15 @@ impl DescribeOptionGroupOptionsError {
                 _ => DescribeOptionGroupOptionsError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeOptionGroupOptionsError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeOptionGroupOptionsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeOptionGroupOptionsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -23615,7 +23951,11 @@ impl DescribeOptionGroupsError {
                 _ => DescribeOptionGroupsError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeOptionGroupsError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeOptionGroupsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeOptionGroupsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -23690,11 +24030,17 @@ impl DescribeOrderableDBInstanceOptionsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeOrderableDBInstanceOptionsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeOrderableDBInstanceOptionsError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeOrderableDBInstanceOptionsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeOrderableDBInstanceOptionsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -23774,11 +24120,17 @@ impl DescribePendingMaintenanceActionsError {
                 }
                 _ => DescribePendingMaintenanceActionsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribePendingMaintenanceActionsError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribePendingMaintenanceActionsError::Unknown(format!("{}", status))
+                } else {
+                    DescribePendingMaintenanceActionsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -23859,11 +24211,17 @@ impl DescribeReservedDBInstancesError {
                 }
                 _ => DescribeReservedDBInstancesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeReservedDBInstancesError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeReservedDBInstancesError::Unknown(format!("{}", status))
+                } else {
+                    DescribeReservedDBInstancesError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -23941,7 +24299,13 @@ impl DescribeReservedDBInstancesOfferingsError {
                                     "ReservedDBInstancesOfferingNotFound" => DescribeReservedDBInstancesOfferingsError::ReservedDBInstancesOfferingNotFoundFault(String::from(parsed_error.message)),_ => DescribeReservedDBInstancesOfferingsError::Unknown(String::from(body))
                                 }
                            },
-                           Err(_) => DescribeReservedDBInstancesOfferingsError::Unknown(format!("{}:{}", body.to_string(), status))
+                           Err(_) => {
+                               if body.len() == 0 {
+                                   DescribeReservedDBInstancesOfferingsError::Unknown(format!("{}", status))
+                               } else {
+                                   DescribeReservedDBInstancesOfferingsError::Unknown(format!("{}:{}", body.to_string(), status))
+                               }
+                            }
                        }
     }
 
@@ -24018,7 +24382,11 @@ impl DescribeSourceRegionsError {
                 _ => DescribeSourceRegionsError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeSourceRegionsError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeSourceRegionsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeSourceRegionsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -24106,11 +24474,17 @@ impl DescribeValidDBInstanceModificationsError {
                 }
                 _ => DescribeValidDBInstanceModificationsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeValidDBInstanceModificationsError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeValidDBInstanceModificationsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeValidDBInstanceModificationsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -24198,7 +24572,15 @@ impl DownloadDBLogFilePortionError {
                 _ => DownloadDBLogFilePortionError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DownloadDBLogFilePortionError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DownloadDBLogFilePortionError::Unknown(format!("{}", status))
+                } else {
+                    DownloadDBLogFilePortionError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -24289,7 +24671,13 @@ impl FailoverDBClusterError {
                 ),
                 _ => FailoverDBClusterError::Unknown(String::from(body)),
             },
-            Err(_) => FailoverDBClusterError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    FailoverDBClusterError::Unknown(format!("{}", status))
+                } else {
+                    FailoverDBClusterError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -24380,7 +24768,13 @@ impl ListTagsForResourceError {
                 ),
                 _ => ListTagsForResourceError::Unknown(String::from(body)),
             },
-            Err(_) => ListTagsForResourceError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ListTagsForResourceError::Unknown(format!("{}", status))
+                } else {
+                    ListTagsForResourceError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -24517,7 +24911,13 @@ impl ModifyDBClusterError {
                 ),
                 _ => ModifyDBClusterError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyDBClusterError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ModifyDBClusterError::Unknown(format!("{}", status))
+                } else {
+                    ModifyDBClusterError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -24613,11 +25013,17 @@ impl ModifyDBClusterParameterGroupError {
                 }
                 _ => ModifyDBClusterParameterGroupError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyDBClusterParameterGroupError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    ModifyDBClusterParameterGroupError::Unknown(format!("{}", status))
+                } else {
+                    ModifyDBClusterParameterGroupError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -24715,11 +25121,17 @@ impl ModifyDBClusterSnapshotAttributeError {
                 }
                 _ => ModifyDBClusterSnapshotAttributeError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyDBClusterSnapshotAttributeError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    ModifyDBClusterSnapshotAttributeError::Unknown(format!("{}", status))
+                } else {
+                    ModifyDBClusterSnapshotAttributeError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -24891,7 +25303,13 @@ impl ModifyDBInstanceError {
                 ),
                 _ => ModifyDBInstanceError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyDBInstanceError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ModifyDBInstanceError::Unknown(format!("{}", status))
+                } else {
+                    ModifyDBInstanceError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -24993,7 +25411,11 @@ impl ModifyDBParameterGroupError {
                 _ => ModifyDBParameterGroupError::Unknown(String::from(body)),
             },
             Err(_) => {
-                ModifyDBParameterGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    ModifyDBParameterGroupError::Unknown(format!("{}", status))
+                } else {
+                    ModifyDBParameterGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -25074,7 +25496,13 @@ impl ModifyDBSnapshotError {
                 ),
                 _ => ModifyDBSnapshotError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyDBSnapshotError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ModifyDBSnapshotError::Unknown(format!("{}", status))
+                } else {
+                    ModifyDBSnapshotError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -25166,7 +25594,15 @@ impl ModifyDBSnapshotAttributeError {
                 _ => ModifyDBSnapshotAttributeError::Unknown(String::from(body)),
             },
             Err(_) => {
-                ModifyDBSnapshotAttributeError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    ModifyDBSnapshotAttributeError::Unknown(format!("{}", status))
+                } else {
+                    ModifyDBSnapshotAttributeError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -25274,7 +25710,13 @@ impl ModifyDBSubnetGroupError {
                 }
                 _ => ModifyDBSubnetGroupError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyDBSubnetGroupError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ModifyDBSubnetGroupError::Unknown(format!("{}", status))
+                } else {
+                    ModifyDBSubnetGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -25387,7 +25829,15 @@ impl ModifyEventSubscriptionError {
                 _ => ModifyEventSubscriptionError::Unknown(String::from(body)),
             },
             Err(_) => {
-                ModifyEventSubscriptionError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    ModifyEventSubscriptionError::Unknown(format!("{}", status))
+                } else {
+                    ModifyEventSubscriptionError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -25479,7 +25929,13 @@ impl ModifyOptionGroupError {
                 ),
                 _ => ModifyOptionGroupError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyOptionGroupError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ModifyOptionGroupError::Unknown(format!("{}", status))
+                } else {
+                    ModifyOptionGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -25564,7 +26020,13 @@ impl PromoteReadReplicaError {
                 ),
                 _ => PromoteReadReplicaError::Unknown(String::from(body)),
             },
-            Err(_) => PromoteReadReplicaError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    PromoteReadReplicaError::Unknown(format!("{}", status))
+                } else {
+                    PromoteReadReplicaError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -25653,11 +26115,17 @@ impl PromoteReadReplicaDBClusterError {
                 }
                 _ => PromoteReadReplicaDBClusterError::Unknown(String::from(body)),
             },
-            Err(_) => PromoteReadReplicaDBClusterError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    PromoteReadReplicaDBClusterError::Unknown(format!("{}", status))
+                } else {
+                    PromoteReadReplicaDBClusterError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -25740,7 +26208,13 @@ impl PurchaseReservedDBInstancesOfferingError {
                                     "ReservedDBInstanceAlreadyExists" => PurchaseReservedDBInstancesOfferingError::ReservedDBInstanceAlreadyExistsFault(String::from(parsed_error.message)),"ReservedDBInstanceQuotaExceeded" => PurchaseReservedDBInstancesOfferingError::ReservedDBInstanceQuotaExceededFault(String::from(parsed_error.message)),"ReservedDBInstancesOfferingNotFound" => PurchaseReservedDBInstancesOfferingError::ReservedDBInstancesOfferingNotFoundFault(String::from(parsed_error.message)),_ => PurchaseReservedDBInstancesOfferingError::Unknown(String::from(body))
                                 }
                            },
-                           Err(_) => PurchaseReservedDBInstancesOfferingError::Unknown(format!("{}:{}", body.to_string(), status))
+                           Err(_) => {
+                               if body.len() == 0 {
+                                   PurchaseReservedDBInstancesOfferingError::Unknown(format!("{}", status))
+                               } else {
+                                   PurchaseReservedDBInstancesOfferingError::Unknown(format!("{}:{}", body.to_string(), status))
+                               }
+                            }
                        }
     }
 
@@ -25832,7 +26306,13 @@ impl RebootDBInstanceError {
                 ),
                 _ => RebootDBInstanceError::Unknown(String::from(body)),
             },
-            Err(_) => RebootDBInstanceError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    RebootDBInstanceError::Unknown(format!("{}", status))
+                } else {
+                    RebootDBInstanceError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -25925,7 +26405,15 @@ impl RemoveRoleFromDBClusterError {
                 _ => RemoveRoleFromDBClusterError::Unknown(String::from(body)),
             },
             Err(_) => {
-                RemoveRoleFromDBClusterError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    RemoveRoleFromDBClusterError::Unknown(format!("{}", status))
+                } else {
+                    RemoveRoleFromDBClusterError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -26016,11 +26504,17 @@ impl RemoveSourceIdentifierFromSubscriptionError {
                 }
                 _ => RemoveSourceIdentifierFromSubscriptionError::Unknown(String::from(body)),
             },
-            Err(_) => RemoveSourceIdentifierFromSubscriptionError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    RemoveSourceIdentifierFromSubscriptionError::Unknown(format!("{}", status))
+                } else {
+                    RemoveSourceIdentifierFromSubscriptionError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -26113,7 +26607,11 @@ impl RemoveTagsFromResourceError {
                 _ => RemoveTagsFromResourceError::Unknown(String::from(body)),
             },
             Err(_) => {
-                RemoveTagsFromResourceError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    RemoveTagsFromResourceError::Unknown(format!("{}", status))
+                } else {
+                    RemoveTagsFromResourceError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -26204,11 +26702,17 @@ impl ResetDBClusterParameterGroupError {
                 }
                 _ => ResetDBClusterParameterGroupError::Unknown(String::from(body)),
             },
-            Err(_) => ResetDBClusterParameterGroupError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    ResetDBClusterParameterGroupError::Unknown(format!("{}", status))
+                } else {
+                    ResetDBClusterParameterGroupError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -26300,7 +26804,11 @@ impl ResetDBParameterGroupError {
                 _ => ResetDBParameterGroupError::Unknown(String::from(body)),
             },
             Err(_) => {
-                ResetDBParameterGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    ResetDBParameterGroupError::Unknown(format!("{}", status))
+                } else {
+                    ResetDBParameterGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -26460,7 +26968,11 @@ impl RestoreDBClusterFromS3Error {
                 _ => RestoreDBClusterFromS3Error::Unknown(String::from(body)),
             },
             Err(_) => {
-                RestoreDBClusterFromS3Error::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    RestoreDBClusterFromS3Error::Unknown(format!("{}", status))
+                } else {
+                    RestoreDBClusterFromS3Error::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -26655,11 +27167,17 @@ impl RestoreDBClusterFromSnapshotError {
                 }
                 _ => RestoreDBClusterFromSnapshotError::Unknown(String::from(body)),
             },
-            Err(_) => RestoreDBClusterFromSnapshotError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    RestoreDBClusterFromSnapshotError::Unknown(format!("{}", status))
+                } else {
+                    RestoreDBClusterFromSnapshotError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -26871,11 +27389,17 @@ impl RestoreDBClusterToPointInTimeError {
                 }
                 _ => RestoreDBClusterToPointInTimeError::Unknown(String::from(body)),
             },
-            Err(_) => RestoreDBClusterToPointInTimeError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    RestoreDBClusterToPointInTimeError::Unknown(format!("{}", status))
+                } else {
+                    RestoreDBClusterToPointInTimeError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -27100,11 +27624,17 @@ impl RestoreDBInstanceFromDBSnapshotError {
                 }
                 _ => RestoreDBInstanceFromDBSnapshotError::Unknown(String::from(body)),
             },
-            Err(_) => RestoreDBInstanceFromDBSnapshotError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    RestoreDBInstanceFromDBSnapshotError::Unknown(format!("{}", status))
+                } else {
+                    RestoreDBInstanceFromDBSnapshotError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -27309,7 +27839,15 @@ impl RestoreDBInstanceFromS3Error {
                 _ => RestoreDBInstanceFromS3Error::Unknown(String::from(body)),
             },
             Err(_) => {
-                RestoreDBInstanceFromS3Error::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    RestoreDBInstanceFromS3Error::Unknown(format!("{}", status))
+                } else {
+                    RestoreDBInstanceFromS3Error::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -27533,11 +28071,17 @@ impl RestoreDBInstanceToPointInTimeError {
                 }
                 _ => RestoreDBInstanceToPointInTimeError::Unknown(String::from(body)),
             },
-            Err(_) => RestoreDBInstanceToPointInTimeError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    RestoreDBInstanceToPointInTimeError::Unknown(format!("{}", status))
+                } else {
+                    RestoreDBInstanceToPointInTimeError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -27659,11 +28203,17 @@ impl RevokeDBSecurityGroupIngressError {
                 }
                 _ => RevokeDBSecurityGroupIngressError::Unknown(String::from(body)),
             },
-            Err(_) => RevokeDBSecurityGroupIngressError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    RevokeDBSecurityGroupIngressError::Unknown(format!("{}", status))
+                } else {
+                    RevokeDBSecurityGroupIngressError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -27798,7 +28348,13 @@ impl StartDBInstanceError {
                 ),
                 _ => StartDBInstanceError::Unknown(String::from(body)),
             },
-            Err(_) => StartDBInstanceError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    StartDBInstanceError::Unknown(format!("{}", status))
+                } else {
+                    StartDBInstanceError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -27905,7 +28461,13 @@ impl StopDBInstanceError {
                 ),
                 _ => StopDBInstanceError::Unknown(String::from(body)),
             },
-            Err(_) => StopDBInstanceError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    StopDBInstanceError::Unknown(format!("{}", status))
+                } else {
+                    StopDBInstanceError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 

--- a/rusoto/services/redshift/src/generated.rs
+++ b/rusoto/services/redshift/src/generated.rs
@@ -11784,7 +11784,7 @@ pub enum AcceptReservedNodeExchangeError {
 }
 
 impl AcceptReservedNodeExchangeError {
-    pub fn from_body(body: &str) -> AcceptReservedNodeExchangeError {
+    pub fn from_body(body: &str, status: u16) -> AcceptReservedNodeExchangeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11827,7 +11827,9 @@ impl AcceptReservedNodeExchangeError {
                 }
                 _ => AcceptReservedNodeExchangeError::Unknown(String::from(body)),
             },
-            Err(_) => AcceptReservedNodeExchangeError::Unknown(body.to_string()),
+            Err(_) => {
+                AcceptReservedNodeExchangeError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -11907,7 +11909,7 @@ pub enum AuthorizeClusterSecurityGroupIngressError {
 }
 
 impl AuthorizeClusterSecurityGroupIngressError {
-    pub fn from_body(body: &str) -> AuthorizeClusterSecurityGroupIngressError {
+    pub fn from_body(body: &str, status: u16) -> AuthorizeClusterSecurityGroupIngressError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11935,7 +11937,11 @@ impl AuthorizeClusterSecurityGroupIngressError {
                 }
                 _ => AuthorizeClusterSecurityGroupIngressError::Unknown(String::from(body)),
             },
-            Err(_) => AuthorizeClusterSecurityGroupIngressError::Unknown(body.to_string()),
+            Err(_) => AuthorizeClusterSecurityGroupIngressError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -12024,7 +12030,7 @@ pub enum AuthorizeSnapshotAccessError {
 }
 
 impl AuthorizeSnapshotAccessError {
-    pub fn from_body(body: &str) -> AuthorizeSnapshotAccessError {
+    pub fn from_body(body: &str, status: u16) -> AuthorizeSnapshotAccessError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -12060,7 +12066,9 @@ impl AuthorizeSnapshotAccessError {
                 ),
                 _ => AuthorizeSnapshotAccessError::Unknown(String::from(body)),
             },
-            Err(_) => AuthorizeSnapshotAccessError::Unknown(body.to_string()),
+            Err(_) => {
+                AuthorizeSnapshotAccessError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -12141,7 +12149,7 @@ pub enum CopyClusterSnapshotError {
 }
 
 impl CopyClusterSnapshotError {
-    pub fn from_body(body: &str) -> CopyClusterSnapshotError {
+    pub fn from_body(body: &str, status: u16) -> CopyClusterSnapshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -12169,7 +12177,7 @@ impl CopyClusterSnapshotError {
                 }
                 _ => CopyClusterSnapshotError::Unknown(String::from(body)),
             },
-            Err(_) => CopyClusterSnapshotError::Unknown(body.to_string()),
+            Err(_) => CopyClusterSnapshotError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -12278,7 +12286,7 @@ pub enum CreateClusterError {
 }
 
 impl CreateClusterError {
-    pub fn from_body(body: &str) -> CreateClusterError {
+    pub fn from_body(body: &str, status: u16) -> CreateClusterError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -12366,7 +12374,7 @@ impl CreateClusterError {
                 }
                 _ => CreateClusterError::Unknown(String::from(body)),
             },
-            Err(_) => CreateClusterError::Unknown(body.to_string()),
+            Err(_) => CreateClusterError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -12457,7 +12465,7 @@ pub enum CreateClusterParameterGroupError {
 }
 
 impl CreateClusterParameterGroupError {
-    pub fn from_body(body: &str) -> CreateClusterParameterGroupError {
+    pub fn from_body(body: &str, status: u16) -> CreateClusterParameterGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -12481,7 +12489,11 @@ impl CreateClusterParameterGroupError {
                 ),
                 _ => CreateClusterParameterGroupError::Unknown(String::from(body)),
             },
-            Err(_) => CreateClusterParameterGroupError::Unknown(body.to_string()),
+            Err(_) => CreateClusterParameterGroupError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -12562,7 +12574,7 @@ pub enum CreateClusterSecurityGroupError {
 }
 
 impl CreateClusterSecurityGroupError {
-    pub fn from_body(body: &str) -> CreateClusterSecurityGroupError {
+    pub fn from_body(body: &str, status: u16) -> CreateClusterSecurityGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -12586,7 +12598,9 @@ impl CreateClusterSecurityGroupError {
                 ),
                 _ => CreateClusterSecurityGroupError::Unknown(String::from(body)),
             },
-            Err(_) => CreateClusterSecurityGroupError::Unknown(body.to_string()),
+            Err(_) => {
+                CreateClusterSecurityGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -12671,7 +12685,7 @@ pub enum CreateClusterSnapshotError {
 }
 
 impl CreateClusterSnapshotError {
-    pub fn from_body(body: &str) -> CreateClusterSnapshotError {
+    pub fn from_body(body: &str, status: u16) -> CreateClusterSnapshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -12701,7 +12715,9 @@ impl CreateClusterSnapshotError {
                 ),
                 _ => CreateClusterSnapshotError::Unknown(String::from(body)),
             },
-            Err(_) => CreateClusterSnapshotError::Unknown(body.to_string()),
+            Err(_) => {
+                CreateClusterSnapshotError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -12788,7 +12804,7 @@ pub enum CreateClusterSubnetGroupError {
 }
 
 impl CreateClusterSubnetGroupError {
-    pub fn from_body(body: &str) -> CreateClusterSubnetGroupError {
+    pub fn from_body(body: &str, status: u16) -> CreateClusterSubnetGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -12828,7 +12844,9 @@ impl CreateClusterSubnetGroupError {
                 ),
                 _ => CreateClusterSubnetGroupError::Unknown(String::from(body)),
             },
-            Err(_) => CreateClusterSubnetGroupError::Unknown(body.to_string()),
+            Err(_) => {
+                CreateClusterSubnetGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -12925,7 +12943,7 @@ pub enum CreateEventSubscriptionError {
 }
 
 impl CreateEventSubscriptionError {
-    pub fn from_body(body: &str) -> CreateEventSubscriptionError {
+    pub fn from_body(body: &str, status: u16) -> CreateEventSubscriptionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -12976,7 +12994,9 @@ impl CreateEventSubscriptionError {
                 ),
                 _ => CreateEventSubscriptionError::Unknown(String::from(body)),
             },
-            Err(_) => CreateEventSubscriptionError::Unknown(body.to_string()),
+            Err(_) => {
+                CreateEventSubscriptionError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -13060,7 +13080,7 @@ pub enum CreateHsmClientCertificateError {
 }
 
 impl CreateHsmClientCertificateError {
-    pub fn from_body(body: &str) -> CreateHsmClientCertificateError {
+    pub fn from_body(body: &str, status: u16) -> CreateHsmClientCertificateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -13084,7 +13104,9 @@ impl CreateHsmClientCertificateError {
                 ),
                 _ => CreateHsmClientCertificateError::Unknown(String::from(body)),
             },
-            Err(_) => CreateHsmClientCertificateError::Unknown(body.to_string()),
+            Err(_) => {
+                CreateHsmClientCertificateError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -13165,7 +13187,7 @@ pub enum CreateHsmConfigurationError {
 }
 
 impl CreateHsmConfigurationError {
-    pub fn from_body(body: &str) -> CreateHsmConfigurationError {
+    pub fn from_body(body: &str, status: u16) -> CreateHsmConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -13189,7 +13211,9 @@ impl CreateHsmConfigurationError {
                 ),
                 _ => CreateHsmConfigurationError::Unknown(String::from(body)),
             },
-            Err(_) => CreateHsmConfigurationError::Unknown(body.to_string()),
+            Err(_) => {
+                CreateHsmConfigurationError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -13270,7 +13294,7 @@ pub enum CreateSnapshotCopyGrantError {
 }
 
 impl CreateSnapshotCopyGrantError {
-    pub fn from_body(body: &str) -> CreateSnapshotCopyGrantError {
+    pub fn from_body(body: &str, status: u16) -> CreateSnapshotCopyGrantError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -13302,7 +13326,9 @@ impl CreateSnapshotCopyGrantError {
                 ),
                 _ => CreateSnapshotCopyGrantError::Unknown(String::from(body)),
             },
-            Err(_) => CreateSnapshotCopyGrantError::Unknown(body.to_string()),
+            Err(_) => {
+                CreateSnapshotCopyGrantError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -13381,7 +13407,7 @@ pub enum CreateTagsError {
 }
 
 impl CreateTagsError {
-    pub fn from_body(body: &str) -> CreateTagsError {
+    pub fn from_body(body: &str, status: u16) -> CreateTagsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -13398,7 +13424,7 @@ impl CreateTagsError {
                 }
                 _ => CreateTagsError::Unknown(String::from(body)),
             },
-            Err(_) => CreateTagsError::Unknown(body.to_string()),
+            Err(_) => CreateTagsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -13472,7 +13498,7 @@ pub enum DeleteClusterError {
 }
 
 impl DeleteClusterError {
-    pub fn from_body(body: &str) -> DeleteClusterError {
+    pub fn from_body(body: &str, status: u16) -> DeleteClusterError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -13496,7 +13522,7 @@ impl DeleteClusterError {
                 }
                 _ => DeleteClusterError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteClusterError::Unknown(body.to_string()),
+            Err(_) => DeleteClusterError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -13567,7 +13593,7 @@ pub enum DeleteClusterParameterGroupError {
 }
 
 impl DeleteClusterParameterGroupError {
-    pub fn from_body(body: &str) -> DeleteClusterParameterGroupError {
+    pub fn from_body(body: &str, status: u16) -> DeleteClusterParameterGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -13585,7 +13611,11 @@ impl DeleteClusterParameterGroupError {
                 }
                 _ => DeleteClusterParameterGroupError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteClusterParameterGroupError::Unknown(body.to_string()),
+            Err(_) => DeleteClusterParameterGroupError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -13660,7 +13690,7 @@ pub enum DeleteClusterSecurityGroupError {
 }
 
 impl DeleteClusterSecurityGroupError {
-    pub fn from_body(body: &str) -> DeleteClusterSecurityGroupError {
+    pub fn from_body(body: &str, status: u16) -> DeleteClusterSecurityGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -13678,7 +13708,9 @@ impl DeleteClusterSecurityGroupError {
                 }
                 _ => DeleteClusterSecurityGroupError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteClusterSecurityGroupError::Unknown(body.to_string()),
+            Err(_) => {
+                DeleteClusterSecurityGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -13751,7 +13783,7 @@ pub enum DeleteClusterSnapshotError {
 }
 
 impl DeleteClusterSnapshotError {
-    pub fn from_body(body: &str) -> DeleteClusterSnapshotError {
+    pub fn from_body(body: &str, status: u16) -> DeleteClusterSnapshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -13769,7 +13801,9 @@ impl DeleteClusterSnapshotError {
                 }
                 _ => DeleteClusterSnapshotError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteClusterSnapshotError::Unknown(body.to_string()),
+            Err(_) => {
+                DeleteClusterSnapshotError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -13842,7 +13876,7 @@ pub enum DeleteClusterSubnetGroupError {
 }
 
 impl DeleteClusterSubnetGroupError {
-    pub fn from_body(body: &str) -> DeleteClusterSubnetGroupError {
+    pub fn from_body(body: &str, status: u16) -> DeleteClusterSubnetGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -13865,7 +13899,9 @@ impl DeleteClusterSubnetGroupError {
                 }
                 _ => DeleteClusterSubnetGroupError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteClusterSubnetGroupError::Unknown(body.to_string()),
+            Err(_) => {
+                DeleteClusterSubnetGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -13937,7 +13973,7 @@ pub enum DeleteEventSubscriptionError {
 }
 
 impl DeleteEventSubscriptionError {
-    pub fn from_body(body: &str) -> DeleteEventSubscriptionError {
+    pub fn from_body(body: &str, status: u16) -> DeleteEventSubscriptionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -13953,7 +13989,9 @@ impl DeleteEventSubscriptionError {
                 ),
                 _ => DeleteEventSubscriptionError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteEventSubscriptionError::Unknown(body.to_string()),
+            Err(_) => {
+                DeleteEventSubscriptionError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -14024,7 +14062,7 @@ pub enum DeleteHsmClientCertificateError {
 }
 
 impl DeleteHsmClientCertificateError {
-    pub fn from_body(body: &str) -> DeleteHsmClientCertificateError {
+    pub fn from_body(body: &str, status: u16) -> DeleteHsmClientCertificateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -14042,7 +14080,9 @@ impl DeleteHsmClientCertificateError {
                 }
                 _ => DeleteHsmClientCertificateError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteHsmClientCertificateError::Unknown(body.to_string()),
+            Err(_) => {
+                DeleteHsmClientCertificateError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -14115,7 +14155,7 @@ pub enum DeleteHsmConfigurationError {
 }
 
 impl DeleteHsmConfigurationError {
-    pub fn from_body(body: &str) -> DeleteHsmConfigurationError {
+    pub fn from_body(body: &str, status: u16) -> DeleteHsmConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -14133,7 +14173,9 @@ impl DeleteHsmConfigurationError {
                 }
                 _ => DeleteHsmConfigurationError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteHsmConfigurationError::Unknown(body.to_string()),
+            Err(_) => {
+                DeleteHsmConfigurationError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -14204,7 +14246,7 @@ pub enum DeleteSnapshotCopyGrantError {
 }
 
 impl DeleteSnapshotCopyGrantError {
-    pub fn from_body(body: &str) -> DeleteSnapshotCopyGrantError {
+    pub fn from_body(body: &str, status: u16) -> DeleteSnapshotCopyGrantError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -14222,7 +14264,9 @@ impl DeleteSnapshotCopyGrantError {
                 }
                 _ => DeleteSnapshotCopyGrantError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteSnapshotCopyGrantError::Unknown(body.to_string()),
+            Err(_) => {
+                DeleteSnapshotCopyGrantError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -14293,7 +14337,7 @@ pub enum DeleteTagsError {
 }
 
 impl DeleteTagsError {
-    pub fn from_body(body: &str) -> DeleteTagsError {
+    pub fn from_body(body: &str, status: u16) -> DeleteTagsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -14307,7 +14351,7 @@ impl DeleteTagsError {
                 }
                 _ => DeleteTagsError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteTagsError::Unknown(body.to_string()),
+            Err(_) => DeleteTagsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -14374,7 +14418,7 @@ pub enum DescribeClusterDbRevisionsError {
 }
 
 impl DescribeClusterDbRevisionsError {
-    pub fn from_body(body: &str) -> DescribeClusterDbRevisionsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeClusterDbRevisionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -14385,7 +14429,9 @@ impl DescribeClusterDbRevisionsError {
                 ),
                 _ => DescribeClusterDbRevisionsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeClusterDbRevisionsError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeClusterDbRevisionsError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -14455,7 +14501,7 @@ pub enum DescribeClusterParameterGroupsError {
 }
 
 impl DescribeClusterParameterGroupsError {
-    pub fn from_body(body: &str) -> DescribeClusterParameterGroupsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeClusterParameterGroupsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -14471,7 +14517,11 @@ impl DescribeClusterParameterGroupsError {
                 ),
                 _ => DescribeClusterParameterGroupsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeClusterParameterGroupsError::Unknown(body.to_string()),
+            Err(_) => DescribeClusterParameterGroupsError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -14542,7 +14592,7 @@ pub enum DescribeClusterParametersError {
 }
 
 impl DescribeClusterParametersError {
-    pub fn from_body(body: &str) -> DescribeClusterParametersError {
+    pub fn from_body(body: &str, status: u16) -> DescribeClusterParametersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -14555,7 +14605,9 @@ impl DescribeClusterParametersError {
                 }
                 _ => DescribeClusterParametersError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeClusterParametersError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeClusterParametersError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -14625,7 +14677,7 @@ pub enum DescribeClusterSecurityGroupsError {
 }
 
 impl DescribeClusterSecurityGroupsError {
-    pub fn from_body(body: &str) -> DescribeClusterSecurityGroupsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeClusterSecurityGroupsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -14641,7 +14693,11 @@ impl DescribeClusterSecurityGroupsError {
                 ),
                 _ => DescribeClusterSecurityGroupsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeClusterSecurityGroupsError::Unknown(body.to_string()),
+            Err(_) => DescribeClusterSecurityGroupsError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -14716,7 +14772,7 @@ pub enum DescribeClusterSnapshotsError {
 }
 
 impl DescribeClusterSnapshotsError {
-    pub fn from_body(body: &str) -> DescribeClusterSnapshotsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeClusterSnapshotsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -14735,7 +14791,9 @@ impl DescribeClusterSnapshotsError {
                 )),
                 _ => DescribeClusterSnapshotsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeClusterSnapshotsError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeClusterSnapshotsError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -14807,7 +14865,7 @@ pub enum DescribeClusterSubnetGroupsError {
 }
 
 impl DescribeClusterSubnetGroupsError {
-    pub fn from_body(body: &str) -> DescribeClusterSubnetGroupsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeClusterSubnetGroupsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -14823,7 +14881,11 @@ impl DescribeClusterSubnetGroupsError {
                 ),
                 _ => DescribeClusterSubnetGroupsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeClusterSubnetGroupsError::Unknown(body.to_string()),
+            Err(_) => DescribeClusterSubnetGroupsError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -14894,7 +14956,7 @@ pub enum DescribeClusterTracksError {
 }
 
 impl DescribeClusterTracksError {
-    pub fn from_body(body: &str) -> DescribeClusterTracksError {
+    pub fn from_body(body: &str, status: u16) -> DescribeClusterTracksError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -14908,7 +14970,9 @@ impl DescribeClusterTracksError {
                 ),
                 _ => DescribeClusterTracksError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeClusterTracksError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeClusterTracksError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -14975,7 +15039,7 @@ pub enum DescribeClusterVersionsError {
 }
 
 impl DescribeClusterVersionsError {
-    pub fn from_body(body: &str) -> DescribeClusterVersionsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeClusterVersionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -14983,7 +15047,9 @@ impl DescribeClusterVersionsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeClusterVersionsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeClusterVersionsError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeClusterVersionsError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -15052,7 +15118,7 @@ pub enum DescribeClustersError {
 }
 
 impl DescribeClustersError {
-    pub fn from_body(body: &str) -> DescribeClustersError {
+    pub fn from_body(body: &str, status: u16) -> DescribeClustersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -15066,7 +15132,7 @@ impl DescribeClustersError {
                 }
                 _ => DescribeClustersError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeClustersError::Unknown(body.to_string()),
+            Err(_) => DescribeClustersError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -15131,7 +15197,7 @@ pub enum DescribeDefaultClusterParametersError {
 }
 
 impl DescribeDefaultClusterParametersError {
-    pub fn from_body(body: &str) -> DescribeDefaultClusterParametersError {
+    pub fn from_body(body: &str, status: u16) -> DescribeDefaultClusterParametersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -15139,7 +15205,11 @@ impl DescribeDefaultClusterParametersError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeDefaultClusterParametersError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeDefaultClusterParametersError::Unknown(body.to_string()),
+            Err(_) => DescribeDefaultClusterParametersError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -15204,7 +15274,7 @@ pub enum DescribeEventCategoriesError {
 }
 
 impl DescribeEventCategoriesError {
-    pub fn from_body(body: &str) -> DescribeEventCategoriesError {
+    pub fn from_body(body: &str, status: u16) -> DescribeEventCategoriesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -15212,7 +15282,9 @@ impl DescribeEventCategoriesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeEventCategoriesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeEventCategoriesError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeEventCategoriesError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -15281,7 +15353,7 @@ pub enum DescribeEventSubscriptionsError {
 }
 
 impl DescribeEventSubscriptionsError {
-    pub fn from_body(body: &str) -> DescribeEventSubscriptionsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeEventSubscriptionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -15297,7 +15369,9 @@ impl DescribeEventSubscriptionsError {
                 }
                 _ => DescribeEventSubscriptionsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeEventSubscriptionsError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeEventSubscriptionsError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -15364,7 +15438,7 @@ pub enum DescribeEventsError {
 }
 
 impl DescribeEventsError {
-    pub fn from_body(body: &str) -> DescribeEventsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeEventsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -15372,7 +15446,7 @@ impl DescribeEventsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeEventsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeEventsError::Unknown(body.to_string()),
+            Err(_) => DescribeEventsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -15439,7 +15513,7 @@ pub enum DescribeHsmClientCertificatesError {
 }
 
 impl DescribeHsmClientCertificatesError {
-    pub fn from_body(body: &str) -> DescribeHsmClientCertificatesError {
+    pub fn from_body(body: &str, status: u16) -> DescribeHsmClientCertificatesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -15455,7 +15529,11 @@ impl DescribeHsmClientCertificatesError {
                 ),
                 _ => DescribeHsmClientCertificatesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeHsmClientCertificatesError::Unknown(body.to_string()),
+            Err(_) => DescribeHsmClientCertificatesError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -15528,7 +15606,7 @@ pub enum DescribeHsmConfigurationsError {
 }
 
 impl DescribeHsmConfigurationsError {
-    pub fn from_body(body: &str) -> DescribeHsmConfigurationsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeHsmConfigurationsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -15544,7 +15622,9 @@ impl DescribeHsmConfigurationsError {
                 )),
                 _ => DescribeHsmConfigurationsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeHsmConfigurationsError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeHsmConfigurationsError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -15613,7 +15693,7 @@ pub enum DescribeLoggingStatusError {
 }
 
 impl DescribeLoggingStatusError {
-    pub fn from_body(body: &str) -> DescribeLoggingStatusError {
+    pub fn from_body(body: &str, status: u16) -> DescribeLoggingStatusError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -15624,7 +15704,9 @@ impl DescribeLoggingStatusError {
                 ),
                 _ => DescribeLoggingStatusError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeLoggingStatusError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeLoggingStatusError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -15690,7 +15772,7 @@ pub enum DescribeOrderableClusterOptionsError {
 }
 
 impl DescribeOrderableClusterOptionsError {
-    pub fn from_body(body: &str) -> DescribeOrderableClusterOptionsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeOrderableClusterOptionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -15698,7 +15780,11 @@ impl DescribeOrderableClusterOptionsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeOrderableClusterOptionsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeOrderableClusterOptionsError::Unknown(body.to_string()),
+            Err(_) => DescribeOrderableClusterOptionsError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -15769,7 +15855,7 @@ pub enum DescribeReservedNodeOfferingsError {
 }
 
 impl DescribeReservedNodeOfferingsError {
-    pub fn from_body(body: &str) -> DescribeReservedNodeOfferingsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeReservedNodeOfferingsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -15792,7 +15878,11 @@ impl DescribeReservedNodeOfferingsError {
                 }
                 _ => DescribeReservedNodeOfferingsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeReservedNodeOfferingsError::Unknown(body.to_string()),
+            Err(_) => DescribeReservedNodeOfferingsError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -15868,7 +15958,7 @@ pub enum DescribeReservedNodesError {
 }
 
 impl DescribeReservedNodesError {
-    pub fn from_body(body: &str) -> DescribeReservedNodesError {
+    pub fn from_body(body: &str, status: u16) -> DescribeReservedNodesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -15884,7 +15974,9 @@ impl DescribeReservedNodesError {
                 ),
                 _ => DescribeReservedNodesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeReservedNodesError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeReservedNodesError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -15955,7 +16047,7 @@ pub enum DescribeResizeError {
 }
 
 impl DescribeResizeError {
-    pub fn from_body(body: &str) -> DescribeResizeError {
+    pub fn from_body(body: &str, status: u16) -> DescribeResizeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -15969,7 +16061,7 @@ impl DescribeResizeError {
                 }
                 _ => DescribeResizeError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeResizeError::Unknown(body.to_string()),
+            Err(_) => DescribeResizeError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -16038,7 +16130,7 @@ pub enum DescribeSnapshotCopyGrantsError {
 }
 
 impl DescribeSnapshotCopyGrantsError {
-    pub fn from_body(body: &str) -> DescribeSnapshotCopyGrantsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeSnapshotCopyGrantsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -16054,7 +16146,9 @@ impl DescribeSnapshotCopyGrantsError {
                 }
                 _ => DescribeSnapshotCopyGrantsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeSnapshotCopyGrantsError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeSnapshotCopyGrantsError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -16125,7 +16219,7 @@ pub enum DescribeTableRestoreStatusError {
 }
 
 impl DescribeTableRestoreStatusError {
-    pub fn from_body(body: &str) -> DescribeTableRestoreStatusError {
+    pub fn from_body(body: &str, status: u16) -> DescribeTableRestoreStatusError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -16141,7 +16235,9 @@ impl DescribeTableRestoreStatusError {
                 }
                 _ => DescribeTableRestoreStatusError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeTableRestoreStatusError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeTableRestoreStatusError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -16212,7 +16308,7 @@ pub enum DescribeTagsError {
 }
 
 impl DescribeTagsError {
-    pub fn from_body(body: &str) -> DescribeTagsError {
+    pub fn from_body(body: &str, status: u16) -> DescribeTagsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -16226,7 +16322,7 @@ impl DescribeTagsError {
                 }
                 _ => DescribeTagsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeTagsError::Unknown(body.to_string()),
+            Err(_) => DescribeTagsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -16293,7 +16389,7 @@ pub enum DisableLoggingError {
 }
 
 impl DisableLoggingError {
-    pub fn from_body(body: &str) -> DisableLoggingError {
+    pub fn from_body(body: &str, status: u16) -> DisableLoggingError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -16304,7 +16400,7 @@ impl DisableLoggingError {
                 }
                 _ => DisableLoggingError::Unknown(String::from(body)),
             },
-            Err(_) => DisableLoggingError::Unknown(body.to_string()),
+            Err(_) => DisableLoggingError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -16376,7 +16472,7 @@ pub enum DisableSnapshotCopyError {
 }
 
 impl DisableSnapshotCopyError {
-    pub fn from_body(body: &str) -> DisableSnapshotCopyError {
+    pub fn from_body(body: &str, status: u16) -> DisableSnapshotCopyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -16398,7 +16494,7 @@ impl DisableSnapshotCopyError {
                 ),
                 _ => DisableSnapshotCopyError::Unknown(String::from(body)),
             },
-            Err(_) => DisableSnapshotCopyError::Unknown(body.to_string()),
+            Err(_) => DisableSnapshotCopyError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -16477,7 +16573,7 @@ pub enum EnableLoggingError {
 }
 
 impl EnableLoggingError {
-    pub fn from_body(body: &str) -> EnableLoggingError {
+    pub fn from_body(body: &str, status: u16) -> EnableLoggingError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -16502,7 +16598,7 @@ impl EnableLoggingError {
                 }
                 _ => EnableLoggingError::Unknown(String::from(body)),
             },
-            Err(_) => EnableLoggingError::Unknown(body.to_string()),
+            Err(_) => EnableLoggingError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -16590,7 +16686,7 @@ pub enum EnableSnapshotCopyError {
 }
 
 impl EnableSnapshotCopyError {
-    pub fn from_body(body: &str) -> EnableSnapshotCopyError {
+    pub fn from_body(body: &str, status: u16) -> EnableSnapshotCopyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -16638,7 +16734,7 @@ impl EnableSnapshotCopyError {
                 }
                 _ => EnableSnapshotCopyError::Unknown(String::from(body)),
             },
-            Err(_) => EnableSnapshotCopyError::Unknown(body.to_string()),
+            Err(_) => EnableSnapshotCopyError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -16717,7 +16813,7 @@ pub enum GetClusterCredentialsError {
 }
 
 impl GetClusterCredentialsError {
-    pub fn from_body(body: &str) -> GetClusterCredentialsError {
+    pub fn from_body(body: &str, status: u16) -> GetClusterCredentialsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -16731,7 +16827,9 @@ impl GetClusterCredentialsError {
                 ),
                 _ => GetClusterCredentialsError::Unknown(String::from(body)),
             },
-            Err(_) => GetClusterCredentialsError::Unknown(body.to_string()),
+            Err(_) => {
+                GetClusterCredentialsError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -16810,7 +16908,7 @@ pub enum GetReservedNodeExchangeOfferingsError {
 }
 
 impl GetReservedNodeExchangeOfferingsError {
-    pub fn from_body(body: &str) -> GetReservedNodeExchangeOfferingsError {
+    pub fn from_body(body: &str, status: u16) -> GetReservedNodeExchangeOfferingsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -16848,7 +16946,11 @@ impl GetReservedNodeExchangeOfferingsError {
                 }
                 _ => GetReservedNodeExchangeOfferingsError::Unknown(String::from(body)),
             },
-            Err(_) => GetReservedNodeExchangeOfferingsError::Unknown(body.to_string()),
+            Err(_) => GetReservedNodeExchangeOfferingsError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -16963,7 +17065,7 @@ pub enum ModifyClusterError {
 }
 
 impl ModifyClusterError {
-    pub fn from_body(body: &str) -> ModifyClusterError {
+    pub fn from_body(body: &str, status: u16) -> ModifyClusterError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -17043,7 +17145,7 @@ impl ModifyClusterError {
                 }
                 _ => ModifyClusterError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyClusterError::Unknown(body.to_string()),
+            Err(_) => ModifyClusterError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -17130,7 +17232,7 @@ pub enum ModifyClusterDbRevisionError {
 }
 
 impl ModifyClusterDbRevisionError {
-    pub fn from_body(body: &str) -> ModifyClusterDbRevisionError {
+    pub fn from_body(body: &str, status: u16) -> ModifyClusterDbRevisionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -17149,7 +17251,9 @@ impl ModifyClusterDbRevisionError {
                 ),
                 _ => ModifyClusterDbRevisionError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyClusterDbRevisionError::Unknown(body.to_string()),
+            Err(_) => {
+                ModifyClusterDbRevisionError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -17221,7 +17325,7 @@ pub enum ModifyClusterIamRolesError {
 }
 
 impl ModifyClusterIamRolesError {
-    pub fn from_body(body: &str) -> ModifyClusterIamRolesError {
+    pub fn from_body(body: &str, status: u16) -> ModifyClusterIamRolesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -17235,7 +17339,9 @@ impl ModifyClusterIamRolesError {
                 ),
                 _ => ModifyClusterIamRolesError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyClusterIamRolesError::Unknown(body.to_string()),
+            Err(_) => {
+                ModifyClusterIamRolesError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -17306,7 +17412,7 @@ pub enum ModifyClusterParameterGroupError {
 }
 
 impl ModifyClusterParameterGroupError {
-    pub fn from_body(body: &str) -> ModifyClusterParameterGroupError {
+    pub fn from_body(body: &str, status: u16) -> ModifyClusterParameterGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -17324,7 +17430,11 @@ impl ModifyClusterParameterGroupError {
                 }
                 _ => ModifyClusterParameterGroupError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyClusterParameterGroupError::Unknown(body.to_string()),
+            Err(_) => ModifyClusterParameterGroupError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -17407,7 +17517,7 @@ pub enum ModifyClusterSubnetGroupError {
 }
 
 impl ModifyClusterSubnetGroupError {
-    pub fn from_body(body: &str) -> ModifyClusterSubnetGroupError {
+    pub fn from_body(body: &str, status: u16) -> ModifyClusterSubnetGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -17439,7 +17549,9 @@ impl ModifyClusterSubnetGroupError {
                 ),
                 _ => ModifyClusterSubnetGroupError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyClusterSubnetGroupError::Unknown(body.to_string()),
+            Err(_) => {
+                ModifyClusterSubnetGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -17530,7 +17642,7 @@ pub enum ModifyEventSubscriptionError {
 }
 
 impl ModifyEventSubscriptionError {
-    pub fn from_body(body: &str) -> ModifyEventSubscriptionError {
+    pub fn from_body(body: &str, status: u16) -> ModifyEventSubscriptionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -17573,7 +17685,9 @@ impl ModifyEventSubscriptionError {
                 }
                 _ => ModifyEventSubscriptionError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyEventSubscriptionError::Unknown(body.to_string()),
+            Err(_) => {
+                ModifyEventSubscriptionError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -17655,7 +17769,7 @@ pub enum ModifySnapshotCopyRetentionPeriodError {
 }
 
 impl ModifySnapshotCopyRetentionPeriodError {
-    pub fn from_body(body: &str) -> ModifySnapshotCopyRetentionPeriodError {
+    pub fn from_body(body: &str, status: u16) -> ModifySnapshotCopyRetentionPeriodError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -17681,7 +17795,11 @@ impl ModifySnapshotCopyRetentionPeriodError {
                 }
                 _ => ModifySnapshotCopyRetentionPeriodError::Unknown(String::from(body)),
             },
-            Err(_) => ModifySnapshotCopyRetentionPeriodError::Unknown(body.to_string()),
+            Err(_) => ModifySnapshotCopyRetentionPeriodError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -17758,7 +17876,7 @@ pub enum PurchaseReservedNodeOfferingError {
 }
 
 impl PurchaseReservedNodeOfferingError {
-    pub fn from_body(body: &str) -> PurchaseReservedNodeOfferingError {
+    pub fn from_body(body: &str, status: u16) -> PurchaseReservedNodeOfferingError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -17786,7 +17904,11 @@ impl PurchaseReservedNodeOfferingError {
                 }
                 _ => PurchaseReservedNodeOfferingError::Unknown(String::from(body)),
             },
-            Err(_) => PurchaseReservedNodeOfferingError::Unknown(body.to_string()),
+            Err(_) => PurchaseReservedNodeOfferingError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -17861,7 +17983,7 @@ pub enum RebootClusterError {
 }
 
 impl RebootClusterError {
-    pub fn from_body(body: &str) -> RebootClusterError {
+    pub fn from_body(body: &str, status: u16) -> RebootClusterError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -17875,7 +17997,7 @@ impl RebootClusterError {
                 }
                 _ => RebootClusterError::Unknown(String::from(body)),
             },
-            Err(_) => RebootClusterError::Unknown(body.to_string()),
+            Err(_) => RebootClusterError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -17944,7 +18066,7 @@ pub enum ResetClusterParameterGroupError {
 }
 
 impl ResetClusterParameterGroupError {
-    pub fn from_body(body: &str) -> ResetClusterParameterGroupError {
+    pub fn from_body(body: &str, status: u16) -> ResetClusterParameterGroupError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -17962,7 +18084,9 @@ impl ResetClusterParameterGroupError {
                 }
                 _ => ResetClusterParameterGroupError::Unknown(String::from(body)),
             },
-            Err(_) => ResetClusterParameterGroupError::Unknown(body.to_string()),
+            Err(_) => {
+                ResetClusterParameterGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -18075,7 +18199,7 @@ pub enum RestoreFromClusterSnapshotError {
 }
 
 impl RestoreFromClusterSnapshotError {
-    pub fn from_body(body: &str) -> RestoreFromClusterSnapshotError {
+    pub fn from_body(body: &str, status: u16) -> RestoreFromClusterSnapshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -18181,7 +18305,9 @@ impl RestoreFromClusterSnapshotError {
                 ),
                 _ => RestoreFromClusterSnapshotError::Unknown(String::from(body)),
             },
-            Err(_) => RestoreFromClusterSnapshotError::Unknown(body.to_string()),
+            Err(_) => {
+                RestoreFromClusterSnapshotError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -18288,7 +18414,7 @@ pub enum RestoreTableFromClusterSnapshotError {
 }
 
 impl RestoreTableFromClusterSnapshotError {
-    pub fn from_body(body: &str) -> RestoreTableFromClusterSnapshotError {
+    pub fn from_body(body: &str, status: u16) -> RestoreTableFromClusterSnapshotError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -18329,7 +18455,11 @@ impl RestoreTableFromClusterSnapshotError {
                 }
                 _ => RestoreTableFromClusterSnapshotError::Unknown(String::from(body)),
             },
-            Err(_) => RestoreTableFromClusterSnapshotError::Unknown(body.to_string()),
+            Err(_) => RestoreTableFromClusterSnapshotError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -18413,7 +18543,7 @@ pub enum RevokeClusterSecurityGroupIngressError {
 }
 
 impl RevokeClusterSecurityGroupIngressError {
-    pub fn from_body(body: &str) -> RevokeClusterSecurityGroupIngressError {
+    pub fn from_body(body: &str, status: u16) -> RevokeClusterSecurityGroupIngressError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -18436,7 +18566,11 @@ impl RevokeClusterSecurityGroupIngressError {
                 }
                 _ => RevokeClusterSecurityGroupIngressError::Unknown(String::from(body)),
             },
-            Err(_) => RevokeClusterSecurityGroupIngressError::Unknown(body.to_string()),
+            Err(_) => RevokeClusterSecurityGroupIngressError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -18514,7 +18648,7 @@ pub enum RevokeSnapshotAccessError {
 }
 
 impl RevokeSnapshotAccessError {
-    pub fn from_body(body: &str) -> RevokeSnapshotAccessError {
+    pub fn from_body(body: &str, status: u16) -> RevokeSnapshotAccessError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -18533,7 +18667,9 @@ impl RevokeSnapshotAccessError {
                 }
                 _ => RevokeSnapshotAccessError::Unknown(String::from(body)),
             },
-            Err(_) => RevokeSnapshotAccessError::Unknown(body.to_string()),
+            Err(_) => {
+                RevokeSnapshotAccessError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -18607,7 +18743,7 @@ pub enum RotateEncryptionKeyError {
 }
 
 impl RotateEncryptionKeyError {
-    pub fn from_body(body: &str) -> RotateEncryptionKeyError {
+    pub fn from_body(body: &str, status: u16) -> RotateEncryptionKeyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -18626,7 +18762,7 @@ impl RotateEncryptionKeyError {
                 ),
                 _ => RotateEncryptionKeyError::Unknown(String::from(body)),
             },
-            Err(_) => RotateEncryptionKeyError::Unknown(body.to_string()),
+            Err(_) => RotateEncryptionKeyError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 

--- a/rusoto/services/redshift/src/generated.rs
+++ b/rusoto/services/redshift/src/generated.rs
@@ -11828,7 +11828,15 @@ impl AcceptReservedNodeExchangeError {
                 _ => AcceptReservedNodeExchangeError::Unknown(String::from(body)),
             },
             Err(_) => {
-                AcceptReservedNodeExchangeError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    AcceptReservedNodeExchangeError::Unknown(format!("{}", status))
+                } else {
+                    AcceptReservedNodeExchangeError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -11937,11 +11945,17 @@ impl AuthorizeClusterSecurityGroupIngressError {
                 }
                 _ => AuthorizeClusterSecurityGroupIngressError::Unknown(String::from(body)),
             },
-            Err(_) => AuthorizeClusterSecurityGroupIngressError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    AuthorizeClusterSecurityGroupIngressError::Unknown(format!("{}", status))
+                } else {
+                    AuthorizeClusterSecurityGroupIngressError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -12067,7 +12081,15 @@ impl AuthorizeSnapshotAccessError {
                 _ => AuthorizeSnapshotAccessError::Unknown(String::from(body)),
             },
             Err(_) => {
-                AuthorizeSnapshotAccessError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    AuthorizeSnapshotAccessError::Unknown(format!("{}", status))
+                } else {
+                    AuthorizeSnapshotAccessError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -12177,7 +12199,13 @@ impl CopyClusterSnapshotError {
                 }
                 _ => CopyClusterSnapshotError::Unknown(String::from(body)),
             },
-            Err(_) => CopyClusterSnapshotError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CopyClusterSnapshotError::Unknown(format!("{}", status))
+                } else {
+                    CopyClusterSnapshotError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -12374,7 +12402,13 @@ impl CreateClusterError {
                 }
                 _ => CreateClusterError::Unknown(String::from(body)),
             },
-            Err(_) => CreateClusterError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateClusterError::Unknown(format!("{}", status))
+                } else {
+                    CreateClusterError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -12489,11 +12523,17 @@ impl CreateClusterParameterGroupError {
                 ),
                 _ => CreateClusterParameterGroupError::Unknown(String::from(body)),
             },
-            Err(_) => CreateClusterParameterGroupError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateClusterParameterGroupError::Unknown(format!("{}", status))
+                } else {
+                    CreateClusterParameterGroupError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -12599,7 +12639,15 @@ impl CreateClusterSecurityGroupError {
                 _ => CreateClusterSecurityGroupError::Unknown(String::from(body)),
             },
             Err(_) => {
-                CreateClusterSecurityGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    CreateClusterSecurityGroupError::Unknown(format!("{}", status))
+                } else {
+                    CreateClusterSecurityGroupError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -12716,7 +12764,11 @@ impl CreateClusterSnapshotError {
                 _ => CreateClusterSnapshotError::Unknown(String::from(body)),
             },
             Err(_) => {
-                CreateClusterSnapshotError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    CreateClusterSnapshotError::Unknown(format!("{}", status))
+                } else {
+                    CreateClusterSnapshotError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -12845,7 +12897,15 @@ impl CreateClusterSubnetGroupError {
                 _ => CreateClusterSubnetGroupError::Unknown(String::from(body)),
             },
             Err(_) => {
-                CreateClusterSubnetGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    CreateClusterSubnetGroupError::Unknown(format!("{}", status))
+                } else {
+                    CreateClusterSubnetGroupError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -12995,7 +13055,15 @@ impl CreateEventSubscriptionError {
                 _ => CreateEventSubscriptionError::Unknown(String::from(body)),
             },
             Err(_) => {
-                CreateEventSubscriptionError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    CreateEventSubscriptionError::Unknown(format!("{}", status))
+                } else {
+                    CreateEventSubscriptionError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -13105,7 +13173,15 @@ impl CreateHsmClientCertificateError {
                 _ => CreateHsmClientCertificateError::Unknown(String::from(body)),
             },
             Err(_) => {
-                CreateHsmClientCertificateError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    CreateHsmClientCertificateError::Unknown(format!("{}", status))
+                } else {
+                    CreateHsmClientCertificateError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -13212,7 +13288,11 @@ impl CreateHsmConfigurationError {
                 _ => CreateHsmConfigurationError::Unknown(String::from(body)),
             },
             Err(_) => {
-                CreateHsmConfigurationError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    CreateHsmConfigurationError::Unknown(format!("{}", status))
+                } else {
+                    CreateHsmConfigurationError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -13327,7 +13407,15 @@ impl CreateSnapshotCopyGrantError {
                 _ => CreateSnapshotCopyGrantError::Unknown(String::from(body)),
             },
             Err(_) => {
-                CreateSnapshotCopyGrantError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    CreateSnapshotCopyGrantError::Unknown(format!("{}", status))
+                } else {
+                    CreateSnapshotCopyGrantError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -13424,7 +13512,13 @@ impl CreateTagsError {
                 }
                 _ => CreateTagsError::Unknown(String::from(body)),
             },
-            Err(_) => CreateTagsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateTagsError::Unknown(format!("{}", status))
+                } else {
+                    CreateTagsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -13522,7 +13616,13 @@ impl DeleteClusterError {
                 }
                 _ => DeleteClusterError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteClusterError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteClusterError::Unknown(format!("{}", status))
+                } else {
+                    DeleteClusterError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -13611,11 +13711,17 @@ impl DeleteClusterParameterGroupError {
                 }
                 _ => DeleteClusterParameterGroupError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteClusterParameterGroupError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteClusterParameterGroupError::Unknown(format!("{}", status))
+                } else {
+                    DeleteClusterParameterGroupError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -13709,7 +13815,15 @@ impl DeleteClusterSecurityGroupError {
                 _ => DeleteClusterSecurityGroupError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DeleteClusterSecurityGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DeleteClusterSecurityGroupError::Unknown(format!("{}", status))
+                } else {
+                    DeleteClusterSecurityGroupError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -13802,7 +13916,11 @@ impl DeleteClusterSnapshotError {
                 _ => DeleteClusterSnapshotError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DeleteClusterSnapshotError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DeleteClusterSnapshotError::Unknown(format!("{}", status))
+                } else {
+                    DeleteClusterSnapshotError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -13900,7 +14018,15 @@ impl DeleteClusterSubnetGroupError {
                 _ => DeleteClusterSubnetGroupError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DeleteClusterSubnetGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DeleteClusterSubnetGroupError::Unknown(format!("{}", status))
+                } else {
+                    DeleteClusterSubnetGroupError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -13990,7 +14116,15 @@ impl DeleteEventSubscriptionError {
                 _ => DeleteEventSubscriptionError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DeleteEventSubscriptionError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DeleteEventSubscriptionError::Unknown(format!("{}", status))
+                } else {
+                    DeleteEventSubscriptionError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -14081,7 +14215,15 @@ impl DeleteHsmClientCertificateError {
                 _ => DeleteHsmClientCertificateError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DeleteHsmClientCertificateError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DeleteHsmClientCertificateError::Unknown(format!("{}", status))
+                } else {
+                    DeleteHsmClientCertificateError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -14174,7 +14316,11 @@ impl DeleteHsmConfigurationError {
                 _ => DeleteHsmConfigurationError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DeleteHsmConfigurationError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DeleteHsmConfigurationError::Unknown(format!("{}", status))
+                } else {
+                    DeleteHsmConfigurationError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -14265,7 +14411,15 @@ impl DeleteSnapshotCopyGrantError {
                 _ => DeleteSnapshotCopyGrantError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DeleteSnapshotCopyGrantError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DeleteSnapshotCopyGrantError::Unknown(format!("{}", status))
+                } else {
+                    DeleteSnapshotCopyGrantError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -14351,7 +14505,13 @@ impl DeleteTagsError {
                 }
                 _ => DeleteTagsError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteTagsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteTagsError::Unknown(format!("{}", status))
+                } else {
+                    DeleteTagsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -14430,7 +14590,15 @@ impl DescribeClusterDbRevisionsError {
                 _ => DescribeClusterDbRevisionsError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeClusterDbRevisionsError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeClusterDbRevisionsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeClusterDbRevisionsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -14517,11 +14685,17 @@ impl DescribeClusterParameterGroupsError {
                 ),
                 _ => DescribeClusterParameterGroupsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeClusterParameterGroupsError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeClusterParameterGroupsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeClusterParameterGroupsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -14606,7 +14780,15 @@ impl DescribeClusterParametersError {
                 _ => DescribeClusterParametersError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeClusterParametersError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeClusterParametersError::Unknown(format!("{}", status))
+                } else {
+                    DescribeClusterParametersError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -14693,11 +14875,17 @@ impl DescribeClusterSecurityGroupsError {
                 ),
                 _ => DescribeClusterSecurityGroupsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeClusterSecurityGroupsError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeClusterSecurityGroupsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeClusterSecurityGroupsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -14792,7 +14980,15 @@ impl DescribeClusterSnapshotsError {
                 _ => DescribeClusterSnapshotsError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeClusterSnapshotsError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeClusterSnapshotsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeClusterSnapshotsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -14881,11 +15077,17 @@ impl DescribeClusterSubnetGroupsError {
                 ),
                 _ => DescribeClusterSubnetGroupsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeClusterSubnetGroupsError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeClusterSubnetGroupsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeClusterSubnetGroupsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -14971,7 +15173,11 @@ impl DescribeClusterTracksError {
                 _ => DescribeClusterTracksError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeClusterTracksError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeClusterTracksError::Unknown(format!("{}", status))
+                } else {
+                    DescribeClusterTracksError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -15048,7 +15254,15 @@ impl DescribeClusterVersionsError {
                 _ => DescribeClusterVersionsError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeClusterVersionsError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeClusterVersionsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeClusterVersionsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -15132,7 +15346,13 @@ impl DescribeClustersError {
                 }
                 _ => DescribeClustersError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeClustersError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeClustersError::Unknown(format!("{}", status))
+                } else {
+                    DescribeClustersError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -15205,11 +15425,17 @@ impl DescribeDefaultClusterParametersError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeDefaultClusterParametersError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeDefaultClusterParametersError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeDefaultClusterParametersError::Unknown(format!("{}", status))
+                } else {
+                    DescribeDefaultClusterParametersError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -15283,7 +15509,15 @@ impl DescribeEventCategoriesError {
                 _ => DescribeEventCategoriesError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeEventCategoriesError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeEventCategoriesError::Unknown(format!("{}", status))
+                } else {
+                    DescribeEventCategoriesError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -15370,7 +15604,15 @@ impl DescribeEventSubscriptionsError {
                 _ => DescribeEventSubscriptionsError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeEventSubscriptionsError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeEventSubscriptionsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeEventSubscriptionsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -15446,7 +15688,13 @@ impl DescribeEventsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeEventsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeEventsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeEventsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeEventsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -15529,11 +15777,17 @@ impl DescribeHsmClientCertificatesError {
                 ),
                 _ => DescribeHsmClientCertificatesError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeHsmClientCertificatesError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeHsmClientCertificatesError::Unknown(format!("{}", status))
+                } else {
+                    DescribeHsmClientCertificatesError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -15623,7 +15877,15 @@ impl DescribeHsmConfigurationsError {
                 _ => DescribeHsmConfigurationsError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeHsmConfigurationsError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeHsmConfigurationsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeHsmConfigurationsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -15705,7 +15967,11 @@ impl DescribeLoggingStatusError {
                 _ => DescribeLoggingStatusError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeLoggingStatusError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeLoggingStatusError::Unknown(format!("{}", status))
+                } else {
+                    DescribeLoggingStatusError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -15780,11 +16046,17 @@ impl DescribeOrderableClusterOptionsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeOrderableClusterOptionsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeOrderableClusterOptionsError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeOrderableClusterOptionsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeOrderableClusterOptionsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -15878,11 +16150,17 @@ impl DescribeReservedNodeOfferingsError {
                 }
                 _ => DescribeReservedNodeOfferingsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeReservedNodeOfferingsError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeReservedNodeOfferingsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeReservedNodeOfferingsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -15975,7 +16253,11 @@ impl DescribeReservedNodesError {
                 _ => DescribeReservedNodesError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeReservedNodesError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeReservedNodesError::Unknown(format!("{}", status))
+                } else {
+                    DescribeReservedNodesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -16061,7 +16343,13 @@ impl DescribeResizeError {
                 }
                 _ => DescribeResizeError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeResizeError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeResizeError::Unknown(format!("{}", status))
+                } else {
+                    DescribeResizeError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -16147,7 +16435,15 @@ impl DescribeSnapshotCopyGrantsError {
                 _ => DescribeSnapshotCopyGrantsError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeSnapshotCopyGrantsError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeSnapshotCopyGrantsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeSnapshotCopyGrantsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -16236,7 +16532,15 @@ impl DescribeTableRestoreStatusError {
                 _ => DescribeTableRestoreStatusError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeTableRestoreStatusError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeTableRestoreStatusError::Unknown(format!("{}", status))
+                } else {
+                    DescribeTableRestoreStatusError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -16322,7 +16626,13 @@ impl DescribeTagsError {
                 }
                 _ => DescribeTagsError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeTagsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeTagsError::Unknown(format!("{}", status))
+                } else {
+                    DescribeTagsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -16400,7 +16710,13 @@ impl DisableLoggingError {
                 }
                 _ => DisableLoggingError::Unknown(String::from(body)),
             },
-            Err(_) => DisableLoggingError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DisableLoggingError::Unknown(format!("{}", status))
+                } else {
+                    DisableLoggingError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -16494,7 +16810,13 @@ impl DisableSnapshotCopyError {
                 ),
                 _ => DisableSnapshotCopyError::Unknown(String::from(body)),
             },
-            Err(_) => DisableSnapshotCopyError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DisableSnapshotCopyError::Unknown(format!("{}", status))
+                } else {
+                    DisableSnapshotCopyError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -16598,7 +16920,13 @@ impl EnableLoggingError {
                 }
                 _ => EnableLoggingError::Unknown(String::from(body)),
             },
-            Err(_) => EnableLoggingError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    EnableLoggingError::Unknown(format!("{}", status))
+                } else {
+                    EnableLoggingError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -16734,7 +17062,13 @@ impl EnableSnapshotCopyError {
                 }
                 _ => EnableSnapshotCopyError::Unknown(String::from(body)),
             },
-            Err(_) => EnableSnapshotCopyError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    EnableSnapshotCopyError::Unknown(format!("{}", status))
+                } else {
+                    EnableSnapshotCopyError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -16828,7 +17162,11 @@ impl GetClusterCredentialsError {
                 _ => GetClusterCredentialsError::Unknown(String::from(body)),
             },
             Err(_) => {
-                GetClusterCredentialsError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    GetClusterCredentialsError::Unknown(format!("{}", status))
+                } else {
+                    GetClusterCredentialsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -16946,11 +17284,17 @@ impl GetReservedNodeExchangeOfferingsError {
                 }
                 _ => GetReservedNodeExchangeOfferingsError::Unknown(String::from(body)),
             },
-            Err(_) => GetReservedNodeExchangeOfferingsError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetReservedNodeExchangeOfferingsError::Unknown(format!("{}", status))
+                } else {
+                    GetReservedNodeExchangeOfferingsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -17145,7 +17489,13 @@ impl ModifyClusterError {
                 }
                 _ => ModifyClusterError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyClusterError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ModifyClusterError::Unknown(format!("{}", status))
+                } else {
+                    ModifyClusterError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -17252,7 +17602,15 @@ impl ModifyClusterDbRevisionError {
                 _ => ModifyClusterDbRevisionError::Unknown(String::from(body)),
             },
             Err(_) => {
-                ModifyClusterDbRevisionError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    ModifyClusterDbRevisionError::Unknown(format!("{}", status))
+                } else {
+                    ModifyClusterDbRevisionError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -17340,7 +17698,11 @@ impl ModifyClusterIamRolesError {
                 _ => ModifyClusterIamRolesError::Unknown(String::from(body)),
             },
             Err(_) => {
-                ModifyClusterIamRolesError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    ModifyClusterIamRolesError::Unknown(format!("{}", status))
+                } else {
+                    ModifyClusterIamRolesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -17430,11 +17792,17 @@ impl ModifyClusterParameterGroupError {
                 }
                 _ => ModifyClusterParameterGroupError::Unknown(String::from(body)),
             },
-            Err(_) => ModifyClusterParameterGroupError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    ModifyClusterParameterGroupError::Unknown(format!("{}", status))
+                } else {
+                    ModifyClusterParameterGroupError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -17550,7 +17918,15 @@ impl ModifyClusterSubnetGroupError {
                 _ => ModifyClusterSubnetGroupError::Unknown(String::from(body)),
             },
             Err(_) => {
-                ModifyClusterSubnetGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    ModifyClusterSubnetGroupError::Unknown(format!("{}", status))
+                } else {
+                    ModifyClusterSubnetGroupError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -17686,7 +18062,15 @@ impl ModifyEventSubscriptionError {
                 _ => ModifyEventSubscriptionError::Unknown(String::from(body)),
             },
             Err(_) => {
-                ModifyEventSubscriptionError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    ModifyEventSubscriptionError::Unknown(format!("{}", status))
+                } else {
+                    ModifyEventSubscriptionError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -17795,11 +18179,17 @@ impl ModifySnapshotCopyRetentionPeriodError {
                 }
                 _ => ModifySnapshotCopyRetentionPeriodError::Unknown(String::from(body)),
             },
-            Err(_) => ModifySnapshotCopyRetentionPeriodError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    ModifySnapshotCopyRetentionPeriodError::Unknown(format!("{}", status))
+                } else {
+                    ModifySnapshotCopyRetentionPeriodError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -17904,11 +18294,17 @@ impl PurchaseReservedNodeOfferingError {
                 }
                 _ => PurchaseReservedNodeOfferingError::Unknown(String::from(body)),
             },
-            Err(_) => PurchaseReservedNodeOfferingError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    PurchaseReservedNodeOfferingError::Unknown(format!("{}", status))
+                } else {
+                    PurchaseReservedNodeOfferingError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -17997,7 +18393,13 @@ impl RebootClusterError {
                 }
                 _ => RebootClusterError::Unknown(String::from(body)),
             },
-            Err(_) => RebootClusterError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    RebootClusterError::Unknown(format!("{}", status))
+                } else {
+                    RebootClusterError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -18085,7 +18487,15 @@ impl ResetClusterParameterGroupError {
                 _ => ResetClusterParameterGroupError::Unknown(String::from(body)),
             },
             Err(_) => {
-                ResetClusterParameterGroupError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    ResetClusterParameterGroupError::Unknown(format!("{}", status))
+                } else {
+                    ResetClusterParameterGroupError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -18306,7 +18716,15 @@ impl RestoreFromClusterSnapshotError {
                 _ => RestoreFromClusterSnapshotError::Unknown(String::from(body)),
             },
             Err(_) => {
-                RestoreFromClusterSnapshotError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    RestoreFromClusterSnapshotError::Unknown(format!("{}", status))
+                } else {
+                    RestoreFromClusterSnapshotError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -18455,11 +18873,17 @@ impl RestoreTableFromClusterSnapshotError {
                 }
                 _ => RestoreTableFromClusterSnapshotError::Unknown(String::from(body)),
             },
-            Err(_) => RestoreTableFromClusterSnapshotError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    RestoreTableFromClusterSnapshotError::Unknown(format!("{}", status))
+                } else {
+                    RestoreTableFromClusterSnapshotError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -18566,11 +18990,17 @@ impl RevokeClusterSecurityGroupIngressError {
                 }
                 _ => RevokeClusterSecurityGroupIngressError::Unknown(String::from(body)),
             },
-            Err(_) => RevokeClusterSecurityGroupIngressError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    RevokeClusterSecurityGroupIngressError::Unknown(format!("{}", status))
+                } else {
+                    RevokeClusterSecurityGroupIngressError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -18668,7 +19098,11 @@ impl RevokeSnapshotAccessError {
                 _ => RevokeSnapshotAccessError::Unknown(String::from(body)),
             },
             Err(_) => {
-                RevokeSnapshotAccessError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    RevokeSnapshotAccessError::Unknown(format!("{}", status))
+                } else {
+                    RevokeSnapshotAccessError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -18762,7 +19196,13 @@ impl RotateEncryptionKeyError {
                 ),
                 _ => RotateEncryptionKeyError::Unknown(String::from(body)),
             },
-            Err(_) => RotateEncryptionKeyError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    RotateEncryptionKeyError::Unknown(format!("{}", status))
+                } else {
+                    RotateEncryptionKeyError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 

--- a/rusoto/services/route53/src/generated.rs
+++ b/rusoto/services/route53/src/generated.rs
@@ -9985,7 +9985,7 @@ pub enum AssociateVPCWithHostedZoneError {
 }
 
 impl AssociateVPCWithHostedZoneError {
-    pub fn from_body(body: &str) -> AssociateVPCWithHostedZoneError {
+    pub fn from_body(body: &str, status: u16) -> AssociateVPCWithHostedZoneError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10018,7 +10018,9 @@ impl AssociateVPCWithHostedZoneError {
                 }
                 _ => AssociateVPCWithHostedZoneError::Unknown(String::from(body)),
             },
-            Err(_) => AssociateVPCWithHostedZoneError::Unknown(body.to_string()),
+            Err(_) => {
+                AssociateVPCWithHostedZoneError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -10100,7 +10102,7 @@ pub enum ChangeResourceRecordSetsError {
 }
 
 impl ChangeResourceRecordSetsError {
-    pub fn from_body(body: &str) -> ChangeResourceRecordSetsError {
+    pub fn from_body(body: &str, status: u16) -> ChangeResourceRecordSetsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10125,7 +10127,9 @@ impl ChangeResourceRecordSetsError {
                 }
                 _ => ChangeResourceRecordSetsError::Unknown(String::from(body)),
             },
-            Err(_) => ChangeResourceRecordSetsError::Unknown(body.to_string()),
+            Err(_) => {
+                ChangeResourceRecordSetsError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -10205,7 +10209,7 @@ pub enum ChangeTagsForResourceError {
 }
 
 impl ChangeTagsForResourceError {
-    pub fn from_body(body: &str) -> ChangeTagsForResourceError {
+    pub fn from_body(body: &str, status: u16) -> ChangeTagsForResourceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10228,7 +10232,9 @@ impl ChangeTagsForResourceError {
                 }
                 _ => ChangeTagsForResourceError::Unknown(String::from(body)),
             },
-            Err(_) => ChangeTagsForResourceError::Unknown(body.to_string()),
+            Err(_) => {
+                ChangeTagsForResourceError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -10304,7 +10310,7 @@ pub enum CreateHealthCheckError {
 }
 
 impl CreateHealthCheckError {
-    pub fn from_body(body: &str) -> CreateHealthCheckError {
+    pub fn from_body(body: &str, status: u16) -> CreateHealthCheckError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10321,7 +10327,7 @@ impl CreateHealthCheckError {
                 }
                 _ => CreateHealthCheckError::Unknown(String::from(body)),
             },
-            Err(_) => CreateHealthCheckError::Unknown(body.to_string()),
+            Err(_) => CreateHealthCheckError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -10407,7 +10413,7 @@ pub enum CreateHostedZoneError {
 }
 
 impl CreateHostedZoneError {
-    pub fn from_body(body: &str) -> CreateHostedZoneError {
+    pub fn from_body(body: &str, status: u16) -> CreateHostedZoneError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10442,7 +10448,7 @@ impl CreateHostedZoneError {
                 }
                 _ => CreateHostedZoneError::Unknown(String::from(body)),
             },
-            Err(_) => CreateHostedZoneError::Unknown(body.to_string()),
+            Err(_) => CreateHostedZoneError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -10526,7 +10532,7 @@ pub enum CreateQueryLoggingConfigError {
 }
 
 impl CreateQueryLoggingConfigError {
-    pub fn from_body(body: &str) -> CreateQueryLoggingConfigError {
+    pub fn from_body(body: &str, status: u16) -> CreateQueryLoggingConfigError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10558,7 +10564,9 @@ impl CreateQueryLoggingConfigError {
                 }
                 _ => CreateQueryLoggingConfigError::Unknown(String::from(body)),
             },
-            Err(_) => CreateQueryLoggingConfigError::Unknown(body.to_string()),
+            Err(_) => {
+                CreateQueryLoggingConfigError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -10645,7 +10653,7 @@ pub enum CreateReusableDelegationSetError {
 }
 
 impl CreateReusableDelegationSetError {
-    pub fn from_body(body: &str) -> CreateReusableDelegationSetError {
+    pub fn from_body(body: &str, status: u16) -> CreateReusableDelegationSetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10680,7 +10688,11 @@ impl CreateReusableDelegationSetError {
                 )),
                 _ => CreateReusableDelegationSetError::Unknown(String::from(body)),
             },
-            Err(_) => CreateReusableDelegationSetError::Unknown(body.to_string()),
+            Err(_) => CreateReusableDelegationSetError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -10760,7 +10772,7 @@ pub enum CreateTrafficPolicyError {
 }
 
 impl CreateTrafficPolicyError {
-    pub fn from_body(body: &str) -> CreateTrafficPolicyError {
+    pub fn from_body(body: &str, status: u16) -> CreateTrafficPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10784,7 +10796,7 @@ impl CreateTrafficPolicyError {
                 }
                 _ => CreateTrafficPolicyError::Unknown(String::from(body)),
             },
-            Err(_) => CreateTrafficPolicyError::Unknown(body.to_string()),
+            Err(_) => CreateTrafficPolicyError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -10863,7 +10875,7 @@ pub enum CreateTrafficPolicyInstanceError {
 }
 
 impl CreateTrafficPolicyInstanceError {
-    pub fn from_body(body: &str) -> CreateTrafficPolicyInstanceError {
+    pub fn from_body(body: &str, status: u16) -> CreateTrafficPolicyInstanceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10890,7 +10902,11 @@ impl CreateTrafficPolicyInstanceError {
                 }
                 _ => CreateTrafficPolicyInstanceError::Unknown(String::from(body)),
             },
-            Err(_) => CreateTrafficPolicyInstanceError::Unknown(body.to_string()),
+            Err(_) => CreateTrafficPolicyInstanceError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -10972,7 +10988,7 @@ pub enum CreateTrafficPolicyVersionError {
 }
 
 impl CreateTrafficPolicyVersionError {
-    pub fn from_body(body: &str) -> CreateTrafficPolicyVersionError {
+    pub fn from_body(body: &str, status: u16) -> CreateTrafficPolicyVersionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11001,7 +11017,9 @@ impl CreateTrafficPolicyVersionError {
                 }
                 _ => CreateTrafficPolicyVersionError::Unknown(String::from(body)),
             },
-            Err(_) => CreateTrafficPolicyVersionError::Unknown(body.to_string()),
+            Err(_) => {
+                CreateTrafficPolicyVersionError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -11083,7 +11101,7 @@ pub enum CreateVPCAssociationAuthorizationError {
 }
 
 impl CreateVPCAssociationAuthorizationError {
-    pub fn from_body(body: &str) -> CreateVPCAssociationAuthorizationError {
+    pub fn from_body(body: &str, status: u16) -> CreateVPCAssociationAuthorizationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11110,7 +11128,11 @@ impl CreateVPCAssociationAuthorizationError {
                 }
                 _ => CreateVPCAssociationAuthorizationError::Unknown(String::from(body)),
             },
-            Err(_) => CreateVPCAssociationAuthorizationError::Unknown(body.to_string()),
+            Err(_) => CreateVPCAssociationAuthorizationError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -11188,7 +11210,7 @@ pub enum DeleteHealthCheckError {
 }
 
 impl DeleteHealthCheckError {
-    pub fn from_body(body: &str) -> DeleteHealthCheckError {
+    pub fn from_body(body: &str, status: u16) -> DeleteHealthCheckError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11205,7 +11227,7 @@ impl DeleteHealthCheckError {
                 }
                 _ => DeleteHealthCheckError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteHealthCheckError::Unknown(body.to_string()),
+            Err(_) => DeleteHealthCheckError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -11283,7 +11305,7 @@ pub enum DeleteHostedZoneError {
 }
 
 impl DeleteHostedZoneError {
-    pub fn from_body(body: &str) -> DeleteHostedZoneError {
+    pub fn from_body(body: &str, status: u16) -> DeleteHostedZoneError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11306,7 +11328,7 @@ impl DeleteHostedZoneError {
                 ),
                 _ => DeleteHostedZoneError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteHostedZoneError::Unknown(body.to_string()),
+            Err(_) => DeleteHostedZoneError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -11380,7 +11402,7 @@ pub enum DeleteQueryLoggingConfigError {
 }
 
 impl DeleteQueryLoggingConfigError {
-    pub fn from_body(body: &str) -> DeleteQueryLoggingConfigError {
+    pub fn from_body(body: &str, status: u16) -> DeleteQueryLoggingConfigError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11399,7 +11421,9 @@ impl DeleteQueryLoggingConfigError {
                 }
                 _ => DeleteQueryLoggingConfigError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteQueryLoggingConfigError::Unknown(body.to_string()),
+            Err(_) => {
+                DeleteQueryLoggingConfigError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -11475,7 +11499,7 @@ pub enum DeleteReusableDelegationSetError {
 }
 
 impl DeleteReusableDelegationSetError {
-    pub fn from_body(body: &str) -> DeleteReusableDelegationSetError {
+    pub fn from_body(body: &str, status: u16) -> DeleteReusableDelegationSetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11497,7 +11521,11 @@ impl DeleteReusableDelegationSetError {
                 ),
                 _ => DeleteReusableDelegationSetError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteReusableDelegationSetError::Unknown(body.to_string()),
+            Err(_) => DeleteReusableDelegationSetError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -11574,7 +11602,7 @@ pub enum DeleteTrafficPolicyError {
 }
 
 impl DeleteTrafficPolicyError {
-    pub fn from_body(body: &str) -> DeleteTrafficPolicyError {
+    pub fn from_body(body: &str, status: u16) -> DeleteTrafficPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11594,7 +11622,7 @@ impl DeleteTrafficPolicyError {
                 }
                 _ => DeleteTrafficPolicyError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteTrafficPolicyError::Unknown(body.to_string()),
+            Err(_) => DeleteTrafficPolicyError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -11669,7 +11697,7 @@ pub enum DeleteTrafficPolicyInstanceError {
 }
 
 impl DeleteTrafficPolicyInstanceError {
-    pub fn from_body(body: &str) -> DeleteTrafficPolicyInstanceError {
+    pub fn from_body(body: &str, status: u16) -> DeleteTrafficPolicyInstanceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11690,7 +11718,11 @@ impl DeleteTrafficPolicyInstanceError {
                 }
                 _ => DeleteTrafficPolicyInstanceError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteTrafficPolicyInstanceError::Unknown(body.to_string()),
+            Err(_) => DeleteTrafficPolicyInstanceError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -11768,7 +11800,7 @@ pub enum DeleteVPCAssociationAuthorizationError {
 }
 
 impl DeleteVPCAssociationAuthorizationError {
-    pub fn from_body(body: &str) -> DeleteVPCAssociationAuthorizationError {
+    pub fn from_body(body: &str, status: u16) -> DeleteVPCAssociationAuthorizationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11795,7 +11827,11 @@ impl DeleteVPCAssociationAuthorizationError {
                 }
                 _ => DeleteVPCAssociationAuthorizationError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteVPCAssociationAuthorizationError::Unknown(body.to_string()),
+            Err(_) => DeleteVPCAssociationAuthorizationError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -11877,7 +11913,7 @@ pub enum DisassociateVPCFromHostedZoneError {
 }
 
 impl DisassociateVPCFromHostedZoneError {
-    pub fn from_body(body: &str) -> DisassociateVPCFromHostedZoneError {
+    pub fn from_body(body: &str, status: u16) -> DisassociateVPCFromHostedZoneError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11902,7 +11938,11 @@ impl DisassociateVPCFromHostedZoneError {
                 }
                 _ => DisassociateVPCFromHostedZoneError::Unknown(String::from(body)),
             },
-            Err(_) => DisassociateVPCFromHostedZoneError::Unknown(body.to_string()),
+            Err(_) => DisassociateVPCFromHostedZoneError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -11974,7 +12014,7 @@ pub enum GetAccountLimitError {
 }
 
 impl GetAccountLimitError {
-    pub fn from_body(body: &str) -> GetAccountLimitError {
+    pub fn from_body(body: &str, status: u16) -> GetAccountLimitError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11985,7 +12025,7 @@ impl GetAccountLimitError {
                 }
                 _ => GetAccountLimitError::Unknown(String::from(body)),
             },
-            Err(_) => GetAccountLimitError::Unknown(body.to_string()),
+            Err(_) => GetAccountLimitError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -12053,7 +12093,7 @@ pub enum GetChangeError {
 }
 
 impl GetChangeError {
-    pub fn from_body(body: &str) -> GetChangeError {
+    pub fn from_body(body: &str, status: u16) -> GetChangeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -12063,7 +12103,7 @@ impl GetChangeError {
                 "NoSuchChange" => GetChangeError::NoSuchChange(String::from(parsed_error.message)),
                 _ => GetChangeError::Unknown(String::from(body)),
             },
-            Err(_) => GetChangeError::Unknown(body.to_string()),
+            Err(_) => GetChangeError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -12128,7 +12168,7 @@ pub enum GetCheckerIpRangesError {
 }
 
 impl GetCheckerIpRangesError {
-    pub fn from_body(body: &str) -> GetCheckerIpRangesError {
+    pub fn from_body(body: &str, status: u16) -> GetCheckerIpRangesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -12136,7 +12176,7 @@ impl GetCheckerIpRangesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetCheckerIpRangesError::Unknown(String::from(body)),
             },
-            Err(_) => GetCheckerIpRangesError::Unknown(body.to_string()),
+            Err(_) => GetCheckerIpRangesError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -12205,7 +12245,7 @@ pub enum GetGeoLocationError {
 }
 
 impl GetGeoLocationError {
-    pub fn from_body(body: &str) -> GetGeoLocationError {
+    pub fn from_body(body: &str, status: u16) -> GetGeoLocationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -12219,7 +12259,7 @@ impl GetGeoLocationError {
                 }
                 _ => GetGeoLocationError::Unknown(String::from(body)),
             },
-            Err(_) => GetGeoLocationError::Unknown(body.to_string()),
+            Err(_) => GetGeoLocationError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -12290,7 +12330,7 @@ pub enum GetHealthCheckError {
 }
 
 impl GetHealthCheckError {
-    pub fn from_body(body: &str) -> GetHealthCheckError {
+    pub fn from_body(body: &str, status: u16) -> GetHealthCheckError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -12307,7 +12347,7 @@ impl GetHealthCheckError {
                 }
                 _ => GetHealthCheckError::Unknown(String::from(body)),
             },
-            Err(_) => GetHealthCheckError::Unknown(body.to_string()),
+            Err(_) => GetHealthCheckError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -12373,7 +12413,7 @@ pub enum GetHealthCheckCountError {
 }
 
 impl GetHealthCheckCountError {
-    pub fn from_body(body: &str) -> GetHealthCheckCountError {
+    pub fn from_body(body: &str, status: u16) -> GetHealthCheckCountError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -12381,7 +12421,7 @@ impl GetHealthCheckCountError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetHealthCheckCountError::Unknown(String::from(body)),
             },
-            Err(_) => GetHealthCheckCountError::Unknown(body.to_string()),
+            Err(_) => GetHealthCheckCountError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -12450,7 +12490,7 @@ pub enum GetHealthCheckLastFailureReasonError {
 }
 
 impl GetHealthCheckLastFailureReasonError {
-    pub fn from_body(body: &str) -> GetHealthCheckLastFailureReasonError {
+    pub fn from_body(body: &str, status: u16) -> GetHealthCheckLastFailureReasonError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -12464,7 +12504,11 @@ impl GetHealthCheckLastFailureReasonError {
                 ),
                 _ => GetHealthCheckLastFailureReasonError::Unknown(String::from(body)),
             },
-            Err(_) => GetHealthCheckLastFailureReasonError::Unknown(body.to_string()),
+            Err(_) => GetHealthCheckLastFailureReasonError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -12535,7 +12579,7 @@ pub enum GetHealthCheckStatusError {
 }
 
 impl GetHealthCheckStatusError {
-    pub fn from_body(body: &str) -> GetHealthCheckStatusError {
+    pub fn from_body(body: &str, status: u16) -> GetHealthCheckStatusError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -12549,7 +12593,9 @@ impl GetHealthCheckStatusError {
                 }
                 _ => GetHealthCheckStatusError::Unknown(String::from(body)),
             },
-            Err(_) => GetHealthCheckStatusError::Unknown(body.to_string()),
+            Err(_) => {
+                GetHealthCheckStatusError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -12620,7 +12666,7 @@ pub enum GetHostedZoneError {
 }
 
 impl GetHostedZoneError {
-    pub fn from_body(body: &str) -> GetHostedZoneError {
+    pub fn from_body(body: &str, status: u16) -> GetHostedZoneError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -12634,7 +12680,7 @@ impl GetHostedZoneError {
                 }
                 _ => GetHostedZoneError::Unknown(String::from(body)),
             },
-            Err(_) => GetHostedZoneError::Unknown(body.to_string()),
+            Err(_) => GetHostedZoneError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -12701,7 +12747,7 @@ pub enum GetHostedZoneCountError {
 }
 
 impl GetHostedZoneCountError {
-    pub fn from_body(body: &str) -> GetHostedZoneCountError {
+    pub fn from_body(body: &str, status: u16) -> GetHostedZoneCountError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -12712,7 +12758,7 @@ impl GetHostedZoneCountError {
                 }
                 _ => GetHostedZoneCountError::Unknown(String::from(body)),
             },
-            Err(_) => GetHostedZoneCountError::Unknown(body.to_string()),
+            Err(_) => GetHostedZoneCountError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -12784,7 +12830,7 @@ pub enum GetHostedZoneLimitError {
 }
 
 impl GetHostedZoneLimitError {
-    pub fn from_body(body: &str) -> GetHostedZoneLimitError {
+    pub fn from_body(body: &str, status: u16) -> GetHostedZoneLimitError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -12801,7 +12847,7 @@ impl GetHostedZoneLimitError {
                 }
                 _ => GetHostedZoneLimitError::Unknown(String::from(body)),
             },
-            Err(_) => GetHostedZoneLimitError::Unknown(body.to_string()),
+            Err(_) => GetHostedZoneLimitError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -12873,7 +12919,7 @@ pub enum GetQueryLoggingConfigError {
 }
 
 impl GetQueryLoggingConfigError {
-    pub fn from_body(body: &str) -> GetQueryLoggingConfigError {
+    pub fn from_body(body: &str, status: u16) -> GetQueryLoggingConfigError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -12887,7 +12933,9 @@ impl GetQueryLoggingConfigError {
                 ),
                 _ => GetQueryLoggingConfigError::Unknown(String::from(body)),
             },
-            Err(_) => GetQueryLoggingConfigError::Unknown(body.to_string()),
+            Err(_) => {
+                GetQueryLoggingConfigError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -12960,7 +13008,7 @@ pub enum GetReusableDelegationSetError {
 }
 
 impl GetReusableDelegationSetError {
-    pub fn from_body(body: &str) -> GetReusableDelegationSetError {
+    pub fn from_body(body: &str, status: u16) -> GetReusableDelegationSetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -12979,7 +13027,9 @@ impl GetReusableDelegationSetError {
                 ),
                 _ => GetReusableDelegationSetError::Unknown(String::from(body)),
             },
-            Err(_) => GetReusableDelegationSetError::Unknown(body.to_string()),
+            Err(_) => {
+                GetReusableDelegationSetError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -13051,7 +13101,7 @@ pub enum GetReusableDelegationSetLimitError {
 }
 
 impl GetReusableDelegationSetLimitError {
-    pub fn from_body(body: &str) -> GetReusableDelegationSetLimitError {
+    pub fn from_body(body: &str, status: u16) -> GetReusableDelegationSetLimitError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -13065,7 +13115,11 @@ impl GetReusableDelegationSetLimitError {
                 ),
                 _ => GetReusableDelegationSetLimitError::Unknown(String::from(body)),
             },
-            Err(_) => GetReusableDelegationSetLimitError::Unknown(body.to_string()),
+            Err(_) => GetReusableDelegationSetLimitError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -13136,7 +13190,7 @@ pub enum GetTrafficPolicyError {
 }
 
 impl GetTrafficPolicyError {
-    pub fn from_body(body: &str) -> GetTrafficPolicyError {
+    pub fn from_body(body: &str, status: u16) -> GetTrafficPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -13150,7 +13204,7 @@ impl GetTrafficPolicyError {
                 }
                 _ => GetTrafficPolicyError::Unknown(String::from(body)),
             },
-            Err(_) => GetTrafficPolicyError::Unknown(body.to_string()),
+            Err(_) => GetTrafficPolicyError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -13219,7 +13273,7 @@ pub enum GetTrafficPolicyInstanceError {
 }
 
 impl GetTrafficPolicyInstanceError {
-    pub fn from_body(body: &str) -> GetTrafficPolicyInstanceError {
+    pub fn from_body(body: &str, status: u16) -> GetTrafficPolicyInstanceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -13235,7 +13289,9 @@ impl GetTrafficPolicyInstanceError {
                 }
                 _ => GetTrafficPolicyInstanceError::Unknown(String::from(body)),
             },
-            Err(_) => GetTrafficPolicyInstanceError::Unknown(body.to_string()),
+            Err(_) => {
+                GetTrafficPolicyInstanceError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -13302,7 +13358,7 @@ pub enum GetTrafficPolicyInstanceCountError {
 }
 
 impl GetTrafficPolicyInstanceCountError {
-    pub fn from_body(body: &str) -> GetTrafficPolicyInstanceCountError {
+    pub fn from_body(body: &str, status: u16) -> GetTrafficPolicyInstanceCountError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -13310,7 +13366,11 @@ impl GetTrafficPolicyInstanceCountError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetTrafficPolicyInstanceCountError::Unknown(String::from(body)),
             },
-            Err(_) => GetTrafficPolicyInstanceCountError::Unknown(body.to_string()),
+            Err(_) => GetTrafficPolicyInstanceCountError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -13377,7 +13437,7 @@ pub enum ListGeoLocationsError {
 }
 
 impl ListGeoLocationsError {
-    pub fn from_body(body: &str) -> ListGeoLocationsError {
+    pub fn from_body(body: &str, status: u16) -> ListGeoLocationsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -13388,7 +13448,7 @@ impl ListGeoLocationsError {
                 }
                 _ => ListGeoLocationsError::Unknown(String::from(body)),
             },
-            Err(_) => ListGeoLocationsError::Unknown(body.to_string()),
+            Err(_) => ListGeoLocationsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -13456,7 +13516,7 @@ pub enum ListHealthChecksError {
 }
 
 impl ListHealthChecksError {
-    pub fn from_body(body: &str) -> ListHealthChecksError {
+    pub fn from_body(body: &str, status: u16) -> ListHealthChecksError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -13470,7 +13530,7 @@ impl ListHealthChecksError {
                 }
                 _ => ListHealthChecksError::Unknown(String::from(body)),
             },
-            Err(_) => ListHealthChecksError::Unknown(body.to_string()),
+            Err(_) => ListHealthChecksError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -13541,7 +13601,7 @@ pub enum ListHostedZonesError {
 }
 
 impl ListHostedZonesError {
-    pub fn from_body(body: &str) -> ListHostedZonesError {
+    pub fn from_body(body: &str, status: u16) -> ListHostedZonesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -13558,7 +13618,7 @@ impl ListHostedZonesError {
                 }
                 _ => ListHostedZonesError::Unknown(String::from(body)),
             },
-            Err(_) => ListHostedZonesError::Unknown(body.to_string()),
+            Err(_) => ListHostedZonesError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -13628,7 +13688,7 @@ pub enum ListHostedZonesByNameError {
 }
 
 impl ListHostedZonesByNameError {
-    pub fn from_body(body: &str) -> ListHostedZonesByNameError {
+    pub fn from_body(body: &str, status: u16) -> ListHostedZonesByNameError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -13642,7 +13702,9 @@ impl ListHostedZonesByNameError {
                 }
                 _ => ListHostedZonesByNameError::Unknown(String::from(body)),
             },
-            Err(_) => ListHostedZonesByNameError::Unknown(body.to_string()),
+            Err(_) => {
+                ListHostedZonesByNameError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -13715,7 +13777,7 @@ pub enum ListQueryLoggingConfigsError {
 }
 
 impl ListQueryLoggingConfigsError {
-    pub fn from_body(body: &str) -> ListQueryLoggingConfigsError {
+    pub fn from_body(body: &str, status: u16) -> ListQueryLoggingConfigsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -13732,7 +13794,9 @@ impl ListQueryLoggingConfigsError {
                 )),
                 _ => ListQueryLoggingConfigsError::Unknown(String::from(body)),
             },
-            Err(_) => ListQueryLoggingConfigsError::Unknown(body.to_string()),
+            Err(_) => {
+                ListQueryLoggingConfigsError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -13804,7 +13868,7 @@ pub enum ListResourceRecordSetsError {
 }
 
 impl ListResourceRecordSetsError {
-    pub fn from_body(body: &str) -> ListResourceRecordSetsError {
+    pub fn from_body(body: &str, status: u16) -> ListResourceRecordSetsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -13818,7 +13882,9 @@ impl ListResourceRecordSetsError {
                 )),
                 _ => ListResourceRecordSetsError::Unknown(String::from(body)),
             },
-            Err(_) => ListResourceRecordSetsError::Unknown(body.to_string()),
+            Err(_) => {
+                ListResourceRecordSetsError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -13887,7 +13953,7 @@ pub enum ListReusableDelegationSetsError {
 }
 
 impl ListReusableDelegationSetsError {
-    pub fn from_body(body: &str) -> ListReusableDelegationSetsError {
+    pub fn from_body(body: &str, status: u16) -> ListReusableDelegationSetsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -13898,7 +13964,9 @@ impl ListReusableDelegationSetsError {
                 )),
                 _ => ListReusableDelegationSetsError::Unknown(String::from(body)),
             },
-            Err(_) => ListReusableDelegationSetsError::Unknown(body.to_string()),
+            Err(_) => {
+                ListReusableDelegationSetsError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -13974,7 +14042,7 @@ pub enum ListTagsForResourceError {
 }
 
 impl ListTagsForResourceError {
-    pub fn from_body(body: &str) -> ListTagsForResourceError {
+    pub fn from_body(body: &str, status: u16) -> ListTagsForResourceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -13997,7 +14065,7 @@ impl ListTagsForResourceError {
                 }
                 _ => ListTagsForResourceError::Unknown(String::from(body)),
             },
-            Err(_) => ListTagsForResourceError::Unknown(body.to_string()),
+            Err(_) => ListTagsForResourceError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -14077,7 +14145,7 @@ pub enum ListTagsForResourcesError {
 }
 
 impl ListTagsForResourcesError {
-    pub fn from_body(body: &str) -> ListTagsForResourcesError {
+    pub fn from_body(body: &str, status: u16) -> ListTagsForResourcesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -14100,7 +14168,9 @@ impl ListTagsForResourcesError {
                 }
                 _ => ListTagsForResourcesError::Unknown(String::from(body)),
             },
-            Err(_) => ListTagsForResourcesError::Unknown(body.to_string()),
+            Err(_) => {
+                ListTagsForResourcesError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -14172,7 +14242,7 @@ pub enum ListTrafficPoliciesError {
 }
 
 impl ListTrafficPoliciesError {
-    pub fn from_body(body: &str) -> ListTrafficPoliciesError {
+    pub fn from_body(body: &str, status: u16) -> ListTrafficPoliciesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -14183,7 +14253,7 @@ impl ListTrafficPoliciesError {
                 }
                 _ => ListTrafficPoliciesError::Unknown(String::from(body)),
             },
-            Err(_) => ListTrafficPoliciesError::Unknown(body.to_string()),
+            Err(_) => ListTrafficPoliciesError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -14253,7 +14323,7 @@ pub enum ListTrafficPolicyInstancesError {
 }
 
 impl ListTrafficPolicyInstancesError {
-    pub fn from_body(body: &str) -> ListTrafficPolicyInstancesError {
+    pub fn from_body(body: &str, status: u16) -> ListTrafficPolicyInstancesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -14269,7 +14339,9 @@ impl ListTrafficPolicyInstancesError {
                 }
                 _ => ListTrafficPolicyInstancesError::Unknown(String::from(body)),
             },
-            Err(_) => ListTrafficPolicyInstancesError::Unknown(body.to_string()),
+            Err(_) => {
+                ListTrafficPolicyInstancesError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -14342,7 +14414,7 @@ pub enum ListTrafficPolicyInstancesByHostedZoneError {
 }
 
 impl ListTrafficPolicyInstancesByHostedZoneError {
-    pub fn from_body(body: &str) -> ListTrafficPolicyInstancesByHostedZoneError {
+    pub fn from_body(body: &str, status: u16) -> ListTrafficPolicyInstancesByHostedZoneError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -14363,7 +14435,11 @@ impl ListTrafficPolicyInstancesByHostedZoneError {
                 }
                 _ => ListTrafficPolicyInstancesByHostedZoneError::Unknown(String::from(body)),
             },
-            Err(_) => ListTrafficPolicyInstancesByHostedZoneError::Unknown(body.to_string()),
+            Err(_) => ListTrafficPolicyInstancesByHostedZoneError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -14439,7 +14515,7 @@ pub enum ListTrafficPolicyInstancesByPolicyError {
 }
 
 impl ListTrafficPolicyInstancesByPolicyError {
-    pub fn from_body(body: &str) -> ListTrafficPolicyInstancesByPolicyError {
+    pub fn from_body(body: &str, status: u16) -> ListTrafficPolicyInstancesByPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -14460,7 +14536,11 @@ impl ListTrafficPolicyInstancesByPolicyError {
                 }
                 _ => ListTrafficPolicyInstancesByPolicyError::Unknown(String::from(body)),
             },
-            Err(_) => ListTrafficPolicyInstancesByPolicyError::Unknown(body.to_string()),
+            Err(_) => ListTrafficPolicyInstancesByPolicyError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -14534,7 +14614,7 @@ pub enum ListTrafficPolicyVersionsError {
 }
 
 impl ListTrafficPolicyVersionsError {
-    pub fn from_body(body: &str) -> ListTrafficPolicyVersionsError {
+    pub fn from_body(body: &str, status: u16) -> ListTrafficPolicyVersionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -14548,7 +14628,9 @@ impl ListTrafficPolicyVersionsError {
                 ),
                 _ => ListTrafficPolicyVersionsError::Unknown(String::from(body)),
             },
-            Err(_) => ListTrafficPolicyVersionsError::Unknown(body.to_string()),
+            Err(_) => {
+                ListTrafficPolicyVersionsError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -14621,7 +14703,7 @@ pub enum ListVPCAssociationAuthorizationsError {
 }
 
 impl ListVPCAssociationAuthorizationsError {
-    pub fn from_body(body: &str) -> ListVPCAssociationAuthorizationsError {
+    pub fn from_body(body: &str, status: u16) -> ListVPCAssociationAuthorizationsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -14640,7 +14722,11 @@ impl ListVPCAssociationAuthorizationsError {
                 ),
                 _ => ListVPCAssociationAuthorizationsError::Unknown(String::from(body)),
             },
-            Err(_) => ListVPCAssociationAuthorizationsError::Unknown(body.to_string()),
+            Err(_) => ListVPCAssociationAuthorizationsError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -14712,7 +14798,7 @@ pub enum TestDNSAnswerError {
 }
 
 impl TestDNSAnswerError {
-    pub fn from_body(body: &str) -> TestDNSAnswerError {
+    pub fn from_body(body: &str, status: u16) -> TestDNSAnswerError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -14726,7 +14812,7 @@ impl TestDNSAnswerError {
                 }
                 _ => TestDNSAnswerError::Unknown(String::from(body)),
             },
-            Err(_) => TestDNSAnswerError::Unknown(body.to_string()),
+            Err(_) => TestDNSAnswerError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -14797,7 +14883,7 @@ pub enum UpdateHealthCheckError {
 }
 
 impl UpdateHealthCheckError {
-    pub fn from_body(body: &str) -> UpdateHealthCheckError {
+    pub fn from_body(body: &str, status: u16) -> UpdateHealthCheckError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -14814,7 +14900,7 @@ impl UpdateHealthCheckError {
                 }
                 _ => UpdateHealthCheckError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateHealthCheckError::Unknown(body.to_string()),
+            Err(_) => UpdateHealthCheckError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -14886,7 +14972,7 @@ pub enum UpdateHostedZoneCommentError {
 }
 
 impl UpdateHostedZoneCommentError {
-    pub fn from_body(body: &str) -> UpdateHostedZoneCommentError {
+    pub fn from_body(body: &str, status: u16) -> UpdateHostedZoneCommentError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -14900,7 +14986,9 @@ impl UpdateHostedZoneCommentError {
                 )),
                 _ => UpdateHostedZoneCommentError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateHostedZoneCommentError::Unknown(body.to_string()),
+            Err(_) => {
+                UpdateHostedZoneCommentError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -14973,7 +15061,7 @@ pub enum UpdateTrafficPolicyCommentError {
 }
 
 impl UpdateTrafficPolicyCommentError {
-    pub fn from_body(body: &str) -> UpdateTrafficPolicyCommentError {
+    pub fn from_body(body: &str, status: u16) -> UpdateTrafficPolicyCommentError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -14992,7 +15080,9 @@ impl UpdateTrafficPolicyCommentError {
                 ),
                 _ => UpdateTrafficPolicyCommentError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateTrafficPolicyCommentError::Unknown(body.to_string()),
+            Err(_) => {
+                UpdateTrafficPolicyCommentError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -15070,7 +15160,7 @@ pub enum UpdateTrafficPolicyInstanceError {
 }
 
 impl UpdateTrafficPolicyInstanceError {
-    pub fn from_body(body: &str) -> UpdateTrafficPolicyInstanceError {
+    pub fn from_body(body: &str, status: u16) -> UpdateTrafficPolicyInstanceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -15097,7 +15187,11 @@ impl UpdateTrafficPolicyInstanceError {
                 }
                 _ => UpdateTrafficPolicyInstanceError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateTrafficPolicyInstanceError::Unknown(body.to_string()),
+            Err(_) => UpdateTrafficPolicyInstanceError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -15566,6 +15660,7 @@ impl Route53 for Route53Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(AssociateVPCWithHostedZoneError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -15621,6 +15716,7 @@ impl Route53 for Route53Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(ChangeResourceRecordSetsError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -15677,6 +15773,7 @@ impl Route53 for Route53Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(ChangeTagsForResourceError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -15729,6 +15826,7 @@ impl Route53 for Route53Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(CreateHealthCheckError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -15783,6 +15881,7 @@ impl Route53 for Route53Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(CreateHostedZoneError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -15837,6 +15936,7 @@ impl Route53 for Route53Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(CreateQueryLoggingConfigError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -15891,6 +15991,7 @@ impl Route53 for Route53Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(CreateReusableDelegationSetError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -15947,6 +16048,7 @@ impl Route53 for Route53Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(CreateTrafficPolicyError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -16001,6 +16103,7 @@ impl Route53 for Route53Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(CreateTrafficPolicyInstanceError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -16057,6 +16160,7 @@ impl Route53 for Route53Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(CreateTrafficPolicyVersionError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -16117,6 +16221,7 @@ impl Route53 for Route53Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(CreateVPCAssociationAuthorizationError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -16165,6 +16270,7 @@ impl Route53 for Route53Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(DeleteHealthCheckError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -16208,6 +16314,7 @@ impl Route53 for Route53Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(DeleteHostedZoneError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -16251,6 +16358,7 @@ impl Route53 for Route53Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(DeleteQueryLoggingConfigError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -16294,6 +16402,7 @@ impl Route53 for Route53Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(DeleteReusableDelegationSetError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -16343,6 +16452,7 @@ impl Route53 for Route53Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(DeleteTrafficPolicyError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -16386,6 +16496,7 @@ impl Route53 for Route53Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(DeleteTrafficPolicyInstanceError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -16446,6 +16557,7 @@ impl Route53 for Route53Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(DeleteVPCAssociationAuthorizationError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -16504,6 +16616,7 @@ impl Route53 for Route53Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(DisassociateVPCFromHostedZoneError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -16549,6 +16662,7 @@ impl Route53 for Route53Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(GetAccountLimitError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -16592,6 +16706,7 @@ impl Route53 for Route53Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(GetChangeError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -16635,6 +16750,7 @@ impl Route53 for Route53Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(GetCheckerIpRangesError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -16690,6 +16806,7 @@ impl Route53 for Route53Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(GetGeoLocationError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -16736,6 +16853,7 @@ impl Route53 for Route53Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(GetHealthCheckError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -16779,6 +16897,7 @@ impl Route53 for Route53Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(GetHealthCheckCountError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -16826,6 +16945,7 @@ impl Route53 for Route53Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(GetHealthCheckLastFailureReasonError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -16874,6 +16994,7 @@ impl Route53 for Route53Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(GetHealthCheckStatusError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -16917,6 +17038,7 @@ impl Route53 for Route53Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(GetHostedZoneError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -16960,6 +17082,7 @@ impl Route53 for Route53Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(GetHostedZoneCountError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -17003,6 +17126,7 @@ impl Route53 for Route53Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(GetHostedZoneLimitError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -17046,6 +17170,7 @@ impl Route53 for Route53Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(GetQueryLoggingConfigError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -17089,6 +17214,7 @@ impl Route53 for Route53Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(GetReusableDelegationSetError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -17133,6 +17259,7 @@ impl Route53 for Route53Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(GetReusableDelegationSetLimitError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -17182,6 +17309,7 @@ impl Route53 for Route53Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(GetTrafficPolicyError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -17225,6 +17353,7 @@ impl Route53 for Route53Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(GetTrafficPolicyInstanceError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -17269,6 +17398,7 @@ impl Route53 for Route53Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(GetTrafficPolicyInstanceCountError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -17329,6 +17459,7 @@ impl Route53 for Route53Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(ListGeoLocationsError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -17381,6 +17512,7 @@ impl Route53 for Route53Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(ListHealthChecksError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -17436,6 +17568,7 @@ impl Route53 for Route53Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(ListHostedZonesError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -17491,6 +17624,7 @@ impl Route53 for Route53Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(ListHostedZonesByNameError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -17546,6 +17680,7 @@ impl Route53 for Route53Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(ListQueryLoggingConfigsError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -17607,6 +17742,7 @@ impl Route53 for Route53Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(ListResourceRecordSetsError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -17659,6 +17795,7 @@ impl Route53 for Route53Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(ListReusableDelegationSetsError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -17706,6 +17843,7 @@ impl Route53 for Route53Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(ListTagsForResourceError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -17761,6 +17899,7 @@ impl Route53 for Route53Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(ListTagsForResourcesError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -17813,6 +17952,7 @@ impl Route53 for Route53Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(ListTrafficPoliciesError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -17871,6 +18011,7 @@ impl Route53 for Route53Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(ListTrafficPolicyInstancesError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -17930,6 +18071,7 @@ impl Route53 for Route53Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(ListTrafficPolicyInstancesByHostedZoneError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -17995,6 +18137,7 @@ impl Route53 for Route53Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(ListTrafficPolicyInstancesByPolicyError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -18049,6 +18192,7 @@ impl Route53 for Route53Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(ListTrafficPolicyVersionsError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -18105,6 +18249,7 @@ impl Route53 for Route53Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(ListVPCAssociationAuthorizationsError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -18165,6 +18310,7 @@ impl Route53 for Route53Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(TestDNSAnswerError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -18220,6 +18366,7 @@ impl Route53 for Route53Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(UpdateHealthCheckError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -18272,6 +18419,7 @@ impl Route53 for Route53Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(UpdateHostedZoneCommentError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -18328,6 +18476,7 @@ impl Route53 for Route53Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(UpdateTrafficPolicyCommentError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -18380,6 +18529,7 @@ impl Route53 for Route53Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(UpdateTrafficPolicyInstanceError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }

--- a/rusoto/services/route53/src/generated.rs
+++ b/rusoto/services/route53/src/generated.rs
@@ -10019,7 +10019,15 @@ impl AssociateVPCWithHostedZoneError {
                 _ => AssociateVPCWithHostedZoneError::Unknown(String::from(body)),
             },
             Err(_) => {
-                AssociateVPCWithHostedZoneError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    AssociateVPCWithHostedZoneError::Unknown(format!("{}", status))
+                } else {
+                    AssociateVPCWithHostedZoneError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -10128,7 +10136,15 @@ impl ChangeResourceRecordSetsError {
                 _ => ChangeResourceRecordSetsError::Unknown(String::from(body)),
             },
             Err(_) => {
-                ChangeResourceRecordSetsError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    ChangeResourceRecordSetsError::Unknown(format!("{}", status))
+                } else {
+                    ChangeResourceRecordSetsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -10233,7 +10249,11 @@ impl ChangeTagsForResourceError {
                 _ => ChangeTagsForResourceError::Unknown(String::from(body)),
             },
             Err(_) => {
-                ChangeTagsForResourceError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    ChangeTagsForResourceError::Unknown(format!("{}", status))
+                } else {
+                    ChangeTagsForResourceError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -10327,7 +10347,13 @@ impl CreateHealthCheckError {
                 }
                 _ => CreateHealthCheckError::Unknown(String::from(body)),
             },
-            Err(_) => CreateHealthCheckError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateHealthCheckError::Unknown(format!("{}", status))
+                } else {
+                    CreateHealthCheckError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -10448,7 +10474,13 @@ impl CreateHostedZoneError {
                 }
                 _ => CreateHostedZoneError::Unknown(String::from(body)),
             },
-            Err(_) => CreateHostedZoneError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateHostedZoneError::Unknown(format!("{}", status))
+                } else {
+                    CreateHostedZoneError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -10565,7 +10597,15 @@ impl CreateQueryLoggingConfigError {
                 _ => CreateQueryLoggingConfigError::Unknown(String::from(body)),
             },
             Err(_) => {
-                CreateQueryLoggingConfigError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    CreateQueryLoggingConfigError::Unknown(format!("{}", status))
+                } else {
+                    CreateQueryLoggingConfigError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -10688,11 +10728,17 @@ impl CreateReusableDelegationSetError {
                 )),
                 _ => CreateReusableDelegationSetError::Unknown(String::from(body)),
             },
-            Err(_) => CreateReusableDelegationSetError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateReusableDelegationSetError::Unknown(format!("{}", status))
+                } else {
+                    CreateReusableDelegationSetError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -10796,7 +10842,13 @@ impl CreateTrafficPolicyError {
                 }
                 _ => CreateTrafficPolicyError::Unknown(String::from(body)),
             },
-            Err(_) => CreateTrafficPolicyError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateTrafficPolicyError::Unknown(format!("{}", status))
+                } else {
+                    CreateTrafficPolicyError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -10902,11 +10954,17 @@ impl CreateTrafficPolicyInstanceError {
                 }
                 _ => CreateTrafficPolicyInstanceError::Unknown(String::from(body)),
             },
-            Err(_) => CreateTrafficPolicyInstanceError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateTrafficPolicyInstanceError::Unknown(format!("{}", status))
+                } else {
+                    CreateTrafficPolicyInstanceError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -11018,7 +11076,15 @@ impl CreateTrafficPolicyVersionError {
                 _ => CreateTrafficPolicyVersionError::Unknown(String::from(body)),
             },
             Err(_) => {
-                CreateTrafficPolicyVersionError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    CreateTrafficPolicyVersionError::Unknown(format!("{}", status))
+                } else {
+                    CreateTrafficPolicyVersionError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -11128,11 +11194,17 @@ impl CreateVPCAssociationAuthorizationError {
                 }
                 _ => CreateVPCAssociationAuthorizationError::Unknown(String::from(body)),
             },
-            Err(_) => CreateVPCAssociationAuthorizationError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateVPCAssociationAuthorizationError::Unknown(format!("{}", status))
+                } else {
+                    CreateVPCAssociationAuthorizationError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -11227,7 +11299,13 @@ impl DeleteHealthCheckError {
                 }
                 _ => DeleteHealthCheckError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteHealthCheckError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteHealthCheckError::Unknown(format!("{}", status))
+                } else {
+                    DeleteHealthCheckError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -11328,7 +11406,13 @@ impl DeleteHostedZoneError {
                 ),
                 _ => DeleteHostedZoneError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteHostedZoneError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteHostedZoneError::Unknown(format!("{}", status))
+                } else {
+                    DeleteHostedZoneError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -11422,7 +11506,15 @@ impl DeleteQueryLoggingConfigError {
                 _ => DeleteQueryLoggingConfigError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DeleteQueryLoggingConfigError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DeleteQueryLoggingConfigError::Unknown(format!("{}", status))
+                } else {
+                    DeleteQueryLoggingConfigError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -11521,11 +11613,17 @@ impl DeleteReusableDelegationSetError {
                 ),
                 _ => DeleteReusableDelegationSetError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteReusableDelegationSetError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteReusableDelegationSetError::Unknown(format!("{}", status))
+                } else {
+                    DeleteReusableDelegationSetError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -11622,7 +11720,13 @@ impl DeleteTrafficPolicyError {
                 }
                 _ => DeleteTrafficPolicyError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteTrafficPolicyError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteTrafficPolicyError::Unknown(format!("{}", status))
+                } else {
+                    DeleteTrafficPolicyError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -11718,11 +11822,17 @@ impl DeleteTrafficPolicyInstanceError {
                 }
                 _ => DeleteTrafficPolicyInstanceError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteTrafficPolicyInstanceError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteTrafficPolicyInstanceError::Unknown(format!("{}", status))
+                } else {
+                    DeleteTrafficPolicyInstanceError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -11827,11 +11937,17 @@ impl DeleteVPCAssociationAuthorizationError {
                 }
                 _ => DeleteVPCAssociationAuthorizationError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteVPCAssociationAuthorizationError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteVPCAssociationAuthorizationError::Unknown(format!("{}", status))
+                } else {
+                    DeleteVPCAssociationAuthorizationError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -11938,11 +12054,17 @@ impl DisassociateVPCFromHostedZoneError {
                 }
                 _ => DisassociateVPCFromHostedZoneError::Unknown(String::from(body)),
             },
-            Err(_) => DisassociateVPCFromHostedZoneError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DisassociateVPCFromHostedZoneError::Unknown(format!("{}", status))
+                } else {
+                    DisassociateVPCFromHostedZoneError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -12025,7 +12147,13 @@ impl GetAccountLimitError {
                 }
                 _ => GetAccountLimitError::Unknown(String::from(body)),
             },
-            Err(_) => GetAccountLimitError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetAccountLimitError::Unknown(format!("{}", status))
+                } else {
+                    GetAccountLimitError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -12103,7 +12231,13 @@ impl GetChangeError {
                 "NoSuchChange" => GetChangeError::NoSuchChange(String::from(parsed_error.message)),
                 _ => GetChangeError::Unknown(String::from(body)),
             },
-            Err(_) => GetChangeError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetChangeError::Unknown(format!("{}", status))
+                } else {
+                    GetChangeError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -12176,7 +12310,13 @@ impl GetCheckerIpRangesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetCheckerIpRangesError::Unknown(String::from(body)),
             },
-            Err(_) => GetCheckerIpRangesError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetCheckerIpRangesError::Unknown(format!("{}", status))
+                } else {
+                    GetCheckerIpRangesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -12259,7 +12399,13 @@ impl GetGeoLocationError {
                 }
                 _ => GetGeoLocationError::Unknown(String::from(body)),
             },
-            Err(_) => GetGeoLocationError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetGeoLocationError::Unknown(format!("{}", status))
+                } else {
+                    GetGeoLocationError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -12347,7 +12493,13 @@ impl GetHealthCheckError {
                 }
                 _ => GetHealthCheckError::Unknown(String::from(body)),
             },
-            Err(_) => GetHealthCheckError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetHealthCheckError::Unknown(format!("{}", status))
+                } else {
+                    GetHealthCheckError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -12421,7 +12573,13 @@ impl GetHealthCheckCountError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetHealthCheckCountError::Unknown(String::from(body)),
             },
-            Err(_) => GetHealthCheckCountError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetHealthCheckCountError::Unknown(format!("{}", status))
+                } else {
+                    GetHealthCheckCountError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -12504,11 +12662,17 @@ impl GetHealthCheckLastFailureReasonError {
                 ),
                 _ => GetHealthCheckLastFailureReasonError::Unknown(String::from(body)),
             },
-            Err(_) => GetHealthCheckLastFailureReasonError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetHealthCheckLastFailureReasonError::Unknown(format!("{}", status))
+                } else {
+                    GetHealthCheckLastFailureReasonError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -12594,7 +12758,11 @@ impl GetHealthCheckStatusError {
                 _ => GetHealthCheckStatusError::Unknown(String::from(body)),
             },
             Err(_) => {
-                GetHealthCheckStatusError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    GetHealthCheckStatusError::Unknown(format!("{}", status))
+                } else {
+                    GetHealthCheckStatusError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -12680,7 +12848,13 @@ impl GetHostedZoneError {
                 }
                 _ => GetHostedZoneError::Unknown(String::from(body)),
             },
-            Err(_) => GetHostedZoneError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetHostedZoneError::Unknown(format!("{}", status))
+                } else {
+                    GetHostedZoneError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -12758,7 +12932,13 @@ impl GetHostedZoneCountError {
                 }
                 _ => GetHostedZoneCountError::Unknown(String::from(body)),
             },
-            Err(_) => GetHostedZoneCountError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetHostedZoneCountError::Unknown(format!("{}", status))
+                } else {
+                    GetHostedZoneCountError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -12847,7 +13027,13 @@ impl GetHostedZoneLimitError {
                 }
                 _ => GetHostedZoneLimitError::Unknown(String::from(body)),
             },
-            Err(_) => GetHostedZoneLimitError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetHostedZoneLimitError::Unknown(format!("{}", status))
+                } else {
+                    GetHostedZoneLimitError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -12934,7 +13120,11 @@ impl GetQueryLoggingConfigError {
                 _ => GetQueryLoggingConfigError::Unknown(String::from(body)),
             },
             Err(_) => {
-                GetQueryLoggingConfigError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    GetQueryLoggingConfigError::Unknown(format!("{}", status))
+                } else {
+                    GetQueryLoggingConfigError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -13028,7 +13218,15 @@ impl GetReusableDelegationSetError {
                 _ => GetReusableDelegationSetError::Unknown(String::from(body)),
             },
             Err(_) => {
-                GetReusableDelegationSetError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    GetReusableDelegationSetError::Unknown(format!("{}", status))
+                } else {
+                    GetReusableDelegationSetError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -13115,11 +13313,17 @@ impl GetReusableDelegationSetLimitError {
                 ),
                 _ => GetReusableDelegationSetLimitError::Unknown(String::from(body)),
             },
-            Err(_) => GetReusableDelegationSetLimitError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetReusableDelegationSetLimitError::Unknown(format!("{}", status))
+                } else {
+                    GetReusableDelegationSetLimitError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -13204,7 +13408,13 @@ impl GetTrafficPolicyError {
                 }
                 _ => GetTrafficPolicyError::Unknown(String::from(body)),
             },
-            Err(_) => GetTrafficPolicyError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetTrafficPolicyError::Unknown(format!("{}", status))
+                } else {
+                    GetTrafficPolicyError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -13290,7 +13500,15 @@ impl GetTrafficPolicyInstanceError {
                 _ => GetTrafficPolicyInstanceError::Unknown(String::from(body)),
             },
             Err(_) => {
-                GetTrafficPolicyInstanceError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    GetTrafficPolicyInstanceError::Unknown(format!("{}", status))
+                } else {
+                    GetTrafficPolicyInstanceError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -13366,11 +13584,17 @@ impl GetTrafficPolicyInstanceCountError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetTrafficPolicyInstanceCountError::Unknown(String::from(body)),
             },
-            Err(_) => GetTrafficPolicyInstanceCountError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetTrafficPolicyInstanceCountError::Unknown(format!("{}", status))
+                } else {
+                    GetTrafficPolicyInstanceCountError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -13448,7 +13672,13 @@ impl ListGeoLocationsError {
                 }
                 _ => ListGeoLocationsError::Unknown(String::from(body)),
             },
-            Err(_) => ListGeoLocationsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ListGeoLocationsError::Unknown(format!("{}", status))
+                } else {
+                    ListGeoLocationsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -13530,7 +13760,13 @@ impl ListHealthChecksError {
                 }
                 _ => ListHealthChecksError::Unknown(String::from(body)),
             },
-            Err(_) => ListHealthChecksError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ListHealthChecksError::Unknown(format!("{}", status))
+                } else {
+                    ListHealthChecksError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -13618,7 +13854,13 @@ impl ListHostedZonesError {
                 }
                 _ => ListHostedZonesError::Unknown(String::from(body)),
             },
-            Err(_) => ListHostedZonesError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ListHostedZonesError::Unknown(format!("{}", status))
+                } else {
+                    ListHostedZonesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -13703,7 +13945,11 @@ impl ListHostedZonesByNameError {
                 _ => ListHostedZonesByNameError::Unknown(String::from(body)),
             },
             Err(_) => {
-                ListHostedZonesByNameError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    ListHostedZonesByNameError::Unknown(format!("{}", status))
+                } else {
+                    ListHostedZonesByNameError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -13795,7 +14041,15 @@ impl ListQueryLoggingConfigsError {
                 _ => ListQueryLoggingConfigsError::Unknown(String::from(body)),
             },
             Err(_) => {
-                ListQueryLoggingConfigsError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    ListQueryLoggingConfigsError::Unknown(format!("{}", status))
+                } else {
+                    ListQueryLoggingConfigsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -13883,7 +14137,11 @@ impl ListResourceRecordSetsError {
                 _ => ListResourceRecordSetsError::Unknown(String::from(body)),
             },
             Err(_) => {
-                ListResourceRecordSetsError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    ListResourceRecordSetsError::Unknown(format!("{}", status))
+                } else {
+                    ListResourceRecordSetsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -13965,7 +14223,15 @@ impl ListReusableDelegationSetsError {
                 _ => ListReusableDelegationSetsError::Unknown(String::from(body)),
             },
             Err(_) => {
-                ListReusableDelegationSetsError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    ListReusableDelegationSetsError::Unknown(format!("{}", status))
+                } else {
+                    ListReusableDelegationSetsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -14065,7 +14331,13 @@ impl ListTagsForResourceError {
                 }
                 _ => ListTagsForResourceError::Unknown(String::from(body)),
             },
-            Err(_) => ListTagsForResourceError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ListTagsForResourceError::Unknown(format!("{}", status))
+                } else {
+                    ListTagsForResourceError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -14169,7 +14441,11 @@ impl ListTagsForResourcesError {
                 _ => ListTagsForResourcesError::Unknown(String::from(body)),
             },
             Err(_) => {
-                ListTagsForResourcesError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    ListTagsForResourcesError::Unknown(format!("{}", status))
+                } else {
+                    ListTagsForResourcesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -14253,7 +14529,13 @@ impl ListTrafficPoliciesError {
                 }
                 _ => ListTrafficPoliciesError::Unknown(String::from(body)),
             },
-            Err(_) => ListTrafficPoliciesError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ListTrafficPoliciesError::Unknown(format!("{}", status))
+                } else {
+                    ListTrafficPoliciesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -14340,7 +14622,15 @@ impl ListTrafficPolicyInstancesError {
                 _ => ListTrafficPolicyInstancesError::Unknown(String::from(body)),
             },
             Err(_) => {
-                ListTrafficPolicyInstancesError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    ListTrafficPolicyInstancesError::Unknown(format!("{}", status))
+                } else {
+                    ListTrafficPolicyInstancesError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -14435,11 +14725,17 @@ impl ListTrafficPolicyInstancesByHostedZoneError {
                 }
                 _ => ListTrafficPolicyInstancesByHostedZoneError::Unknown(String::from(body)),
             },
-            Err(_) => ListTrafficPolicyInstancesByHostedZoneError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    ListTrafficPolicyInstancesByHostedZoneError::Unknown(format!("{}", status))
+                } else {
+                    ListTrafficPolicyInstancesByHostedZoneError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -14536,11 +14832,17 @@ impl ListTrafficPolicyInstancesByPolicyError {
                 }
                 _ => ListTrafficPolicyInstancesByPolicyError::Unknown(String::from(body)),
             },
-            Err(_) => ListTrafficPolicyInstancesByPolicyError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    ListTrafficPolicyInstancesByPolicyError::Unknown(format!("{}", status))
+                } else {
+                    ListTrafficPolicyInstancesByPolicyError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -14629,7 +14931,15 @@ impl ListTrafficPolicyVersionsError {
                 _ => ListTrafficPolicyVersionsError::Unknown(String::from(body)),
             },
             Err(_) => {
-                ListTrafficPolicyVersionsError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    ListTrafficPolicyVersionsError::Unknown(format!("{}", status))
+                } else {
+                    ListTrafficPolicyVersionsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -14722,11 +15032,17 @@ impl ListVPCAssociationAuthorizationsError {
                 ),
                 _ => ListVPCAssociationAuthorizationsError::Unknown(String::from(body)),
             },
-            Err(_) => ListVPCAssociationAuthorizationsError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    ListVPCAssociationAuthorizationsError::Unknown(format!("{}", status))
+                } else {
+                    ListVPCAssociationAuthorizationsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -14812,7 +15128,13 @@ impl TestDNSAnswerError {
                 }
                 _ => TestDNSAnswerError::Unknown(String::from(body)),
             },
-            Err(_) => TestDNSAnswerError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    TestDNSAnswerError::Unknown(format!("{}", status))
+                } else {
+                    TestDNSAnswerError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -14900,7 +15222,13 @@ impl UpdateHealthCheckError {
                 }
                 _ => UpdateHealthCheckError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateHealthCheckError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    UpdateHealthCheckError::Unknown(format!("{}", status))
+                } else {
+                    UpdateHealthCheckError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -14987,7 +15315,15 @@ impl UpdateHostedZoneCommentError {
                 _ => UpdateHostedZoneCommentError::Unknown(String::from(body)),
             },
             Err(_) => {
-                UpdateHostedZoneCommentError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    UpdateHostedZoneCommentError::Unknown(format!("{}", status))
+                } else {
+                    UpdateHostedZoneCommentError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -15081,7 +15417,15 @@ impl UpdateTrafficPolicyCommentError {
                 _ => UpdateTrafficPolicyCommentError::Unknown(String::from(body)),
             },
             Err(_) => {
-                UpdateTrafficPolicyCommentError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    UpdateTrafficPolicyCommentError::Unknown(format!("{}", status))
+                } else {
+                    UpdateTrafficPolicyCommentError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -15187,11 +15531,17 @@ impl UpdateTrafficPolicyInstanceError {
                 }
                 _ => UpdateTrafficPolicyInstanceError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateTrafficPolicyInstanceError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    UpdateTrafficPolicyInstanceError::Unknown(format!("{}", status))
+                } else {
+                    UpdateTrafficPolicyInstanceError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 

--- a/rusoto/services/s3/src/generated.rs
+++ b/rusoto/services/s3/src/generated.rs
@@ -16284,7 +16284,11 @@ impl AbortMultipartUploadError {
                 _ => AbortMultipartUploadError::Unknown(String::from(body)),
             },
             Err(_) => {
-                AbortMultipartUploadError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    AbortMultipartUploadError::Unknown(format!("{}", status))
+                } else {
+                    AbortMultipartUploadError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -16359,7 +16363,15 @@ impl CompleteMultipartUploadError {
                 _ => CompleteMultipartUploadError::Unknown(String::from(body)),
             },
             Err(_) => {
-                CompleteMultipartUploadError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    CompleteMultipartUploadError::Unknown(format!("{}", status))
+                } else {
+                    CompleteMultipartUploadError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -16437,7 +16449,13 @@ impl CopyObjectError {
                 }
                 _ => CopyObjectError::Unknown(String::from(body)),
             },
-            Err(_) => CopyObjectError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CopyObjectError::Unknown(format!("{}", status))
+                } else {
+                    CopyObjectError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -16518,7 +16536,13 @@ impl CreateBucketError {
                 }
                 _ => CreateBucketError::Unknown(String::from(body)),
             },
-            Err(_) => CreateBucketError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateBucketError::Unknown(format!("{}", status))
+                } else {
+                    CreateBucketError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -16591,7 +16615,11 @@ impl CreateMultipartUploadError {
                 _ => CreateMultipartUploadError::Unknown(String::from(body)),
             },
             Err(_) => {
-                CreateMultipartUploadError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    CreateMultipartUploadError::Unknown(format!("{}", status))
+                } else {
+                    CreateMultipartUploadError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -16664,7 +16692,13 @@ impl DeleteBucketError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteBucketError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteBucketError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteBucketError::Unknown(format!("{}", status))
+                } else {
+                    DeleteBucketError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -16734,11 +16768,17 @@ impl DeleteBucketAnalyticsConfigurationError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteBucketAnalyticsConfigurationError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteBucketAnalyticsConfigurationError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteBucketAnalyticsConfigurationError::Unknown(format!("{}", status))
+                } else {
+                    DeleteBucketAnalyticsConfigurationError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -16810,7 +16850,13 @@ impl DeleteBucketCorsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteBucketCorsError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteBucketCorsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteBucketCorsError::Unknown(format!("{}", status))
+                } else {
+                    DeleteBucketCorsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -16881,7 +16927,11 @@ impl DeleteBucketEncryptionError {
                 _ => DeleteBucketEncryptionError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DeleteBucketEncryptionError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DeleteBucketEncryptionError::Unknown(format!("{}", status))
+                } else {
+                    DeleteBucketEncryptionError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -16954,11 +17004,17 @@ impl DeleteBucketInventoryConfigurationError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteBucketInventoryConfigurationError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteBucketInventoryConfigurationError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteBucketInventoryConfigurationError::Unknown(format!("{}", status))
+                } else {
+                    DeleteBucketInventoryConfigurationError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -17031,7 +17087,11 @@ impl DeleteBucketLifecycleError {
                 _ => DeleteBucketLifecycleError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DeleteBucketLifecycleError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DeleteBucketLifecycleError::Unknown(format!("{}", status))
+                } else {
+                    DeleteBucketLifecycleError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -17104,11 +17164,17 @@ impl DeleteBucketMetricsConfigurationError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteBucketMetricsConfigurationError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteBucketMetricsConfigurationError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteBucketMetricsConfigurationError::Unknown(format!("{}", status))
+                } else {
+                    DeleteBucketMetricsConfigurationError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -17180,7 +17246,13 @@ impl DeleteBucketPolicyError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteBucketPolicyError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteBucketPolicyError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteBucketPolicyError::Unknown(format!("{}", status))
+                } else {
+                    DeleteBucketPolicyError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -17253,7 +17325,15 @@ impl DeleteBucketReplicationError {
                 _ => DeleteBucketReplicationError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DeleteBucketReplicationError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DeleteBucketReplicationError::Unknown(format!("{}", status))
+                } else {
+                    DeleteBucketReplicationError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -17326,7 +17406,13 @@ impl DeleteBucketTaggingError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteBucketTaggingError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteBucketTaggingError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteBucketTaggingError::Unknown(format!("{}", status))
+                } else {
+                    DeleteBucketTaggingError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -17398,7 +17484,13 @@ impl DeleteBucketWebsiteError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteBucketWebsiteError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteBucketWebsiteError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteBucketWebsiteError::Unknown(format!("{}", status))
+                } else {
+                    DeleteBucketWebsiteError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -17470,7 +17562,13 @@ impl DeleteObjectError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteObjectError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteObjectError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteObjectError::Unknown(format!("{}", status))
+                } else {
+                    DeleteObjectError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -17540,7 +17638,13 @@ impl DeleteObjectTaggingError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteObjectTaggingError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteObjectTaggingError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteObjectTaggingError::Unknown(format!("{}", status))
+                } else {
+                    DeleteObjectTaggingError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -17612,7 +17716,13 @@ impl DeleteObjectsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteObjectsError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteObjectsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteObjectsError::Unknown(format!("{}", status))
+                } else {
+                    DeleteObjectsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -17682,11 +17792,17 @@ impl GetBucketAccelerateConfigurationError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketAccelerateConfigurationError::Unknown(String::from(body)),
             },
-            Err(_) => GetBucketAccelerateConfigurationError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetBucketAccelerateConfigurationError::Unknown(format!("{}", status))
+                } else {
+                    GetBucketAccelerateConfigurationError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -17758,7 +17874,13 @@ impl GetBucketAclError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketAclError::Unknown(String::from(body)),
             },
-            Err(_) => GetBucketAclError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetBucketAclError::Unknown(format!("{}", status))
+                } else {
+                    GetBucketAclError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -17828,11 +17950,17 @@ impl GetBucketAnalyticsConfigurationError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketAnalyticsConfigurationError::Unknown(String::from(body)),
             },
-            Err(_) => GetBucketAnalyticsConfigurationError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetBucketAnalyticsConfigurationError::Unknown(format!("{}", status))
+                } else {
+                    GetBucketAnalyticsConfigurationError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -17904,7 +18032,13 @@ impl GetBucketCorsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketCorsError::Unknown(String::from(body)),
             },
-            Err(_) => GetBucketCorsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetBucketCorsError::Unknown(format!("{}", status))
+                } else {
+                    GetBucketCorsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -17974,7 +18108,13 @@ impl GetBucketEncryptionError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketEncryptionError::Unknown(String::from(body)),
             },
-            Err(_) => GetBucketEncryptionError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetBucketEncryptionError::Unknown(format!("{}", status))
+                } else {
+                    GetBucketEncryptionError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -18046,11 +18186,17 @@ impl GetBucketInventoryConfigurationError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketInventoryConfigurationError::Unknown(String::from(body)),
             },
-            Err(_) => GetBucketInventoryConfigurationError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetBucketInventoryConfigurationError::Unknown(format!("{}", status))
+                } else {
+                    GetBucketInventoryConfigurationError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -18122,7 +18268,13 @@ impl GetBucketLifecycleError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketLifecycleError::Unknown(String::from(body)),
             },
-            Err(_) => GetBucketLifecycleError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetBucketLifecycleError::Unknown(format!("{}", status))
+                } else {
+                    GetBucketLifecycleError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -18194,11 +18346,17 @@ impl GetBucketLifecycleConfigurationError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketLifecycleConfigurationError::Unknown(String::from(body)),
             },
-            Err(_) => GetBucketLifecycleConfigurationError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetBucketLifecycleConfigurationError::Unknown(format!("{}", status))
+                } else {
+                    GetBucketLifecycleConfigurationError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -18270,7 +18428,13 @@ impl GetBucketLocationError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketLocationError::Unknown(String::from(body)),
             },
-            Err(_) => GetBucketLocationError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetBucketLocationError::Unknown(format!("{}", status))
+                } else {
+                    GetBucketLocationError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -18342,7 +18506,13 @@ impl GetBucketLoggingError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketLoggingError::Unknown(String::from(body)),
             },
-            Err(_) => GetBucketLoggingError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetBucketLoggingError::Unknown(format!("{}", status))
+                } else {
+                    GetBucketLoggingError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -18412,11 +18582,17 @@ impl GetBucketMetricsConfigurationError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketMetricsConfigurationError::Unknown(String::from(body)),
             },
-            Err(_) => GetBucketMetricsConfigurationError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetBucketMetricsConfigurationError::Unknown(format!("{}", status))
+                } else {
+                    GetBucketMetricsConfigurationError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -18489,7 +18665,11 @@ impl GetBucketNotificationError {
                 _ => GetBucketNotificationError::Unknown(String::from(body)),
             },
             Err(_) => {
-                GetBucketNotificationError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    GetBucketNotificationError::Unknown(format!("{}", status))
+                } else {
+                    GetBucketNotificationError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -18562,11 +18742,17 @@ impl GetBucketNotificationConfigurationError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketNotificationConfigurationError::Unknown(String::from(body)),
             },
-            Err(_) => GetBucketNotificationConfigurationError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetBucketNotificationConfigurationError::Unknown(format!("{}", status))
+                } else {
+                    GetBucketNotificationConfigurationError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -18638,7 +18824,13 @@ impl GetBucketPolicyError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketPolicyError::Unknown(String::from(body)),
             },
-            Err(_) => GetBucketPolicyError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetBucketPolicyError::Unknown(format!("{}", status))
+                } else {
+                    GetBucketPolicyError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -18709,7 +18901,11 @@ impl GetBucketReplicationError {
                 _ => GetBucketReplicationError::Unknown(String::from(body)),
             },
             Err(_) => {
-                GetBucketReplicationError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    GetBucketReplicationError::Unknown(format!("{}", status))
+                } else {
+                    GetBucketReplicationError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -18783,7 +18979,15 @@ impl GetBucketRequestPaymentError {
                 _ => GetBucketRequestPaymentError::Unknown(String::from(body)),
             },
             Err(_) => {
-                GetBucketRequestPaymentError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    GetBucketRequestPaymentError::Unknown(format!("{}", status))
+                } else {
+                    GetBucketRequestPaymentError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -18856,7 +19060,13 @@ impl GetBucketTaggingError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketTaggingError::Unknown(String::from(body)),
             },
-            Err(_) => GetBucketTaggingError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetBucketTaggingError::Unknown(format!("{}", status))
+                } else {
+                    GetBucketTaggingError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -18926,7 +19136,13 @@ impl GetBucketVersioningError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketVersioningError::Unknown(String::from(body)),
             },
-            Err(_) => GetBucketVersioningError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetBucketVersioningError::Unknown(format!("{}", status))
+                } else {
+                    GetBucketVersioningError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -18998,7 +19214,13 @@ impl GetBucketWebsiteError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketWebsiteError::Unknown(String::from(body)),
             },
-            Err(_) => GetBucketWebsiteError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetBucketWebsiteError::Unknown(format!("{}", status))
+                } else {
+                    GetBucketWebsiteError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -19071,7 +19293,13 @@ impl GetObjectError {
                 "NoSuchKey" => GetObjectError::NoSuchKey(String::from(parsed_error.message)),
                 _ => GetObjectError::Unknown(String::from(body)),
             },
-            Err(_) => GetObjectError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetObjectError::Unknown(format!("{}", status))
+                } else {
+                    GetObjectError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -19145,7 +19373,13 @@ impl GetObjectAclError {
                 "NoSuchKey" => GetObjectAclError::NoSuchKey(String::from(parsed_error.message)),
                 _ => GetObjectAclError::Unknown(String::from(body)),
             },
-            Err(_) => GetObjectAclError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetObjectAclError::Unknown(format!("{}", status))
+                } else {
+                    GetObjectAclError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -19216,7 +19450,13 @@ impl GetObjectTaggingError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetObjectTaggingError::Unknown(String::from(body)),
             },
-            Err(_) => GetObjectTaggingError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetObjectTaggingError::Unknown(format!("{}", status))
+                } else {
+                    GetObjectTaggingError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -19286,7 +19526,13 @@ impl GetObjectTorrentError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetObjectTorrentError::Unknown(String::from(body)),
             },
-            Err(_) => GetObjectTorrentError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetObjectTorrentError::Unknown(format!("{}", status))
+                } else {
+                    GetObjectTorrentError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -19359,7 +19605,13 @@ impl HeadBucketError {
                 "NoSuchBucket" => HeadBucketError::NoSuchBucket(String::from(parsed_error.message)),
                 _ => HeadBucketError::Unknown(String::from(body)),
             },
-            Err(_) => HeadBucketError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    HeadBucketError::Unknown(format!("{}", status))
+                } else {
+                    HeadBucketError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -19433,7 +19685,13 @@ impl HeadObjectError {
                 "NoSuchKey" => HeadObjectError::NoSuchKey(String::from(parsed_error.message)),
                 _ => HeadObjectError::Unknown(String::from(body)),
             },
-            Err(_) => HeadObjectError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    HeadObjectError::Unknown(format!("{}", status))
+                } else {
+                    HeadObjectError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -19504,11 +19762,17 @@ impl ListBucketAnalyticsConfigurationsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListBucketAnalyticsConfigurationsError::Unknown(String::from(body)),
             },
-            Err(_) => ListBucketAnalyticsConfigurationsError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    ListBucketAnalyticsConfigurationsError::Unknown(format!("{}", status))
+                } else {
+                    ListBucketAnalyticsConfigurationsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -19580,11 +19844,17 @@ impl ListBucketInventoryConfigurationsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListBucketInventoryConfigurationsError::Unknown(String::from(body)),
             },
-            Err(_) => ListBucketInventoryConfigurationsError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    ListBucketInventoryConfigurationsError::Unknown(format!("{}", status))
+                } else {
+                    ListBucketInventoryConfigurationsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -19656,11 +19926,17 @@ impl ListBucketMetricsConfigurationsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListBucketMetricsConfigurationsError::Unknown(String::from(body)),
             },
-            Err(_) => ListBucketMetricsConfigurationsError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    ListBucketMetricsConfigurationsError::Unknown(format!("{}", status))
+                } else {
+                    ListBucketMetricsConfigurationsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -19732,7 +20008,13 @@ impl ListBucketsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListBucketsError::Unknown(String::from(body)),
             },
-            Err(_) => ListBucketsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ListBucketsError::Unknown(format!("{}", status))
+                } else {
+                    ListBucketsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -19803,7 +20085,11 @@ impl ListMultipartUploadsError {
                 _ => ListMultipartUploadsError::Unknown(String::from(body)),
             },
             Err(_) => {
-                ListMultipartUploadsError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    ListMultipartUploadsError::Unknown(format!("{}", status))
+                } else {
+                    ListMultipartUploadsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -19876,7 +20162,13 @@ impl ListObjectVersionsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListObjectVersionsError::Unknown(String::from(body)),
             },
-            Err(_) => ListObjectVersionsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ListObjectVersionsError::Unknown(format!("{}", status))
+                } else {
+                    ListObjectVersionsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -19953,7 +20245,13 @@ impl ListObjectsError {
                 }
                 _ => ListObjectsError::Unknown(String::from(body)),
             },
-            Err(_) => ListObjectsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ListObjectsError::Unknown(format!("{}", status))
+                } else {
+                    ListObjectsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -20029,7 +20327,13 @@ impl ListObjectsV2Error {
                 }
                 _ => ListObjectsV2Error::Unknown(String::from(body)),
             },
-            Err(_) => ListObjectsV2Error::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ListObjectsV2Error::Unknown(format!("{}", status))
+                } else {
+                    ListObjectsV2Error::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -20100,7 +20404,13 @@ impl ListPartsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListPartsError::Unknown(String::from(body)),
             },
-            Err(_) => ListPartsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ListPartsError::Unknown(format!("{}", status))
+                } else {
+                    ListPartsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -20170,11 +20480,17 @@ impl PutBucketAccelerateConfigurationError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutBucketAccelerateConfigurationError::Unknown(String::from(body)),
             },
-            Err(_) => PutBucketAccelerateConfigurationError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    PutBucketAccelerateConfigurationError::Unknown(format!("{}", status))
+                } else {
+                    PutBucketAccelerateConfigurationError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -20246,7 +20562,13 @@ impl PutBucketAclError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutBucketAclError::Unknown(String::from(body)),
             },
-            Err(_) => PutBucketAclError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    PutBucketAclError::Unknown(format!("{}", status))
+                } else {
+                    PutBucketAclError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -20316,11 +20638,17 @@ impl PutBucketAnalyticsConfigurationError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutBucketAnalyticsConfigurationError::Unknown(String::from(body)),
             },
-            Err(_) => PutBucketAnalyticsConfigurationError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    PutBucketAnalyticsConfigurationError::Unknown(format!("{}", status))
+                } else {
+                    PutBucketAnalyticsConfigurationError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -20392,7 +20720,13 @@ impl PutBucketCorsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutBucketCorsError::Unknown(String::from(body)),
             },
-            Err(_) => PutBucketCorsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    PutBucketCorsError::Unknown(format!("{}", status))
+                } else {
+                    PutBucketCorsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -20462,7 +20796,13 @@ impl PutBucketEncryptionError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutBucketEncryptionError::Unknown(String::from(body)),
             },
-            Err(_) => PutBucketEncryptionError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    PutBucketEncryptionError::Unknown(format!("{}", status))
+                } else {
+                    PutBucketEncryptionError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -20534,11 +20874,17 @@ impl PutBucketInventoryConfigurationError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutBucketInventoryConfigurationError::Unknown(String::from(body)),
             },
-            Err(_) => PutBucketInventoryConfigurationError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    PutBucketInventoryConfigurationError::Unknown(format!("{}", status))
+                } else {
+                    PutBucketInventoryConfigurationError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -20610,7 +20956,13 @@ impl PutBucketLifecycleError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutBucketLifecycleError::Unknown(String::from(body)),
             },
-            Err(_) => PutBucketLifecycleError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    PutBucketLifecycleError::Unknown(format!("{}", status))
+                } else {
+                    PutBucketLifecycleError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -20682,11 +21034,17 @@ impl PutBucketLifecycleConfigurationError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutBucketLifecycleConfigurationError::Unknown(String::from(body)),
             },
-            Err(_) => PutBucketLifecycleConfigurationError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    PutBucketLifecycleConfigurationError::Unknown(format!("{}", status))
+                } else {
+                    PutBucketLifecycleConfigurationError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -20758,7 +21116,13 @@ impl PutBucketLoggingError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutBucketLoggingError::Unknown(String::from(body)),
             },
-            Err(_) => PutBucketLoggingError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    PutBucketLoggingError::Unknown(format!("{}", status))
+                } else {
+                    PutBucketLoggingError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -20828,11 +21192,17 @@ impl PutBucketMetricsConfigurationError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutBucketMetricsConfigurationError::Unknown(String::from(body)),
             },
-            Err(_) => PutBucketMetricsConfigurationError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    PutBucketMetricsConfigurationError::Unknown(format!("{}", status))
+                } else {
+                    PutBucketMetricsConfigurationError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -20905,7 +21275,11 @@ impl PutBucketNotificationError {
                 _ => PutBucketNotificationError::Unknown(String::from(body)),
             },
             Err(_) => {
-                PutBucketNotificationError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    PutBucketNotificationError::Unknown(format!("{}", status))
+                } else {
+                    PutBucketNotificationError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -20978,11 +21352,17 @@ impl PutBucketNotificationConfigurationError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutBucketNotificationConfigurationError::Unknown(String::from(body)),
             },
-            Err(_) => PutBucketNotificationConfigurationError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    PutBucketNotificationConfigurationError::Unknown(format!("{}", status))
+                } else {
+                    PutBucketNotificationConfigurationError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -21054,7 +21434,13 @@ impl PutBucketPolicyError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutBucketPolicyError::Unknown(String::from(body)),
             },
-            Err(_) => PutBucketPolicyError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    PutBucketPolicyError::Unknown(format!("{}", status))
+                } else {
+                    PutBucketPolicyError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -21125,7 +21511,11 @@ impl PutBucketReplicationError {
                 _ => PutBucketReplicationError::Unknown(String::from(body)),
             },
             Err(_) => {
-                PutBucketReplicationError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    PutBucketReplicationError::Unknown(format!("{}", status))
+                } else {
+                    PutBucketReplicationError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -21199,7 +21589,15 @@ impl PutBucketRequestPaymentError {
                 _ => PutBucketRequestPaymentError::Unknown(String::from(body)),
             },
             Err(_) => {
-                PutBucketRequestPaymentError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    PutBucketRequestPaymentError::Unknown(format!("{}", status))
+                } else {
+                    PutBucketRequestPaymentError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -21272,7 +21670,13 @@ impl PutBucketTaggingError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutBucketTaggingError::Unknown(String::from(body)),
             },
-            Err(_) => PutBucketTaggingError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    PutBucketTaggingError::Unknown(format!("{}", status))
+                } else {
+                    PutBucketTaggingError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -21342,7 +21746,13 @@ impl PutBucketVersioningError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutBucketVersioningError::Unknown(String::from(body)),
             },
-            Err(_) => PutBucketVersioningError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    PutBucketVersioningError::Unknown(format!("{}", status))
+                } else {
+                    PutBucketVersioningError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -21414,7 +21824,13 @@ impl PutBucketWebsiteError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutBucketWebsiteError::Unknown(String::from(body)),
             },
-            Err(_) => PutBucketWebsiteError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    PutBucketWebsiteError::Unknown(format!("{}", status))
+                } else {
+                    PutBucketWebsiteError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -21484,7 +21900,13 @@ impl PutObjectError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutObjectError::Unknown(String::from(body)),
             },
-            Err(_) => PutObjectError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    PutObjectError::Unknown(format!("{}", status))
+                } else {
+                    PutObjectError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -21557,7 +21979,13 @@ impl PutObjectAclError {
                 "NoSuchKey" => PutObjectAclError::NoSuchKey(String::from(parsed_error.message)),
                 _ => PutObjectAclError::Unknown(String::from(body)),
             },
-            Err(_) => PutObjectAclError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    PutObjectAclError::Unknown(format!("{}", status))
+                } else {
+                    PutObjectAclError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -21628,7 +22056,13 @@ impl PutObjectTaggingError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutObjectTaggingError::Unknown(String::from(body)),
             },
-            Err(_) => PutObjectTaggingError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    PutObjectTaggingError::Unknown(format!("{}", status))
+                } else {
+                    PutObjectTaggingError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -21705,7 +22139,13 @@ impl RestoreObjectError {
                 }
                 _ => RestoreObjectError::Unknown(String::from(body)),
             },
-            Err(_) => RestoreObjectError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    RestoreObjectError::Unknown(format!("{}", status))
+                } else {
+                    RestoreObjectError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -21776,7 +22216,13 @@ impl SelectObjectContentError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => SelectObjectContentError::Unknown(String::from(body)),
             },
-            Err(_) => SelectObjectContentError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    SelectObjectContentError::Unknown(format!("{}", status))
+                } else {
+                    SelectObjectContentError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -21848,7 +22294,13 @@ impl UploadPartError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => UploadPartError::Unknown(String::from(body)),
             },
-            Err(_) => UploadPartError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    UploadPartError::Unknown(format!("{}", status))
+                } else {
+                    UploadPartError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -21918,7 +22370,13 @@ impl UploadPartCopyError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => UploadPartCopyError::Unknown(String::from(body)),
             },
-            Err(_) => UploadPartCopyError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    UploadPartCopyError::Unknown(format!("{}", status))
+                } else {
+                    UploadPartCopyError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 

--- a/rusoto/services/s3/src/generated.rs
+++ b/rusoto/services/s3/src/generated.rs
@@ -16272,7 +16272,7 @@ pub enum AbortMultipartUploadError {
 }
 
 impl AbortMultipartUploadError {
-    pub fn from_body(body: &str) -> AbortMultipartUploadError {
+    pub fn from_body(body: &str, status: u16) -> AbortMultipartUploadError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -16283,7 +16283,9 @@ impl AbortMultipartUploadError {
                 }
                 _ => AbortMultipartUploadError::Unknown(String::from(body)),
             },
-            Err(_) => AbortMultipartUploadError::Unknown(body.to_string()),
+            Err(_) => {
+                AbortMultipartUploadError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -16348,7 +16350,7 @@ pub enum CompleteMultipartUploadError {
 }
 
 impl CompleteMultipartUploadError {
-    pub fn from_body(body: &str) -> CompleteMultipartUploadError {
+    pub fn from_body(body: &str, status: u16) -> CompleteMultipartUploadError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -16356,7 +16358,9 @@ impl CompleteMultipartUploadError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CompleteMultipartUploadError::Unknown(String::from(body)),
             },
-            Err(_) => CompleteMultipartUploadError::Unknown(body.to_string()),
+            Err(_) => {
+                CompleteMultipartUploadError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -16422,7 +16426,7 @@ pub enum CopyObjectError {
 }
 
 impl CopyObjectError {
-    pub fn from_body(body: &str) -> CopyObjectError {
+    pub fn from_body(body: &str, status: u16) -> CopyObjectError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -16433,7 +16437,7 @@ impl CopyObjectError {
                 }
                 _ => CopyObjectError::Unknown(String::from(body)),
             },
-            Err(_) => CopyObjectError::Unknown(body.to_string()),
+            Err(_) => CopyObjectError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -16500,7 +16504,7 @@ pub enum CreateBucketError {
 }
 
 impl CreateBucketError {
-    pub fn from_body(body: &str) -> CreateBucketError {
+    pub fn from_body(body: &str, status: u16) -> CreateBucketError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -16514,7 +16518,7 @@ impl CreateBucketError {
                 }
                 _ => CreateBucketError::Unknown(String::from(body)),
             },
-            Err(_) => CreateBucketError::Unknown(body.to_string()),
+            Err(_) => CreateBucketError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -16578,7 +16582,7 @@ pub enum CreateMultipartUploadError {
 }
 
 impl CreateMultipartUploadError {
-    pub fn from_body(body: &str) -> CreateMultipartUploadError {
+    pub fn from_body(body: &str, status: u16) -> CreateMultipartUploadError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -16586,7 +16590,9 @@ impl CreateMultipartUploadError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => CreateMultipartUploadError::Unknown(String::from(body)),
             },
-            Err(_) => CreateMultipartUploadError::Unknown(body.to_string()),
+            Err(_) => {
+                CreateMultipartUploadError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -16650,7 +16656,7 @@ pub enum DeleteBucketError {
 }
 
 impl DeleteBucketError {
-    pub fn from_body(body: &str) -> DeleteBucketError {
+    pub fn from_body(body: &str, status: u16) -> DeleteBucketError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -16658,7 +16664,7 @@ impl DeleteBucketError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteBucketError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteBucketError::Unknown(body.to_string()),
+            Err(_) => DeleteBucketError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -16720,7 +16726,7 @@ pub enum DeleteBucketAnalyticsConfigurationError {
 }
 
 impl DeleteBucketAnalyticsConfigurationError {
-    pub fn from_body(body: &str) -> DeleteBucketAnalyticsConfigurationError {
+    pub fn from_body(body: &str, status: u16) -> DeleteBucketAnalyticsConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -16728,7 +16734,11 @@ impl DeleteBucketAnalyticsConfigurationError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteBucketAnalyticsConfigurationError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteBucketAnalyticsConfigurationError::Unknown(body.to_string()),
+            Err(_) => DeleteBucketAnalyticsConfigurationError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -16792,7 +16802,7 @@ pub enum DeleteBucketCorsError {
 }
 
 impl DeleteBucketCorsError {
-    pub fn from_body(body: &str) -> DeleteBucketCorsError {
+    pub fn from_body(body: &str, status: u16) -> DeleteBucketCorsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -16800,7 +16810,7 @@ impl DeleteBucketCorsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteBucketCorsError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteBucketCorsError::Unknown(body.to_string()),
+            Err(_) => DeleteBucketCorsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -16862,7 +16872,7 @@ pub enum DeleteBucketEncryptionError {
 }
 
 impl DeleteBucketEncryptionError {
-    pub fn from_body(body: &str) -> DeleteBucketEncryptionError {
+    pub fn from_body(body: &str, status: u16) -> DeleteBucketEncryptionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -16870,7 +16880,9 @@ impl DeleteBucketEncryptionError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteBucketEncryptionError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteBucketEncryptionError::Unknown(body.to_string()),
+            Err(_) => {
+                DeleteBucketEncryptionError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -16934,7 +16946,7 @@ pub enum DeleteBucketInventoryConfigurationError {
 }
 
 impl DeleteBucketInventoryConfigurationError {
-    pub fn from_body(body: &str) -> DeleteBucketInventoryConfigurationError {
+    pub fn from_body(body: &str, status: u16) -> DeleteBucketInventoryConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -16942,7 +16954,11 @@ impl DeleteBucketInventoryConfigurationError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteBucketInventoryConfigurationError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteBucketInventoryConfigurationError::Unknown(body.to_string()),
+            Err(_) => DeleteBucketInventoryConfigurationError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -17006,7 +17022,7 @@ pub enum DeleteBucketLifecycleError {
 }
 
 impl DeleteBucketLifecycleError {
-    pub fn from_body(body: &str) -> DeleteBucketLifecycleError {
+    pub fn from_body(body: &str, status: u16) -> DeleteBucketLifecycleError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -17014,7 +17030,9 @@ impl DeleteBucketLifecycleError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteBucketLifecycleError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteBucketLifecycleError::Unknown(body.to_string()),
+            Err(_) => {
+                DeleteBucketLifecycleError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -17078,7 +17096,7 @@ pub enum DeleteBucketMetricsConfigurationError {
 }
 
 impl DeleteBucketMetricsConfigurationError {
-    pub fn from_body(body: &str) -> DeleteBucketMetricsConfigurationError {
+    pub fn from_body(body: &str, status: u16) -> DeleteBucketMetricsConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -17086,7 +17104,11 @@ impl DeleteBucketMetricsConfigurationError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteBucketMetricsConfigurationError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteBucketMetricsConfigurationError::Unknown(body.to_string()),
+            Err(_) => DeleteBucketMetricsConfigurationError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -17150,7 +17172,7 @@ pub enum DeleteBucketPolicyError {
 }
 
 impl DeleteBucketPolicyError {
-    pub fn from_body(body: &str) -> DeleteBucketPolicyError {
+    pub fn from_body(body: &str, status: u16) -> DeleteBucketPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -17158,7 +17180,7 @@ impl DeleteBucketPolicyError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteBucketPolicyError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteBucketPolicyError::Unknown(body.to_string()),
+            Err(_) => DeleteBucketPolicyError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -17222,7 +17244,7 @@ pub enum DeleteBucketReplicationError {
 }
 
 impl DeleteBucketReplicationError {
-    pub fn from_body(body: &str) -> DeleteBucketReplicationError {
+    pub fn from_body(body: &str, status: u16) -> DeleteBucketReplicationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -17230,7 +17252,9 @@ impl DeleteBucketReplicationError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteBucketReplicationError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteBucketReplicationError::Unknown(body.to_string()),
+            Err(_) => {
+                DeleteBucketReplicationError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -17294,7 +17318,7 @@ pub enum DeleteBucketTaggingError {
 }
 
 impl DeleteBucketTaggingError {
-    pub fn from_body(body: &str) -> DeleteBucketTaggingError {
+    pub fn from_body(body: &str, status: u16) -> DeleteBucketTaggingError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -17302,7 +17326,7 @@ impl DeleteBucketTaggingError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteBucketTaggingError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteBucketTaggingError::Unknown(body.to_string()),
+            Err(_) => DeleteBucketTaggingError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -17366,7 +17390,7 @@ pub enum DeleteBucketWebsiteError {
 }
 
 impl DeleteBucketWebsiteError {
-    pub fn from_body(body: &str) -> DeleteBucketWebsiteError {
+    pub fn from_body(body: &str, status: u16) -> DeleteBucketWebsiteError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -17374,7 +17398,7 @@ impl DeleteBucketWebsiteError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteBucketWebsiteError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteBucketWebsiteError::Unknown(body.to_string()),
+            Err(_) => DeleteBucketWebsiteError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -17438,7 +17462,7 @@ pub enum DeleteObjectError {
 }
 
 impl DeleteObjectError {
-    pub fn from_body(body: &str) -> DeleteObjectError {
+    pub fn from_body(body: &str, status: u16) -> DeleteObjectError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -17446,7 +17470,7 @@ impl DeleteObjectError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteObjectError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteObjectError::Unknown(body.to_string()),
+            Err(_) => DeleteObjectError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -17508,7 +17532,7 @@ pub enum DeleteObjectTaggingError {
 }
 
 impl DeleteObjectTaggingError {
-    pub fn from_body(body: &str) -> DeleteObjectTaggingError {
+    pub fn from_body(body: &str, status: u16) -> DeleteObjectTaggingError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -17516,7 +17540,7 @@ impl DeleteObjectTaggingError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteObjectTaggingError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteObjectTaggingError::Unknown(body.to_string()),
+            Err(_) => DeleteObjectTaggingError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -17580,7 +17604,7 @@ pub enum DeleteObjectsError {
 }
 
 impl DeleteObjectsError {
-    pub fn from_body(body: &str) -> DeleteObjectsError {
+    pub fn from_body(body: &str, status: u16) -> DeleteObjectsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -17588,7 +17612,7 @@ impl DeleteObjectsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteObjectsError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteObjectsError::Unknown(body.to_string()),
+            Err(_) => DeleteObjectsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -17650,7 +17674,7 @@ pub enum GetBucketAccelerateConfigurationError {
 }
 
 impl GetBucketAccelerateConfigurationError {
-    pub fn from_body(body: &str) -> GetBucketAccelerateConfigurationError {
+    pub fn from_body(body: &str, status: u16) -> GetBucketAccelerateConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -17658,7 +17682,11 @@ impl GetBucketAccelerateConfigurationError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketAccelerateConfigurationError::Unknown(String::from(body)),
             },
-            Err(_) => GetBucketAccelerateConfigurationError::Unknown(body.to_string()),
+            Err(_) => GetBucketAccelerateConfigurationError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -17722,7 +17750,7 @@ pub enum GetBucketAclError {
 }
 
 impl GetBucketAclError {
-    pub fn from_body(body: &str) -> GetBucketAclError {
+    pub fn from_body(body: &str, status: u16) -> GetBucketAclError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -17730,7 +17758,7 @@ impl GetBucketAclError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketAclError::Unknown(String::from(body)),
             },
-            Err(_) => GetBucketAclError::Unknown(body.to_string()),
+            Err(_) => GetBucketAclError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -17792,7 +17820,7 @@ pub enum GetBucketAnalyticsConfigurationError {
 }
 
 impl GetBucketAnalyticsConfigurationError {
-    pub fn from_body(body: &str) -> GetBucketAnalyticsConfigurationError {
+    pub fn from_body(body: &str, status: u16) -> GetBucketAnalyticsConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -17800,7 +17828,11 @@ impl GetBucketAnalyticsConfigurationError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketAnalyticsConfigurationError::Unknown(String::from(body)),
             },
-            Err(_) => GetBucketAnalyticsConfigurationError::Unknown(body.to_string()),
+            Err(_) => GetBucketAnalyticsConfigurationError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -17864,7 +17896,7 @@ pub enum GetBucketCorsError {
 }
 
 impl GetBucketCorsError {
-    pub fn from_body(body: &str) -> GetBucketCorsError {
+    pub fn from_body(body: &str, status: u16) -> GetBucketCorsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -17872,7 +17904,7 @@ impl GetBucketCorsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketCorsError::Unknown(String::from(body)),
             },
-            Err(_) => GetBucketCorsError::Unknown(body.to_string()),
+            Err(_) => GetBucketCorsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -17934,7 +17966,7 @@ pub enum GetBucketEncryptionError {
 }
 
 impl GetBucketEncryptionError {
-    pub fn from_body(body: &str) -> GetBucketEncryptionError {
+    pub fn from_body(body: &str, status: u16) -> GetBucketEncryptionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -17942,7 +17974,7 @@ impl GetBucketEncryptionError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketEncryptionError::Unknown(String::from(body)),
             },
-            Err(_) => GetBucketEncryptionError::Unknown(body.to_string()),
+            Err(_) => GetBucketEncryptionError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -18006,7 +18038,7 @@ pub enum GetBucketInventoryConfigurationError {
 }
 
 impl GetBucketInventoryConfigurationError {
-    pub fn from_body(body: &str) -> GetBucketInventoryConfigurationError {
+    pub fn from_body(body: &str, status: u16) -> GetBucketInventoryConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -18014,7 +18046,11 @@ impl GetBucketInventoryConfigurationError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketInventoryConfigurationError::Unknown(String::from(body)),
             },
-            Err(_) => GetBucketInventoryConfigurationError::Unknown(body.to_string()),
+            Err(_) => GetBucketInventoryConfigurationError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -18078,7 +18114,7 @@ pub enum GetBucketLifecycleError {
 }
 
 impl GetBucketLifecycleError {
-    pub fn from_body(body: &str) -> GetBucketLifecycleError {
+    pub fn from_body(body: &str, status: u16) -> GetBucketLifecycleError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -18086,7 +18122,7 @@ impl GetBucketLifecycleError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketLifecycleError::Unknown(String::from(body)),
             },
-            Err(_) => GetBucketLifecycleError::Unknown(body.to_string()),
+            Err(_) => GetBucketLifecycleError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -18150,7 +18186,7 @@ pub enum GetBucketLifecycleConfigurationError {
 }
 
 impl GetBucketLifecycleConfigurationError {
-    pub fn from_body(body: &str) -> GetBucketLifecycleConfigurationError {
+    pub fn from_body(body: &str, status: u16) -> GetBucketLifecycleConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -18158,7 +18194,11 @@ impl GetBucketLifecycleConfigurationError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketLifecycleConfigurationError::Unknown(String::from(body)),
             },
-            Err(_) => GetBucketLifecycleConfigurationError::Unknown(body.to_string()),
+            Err(_) => GetBucketLifecycleConfigurationError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -18222,7 +18262,7 @@ pub enum GetBucketLocationError {
 }
 
 impl GetBucketLocationError {
-    pub fn from_body(body: &str) -> GetBucketLocationError {
+    pub fn from_body(body: &str, status: u16) -> GetBucketLocationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -18230,7 +18270,7 @@ impl GetBucketLocationError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketLocationError::Unknown(String::from(body)),
             },
-            Err(_) => GetBucketLocationError::Unknown(body.to_string()),
+            Err(_) => GetBucketLocationError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -18294,7 +18334,7 @@ pub enum GetBucketLoggingError {
 }
 
 impl GetBucketLoggingError {
-    pub fn from_body(body: &str) -> GetBucketLoggingError {
+    pub fn from_body(body: &str, status: u16) -> GetBucketLoggingError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -18302,7 +18342,7 @@ impl GetBucketLoggingError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketLoggingError::Unknown(String::from(body)),
             },
-            Err(_) => GetBucketLoggingError::Unknown(body.to_string()),
+            Err(_) => GetBucketLoggingError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -18364,7 +18404,7 @@ pub enum GetBucketMetricsConfigurationError {
 }
 
 impl GetBucketMetricsConfigurationError {
-    pub fn from_body(body: &str) -> GetBucketMetricsConfigurationError {
+    pub fn from_body(body: &str, status: u16) -> GetBucketMetricsConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -18372,7 +18412,11 @@ impl GetBucketMetricsConfigurationError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketMetricsConfigurationError::Unknown(String::from(body)),
             },
-            Err(_) => GetBucketMetricsConfigurationError::Unknown(body.to_string()),
+            Err(_) => GetBucketMetricsConfigurationError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -18436,7 +18480,7 @@ pub enum GetBucketNotificationError {
 }
 
 impl GetBucketNotificationError {
-    pub fn from_body(body: &str) -> GetBucketNotificationError {
+    pub fn from_body(body: &str, status: u16) -> GetBucketNotificationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -18444,7 +18488,9 @@ impl GetBucketNotificationError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketNotificationError::Unknown(String::from(body)),
             },
-            Err(_) => GetBucketNotificationError::Unknown(body.to_string()),
+            Err(_) => {
+                GetBucketNotificationError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -18508,7 +18554,7 @@ pub enum GetBucketNotificationConfigurationError {
 }
 
 impl GetBucketNotificationConfigurationError {
-    pub fn from_body(body: &str) -> GetBucketNotificationConfigurationError {
+    pub fn from_body(body: &str, status: u16) -> GetBucketNotificationConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -18516,7 +18562,11 @@ impl GetBucketNotificationConfigurationError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketNotificationConfigurationError::Unknown(String::from(body)),
             },
-            Err(_) => GetBucketNotificationConfigurationError::Unknown(body.to_string()),
+            Err(_) => GetBucketNotificationConfigurationError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -18580,7 +18630,7 @@ pub enum GetBucketPolicyError {
 }
 
 impl GetBucketPolicyError {
-    pub fn from_body(body: &str) -> GetBucketPolicyError {
+    pub fn from_body(body: &str, status: u16) -> GetBucketPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -18588,7 +18638,7 @@ impl GetBucketPolicyError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketPolicyError::Unknown(String::from(body)),
             },
-            Err(_) => GetBucketPolicyError::Unknown(body.to_string()),
+            Err(_) => GetBucketPolicyError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -18650,7 +18700,7 @@ pub enum GetBucketReplicationError {
 }
 
 impl GetBucketReplicationError {
-    pub fn from_body(body: &str) -> GetBucketReplicationError {
+    pub fn from_body(body: &str, status: u16) -> GetBucketReplicationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -18658,7 +18708,9 @@ impl GetBucketReplicationError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketReplicationError::Unknown(String::from(body)),
             },
-            Err(_) => GetBucketReplicationError::Unknown(body.to_string()),
+            Err(_) => {
+                GetBucketReplicationError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -18722,7 +18774,7 @@ pub enum GetBucketRequestPaymentError {
 }
 
 impl GetBucketRequestPaymentError {
-    pub fn from_body(body: &str) -> GetBucketRequestPaymentError {
+    pub fn from_body(body: &str, status: u16) -> GetBucketRequestPaymentError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -18730,7 +18782,9 @@ impl GetBucketRequestPaymentError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketRequestPaymentError::Unknown(String::from(body)),
             },
-            Err(_) => GetBucketRequestPaymentError::Unknown(body.to_string()),
+            Err(_) => {
+                GetBucketRequestPaymentError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -18794,7 +18848,7 @@ pub enum GetBucketTaggingError {
 }
 
 impl GetBucketTaggingError {
-    pub fn from_body(body: &str) -> GetBucketTaggingError {
+    pub fn from_body(body: &str, status: u16) -> GetBucketTaggingError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -18802,7 +18856,7 @@ impl GetBucketTaggingError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketTaggingError::Unknown(String::from(body)),
             },
-            Err(_) => GetBucketTaggingError::Unknown(body.to_string()),
+            Err(_) => GetBucketTaggingError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -18864,7 +18918,7 @@ pub enum GetBucketVersioningError {
 }
 
 impl GetBucketVersioningError {
-    pub fn from_body(body: &str) -> GetBucketVersioningError {
+    pub fn from_body(body: &str, status: u16) -> GetBucketVersioningError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -18872,7 +18926,7 @@ impl GetBucketVersioningError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketVersioningError::Unknown(String::from(body)),
             },
-            Err(_) => GetBucketVersioningError::Unknown(body.to_string()),
+            Err(_) => GetBucketVersioningError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -18936,7 +18990,7 @@ pub enum GetBucketWebsiteError {
 }
 
 impl GetBucketWebsiteError {
-    pub fn from_body(body: &str) -> GetBucketWebsiteError {
+    pub fn from_body(body: &str, status: u16) -> GetBucketWebsiteError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -18944,7 +18998,7 @@ impl GetBucketWebsiteError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetBucketWebsiteError::Unknown(String::from(body)),
             },
-            Err(_) => GetBucketWebsiteError::Unknown(body.to_string()),
+            Err(_) => GetBucketWebsiteError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -19008,7 +19062,7 @@ pub enum GetObjectError {
 }
 
 impl GetObjectError {
-    pub fn from_body(body: &str) -> GetObjectError {
+    pub fn from_body(body: &str, status: u16) -> GetObjectError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -19017,7 +19071,7 @@ impl GetObjectError {
                 "NoSuchKey" => GetObjectError::NoSuchKey(String::from(parsed_error.message)),
                 _ => GetObjectError::Unknown(String::from(body)),
             },
-            Err(_) => GetObjectError::Unknown(body.to_string()),
+            Err(_) => GetObjectError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -19082,7 +19136,7 @@ pub enum GetObjectAclError {
 }
 
 impl GetObjectAclError {
-    pub fn from_body(body: &str) -> GetObjectAclError {
+    pub fn from_body(body: &str, status: u16) -> GetObjectAclError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -19091,7 +19145,7 @@ impl GetObjectAclError {
                 "NoSuchKey" => GetObjectAclError::NoSuchKey(String::from(parsed_error.message)),
                 _ => GetObjectAclError::Unknown(String::from(body)),
             },
-            Err(_) => GetObjectAclError::Unknown(body.to_string()),
+            Err(_) => GetObjectAclError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -19154,7 +19208,7 @@ pub enum GetObjectTaggingError {
 }
 
 impl GetObjectTaggingError {
-    pub fn from_body(body: &str) -> GetObjectTaggingError {
+    pub fn from_body(body: &str, status: u16) -> GetObjectTaggingError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -19162,7 +19216,7 @@ impl GetObjectTaggingError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetObjectTaggingError::Unknown(String::from(body)),
             },
-            Err(_) => GetObjectTaggingError::Unknown(body.to_string()),
+            Err(_) => GetObjectTaggingError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -19224,7 +19278,7 @@ pub enum GetObjectTorrentError {
 }
 
 impl GetObjectTorrentError {
-    pub fn from_body(body: &str) -> GetObjectTorrentError {
+    pub fn from_body(body: &str, status: u16) -> GetObjectTorrentError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -19232,7 +19286,7 @@ impl GetObjectTorrentError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetObjectTorrentError::Unknown(String::from(body)),
             },
-            Err(_) => GetObjectTorrentError::Unknown(body.to_string()),
+            Err(_) => GetObjectTorrentError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -19296,7 +19350,7 @@ pub enum HeadBucketError {
 }
 
 impl HeadBucketError {
-    pub fn from_body(body: &str) -> HeadBucketError {
+    pub fn from_body(body: &str, status: u16) -> HeadBucketError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -19305,7 +19359,7 @@ impl HeadBucketError {
                 "NoSuchBucket" => HeadBucketError::NoSuchBucket(String::from(parsed_error.message)),
                 _ => HeadBucketError::Unknown(String::from(body)),
             },
-            Err(_) => HeadBucketError::Unknown(body.to_string()),
+            Err(_) => HeadBucketError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -19370,7 +19424,7 @@ pub enum HeadObjectError {
 }
 
 impl HeadObjectError {
-    pub fn from_body(body: &str) -> HeadObjectError {
+    pub fn from_body(body: &str, status: u16) -> HeadObjectError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -19379,7 +19433,7 @@ impl HeadObjectError {
                 "NoSuchKey" => HeadObjectError::NoSuchKey(String::from(parsed_error.message)),
                 _ => HeadObjectError::Unknown(String::from(body)),
             },
-            Err(_) => HeadObjectError::Unknown(body.to_string()),
+            Err(_) => HeadObjectError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -19442,7 +19496,7 @@ pub enum ListBucketAnalyticsConfigurationsError {
 }
 
 impl ListBucketAnalyticsConfigurationsError {
-    pub fn from_body(body: &str) -> ListBucketAnalyticsConfigurationsError {
+    pub fn from_body(body: &str, status: u16) -> ListBucketAnalyticsConfigurationsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -19450,7 +19504,11 @@ impl ListBucketAnalyticsConfigurationsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListBucketAnalyticsConfigurationsError::Unknown(String::from(body)),
             },
-            Err(_) => ListBucketAnalyticsConfigurationsError::Unknown(body.to_string()),
+            Err(_) => ListBucketAnalyticsConfigurationsError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -19514,7 +19572,7 @@ pub enum ListBucketInventoryConfigurationsError {
 }
 
 impl ListBucketInventoryConfigurationsError {
-    pub fn from_body(body: &str) -> ListBucketInventoryConfigurationsError {
+    pub fn from_body(body: &str, status: u16) -> ListBucketInventoryConfigurationsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -19522,7 +19580,11 @@ impl ListBucketInventoryConfigurationsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListBucketInventoryConfigurationsError::Unknown(String::from(body)),
             },
-            Err(_) => ListBucketInventoryConfigurationsError::Unknown(body.to_string()),
+            Err(_) => ListBucketInventoryConfigurationsError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -19586,7 +19648,7 @@ pub enum ListBucketMetricsConfigurationsError {
 }
 
 impl ListBucketMetricsConfigurationsError {
-    pub fn from_body(body: &str) -> ListBucketMetricsConfigurationsError {
+    pub fn from_body(body: &str, status: u16) -> ListBucketMetricsConfigurationsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -19594,7 +19656,11 @@ impl ListBucketMetricsConfigurationsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListBucketMetricsConfigurationsError::Unknown(String::from(body)),
             },
-            Err(_) => ListBucketMetricsConfigurationsError::Unknown(body.to_string()),
+            Err(_) => ListBucketMetricsConfigurationsError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -19658,7 +19724,7 @@ pub enum ListBucketsError {
 }
 
 impl ListBucketsError {
-    pub fn from_body(body: &str) -> ListBucketsError {
+    pub fn from_body(body: &str, status: u16) -> ListBucketsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -19666,7 +19732,7 @@ impl ListBucketsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListBucketsError::Unknown(String::from(body)),
             },
-            Err(_) => ListBucketsError::Unknown(body.to_string()),
+            Err(_) => ListBucketsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -19728,7 +19794,7 @@ pub enum ListMultipartUploadsError {
 }
 
 impl ListMultipartUploadsError {
-    pub fn from_body(body: &str) -> ListMultipartUploadsError {
+    pub fn from_body(body: &str, status: u16) -> ListMultipartUploadsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -19736,7 +19802,9 @@ impl ListMultipartUploadsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListMultipartUploadsError::Unknown(String::from(body)),
             },
-            Err(_) => ListMultipartUploadsError::Unknown(body.to_string()),
+            Err(_) => {
+                ListMultipartUploadsError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -19800,7 +19868,7 @@ pub enum ListObjectVersionsError {
 }
 
 impl ListObjectVersionsError {
-    pub fn from_body(body: &str) -> ListObjectVersionsError {
+    pub fn from_body(body: &str, status: u16) -> ListObjectVersionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -19808,7 +19876,7 @@ impl ListObjectVersionsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListObjectVersionsError::Unknown(String::from(body)),
             },
-            Err(_) => ListObjectVersionsError::Unknown(body.to_string()),
+            Err(_) => ListObjectVersionsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -19874,7 +19942,7 @@ pub enum ListObjectsError {
 }
 
 impl ListObjectsError {
-    pub fn from_body(body: &str) -> ListObjectsError {
+    pub fn from_body(body: &str, status: u16) -> ListObjectsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -19885,7 +19953,7 @@ impl ListObjectsError {
                 }
                 _ => ListObjectsError::Unknown(String::from(body)),
             },
-            Err(_) => ListObjectsError::Unknown(body.to_string()),
+            Err(_) => ListObjectsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -19950,7 +20018,7 @@ pub enum ListObjectsV2Error {
 }
 
 impl ListObjectsV2Error {
-    pub fn from_body(body: &str) -> ListObjectsV2Error {
+    pub fn from_body(body: &str, status: u16) -> ListObjectsV2Error {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -19961,7 +20029,7 @@ impl ListObjectsV2Error {
                 }
                 _ => ListObjectsV2Error::Unknown(String::from(body)),
             },
-            Err(_) => ListObjectsV2Error::Unknown(body.to_string()),
+            Err(_) => ListObjectsV2Error::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -20024,7 +20092,7 @@ pub enum ListPartsError {
 }
 
 impl ListPartsError {
-    pub fn from_body(body: &str) -> ListPartsError {
+    pub fn from_body(body: &str, status: u16) -> ListPartsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -20032,7 +20100,7 @@ impl ListPartsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListPartsError::Unknown(String::from(body)),
             },
-            Err(_) => ListPartsError::Unknown(body.to_string()),
+            Err(_) => ListPartsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -20094,7 +20162,7 @@ pub enum PutBucketAccelerateConfigurationError {
 }
 
 impl PutBucketAccelerateConfigurationError {
-    pub fn from_body(body: &str) -> PutBucketAccelerateConfigurationError {
+    pub fn from_body(body: &str, status: u16) -> PutBucketAccelerateConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -20102,7 +20170,11 @@ impl PutBucketAccelerateConfigurationError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutBucketAccelerateConfigurationError::Unknown(String::from(body)),
             },
-            Err(_) => PutBucketAccelerateConfigurationError::Unknown(body.to_string()),
+            Err(_) => PutBucketAccelerateConfigurationError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -20166,7 +20238,7 @@ pub enum PutBucketAclError {
 }
 
 impl PutBucketAclError {
-    pub fn from_body(body: &str) -> PutBucketAclError {
+    pub fn from_body(body: &str, status: u16) -> PutBucketAclError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -20174,7 +20246,7 @@ impl PutBucketAclError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutBucketAclError::Unknown(String::from(body)),
             },
-            Err(_) => PutBucketAclError::Unknown(body.to_string()),
+            Err(_) => PutBucketAclError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -20236,7 +20308,7 @@ pub enum PutBucketAnalyticsConfigurationError {
 }
 
 impl PutBucketAnalyticsConfigurationError {
-    pub fn from_body(body: &str) -> PutBucketAnalyticsConfigurationError {
+    pub fn from_body(body: &str, status: u16) -> PutBucketAnalyticsConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -20244,7 +20316,11 @@ impl PutBucketAnalyticsConfigurationError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutBucketAnalyticsConfigurationError::Unknown(String::from(body)),
             },
-            Err(_) => PutBucketAnalyticsConfigurationError::Unknown(body.to_string()),
+            Err(_) => PutBucketAnalyticsConfigurationError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -20308,7 +20384,7 @@ pub enum PutBucketCorsError {
 }
 
 impl PutBucketCorsError {
-    pub fn from_body(body: &str) -> PutBucketCorsError {
+    pub fn from_body(body: &str, status: u16) -> PutBucketCorsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -20316,7 +20392,7 @@ impl PutBucketCorsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutBucketCorsError::Unknown(String::from(body)),
             },
-            Err(_) => PutBucketCorsError::Unknown(body.to_string()),
+            Err(_) => PutBucketCorsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -20378,7 +20454,7 @@ pub enum PutBucketEncryptionError {
 }
 
 impl PutBucketEncryptionError {
-    pub fn from_body(body: &str) -> PutBucketEncryptionError {
+    pub fn from_body(body: &str, status: u16) -> PutBucketEncryptionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -20386,7 +20462,7 @@ impl PutBucketEncryptionError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutBucketEncryptionError::Unknown(String::from(body)),
             },
-            Err(_) => PutBucketEncryptionError::Unknown(body.to_string()),
+            Err(_) => PutBucketEncryptionError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -20450,7 +20526,7 @@ pub enum PutBucketInventoryConfigurationError {
 }
 
 impl PutBucketInventoryConfigurationError {
-    pub fn from_body(body: &str) -> PutBucketInventoryConfigurationError {
+    pub fn from_body(body: &str, status: u16) -> PutBucketInventoryConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -20458,7 +20534,11 @@ impl PutBucketInventoryConfigurationError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutBucketInventoryConfigurationError::Unknown(String::from(body)),
             },
-            Err(_) => PutBucketInventoryConfigurationError::Unknown(body.to_string()),
+            Err(_) => PutBucketInventoryConfigurationError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -20522,7 +20602,7 @@ pub enum PutBucketLifecycleError {
 }
 
 impl PutBucketLifecycleError {
-    pub fn from_body(body: &str) -> PutBucketLifecycleError {
+    pub fn from_body(body: &str, status: u16) -> PutBucketLifecycleError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -20530,7 +20610,7 @@ impl PutBucketLifecycleError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutBucketLifecycleError::Unknown(String::from(body)),
             },
-            Err(_) => PutBucketLifecycleError::Unknown(body.to_string()),
+            Err(_) => PutBucketLifecycleError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -20594,7 +20674,7 @@ pub enum PutBucketLifecycleConfigurationError {
 }
 
 impl PutBucketLifecycleConfigurationError {
-    pub fn from_body(body: &str) -> PutBucketLifecycleConfigurationError {
+    pub fn from_body(body: &str, status: u16) -> PutBucketLifecycleConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -20602,7 +20682,11 @@ impl PutBucketLifecycleConfigurationError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutBucketLifecycleConfigurationError::Unknown(String::from(body)),
             },
-            Err(_) => PutBucketLifecycleConfigurationError::Unknown(body.to_string()),
+            Err(_) => PutBucketLifecycleConfigurationError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -20666,7 +20750,7 @@ pub enum PutBucketLoggingError {
 }
 
 impl PutBucketLoggingError {
-    pub fn from_body(body: &str) -> PutBucketLoggingError {
+    pub fn from_body(body: &str, status: u16) -> PutBucketLoggingError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -20674,7 +20758,7 @@ impl PutBucketLoggingError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutBucketLoggingError::Unknown(String::from(body)),
             },
-            Err(_) => PutBucketLoggingError::Unknown(body.to_string()),
+            Err(_) => PutBucketLoggingError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -20736,7 +20820,7 @@ pub enum PutBucketMetricsConfigurationError {
 }
 
 impl PutBucketMetricsConfigurationError {
-    pub fn from_body(body: &str) -> PutBucketMetricsConfigurationError {
+    pub fn from_body(body: &str, status: u16) -> PutBucketMetricsConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -20744,7 +20828,11 @@ impl PutBucketMetricsConfigurationError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutBucketMetricsConfigurationError::Unknown(String::from(body)),
             },
-            Err(_) => PutBucketMetricsConfigurationError::Unknown(body.to_string()),
+            Err(_) => PutBucketMetricsConfigurationError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -20808,7 +20896,7 @@ pub enum PutBucketNotificationError {
 }
 
 impl PutBucketNotificationError {
-    pub fn from_body(body: &str) -> PutBucketNotificationError {
+    pub fn from_body(body: &str, status: u16) -> PutBucketNotificationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -20816,7 +20904,9 @@ impl PutBucketNotificationError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutBucketNotificationError::Unknown(String::from(body)),
             },
-            Err(_) => PutBucketNotificationError::Unknown(body.to_string()),
+            Err(_) => {
+                PutBucketNotificationError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -20880,7 +20970,7 @@ pub enum PutBucketNotificationConfigurationError {
 }
 
 impl PutBucketNotificationConfigurationError {
-    pub fn from_body(body: &str) -> PutBucketNotificationConfigurationError {
+    pub fn from_body(body: &str, status: u16) -> PutBucketNotificationConfigurationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -20888,7 +20978,11 @@ impl PutBucketNotificationConfigurationError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutBucketNotificationConfigurationError::Unknown(String::from(body)),
             },
-            Err(_) => PutBucketNotificationConfigurationError::Unknown(body.to_string()),
+            Err(_) => PutBucketNotificationConfigurationError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -20952,7 +21046,7 @@ pub enum PutBucketPolicyError {
 }
 
 impl PutBucketPolicyError {
-    pub fn from_body(body: &str) -> PutBucketPolicyError {
+    pub fn from_body(body: &str, status: u16) -> PutBucketPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -20960,7 +21054,7 @@ impl PutBucketPolicyError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutBucketPolicyError::Unknown(String::from(body)),
             },
-            Err(_) => PutBucketPolicyError::Unknown(body.to_string()),
+            Err(_) => PutBucketPolicyError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -21022,7 +21116,7 @@ pub enum PutBucketReplicationError {
 }
 
 impl PutBucketReplicationError {
-    pub fn from_body(body: &str) -> PutBucketReplicationError {
+    pub fn from_body(body: &str, status: u16) -> PutBucketReplicationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -21030,7 +21124,9 @@ impl PutBucketReplicationError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutBucketReplicationError::Unknown(String::from(body)),
             },
-            Err(_) => PutBucketReplicationError::Unknown(body.to_string()),
+            Err(_) => {
+                PutBucketReplicationError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -21094,7 +21190,7 @@ pub enum PutBucketRequestPaymentError {
 }
 
 impl PutBucketRequestPaymentError {
-    pub fn from_body(body: &str) -> PutBucketRequestPaymentError {
+    pub fn from_body(body: &str, status: u16) -> PutBucketRequestPaymentError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -21102,7 +21198,9 @@ impl PutBucketRequestPaymentError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutBucketRequestPaymentError::Unknown(String::from(body)),
             },
-            Err(_) => PutBucketRequestPaymentError::Unknown(body.to_string()),
+            Err(_) => {
+                PutBucketRequestPaymentError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -21166,7 +21264,7 @@ pub enum PutBucketTaggingError {
 }
 
 impl PutBucketTaggingError {
-    pub fn from_body(body: &str) -> PutBucketTaggingError {
+    pub fn from_body(body: &str, status: u16) -> PutBucketTaggingError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -21174,7 +21272,7 @@ impl PutBucketTaggingError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutBucketTaggingError::Unknown(String::from(body)),
             },
-            Err(_) => PutBucketTaggingError::Unknown(body.to_string()),
+            Err(_) => PutBucketTaggingError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -21236,7 +21334,7 @@ pub enum PutBucketVersioningError {
 }
 
 impl PutBucketVersioningError {
-    pub fn from_body(body: &str) -> PutBucketVersioningError {
+    pub fn from_body(body: &str, status: u16) -> PutBucketVersioningError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -21244,7 +21342,7 @@ impl PutBucketVersioningError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutBucketVersioningError::Unknown(String::from(body)),
             },
-            Err(_) => PutBucketVersioningError::Unknown(body.to_string()),
+            Err(_) => PutBucketVersioningError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -21308,7 +21406,7 @@ pub enum PutBucketWebsiteError {
 }
 
 impl PutBucketWebsiteError {
-    pub fn from_body(body: &str) -> PutBucketWebsiteError {
+    pub fn from_body(body: &str, status: u16) -> PutBucketWebsiteError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -21316,7 +21414,7 @@ impl PutBucketWebsiteError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutBucketWebsiteError::Unknown(String::from(body)),
             },
-            Err(_) => PutBucketWebsiteError::Unknown(body.to_string()),
+            Err(_) => PutBucketWebsiteError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -21378,7 +21476,7 @@ pub enum PutObjectError {
 }
 
 impl PutObjectError {
-    pub fn from_body(body: &str) -> PutObjectError {
+    pub fn from_body(body: &str, status: u16) -> PutObjectError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -21386,7 +21484,7 @@ impl PutObjectError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutObjectError::Unknown(String::from(body)),
             },
-            Err(_) => PutObjectError::Unknown(body.to_string()),
+            Err(_) => PutObjectError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -21450,7 +21548,7 @@ pub enum PutObjectAclError {
 }
 
 impl PutObjectAclError {
-    pub fn from_body(body: &str) -> PutObjectAclError {
+    pub fn from_body(body: &str, status: u16) -> PutObjectAclError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -21459,7 +21557,7 @@ impl PutObjectAclError {
                 "NoSuchKey" => PutObjectAclError::NoSuchKey(String::from(parsed_error.message)),
                 _ => PutObjectAclError::Unknown(String::from(body)),
             },
-            Err(_) => PutObjectAclError::Unknown(body.to_string()),
+            Err(_) => PutObjectAclError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -21522,7 +21620,7 @@ pub enum PutObjectTaggingError {
 }
 
 impl PutObjectTaggingError {
-    pub fn from_body(body: &str) -> PutObjectTaggingError {
+    pub fn from_body(body: &str, status: u16) -> PutObjectTaggingError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -21530,7 +21628,7 @@ impl PutObjectTaggingError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => PutObjectTaggingError::Unknown(String::from(body)),
             },
-            Err(_) => PutObjectTaggingError::Unknown(body.to_string()),
+            Err(_) => PutObjectTaggingError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -21594,7 +21692,7 @@ pub enum RestoreObjectError {
 }
 
 impl RestoreObjectError {
-    pub fn from_body(body: &str) -> RestoreObjectError {
+    pub fn from_body(body: &str, status: u16) -> RestoreObjectError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -21607,7 +21705,7 @@ impl RestoreObjectError {
                 }
                 _ => RestoreObjectError::Unknown(String::from(body)),
             },
-            Err(_) => RestoreObjectError::Unknown(body.to_string()),
+            Err(_) => RestoreObjectError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -21670,7 +21768,7 @@ pub enum SelectObjectContentError {
 }
 
 impl SelectObjectContentError {
-    pub fn from_body(body: &str) -> SelectObjectContentError {
+    pub fn from_body(body: &str, status: u16) -> SelectObjectContentError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -21678,7 +21776,7 @@ impl SelectObjectContentError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => SelectObjectContentError::Unknown(String::from(body)),
             },
-            Err(_) => SelectObjectContentError::Unknown(body.to_string()),
+            Err(_) => SelectObjectContentError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -21742,7 +21840,7 @@ pub enum UploadPartError {
 }
 
 impl UploadPartError {
-    pub fn from_body(body: &str) -> UploadPartError {
+    pub fn from_body(body: &str, status: u16) -> UploadPartError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -21750,7 +21848,7 @@ impl UploadPartError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => UploadPartError::Unknown(String::from(body)),
             },
-            Err(_) => UploadPartError::Unknown(body.to_string()),
+            Err(_) => UploadPartError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -21812,7 +21910,7 @@ pub enum UploadPartCopyError {
 }
 
 impl UploadPartCopyError {
-    pub fn from_body(body: &str) -> UploadPartCopyError {
+    pub fn from_body(body: &str, status: u16) -> UploadPartCopyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -21820,7 +21918,7 @@ impl UploadPartCopyError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => UploadPartCopyError::Unknown(String::from(body)),
             },
-            Err(_) => UploadPartCopyError::Unknown(body.to_string()),
+            Err(_) => UploadPartCopyError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -22372,6 +22470,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(AbortMultipartUploadError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -22437,6 +22536,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(CompleteMultipartUploadError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -22670,6 +22770,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(CopyObjectError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -22794,6 +22895,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(CreateBucketError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -22949,6 +23051,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(CreateMultipartUploadError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -23028,6 +23131,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(DeleteBucketError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -23056,6 +23160,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(DeleteBucketAnalyticsConfigurationError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -23083,6 +23188,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(DeleteBucketCorsError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -23110,6 +23216,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(DeleteBucketEncryptionError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -23138,6 +23245,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(DeleteBucketInventoryConfigurationError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -23165,6 +23273,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(DeleteBucketLifecycleError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -23193,6 +23302,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(DeleteBucketMetricsConfigurationError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -23220,6 +23330,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(DeleteBucketPolicyError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -23247,6 +23358,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(DeleteBucketReplicationError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -23274,6 +23386,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(DeleteBucketTaggingError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -23301,6 +23414,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(DeleteBucketWebsiteError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -23337,6 +23451,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(DeleteObjectError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -23399,6 +23514,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(DeleteObjectTaggingError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -23461,6 +23577,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(DeleteObjectsError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -23513,6 +23630,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(GetBucketAccelerateConfigurationError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -23562,6 +23680,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(GetBucketAclError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -23611,6 +23730,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(GetBucketAnalyticsConfigurationError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -23660,6 +23780,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(GetBucketCorsError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -23707,6 +23828,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(GetBucketEncryptionError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -23756,6 +23878,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(GetBucketInventoryConfigurationError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -23805,6 +23928,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(GetBucketLifecycleError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -23853,6 +23977,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(GetBucketLifecycleConfigurationError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -23902,6 +24027,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(GetBucketLocationError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -23949,6 +24075,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(GetBucketLoggingError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -23997,6 +24124,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(GetBucketMetricsConfigurationError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -24046,6 +24174,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(GetBucketNotificationError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -24095,6 +24224,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(GetBucketNotificationConfigurationError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -24142,6 +24272,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(GetBucketPolicyError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -24174,6 +24305,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(GetBucketReplicationError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -24221,6 +24353,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(GetBucketRequestPaymentError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -24268,6 +24401,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(GetBucketTaggingError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -24315,6 +24449,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(GetBucketVersioningError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -24362,6 +24497,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(GetBucketWebsiteError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -24473,6 +24609,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(GetObjectError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -24635,6 +24772,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(GetObjectAclError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -24689,6 +24827,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(GetObjectTaggingError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -24743,6 +24882,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(GetObjectTorrentError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -24772,6 +24912,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(HeadBucketError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -24848,6 +24989,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(HeadObjectError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -25015,6 +25157,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(ListBucketAnalyticsConfigurationsError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -25068,6 +25211,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(ListBucketInventoryConfigurationsError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -25121,6 +25265,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(ListBucketMetricsConfigurationsError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -25163,6 +25308,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(ListBucketsError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -25228,6 +25374,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(ListMultipartUploadsError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -25293,6 +25440,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(ListObjectVersionsError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -25357,6 +25505,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(ListObjectsError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -25428,6 +25577,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(ListObjectsV2Error::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -25481,6 +25631,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(ListPartsError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -25547,6 +25698,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(PutBucketAccelerateConfigurationError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -25609,6 +25761,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(PutBucketAclError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -25644,6 +25797,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(PutBucketAnalyticsConfigurationError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -25679,6 +25833,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(PutBucketCorsError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -25716,6 +25871,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(PutBucketEncryptionError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -25751,6 +25907,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(PutBucketInventoryConfigurationError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -25793,6 +25950,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(PutBucketLifecycleError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -25832,6 +25990,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(PutBucketLifecycleConfigurationError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -25869,6 +26028,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(PutBucketLoggingError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -25904,6 +26064,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(PutBucketMetricsConfigurationError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -25941,6 +26102,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(PutBucketNotificationError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -25975,6 +26137,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(PutBucketNotificationConfigurationError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -26016,6 +26179,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(PutBucketPolicyError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -26054,6 +26218,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(PutBucketReplicationError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -26091,6 +26256,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(PutBucketRequestPaymentError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -26125,6 +26291,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(PutBucketTaggingError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -26166,6 +26333,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(PutBucketVersioningError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -26203,6 +26371,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(PutBucketWebsiteError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -26340,6 +26509,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(PutObjectError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -26475,6 +26645,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(PutObjectAclError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -26535,6 +26706,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(PutObjectTaggingError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -26603,6 +26775,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(RestoreObjectError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -26687,6 +26860,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(SelectObjectContentError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -26770,6 +26944,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(UploadPartError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }
@@ -26934,6 +27109,7 @@ impl S3 for S3Client {
                 return Box::new(response.buffer().from_err().and_then(|response| {
                     Err(UploadPartCopyError::from_body(
                         String::from_utf8_lossy(response.body.as_ref()).as_ref(),
+                        response.status.as_u16(),
                     ))
                 }));
             }

--- a/rusoto/services/sdb/src/generated.rs
+++ b/rusoto/services/sdb/src/generated.rs
@@ -1032,7 +1032,7 @@ pub enum BatchDeleteAttributesError {
 }
 
 impl BatchDeleteAttributesError {
-    pub fn from_body(body: &str) -> BatchDeleteAttributesError {
+    pub fn from_body(body: &str, status: u16) -> BatchDeleteAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -1040,7 +1040,9 @@ impl BatchDeleteAttributesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => BatchDeleteAttributesError::Unknown(String::from(body)),
             },
-            Err(_) => BatchDeleteAttributesError::Unknown(body.to_string()),
+            Err(_) => {
+                BatchDeleteAttributesError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -1123,7 +1125,7 @@ pub enum BatchPutAttributesError {
 }
 
 impl BatchPutAttributesError {
-    pub fn from_body(body: &str) -> BatchPutAttributesError {
+    pub fn from_body(body: &str, status: u16) -> BatchPutAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -1166,7 +1168,7 @@ impl BatchPutAttributesError {
                 }
                 _ => BatchPutAttributesError::Unknown(String::from(body)),
             },
-            Err(_) => BatchPutAttributesError::Unknown(body.to_string()),
+            Err(_) => BatchPutAttributesError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -1246,7 +1248,7 @@ pub enum CreateDomainError {
 }
 
 impl CreateDomainError {
-    pub fn from_body(body: &str) -> CreateDomainError {
+    pub fn from_body(body: &str, status: u16) -> CreateDomainError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -1263,7 +1265,7 @@ impl CreateDomainError {
                 }
                 _ => CreateDomainError::Unknown(String::from(body)),
             },
-            Err(_) => CreateDomainError::Unknown(body.to_string()),
+            Err(_) => CreateDomainError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -1337,7 +1339,7 @@ pub enum DeleteAttributesError {
 }
 
 impl DeleteAttributesError {
-    pub fn from_body(body: &str) -> DeleteAttributesError {
+    pub fn from_body(body: &str, status: u16) -> DeleteAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -1357,7 +1359,7 @@ impl DeleteAttributesError {
                 }
                 _ => DeleteAttributesError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteAttributesError::Unknown(body.to_string()),
+            Err(_) => DeleteAttributesError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -1426,7 +1428,7 @@ pub enum DeleteDomainError {
 }
 
 impl DeleteDomainError {
-    pub fn from_body(body: &str) -> DeleteDomainError {
+    pub fn from_body(body: &str, status: u16) -> DeleteDomainError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -1437,7 +1439,7 @@ impl DeleteDomainError {
                 }
                 _ => DeleteDomainError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteDomainError::Unknown(body.to_string()),
+            Err(_) => DeleteDomainError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -1505,7 +1507,7 @@ pub enum DomainMetadataError {
 }
 
 impl DomainMetadataError {
-    pub fn from_body(body: &str) -> DomainMetadataError {
+    pub fn from_body(body: &str, status: u16) -> DomainMetadataError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -1519,7 +1521,7 @@ impl DomainMetadataError {
                 }
                 _ => DomainMetadataError::Unknown(String::from(body)),
             },
-            Err(_) => DomainMetadataError::Unknown(body.to_string()),
+            Err(_) => DomainMetadataError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -1590,7 +1592,7 @@ pub enum GetAttributesError {
 }
 
 impl GetAttributesError {
-    pub fn from_body(body: &str) -> GetAttributesError {
+    pub fn from_body(body: &str, status: u16) -> GetAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -1607,7 +1609,7 @@ impl GetAttributesError {
                 }
                 _ => GetAttributesError::Unknown(String::from(body)),
             },
-            Err(_) => GetAttributesError::Unknown(body.to_string()),
+            Err(_) => GetAttributesError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -1677,7 +1679,7 @@ pub enum ListDomainsError {
 }
 
 impl ListDomainsError {
-    pub fn from_body(body: &str) -> ListDomainsError {
+    pub fn from_body(body: &str, status: u16) -> ListDomainsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -1691,7 +1693,7 @@ impl ListDomainsError {
                 }
                 _ => ListDomainsError::Unknown(String::from(body)),
             },
-            Err(_) => ListDomainsError::Unknown(body.to_string()),
+            Err(_) => ListDomainsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -1770,7 +1772,7 @@ pub enum PutAttributesError {
 }
 
 impl PutAttributesError {
-    pub fn from_body(body: &str) -> PutAttributesError {
+    pub fn from_body(body: &str, status: u16) -> PutAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -1801,7 +1803,7 @@ impl PutAttributesError {
                 ),
                 _ => PutAttributesError::Unknown(String::from(body)),
             },
-            Err(_) => PutAttributesError::Unknown(body.to_string()),
+            Err(_) => PutAttributesError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -1889,7 +1891,7 @@ pub enum SelectError {
 }
 
 impl SelectError {
-    pub fn from_body(body: &str) -> SelectError {
+    pub fn from_body(body: &str, status: u16) -> SelectError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -1920,7 +1922,7 @@ impl SelectError {
                 }
                 _ => SelectError::Unknown(String::from(body)),
             },
-            Err(_) => SelectError::Unknown(body.to_string()),
+            Err(_) => SelectError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 

--- a/rusoto/services/sdb/src/generated.rs
+++ b/rusoto/services/sdb/src/generated.rs
@@ -1041,7 +1041,11 @@ impl BatchDeleteAttributesError {
                 _ => BatchDeleteAttributesError::Unknown(String::from(body)),
             },
             Err(_) => {
-                BatchDeleteAttributesError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    BatchDeleteAttributesError::Unknown(format!("{}", status))
+                } else {
+                    BatchDeleteAttributesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -1168,7 +1172,13 @@ impl BatchPutAttributesError {
                 }
                 _ => BatchPutAttributesError::Unknown(String::from(body)),
             },
-            Err(_) => BatchPutAttributesError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    BatchPutAttributesError::Unknown(format!("{}", status))
+                } else {
+                    BatchPutAttributesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -1265,7 +1275,13 @@ impl CreateDomainError {
                 }
                 _ => CreateDomainError::Unknown(String::from(body)),
             },
-            Err(_) => CreateDomainError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateDomainError::Unknown(format!("{}", status))
+                } else {
+                    CreateDomainError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -1359,7 +1375,13 @@ impl DeleteAttributesError {
                 }
                 _ => DeleteAttributesError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteAttributesError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteAttributesError::Unknown(format!("{}", status))
+                } else {
+                    DeleteAttributesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -1439,7 +1461,13 @@ impl DeleteDomainError {
                 }
                 _ => DeleteDomainError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteDomainError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteDomainError::Unknown(format!("{}", status))
+                } else {
+                    DeleteDomainError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -1521,7 +1549,13 @@ impl DomainMetadataError {
                 }
                 _ => DomainMetadataError::Unknown(String::from(body)),
             },
-            Err(_) => DomainMetadataError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DomainMetadataError::Unknown(format!("{}", status))
+                } else {
+                    DomainMetadataError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -1609,7 +1643,13 @@ impl GetAttributesError {
                 }
                 _ => GetAttributesError::Unknown(String::from(body)),
             },
-            Err(_) => GetAttributesError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetAttributesError::Unknown(format!("{}", status))
+                } else {
+                    GetAttributesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -1693,7 +1733,13 @@ impl ListDomainsError {
                 }
                 _ => ListDomainsError::Unknown(String::from(body)),
             },
-            Err(_) => ListDomainsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ListDomainsError::Unknown(format!("{}", status))
+                } else {
+                    ListDomainsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -1803,7 +1849,13 @@ impl PutAttributesError {
                 ),
                 _ => PutAttributesError::Unknown(String::from(body)),
             },
-            Err(_) => PutAttributesError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    PutAttributesError::Unknown(format!("{}", status))
+                } else {
+                    PutAttributesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -1922,7 +1974,13 @@ impl SelectError {
                 }
                 _ => SelectError::Unknown(String::from(body)),
             },
-            Err(_) => SelectError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    SelectError::Unknown(format!("{}", status))
+                } else {
+                    SelectError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 

--- a/rusoto/services/ses/src/generated.rs
+++ b/rusoto/services/ses/src/generated.rs
@@ -8666,7 +8666,7 @@ pub enum CloneReceiptRuleSetError {
 }
 
 impl CloneReceiptRuleSetError {
-    pub fn from_body(body: &str) -> CloneReceiptRuleSetError {
+    pub fn from_body(body: &str, status: u16) -> CloneReceiptRuleSetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -8683,7 +8683,7 @@ impl CloneReceiptRuleSetError {
                 ),
                 _ => CloneReceiptRuleSetError::Unknown(String::from(body)),
             },
-            Err(_) => CloneReceiptRuleSetError::Unknown(body.to_string()),
+            Err(_) => CloneReceiptRuleSetError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -8757,7 +8757,7 @@ pub enum CreateConfigurationSetError {
 }
 
 impl CreateConfigurationSetError {
-    pub fn from_body(body: &str) -> CreateConfigurationSetError {
+    pub fn from_body(body: &str, status: u16) -> CreateConfigurationSetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -8776,7 +8776,9 @@ impl CreateConfigurationSetError {
                 }
                 _ => CreateConfigurationSetError::Unknown(String::from(body)),
             },
-            Err(_) => CreateConfigurationSetError::Unknown(body.to_string()),
+            Err(_) => {
+                CreateConfigurationSetError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -8856,7 +8858,7 @@ pub enum CreateConfigurationSetEventDestinationError {
 }
 
 impl CreateConfigurationSetEventDestinationError {
-    pub fn from_body(body: &str) -> CreateConfigurationSetEventDestinationError {
+    pub fn from_body(body: &str, status: u16) -> CreateConfigurationSetEventDestinationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -8892,7 +8894,11 @@ impl CreateConfigurationSetEventDestinationError {
                 ),
                 _ => CreateConfigurationSetEventDestinationError::Unknown(String::from(body)),
             },
-            Err(_) => CreateConfigurationSetEventDestinationError::Unknown(body.to_string()),
+            Err(_) => CreateConfigurationSetEventDestinationError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -8977,7 +8983,7 @@ pub enum CreateConfigurationSetTrackingOptionsError {
 }
 
 impl CreateConfigurationSetTrackingOptionsError {
-    pub fn from_body(body: &str) -> CreateConfigurationSetTrackingOptionsError {
+    pub fn from_body(body: &str, status: u16) -> CreateConfigurationSetTrackingOptionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -9000,7 +9006,11 @@ impl CreateConfigurationSetTrackingOptionsError {
                 }
                 _ => CreateConfigurationSetTrackingOptionsError::Unknown(String::from(body)),
             },
-            Err(_) => CreateConfigurationSetTrackingOptionsError::Unknown(body.to_string()),
+            Err(_) => CreateConfigurationSetTrackingOptionsError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -9080,7 +9090,7 @@ pub enum CreateCustomVerificationEmailTemplateError {
 }
 
 impl CreateCustomVerificationEmailTemplateError {
-    pub fn from_body(body: &str) -> CreateCustomVerificationEmailTemplateError {
+    pub fn from_body(body: &str, status: u16) -> CreateCustomVerificationEmailTemplateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -9090,7 +9100,7 @@ impl CreateCustomVerificationEmailTemplateError {
                                     "CustomVerificationEmailInvalidContent" => CreateCustomVerificationEmailTemplateError::CustomVerificationEmailInvalidContent(String::from(parsed_error.message)),"CustomVerificationEmailTemplateAlreadyExists" => CreateCustomVerificationEmailTemplateError::CustomVerificationEmailTemplateAlreadyExists(String::from(parsed_error.message)),"FromEmailAddressNotVerified" => CreateCustomVerificationEmailTemplateError::FromEmailAddressNotVerified(String::from(parsed_error.message)),"LimitExceeded" => CreateCustomVerificationEmailTemplateError::LimitExceeded(String::from(parsed_error.message)),_ => CreateCustomVerificationEmailTemplateError::Unknown(String::from(body))
                                 }
                            },
-                           Err(_) => CreateCustomVerificationEmailTemplateError::Unknown(body.to_string())
+                           Err(_) => CreateCustomVerificationEmailTemplateError::Unknown(format!("{}:{}", body.to_string(), status))
                        }
     }
 
@@ -9161,7 +9171,7 @@ pub enum CreateReceiptFilterError {
 }
 
 impl CreateReceiptFilterError {
-    pub fn from_body(body: &str) -> CreateReceiptFilterError {
+    pub fn from_body(body: &str, status: u16) -> CreateReceiptFilterError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -9175,7 +9185,7 @@ impl CreateReceiptFilterError {
                 }
                 _ => CreateReceiptFilterError::Unknown(String::from(body)),
             },
-            Err(_) => CreateReceiptFilterError::Unknown(body.to_string()),
+            Err(_) => CreateReceiptFilterError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -9256,7 +9266,7 @@ pub enum CreateReceiptRuleError {
 }
 
 impl CreateReceiptRuleError {
-    pub fn from_body(body: &str) -> CreateReceiptRuleError {
+    pub fn from_body(body: &str, status: u16) -> CreateReceiptRuleError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -9285,7 +9295,7 @@ impl CreateReceiptRuleError {
                 }
                 _ => CreateReceiptRuleError::Unknown(String::from(body)),
             },
-            Err(_) => CreateReceiptRuleError::Unknown(body.to_string()),
+            Err(_) => CreateReceiptRuleError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -9361,7 +9371,7 @@ pub enum CreateReceiptRuleSetError {
 }
 
 impl CreateReceiptRuleSetError {
-    pub fn from_body(body: &str) -> CreateReceiptRuleSetError {
+    pub fn from_body(body: &str, status: u16) -> CreateReceiptRuleSetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -9375,7 +9385,9 @@ impl CreateReceiptRuleSetError {
                 }
                 _ => CreateReceiptRuleSetError::Unknown(String::from(body)),
             },
-            Err(_) => CreateReceiptRuleSetError::Unknown(body.to_string()),
+            Err(_) => {
+                CreateReceiptRuleSetError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -9448,7 +9460,7 @@ pub enum CreateTemplateError {
 }
 
 impl CreateTemplateError {
-    pub fn from_body(body: &str) -> CreateTemplateError {
+    pub fn from_body(body: &str, status: u16) -> CreateTemplateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -9465,7 +9477,7 @@ impl CreateTemplateError {
                 }
                 _ => CreateTemplateError::Unknown(String::from(body)),
             },
-            Err(_) => CreateTemplateError::Unknown(body.to_string()),
+            Err(_) => CreateTemplateError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -9533,7 +9545,7 @@ pub enum DeleteConfigurationSetError {
 }
 
 impl DeleteConfigurationSetError {
-    pub fn from_body(body: &str) -> DeleteConfigurationSetError {
+    pub fn from_body(body: &str, status: u16) -> DeleteConfigurationSetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -9546,7 +9558,9 @@ impl DeleteConfigurationSetError {
                 }
                 _ => DeleteConfigurationSetError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteConfigurationSetError::Unknown(body.to_string()),
+            Err(_) => {
+                DeleteConfigurationSetError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -9616,7 +9630,7 @@ pub enum DeleteConfigurationSetEventDestinationError {
 }
 
 impl DeleteConfigurationSetEventDestinationError {
-    pub fn from_body(body: &str) -> DeleteConfigurationSetEventDestinationError {
+    pub fn from_body(body: &str, status: u16) -> DeleteConfigurationSetEventDestinationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -9634,7 +9648,11 @@ impl DeleteConfigurationSetEventDestinationError {
                 }
                 _ => DeleteConfigurationSetEventDestinationError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteConfigurationSetEventDestinationError::Unknown(body.to_string()),
+            Err(_) => DeleteConfigurationSetEventDestinationError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -9709,7 +9727,7 @@ pub enum DeleteConfigurationSetTrackingOptionsError {
 }
 
 impl DeleteConfigurationSetTrackingOptionsError {
-    pub fn from_body(body: &str) -> DeleteConfigurationSetTrackingOptionsError {
+    pub fn from_body(body: &str, status: u16) -> DeleteConfigurationSetTrackingOptionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -9727,7 +9745,11 @@ impl DeleteConfigurationSetTrackingOptionsError {
                 }
                 _ => DeleteConfigurationSetTrackingOptionsError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteConfigurationSetTrackingOptionsError::Unknown(body.to_string()),
+            Err(_) => DeleteConfigurationSetTrackingOptionsError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -9798,7 +9820,7 @@ pub enum DeleteCustomVerificationEmailTemplateError {
 }
 
 impl DeleteCustomVerificationEmailTemplateError {
-    pub fn from_body(body: &str) -> DeleteCustomVerificationEmailTemplateError {
+    pub fn from_body(body: &str, status: u16) -> DeleteCustomVerificationEmailTemplateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -9806,7 +9828,11 @@ impl DeleteCustomVerificationEmailTemplateError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteCustomVerificationEmailTemplateError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteCustomVerificationEmailTemplateError::Unknown(body.to_string()),
+            Err(_) => DeleteCustomVerificationEmailTemplateError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -9871,7 +9897,7 @@ pub enum DeleteIdentityError {
 }
 
 impl DeleteIdentityError {
-    pub fn from_body(body: &str) -> DeleteIdentityError {
+    pub fn from_body(body: &str, status: u16) -> DeleteIdentityError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -9879,7 +9905,7 @@ impl DeleteIdentityError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteIdentityError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteIdentityError::Unknown(body.to_string()),
+            Err(_) => DeleteIdentityError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -9942,7 +9968,7 @@ pub enum DeleteIdentityPolicyError {
 }
 
 impl DeleteIdentityPolicyError {
-    pub fn from_body(body: &str) -> DeleteIdentityPolicyError {
+    pub fn from_body(body: &str, status: u16) -> DeleteIdentityPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -9950,7 +9976,9 @@ impl DeleteIdentityPolicyError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteIdentityPolicyError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteIdentityPolicyError::Unknown(body.to_string()),
+            Err(_) => {
+                DeleteIdentityPolicyError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -10015,7 +10043,7 @@ pub enum DeleteReceiptFilterError {
 }
 
 impl DeleteReceiptFilterError {
-    pub fn from_body(body: &str) -> DeleteReceiptFilterError {
+    pub fn from_body(body: &str, status: u16) -> DeleteReceiptFilterError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10023,7 +10051,7 @@ impl DeleteReceiptFilterError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteReceiptFilterError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteReceiptFilterError::Unknown(body.to_string()),
+            Err(_) => DeleteReceiptFilterError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -10090,7 +10118,7 @@ pub enum DeleteReceiptRuleError {
 }
 
 impl DeleteReceiptRuleError {
-    pub fn from_body(body: &str) -> DeleteReceiptRuleError {
+    pub fn from_body(body: &str, status: u16) -> DeleteReceiptRuleError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10101,7 +10129,7 @@ impl DeleteReceiptRuleError {
                 }
                 _ => DeleteReceiptRuleError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteReceiptRuleError::Unknown(body.to_string()),
+            Err(_) => DeleteReceiptRuleError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -10169,7 +10197,7 @@ pub enum DeleteReceiptRuleSetError {
 }
 
 impl DeleteReceiptRuleSetError {
-    pub fn from_body(body: &str) -> DeleteReceiptRuleSetError {
+    pub fn from_body(body: &str, status: u16) -> DeleteReceiptRuleSetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10180,7 +10208,9 @@ impl DeleteReceiptRuleSetError {
                 }
                 _ => DeleteReceiptRuleSetError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteReceiptRuleSetError::Unknown(body.to_string()),
+            Err(_) => {
+                DeleteReceiptRuleSetError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -10246,7 +10276,7 @@ pub enum DeleteTemplateError {
 }
 
 impl DeleteTemplateError {
-    pub fn from_body(body: &str) -> DeleteTemplateError {
+    pub fn from_body(body: &str, status: u16) -> DeleteTemplateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10254,7 +10284,7 @@ impl DeleteTemplateError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteTemplateError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteTemplateError::Unknown(body.to_string()),
+            Err(_) => DeleteTemplateError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -10317,7 +10347,7 @@ pub enum DeleteVerifiedEmailAddressError {
 }
 
 impl DeleteVerifiedEmailAddressError {
-    pub fn from_body(body: &str) -> DeleteVerifiedEmailAddressError {
+    pub fn from_body(body: &str, status: u16) -> DeleteVerifiedEmailAddressError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10325,7 +10355,9 @@ impl DeleteVerifiedEmailAddressError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteVerifiedEmailAddressError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteVerifiedEmailAddressError::Unknown(body.to_string()),
+            Err(_) => {
+                DeleteVerifiedEmailAddressError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -10390,7 +10422,7 @@ pub enum DescribeActiveReceiptRuleSetError {
 }
 
 impl DescribeActiveReceiptRuleSetError {
-    pub fn from_body(body: &str) -> DescribeActiveReceiptRuleSetError {
+    pub fn from_body(body: &str, status: u16) -> DescribeActiveReceiptRuleSetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10398,7 +10430,11 @@ impl DescribeActiveReceiptRuleSetError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeActiveReceiptRuleSetError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeActiveReceiptRuleSetError::Unknown(body.to_string()),
+            Err(_) => DescribeActiveReceiptRuleSetError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -10465,7 +10501,7 @@ pub enum DescribeConfigurationSetError {
 }
 
 impl DescribeConfigurationSetError {
-    pub fn from_body(body: &str) -> DescribeConfigurationSetError {
+    pub fn from_body(body: &str, status: u16) -> DescribeConfigurationSetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10478,7 +10514,9 @@ impl DescribeConfigurationSetError {
                 }
                 _ => DescribeConfigurationSetError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeConfigurationSetError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeConfigurationSetError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -10548,7 +10586,7 @@ pub enum DescribeReceiptRuleError {
 }
 
 impl DescribeReceiptRuleError {
-    pub fn from_body(body: &str) -> DescribeReceiptRuleError {
+    pub fn from_body(body: &str, status: u16) -> DescribeReceiptRuleError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10562,7 +10600,7 @@ impl DescribeReceiptRuleError {
                 ),
                 _ => DescribeReceiptRuleError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeReceiptRuleError::Unknown(body.to_string()),
+            Err(_) => DescribeReceiptRuleError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -10631,7 +10669,7 @@ pub enum DescribeReceiptRuleSetError {
 }
 
 impl DescribeReceiptRuleSetError {
-    pub fn from_body(body: &str) -> DescribeReceiptRuleSetError {
+    pub fn from_body(body: &str, status: u16) -> DescribeReceiptRuleSetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10642,7 +10680,9 @@ impl DescribeReceiptRuleSetError {
                 ),
                 _ => DescribeReceiptRuleSetError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeReceiptRuleSetError::Unknown(body.to_string()),
+            Err(_) => {
+                DescribeReceiptRuleSetError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -10708,7 +10748,7 @@ pub enum GetAccountSendingEnabledError {
 }
 
 impl GetAccountSendingEnabledError {
-    pub fn from_body(body: &str) -> GetAccountSendingEnabledError {
+    pub fn from_body(body: &str, status: u16) -> GetAccountSendingEnabledError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10716,7 +10756,9 @@ impl GetAccountSendingEnabledError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetAccountSendingEnabledError::Unknown(String::from(body)),
             },
-            Err(_) => GetAccountSendingEnabledError::Unknown(body.to_string()),
+            Err(_) => {
+                GetAccountSendingEnabledError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -10783,7 +10825,7 @@ pub enum GetCustomVerificationEmailTemplateError {
 }
 
 impl GetCustomVerificationEmailTemplateError {
-    pub fn from_body(body: &str) -> GetCustomVerificationEmailTemplateError {
+    pub fn from_body(body: &str, status: u16) -> GetCustomVerificationEmailTemplateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10793,7 +10835,7 @@ impl GetCustomVerificationEmailTemplateError {
                                     "CustomVerificationEmailTemplateDoesNotExist" => GetCustomVerificationEmailTemplateError::CustomVerificationEmailTemplateDoesNotExist(String::from(parsed_error.message)),_ => GetCustomVerificationEmailTemplateError::Unknown(String::from(body))
                                 }
                            },
-                           Err(_) => GetCustomVerificationEmailTemplateError::Unknown(body.to_string())
+                           Err(_) => GetCustomVerificationEmailTemplateError::Unknown(format!("{}:{}", body.to_string(), status))
                        }
     }
 
@@ -10857,7 +10899,7 @@ pub enum GetIdentityDkimAttributesError {
 }
 
 impl GetIdentityDkimAttributesError {
-    pub fn from_body(body: &str) -> GetIdentityDkimAttributesError {
+    pub fn from_body(body: &str, status: u16) -> GetIdentityDkimAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10865,7 +10907,9 @@ impl GetIdentityDkimAttributesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetIdentityDkimAttributesError::Unknown(String::from(body)),
             },
-            Err(_) => GetIdentityDkimAttributesError::Unknown(body.to_string()),
+            Err(_) => {
+                GetIdentityDkimAttributesError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -10930,7 +10974,7 @@ pub enum GetIdentityMailFromDomainAttributesError {
 }
 
 impl GetIdentityMailFromDomainAttributesError {
-    pub fn from_body(body: &str) -> GetIdentityMailFromDomainAttributesError {
+    pub fn from_body(body: &str, status: u16) -> GetIdentityMailFromDomainAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -10938,7 +10982,11 @@ impl GetIdentityMailFromDomainAttributesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetIdentityMailFromDomainAttributesError::Unknown(String::from(body)),
             },
-            Err(_) => GetIdentityMailFromDomainAttributesError::Unknown(body.to_string()),
+            Err(_) => GetIdentityMailFromDomainAttributesError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -11003,7 +11051,7 @@ pub enum GetIdentityNotificationAttributesError {
 }
 
 impl GetIdentityNotificationAttributesError {
-    pub fn from_body(body: &str) -> GetIdentityNotificationAttributesError {
+    pub fn from_body(body: &str, status: u16) -> GetIdentityNotificationAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11011,7 +11059,11 @@ impl GetIdentityNotificationAttributesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetIdentityNotificationAttributesError::Unknown(String::from(body)),
             },
-            Err(_) => GetIdentityNotificationAttributesError::Unknown(body.to_string()),
+            Err(_) => GetIdentityNotificationAttributesError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -11076,7 +11128,7 @@ pub enum GetIdentityPoliciesError {
 }
 
 impl GetIdentityPoliciesError {
-    pub fn from_body(body: &str) -> GetIdentityPoliciesError {
+    pub fn from_body(body: &str, status: u16) -> GetIdentityPoliciesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11084,7 +11136,7 @@ impl GetIdentityPoliciesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetIdentityPoliciesError::Unknown(String::from(body)),
             },
-            Err(_) => GetIdentityPoliciesError::Unknown(body.to_string()),
+            Err(_) => GetIdentityPoliciesError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -11149,7 +11201,7 @@ pub enum GetIdentityVerificationAttributesError {
 }
 
 impl GetIdentityVerificationAttributesError {
-    pub fn from_body(body: &str) -> GetIdentityVerificationAttributesError {
+    pub fn from_body(body: &str, status: u16) -> GetIdentityVerificationAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11157,7 +11209,11 @@ impl GetIdentityVerificationAttributesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetIdentityVerificationAttributesError::Unknown(String::from(body)),
             },
-            Err(_) => GetIdentityVerificationAttributesError::Unknown(body.to_string()),
+            Err(_) => GetIdentityVerificationAttributesError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -11222,7 +11278,7 @@ pub enum GetSendQuotaError {
 }
 
 impl GetSendQuotaError {
-    pub fn from_body(body: &str) -> GetSendQuotaError {
+    pub fn from_body(body: &str, status: u16) -> GetSendQuotaError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11230,7 +11286,7 @@ impl GetSendQuotaError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetSendQuotaError::Unknown(String::from(body)),
             },
-            Err(_) => GetSendQuotaError::Unknown(body.to_string()),
+            Err(_) => GetSendQuotaError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -11293,7 +11349,7 @@ pub enum GetSendStatisticsError {
 }
 
 impl GetSendStatisticsError {
-    pub fn from_body(body: &str) -> GetSendStatisticsError {
+    pub fn from_body(body: &str, status: u16) -> GetSendStatisticsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11301,7 +11357,7 @@ impl GetSendStatisticsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetSendStatisticsError::Unknown(String::from(body)),
             },
-            Err(_) => GetSendStatisticsError::Unknown(body.to_string()),
+            Err(_) => GetSendStatisticsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -11368,7 +11424,7 @@ pub enum GetTemplateError {
 }
 
 impl GetTemplateError {
-    pub fn from_body(body: &str) -> GetTemplateError {
+    pub fn from_body(body: &str, status: u16) -> GetTemplateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11379,7 +11435,7 @@ impl GetTemplateError {
                 }
                 _ => GetTemplateError::Unknown(String::from(body)),
             },
-            Err(_) => GetTemplateError::Unknown(body.to_string()),
+            Err(_) => GetTemplateError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -11443,7 +11499,7 @@ pub enum ListConfigurationSetsError {
 }
 
 impl ListConfigurationSetsError {
-    pub fn from_body(body: &str) -> ListConfigurationSetsError {
+    pub fn from_body(body: &str, status: u16) -> ListConfigurationSetsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11451,7 +11507,9 @@ impl ListConfigurationSetsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListConfigurationSetsError::Unknown(String::from(body)),
             },
-            Err(_) => ListConfigurationSetsError::Unknown(body.to_string()),
+            Err(_) => {
+                ListConfigurationSetsError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -11516,7 +11574,7 @@ pub enum ListCustomVerificationEmailTemplatesError {
 }
 
 impl ListCustomVerificationEmailTemplatesError {
-    pub fn from_body(body: &str) -> ListCustomVerificationEmailTemplatesError {
+    pub fn from_body(body: &str, status: u16) -> ListCustomVerificationEmailTemplatesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11524,7 +11582,11 @@ impl ListCustomVerificationEmailTemplatesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListCustomVerificationEmailTemplatesError::Unknown(String::from(body)),
             },
-            Err(_) => ListCustomVerificationEmailTemplatesError::Unknown(body.to_string()),
+            Err(_) => ListCustomVerificationEmailTemplatesError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -11589,7 +11651,7 @@ pub enum ListIdentitiesError {
 }
 
 impl ListIdentitiesError {
-    pub fn from_body(body: &str) -> ListIdentitiesError {
+    pub fn from_body(body: &str, status: u16) -> ListIdentitiesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11597,7 +11659,7 @@ impl ListIdentitiesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListIdentitiesError::Unknown(String::from(body)),
             },
-            Err(_) => ListIdentitiesError::Unknown(body.to_string()),
+            Err(_) => ListIdentitiesError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -11660,7 +11722,7 @@ pub enum ListIdentityPoliciesError {
 }
 
 impl ListIdentityPoliciesError {
-    pub fn from_body(body: &str) -> ListIdentityPoliciesError {
+    pub fn from_body(body: &str, status: u16) -> ListIdentityPoliciesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11668,7 +11730,9 @@ impl ListIdentityPoliciesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListIdentityPoliciesError::Unknown(String::from(body)),
             },
-            Err(_) => ListIdentityPoliciesError::Unknown(body.to_string()),
+            Err(_) => {
+                ListIdentityPoliciesError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -11733,7 +11797,7 @@ pub enum ListReceiptFiltersError {
 }
 
 impl ListReceiptFiltersError {
-    pub fn from_body(body: &str) -> ListReceiptFiltersError {
+    pub fn from_body(body: &str, status: u16) -> ListReceiptFiltersError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11741,7 +11805,7 @@ impl ListReceiptFiltersError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListReceiptFiltersError::Unknown(String::from(body)),
             },
-            Err(_) => ListReceiptFiltersError::Unknown(body.to_string()),
+            Err(_) => ListReceiptFiltersError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -11806,7 +11870,7 @@ pub enum ListReceiptRuleSetsError {
 }
 
 impl ListReceiptRuleSetsError {
-    pub fn from_body(body: &str) -> ListReceiptRuleSetsError {
+    pub fn from_body(body: &str, status: u16) -> ListReceiptRuleSetsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11814,7 +11878,7 @@ impl ListReceiptRuleSetsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListReceiptRuleSetsError::Unknown(String::from(body)),
             },
-            Err(_) => ListReceiptRuleSetsError::Unknown(body.to_string()),
+            Err(_) => ListReceiptRuleSetsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -11879,7 +11943,7 @@ pub enum ListTemplatesError {
 }
 
 impl ListTemplatesError {
-    pub fn from_body(body: &str) -> ListTemplatesError {
+    pub fn from_body(body: &str, status: u16) -> ListTemplatesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11887,7 +11951,7 @@ impl ListTemplatesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListTemplatesError::Unknown(String::from(body)),
             },
-            Err(_) => ListTemplatesError::Unknown(body.to_string()),
+            Err(_) => ListTemplatesError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -11950,7 +12014,7 @@ pub enum ListVerifiedEmailAddressesError {
 }
 
 impl ListVerifiedEmailAddressesError {
-    pub fn from_body(body: &str) -> ListVerifiedEmailAddressesError {
+    pub fn from_body(body: &str, status: u16) -> ListVerifiedEmailAddressesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -11958,7 +12022,9 @@ impl ListVerifiedEmailAddressesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListVerifiedEmailAddressesError::Unknown(String::from(body)),
             },
-            Err(_) => ListVerifiedEmailAddressesError::Unknown(body.to_string()),
+            Err(_) => {
+                ListVerifiedEmailAddressesError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -12025,7 +12091,7 @@ pub enum PutIdentityPolicyError {
 }
 
 impl PutIdentityPolicyError {
-    pub fn from_body(body: &str) -> PutIdentityPolicyError {
+    pub fn from_body(body: &str, status: u16) -> PutIdentityPolicyError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -12036,7 +12102,7 @@ impl PutIdentityPolicyError {
                 }
                 _ => PutIdentityPolicyError::Unknown(String::from(body)),
             },
-            Err(_) => PutIdentityPolicyError::Unknown(body.to_string()),
+            Err(_) => PutIdentityPolicyError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -12106,7 +12172,7 @@ pub enum ReorderReceiptRuleSetError {
 }
 
 impl ReorderReceiptRuleSetError {
-    pub fn from_body(body: &str) -> ReorderReceiptRuleSetError {
+    pub fn from_body(body: &str, status: u16) -> ReorderReceiptRuleSetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -12120,7 +12186,9 @@ impl ReorderReceiptRuleSetError {
                 ),
                 _ => ReorderReceiptRuleSetError::Unknown(String::from(body)),
             },
-            Err(_) => ReorderReceiptRuleSetError::Unknown(body.to_string()),
+            Err(_) => {
+                ReorderReceiptRuleSetError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -12189,7 +12257,7 @@ pub enum SendBounceError {
 }
 
 impl SendBounceError {
-    pub fn from_body(body: &str) -> SendBounceError {
+    pub fn from_body(body: &str, status: u16) -> SendBounceError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -12200,7 +12268,7 @@ impl SendBounceError {
                 }
                 _ => SendBounceError::Unknown(String::from(body)),
             },
-            Err(_) => SendBounceError::Unknown(body.to_string()),
+            Err(_) => SendBounceError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -12276,7 +12344,7 @@ pub enum SendBulkTemplatedEmailError {
 }
 
 impl SendBulkTemplatedEmailError {
-    pub fn from_body(body: &str) -> SendBulkTemplatedEmailError {
+    pub fn from_body(body: &str, status: u16) -> SendBulkTemplatedEmailError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -12310,7 +12378,9 @@ impl SendBulkTemplatedEmailError {
                 ),
                 _ => SendBulkTemplatedEmailError::Unknown(String::from(body)),
             },
-            Err(_) => SendBulkTemplatedEmailError::Unknown(body.to_string()),
+            Err(_) => {
+                SendBulkTemplatedEmailError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -12391,7 +12461,7 @@ pub enum SendCustomVerificationEmailError {
 }
 
 impl SendCustomVerificationEmailError {
-    pub fn from_body(body: &str) -> SendCustomVerificationEmailError {
+    pub fn from_body(body: &str, status: u16) -> SendCustomVerificationEmailError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -12422,7 +12492,11 @@ impl SendCustomVerificationEmailError {
                 }
                 _ => SendCustomVerificationEmailError::Unknown(String::from(body)),
             },
-            Err(_) => SendCustomVerificationEmailError::Unknown(body.to_string()),
+            Err(_) => SendCustomVerificationEmailError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -12504,7 +12578,7 @@ pub enum SendEmailError {
 }
 
 impl SendEmailError {
-    pub fn from_body(body: &str) -> SendEmailError {
+    pub fn from_body(body: &str, status: u16) -> SendEmailError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -12529,7 +12603,7 @@ impl SendEmailError {
                 }
                 _ => SendEmailError::Unknown(String::from(body)),
             },
-            Err(_) => SendEmailError::Unknown(body.to_string()),
+            Err(_) => SendEmailError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -12607,7 +12681,7 @@ pub enum SendRawEmailError {
 }
 
 impl SendRawEmailError {
-    pub fn from_body(body: &str) -> SendRawEmailError {
+    pub fn from_body(body: &str, status: u16) -> SendRawEmailError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -12632,7 +12706,7 @@ impl SendRawEmailError {
                 }
                 _ => SendRawEmailError::Unknown(String::from(body)),
             },
-            Err(_) => SendRawEmailError::Unknown(body.to_string()),
+            Err(_) => SendRawEmailError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -12712,7 +12786,7 @@ pub enum SendTemplatedEmailError {
 }
 
 impl SendTemplatedEmailError {
-    pub fn from_body(body: &str) -> SendTemplatedEmailError {
+    pub fn from_body(body: &str, status: u16) -> SendTemplatedEmailError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -12744,7 +12818,7 @@ impl SendTemplatedEmailError {
                 ),
                 _ => SendTemplatedEmailError::Unknown(String::from(body)),
             },
-            Err(_) => SendTemplatedEmailError::Unknown(body.to_string()),
+            Err(_) => SendTemplatedEmailError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -12817,7 +12891,7 @@ pub enum SetActiveReceiptRuleSetError {
 }
 
 impl SetActiveReceiptRuleSetError {
-    pub fn from_body(body: &str) -> SetActiveReceiptRuleSetError {
+    pub fn from_body(body: &str, status: u16) -> SetActiveReceiptRuleSetError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -12828,7 +12902,9 @@ impl SetActiveReceiptRuleSetError {
                 ),
                 _ => SetActiveReceiptRuleSetError::Unknown(String::from(body)),
             },
-            Err(_) => SetActiveReceiptRuleSetError::Unknown(body.to_string()),
+            Err(_) => {
+                SetActiveReceiptRuleSetError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -12894,7 +12970,7 @@ pub enum SetIdentityDkimEnabledError {
 }
 
 impl SetIdentityDkimEnabledError {
-    pub fn from_body(body: &str) -> SetIdentityDkimEnabledError {
+    pub fn from_body(body: &str, status: u16) -> SetIdentityDkimEnabledError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -12902,7 +12978,9 @@ impl SetIdentityDkimEnabledError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => SetIdentityDkimEnabledError::Unknown(String::from(body)),
             },
-            Err(_) => SetIdentityDkimEnabledError::Unknown(body.to_string()),
+            Err(_) => {
+                SetIdentityDkimEnabledError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -12967,7 +13045,7 @@ pub enum SetIdentityFeedbackForwardingEnabledError {
 }
 
 impl SetIdentityFeedbackForwardingEnabledError {
-    pub fn from_body(body: &str) -> SetIdentityFeedbackForwardingEnabledError {
+    pub fn from_body(body: &str, status: u16) -> SetIdentityFeedbackForwardingEnabledError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -12975,7 +13053,11 @@ impl SetIdentityFeedbackForwardingEnabledError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => SetIdentityFeedbackForwardingEnabledError::Unknown(String::from(body)),
             },
-            Err(_) => SetIdentityFeedbackForwardingEnabledError::Unknown(body.to_string()),
+            Err(_) => SetIdentityFeedbackForwardingEnabledError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -13040,7 +13122,7 @@ pub enum SetIdentityHeadersInNotificationsEnabledError {
 }
 
 impl SetIdentityHeadersInNotificationsEnabledError {
-    pub fn from_body(body: &str) -> SetIdentityHeadersInNotificationsEnabledError {
+    pub fn from_body(body: &str, status: u16) -> SetIdentityHeadersInNotificationsEnabledError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -13048,7 +13130,11 @@ impl SetIdentityHeadersInNotificationsEnabledError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => SetIdentityHeadersInNotificationsEnabledError::Unknown(String::from(body)),
             },
-            Err(_) => SetIdentityHeadersInNotificationsEnabledError::Unknown(body.to_string()),
+            Err(_) => SetIdentityHeadersInNotificationsEnabledError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -13115,7 +13201,7 @@ pub enum SetIdentityMailFromDomainError {
 }
 
 impl SetIdentityMailFromDomainError {
-    pub fn from_body(body: &str) -> SetIdentityMailFromDomainError {
+    pub fn from_body(body: &str, status: u16) -> SetIdentityMailFromDomainError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -13123,7 +13209,9 @@ impl SetIdentityMailFromDomainError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => SetIdentityMailFromDomainError::Unknown(String::from(body)),
             },
-            Err(_) => SetIdentityMailFromDomainError::Unknown(body.to_string()),
+            Err(_) => {
+                SetIdentityMailFromDomainError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -13188,7 +13276,7 @@ pub enum SetIdentityNotificationTopicError {
 }
 
 impl SetIdentityNotificationTopicError {
-    pub fn from_body(body: &str) -> SetIdentityNotificationTopicError {
+    pub fn from_body(body: &str, status: u16) -> SetIdentityNotificationTopicError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -13196,7 +13284,11 @@ impl SetIdentityNotificationTopicError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => SetIdentityNotificationTopicError::Unknown(String::from(body)),
             },
-            Err(_) => SetIdentityNotificationTopicError::Unknown(body.to_string()),
+            Err(_) => SetIdentityNotificationTopicError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -13265,7 +13357,7 @@ pub enum SetReceiptRulePositionError {
 }
 
 impl SetReceiptRulePositionError {
-    pub fn from_body(body: &str) -> SetReceiptRulePositionError {
+    pub fn from_body(body: &str, status: u16) -> SetReceiptRulePositionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -13279,7 +13371,9 @@ impl SetReceiptRulePositionError {
                 ),
                 _ => SetReceiptRulePositionError::Unknown(String::from(body)),
             },
-            Err(_) => SetReceiptRulePositionError::Unknown(body.to_string()),
+            Err(_) => {
+                SetReceiptRulePositionError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -13352,7 +13446,7 @@ pub enum TestRenderTemplateError {
 }
 
 impl TestRenderTemplateError {
-    pub fn from_body(body: &str) -> TestRenderTemplateError {
+    pub fn from_body(body: &str, status: u16) -> TestRenderTemplateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -13369,7 +13463,7 @@ impl TestRenderTemplateError {
                 ),
                 _ => TestRenderTemplateError::Unknown(String::from(body)),
             },
-            Err(_) => TestRenderTemplateError::Unknown(body.to_string()),
+            Err(_) => TestRenderTemplateError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -13437,7 +13531,7 @@ pub enum UpdateAccountSendingEnabledError {
 }
 
 impl UpdateAccountSendingEnabledError {
-    pub fn from_body(body: &str) -> UpdateAccountSendingEnabledError {
+    pub fn from_body(body: &str, status: u16) -> UpdateAccountSendingEnabledError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -13445,7 +13539,11 @@ impl UpdateAccountSendingEnabledError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => UpdateAccountSendingEnabledError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateAccountSendingEnabledError::Unknown(body.to_string()),
+            Err(_) => UpdateAccountSendingEnabledError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -13520,7 +13618,7 @@ pub enum UpdateConfigurationSetEventDestinationError {
 }
 
 impl UpdateConfigurationSetEventDestinationError {
-    pub fn from_body(body: &str) -> UpdateConfigurationSetEventDestinationError {
+    pub fn from_body(body: &str, status: u16) -> UpdateConfigurationSetEventDestinationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -13553,7 +13651,11 @@ impl UpdateConfigurationSetEventDestinationError {
                 }
                 _ => UpdateConfigurationSetEventDestinationError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateConfigurationSetEventDestinationError::Unknown(body.to_string()),
+            Err(_) => UpdateConfigurationSetEventDestinationError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -13633,7 +13735,10 @@ pub enum UpdateConfigurationSetReputationMetricsEnabledError {
 }
 
 impl UpdateConfigurationSetReputationMetricsEnabledError {
-    pub fn from_body(body: &str) -> UpdateConfigurationSetReputationMetricsEnabledError {
+    pub fn from_body(
+        body: &str,
+        status: u16,
+    ) -> UpdateConfigurationSetReputationMetricsEnabledError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -13643,7 +13748,7 @@ impl UpdateConfigurationSetReputationMetricsEnabledError {
                                     "ConfigurationSetDoesNotExist" => UpdateConfigurationSetReputationMetricsEnabledError::ConfigurationSetDoesNotExist(String::from(parsed_error.message)),_ => UpdateConfigurationSetReputationMetricsEnabledError::Unknown(String::from(body))
                                 }
                            },
-                           Err(_) => UpdateConfigurationSetReputationMetricsEnabledError::Unknown(body.to_string())
+                           Err(_) => UpdateConfigurationSetReputationMetricsEnabledError::Unknown(format!("{}:{}", body.to_string(), status))
                        }
     }
 
@@ -13717,7 +13822,7 @@ pub enum UpdateConfigurationSetSendingEnabledError {
 }
 
 impl UpdateConfigurationSetSendingEnabledError {
-    pub fn from_body(body: &str) -> UpdateConfigurationSetSendingEnabledError {
+    pub fn from_body(body: &str, status: u16) -> UpdateConfigurationSetSendingEnabledError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -13730,7 +13835,11 @@ impl UpdateConfigurationSetSendingEnabledError {
                 }
                 _ => UpdateConfigurationSetSendingEnabledError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateConfigurationSetSendingEnabledError::Unknown(body.to_string()),
+            Err(_) => UpdateConfigurationSetSendingEnabledError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -13804,7 +13913,7 @@ pub enum UpdateConfigurationSetTrackingOptionsError {
 }
 
 impl UpdateConfigurationSetTrackingOptionsError {
-    pub fn from_body(body: &str) -> UpdateConfigurationSetTrackingOptionsError {
+    pub fn from_body(body: &str, status: u16) -> UpdateConfigurationSetTrackingOptionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -13827,7 +13936,11 @@ impl UpdateConfigurationSetTrackingOptionsError {
                 }
                 _ => UpdateConfigurationSetTrackingOptionsError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateConfigurationSetTrackingOptionsError::Unknown(body.to_string()),
+            Err(_) => UpdateConfigurationSetTrackingOptionsError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -13905,7 +14018,7 @@ pub enum UpdateCustomVerificationEmailTemplateError {
 }
 
 impl UpdateCustomVerificationEmailTemplateError {
-    pub fn from_body(body: &str) -> UpdateCustomVerificationEmailTemplateError {
+    pub fn from_body(body: &str, status: u16) -> UpdateCustomVerificationEmailTemplateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -13915,7 +14028,7 @@ impl UpdateCustomVerificationEmailTemplateError {
                                     "CustomVerificationEmailInvalidContent" => UpdateCustomVerificationEmailTemplateError::CustomVerificationEmailInvalidContent(String::from(parsed_error.message)),"CustomVerificationEmailTemplateDoesNotExist" => UpdateCustomVerificationEmailTemplateError::CustomVerificationEmailTemplateDoesNotExist(String::from(parsed_error.message)),"FromEmailAddressNotVerified" => UpdateCustomVerificationEmailTemplateError::FromEmailAddressNotVerified(String::from(parsed_error.message)),_ => UpdateCustomVerificationEmailTemplateError::Unknown(String::from(body))
                                 }
                            },
-                           Err(_) => UpdateCustomVerificationEmailTemplateError::Unknown(body.to_string())
+                           Err(_) => UpdateCustomVerificationEmailTemplateError::Unknown(format!("{}:{}", body.to_string(), status))
                        }
     }
 
@@ -13993,7 +14106,7 @@ pub enum UpdateReceiptRuleError {
 }
 
 impl UpdateReceiptRuleError {
-    pub fn from_body(body: &str) -> UpdateReceiptRuleError {
+    pub fn from_body(body: &str, status: u16) -> UpdateReceiptRuleError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -14019,7 +14132,7 @@ impl UpdateReceiptRuleError {
                 }
                 _ => UpdateReceiptRuleError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateReceiptRuleError::Unknown(body.to_string()),
+            Err(_) => UpdateReceiptRuleError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -14094,7 +14207,7 @@ pub enum UpdateTemplateError {
 }
 
 impl UpdateTemplateError {
-    pub fn from_body(body: &str) -> UpdateTemplateError {
+    pub fn from_body(body: &str, status: u16) -> UpdateTemplateError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -14108,7 +14221,7 @@ impl UpdateTemplateError {
                 }
                 _ => UpdateTemplateError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateTemplateError::Unknown(body.to_string()),
+            Err(_) => UpdateTemplateError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -14173,7 +14286,7 @@ pub enum VerifyDomainDkimError {
 }
 
 impl VerifyDomainDkimError {
-    pub fn from_body(body: &str) -> VerifyDomainDkimError {
+    pub fn from_body(body: &str, status: u16) -> VerifyDomainDkimError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -14181,7 +14294,7 @@ impl VerifyDomainDkimError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => VerifyDomainDkimError::Unknown(String::from(body)),
             },
-            Err(_) => VerifyDomainDkimError::Unknown(body.to_string()),
+            Err(_) => VerifyDomainDkimError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -14244,7 +14357,7 @@ pub enum VerifyDomainIdentityError {
 }
 
 impl VerifyDomainIdentityError {
-    pub fn from_body(body: &str) -> VerifyDomainIdentityError {
+    pub fn from_body(body: &str, status: u16) -> VerifyDomainIdentityError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -14252,7 +14365,9 @@ impl VerifyDomainIdentityError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => VerifyDomainIdentityError::Unknown(String::from(body)),
             },
-            Err(_) => VerifyDomainIdentityError::Unknown(body.to_string()),
+            Err(_) => {
+                VerifyDomainIdentityError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -14317,7 +14432,7 @@ pub enum VerifyEmailAddressError {
 }
 
 impl VerifyEmailAddressError {
-    pub fn from_body(body: &str) -> VerifyEmailAddressError {
+    pub fn from_body(body: &str, status: u16) -> VerifyEmailAddressError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -14325,7 +14440,7 @@ impl VerifyEmailAddressError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => VerifyEmailAddressError::Unknown(String::from(body)),
             },
-            Err(_) => VerifyEmailAddressError::Unknown(body.to_string()),
+            Err(_) => VerifyEmailAddressError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -14390,7 +14505,7 @@ pub enum VerifyEmailIdentityError {
 }
 
 impl VerifyEmailIdentityError {
-    pub fn from_body(body: &str) -> VerifyEmailIdentityError {
+    pub fn from_body(body: &str, status: u16) -> VerifyEmailIdentityError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -14398,7 +14513,7 @@ impl VerifyEmailIdentityError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => VerifyEmailIdentityError::Unknown(String::from(body)),
             },
-            Err(_) => VerifyEmailIdentityError::Unknown(body.to_string()),
+            Err(_) => VerifyEmailIdentityError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 

--- a/rusoto/services/ses/src/generated.rs
+++ b/rusoto/services/ses/src/generated.rs
@@ -8683,7 +8683,13 @@ impl CloneReceiptRuleSetError {
                 ),
                 _ => CloneReceiptRuleSetError::Unknown(String::from(body)),
             },
-            Err(_) => CloneReceiptRuleSetError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CloneReceiptRuleSetError::Unknown(format!("{}", status))
+                } else {
+                    CloneReceiptRuleSetError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -8777,7 +8783,11 @@ impl CreateConfigurationSetError {
                 _ => CreateConfigurationSetError::Unknown(String::from(body)),
             },
             Err(_) => {
-                CreateConfigurationSetError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    CreateConfigurationSetError::Unknown(format!("{}", status))
+                } else {
+                    CreateConfigurationSetError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -8894,11 +8904,17 @@ impl CreateConfigurationSetEventDestinationError {
                 ),
                 _ => CreateConfigurationSetEventDestinationError::Unknown(String::from(body)),
             },
-            Err(_) => CreateConfigurationSetEventDestinationError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateConfigurationSetEventDestinationError::Unknown(format!("{}", status))
+                } else {
+                    CreateConfigurationSetEventDestinationError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -9006,11 +9022,17 @@ impl CreateConfigurationSetTrackingOptionsError {
                 }
                 _ => CreateConfigurationSetTrackingOptionsError::Unknown(String::from(body)),
             },
-            Err(_) => CreateConfigurationSetTrackingOptionsError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateConfigurationSetTrackingOptionsError::Unknown(format!("{}", status))
+                } else {
+                    CreateConfigurationSetTrackingOptionsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -9100,7 +9122,13 @@ impl CreateCustomVerificationEmailTemplateError {
                                     "CustomVerificationEmailInvalidContent" => CreateCustomVerificationEmailTemplateError::CustomVerificationEmailInvalidContent(String::from(parsed_error.message)),"CustomVerificationEmailTemplateAlreadyExists" => CreateCustomVerificationEmailTemplateError::CustomVerificationEmailTemplateAlreadyExists(String::from(parsed_error.message)),"FromEmailAddressNotVerified" => CreateCustomVerificationEmailTemplateError::FromEmailAddressNotVerified(String::from(parsed_error.message)),"LimitExceeded" => CreateCustomVerificationEmailTemplateError::LimitExceeded(String::from(parsed_error.message)),_ => CreateCustomVerificationEmailTemplateError::Unknown(String::from(body))
                                 }
                            },
-                           Err(_) => CreateCustomVerificationEmailTemplateError::Unknown(format!("{}:{}", body.to_string(), status))
+                           Err(_) => {
+                               if body.len() == 0 {
+                                   CreateCustomVerificationEmailTemplateError::Unknown(format!("{}", status))
+                               } else {
+                                   CreateCustomVerificationEmailTemplateError::Unknown(format!("{}:{}", body.to_string(), status))
+                               }
+                            }
                        }
     }
 
@@ -9185,7 +9213,13 @@ impl CreateReceiptFilterError {
                 }
                 _ => CreateReceiptFilterError::Unknown(String::from(body)),
             },
-            Err(_) => CreateReceiptFilterError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateReceiptFilterError::Unknown(format!("{}", status))
+                } else {
+                    CreateReceiptFilterError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -9295,7 +9329,13 @@ impl CreateReceiptRuleError {
                 }
                 _ => CreateReceiptRuleError::Unknown(String::from(body)),
             },
-            Err(_) => CreateReceiptRuleError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateReceiptRuleError::Unknown(format!("{}", status))
+                } else {
+                    CreateReceiptRuleError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -9386,7 +9426,11 @@ impl CreateReceiptRuleSetError {
                 _ => CreateReceiptRuleSetError::Unknown(String::from(body)),
             },
             Err(_) => {
-                CreateReceiptRuleSetError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    CreateReceiptRuleSetError::Unknown(format!("{}", status))
+                } else {
+                    CreateReceiptRuleSetError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -9477,7 +9521,13 @@ impl CreateTemplateError {
                 }
                 _ => CreateTemplateError::Unknown(String::from(body)),
             },
-            Err(_) => CreateTemplateError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateTemplateError::Unknown(format!("{}", status))
+                } else {
+                    CreateTemplateError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -9559,7 +9609,11 @@ impl DeleteConfigurationSetError {
                 _ => DeleteConfigurationSetError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DeleteConfigurationSetError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DeleteConfigurationSetError::Unknown(format!("{}", status))
+                } else {
+                    DeleteConfigurationSetError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -9648,11 +9702,17 @@ impl DeleteConfigurationSetEventDestinationError {
                 }
                 _ => DeleteConfigurationSetEventDestinationError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteConfigurationSetEventDestinationError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteConfigurationSetEventDestinationError::Unknown(format!("{}", status))
+                } else {
+                    DeleteConfigurationSetEventDestinationError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -9745,11 +9805,17 @@ impl DeleteConfigurationSetTrackingOptionsError {
                 }
                 _ => DeleteConfigurationSetTrackingOptionsError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteConfigurationSetTrackingOptionsError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteConfigurationSetTrackingOptionsError::Unknown(format!("{}", status))
+                } else {
+                    DeleteConfigurationSetTrackingOptionsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -9828,11 +9894,17 @@ impl DeleteCustomVerificationEmailTemplateError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteCustomVerificationEmailTemplateError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteCustomVerificationEmailTemplateError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteCustomVerificationEmailTemplateError::Unknown(format!("{}", status))
+                } else {
+                    DeleteCustomVerificationEmailTemplateError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -9905,7 +9977,13 @@ impl DeleteIdentityError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteIdentityError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteIdentityError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteIdentityError::Unknown(format!("{}", status))
+                } else {
+                    DeleteIdentityError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -9977,7 +10055,11 @@ impl DeleteIdentityPolicyError {
                 _ => DeleteIdentityPolicyError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DeleteIdentityPolicyError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DeleteIdentityPolicyError::Unknown(format!("{}", status))
+                } else {
+                    DeleteIdentityPolicyError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -10051,7 +10133,13 @@ impl DeleteReceiptFilterError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteReceiptFilterError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteReceiptFilterError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteReceiptFilterError::Unknown(format!("{}", status))
+                } else {
+                    DeleteReceiptFilterError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -10129,7 +10217,13 @@ impl DeleteReceiptRuleError {
                 }
                 _ => DeleteReceiptRuleError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteReceiptRuleError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteReceiptRuleError::Unknown(format!("{}", status))
+                } else {
+                    DeleteReceiptRuleError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -10209,7 +10303,11 @@ impl DeleteReceiptRuleSetError {
                 _ => DeleteReceiptRuleSetError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DeleteReceiptRuleSetError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DeleteReceiptRuleSetError::Unknown(format!("{}", status))
+                } else {
+                    DeleteReceiptRuleSetError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -10284,7 +10382,13 @@ impl DeleteTemplateError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteTemplateError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteTemplateError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteTemplateError::Unknown(format!("{}", status))
+                } else {
+                    DeleteTemplateError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -10356,7 +10460,15 @@ impl DeleteVerifiedEmailAddressError {
                 _ => DeleteVerifiedEmailAddressError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DeleteVerifiedEmailAddressError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DeleteVerifiedEmailAddressError::Unknown(format!("{}", status))
+                } else {
+                    DeleteVerifiedEmailAddressError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -10430,11 +10542,17 @@ impl DescribeActiveReceiptRuleSetError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DescribeActiveReceiptRuleSetError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeActiveReceiptRuleSetError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeActiveReceiptRuleSetError::Unknown(format!("{}", status))
+                } else {
+                    DescribeActiveReceiptRuleSetError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -10515,7 +10633,15 @@ impl DescribeConfigurationSetError {
                 _ => DescribeConfigurationSetError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeConfigurationSetError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeConfigurationSetError::Unknown(format!("{}", status))
+                } else {
+                    DescribeConfigurationSetError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -10600,7 +10726,13 @@ impl DescribeReceiptRuleError {
                 ),
                 _ => DescribeReceiptRuleError::Unknown(String::from(body)),
             },
-            Err(_) => DescribeReceiptRuleError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DescribeReceiptRuleError::Unknown(format!("{}", status))
+                } else {
+                    DescribeReceiptRuleError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -10681,7 +10813,11 @@ impl DescribeReceiptRuleSetError {
                 _ => DescribeReceiptRuleSetError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DescribeReceiptRuleSetError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DescribeReceiptRuleSetError::Unknown(format!("{}", status))
+                } else {
+                    DescribeReceiptRuleSetError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -10757,7 +10893,15 @@ impl GetAccountSendingEnabledError {
                 _ => GetAccountSendingEnabledError::Unknown(String::from(body)),
             },
             Err(_) => {
-                GetAccountSendingEnabledError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    GetAccountSendingEnabledError::Unknown(format!("{}", status))
+                } else {
+                    GetAccountSendingEnabledError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -10835,7 +10979,13 @@ impl GetCustomVerificationEmailTemplateError {
                                     "CustomVerificationEmailTemplateDoesNotExist" => GetCustomVerificationEmailTemplateError::CustomVerificationEmailTemplateDoesNotExist(String::from(parsed_error.message)),_ => GetCustomVerificationEmailTemplateError::Unknown(String::from(body))
                                 }
                            },
-                           Err(_) => GetCustomVerificationEmailTemplateError::Unknown(format!("{}:{}", body.to_string(), status))
+                           Err(_) => {
+                               if body.len() == 0 {
+                                   GetCustomVerificationEmailTemplateError::Unknown(format!("{}", status))
+                               } else {
+                                   GetCustomVerificationEmailTemplateError::Unknown(format!("{}:{}", body.to_string(), status))
+                               }
+                            }
                        }
     }
 
@@ -10908,7 +11058,15 @@ impl GetIdentityDkimAttributesError {
                 _ => GetIdentityDkimAttributesError::Unknown(String::from(body)),
             },
             Err(_) => {
-                GetIdentityDkimAttributesError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    GetIdentityDkimAttributesError::Unknown(format!("{}", status))
+                } else {
+                    GetIdentityDkimAttributesError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -10982,11 +11140,17 @@ impl GetIdentityMailFromDomainAttributesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetIdentityMailFromDomainAttributesError::Unknown(String::from(body)),
             },
-            Err(_) => GetIdentityMailFromDomainAttributesError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetIdentityMailFromDomainAttributesError::Unknown(format!("{}", status))
+                } else {
+                    GetIdentityMailFromDomainAttributesError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -11059,11 +11223,17 @@ impl GetIdentityNotificationAttributesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetIdentityNotificationAttributesError::Unknown(String::from(body)),
             },
-            Err(_) => GetIdentityNotificationAttributesError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetIdentityNotificationAttributesError::Unknown(format!("{}", status))
+                } else {
+                    GetIdentityNotificationAttributesError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -11136,7 +11306,13 @@ impl GetIdentityPoliciesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetIdentityPoliciesError::Unknown(String::from(body)),
             },
-            Err(_) => GetIdentityPoliciesError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetIdentityPoliciesError::Unknown(format!("{}", status))
+                } else {
+                    GetIdentityPoliciesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -11209,11 +11385,17 @@ impl GetIdentityVerificationAttributesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetIdentityVerificationAttributesError::Unknown(String::from(body)),
             },
-            Err(_) => GetIdentityVerificationAttributesError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetIdentityVerificationAttributesError::Unknown(format!("{}", status))
+                } else {
+                    GetIdentityVerificationAttributesError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -11286,7 +11468,13 @@ impl GetSendQuotaError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetSendQuotaError::Unknown(String::from(body)),
             },
-            Err(_) => GetSendQuotaError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetSendQuotaError::Unknown(format!("{}", status))
+                } else {
+                    GetSendQuotaError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -11357,7 +11545,13 @@ impl GetSendStatisticsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetSendStatisticsError::Unknown(String::from(body)),
             },
-            Err(_) => GetSendStatisticsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetSendStatisticsError::Unknown(format!("{}", status))
+                } else {
+                    GetSendStatisticsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -11435,7 +11629,13 @@ impl GetTemplateError {
                 }
                 _ => GetTemplateError::Unknown(String::from(body)),
             },
-            Err(_) => GetTemplateError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetTemplateError::Unknown(format!("{}", status))
+                } else {
+                    GetTemplateError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -11508,7 +11708,11 @@ impl ListConfigurationSetsError {
                 _ => ListConfigurationSetsError::Unknown(String::from(body)),
             },
             Err(_) => {
-                ListConfigurationSetsError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    ListConfigurationSetsError::Unknown(format!("{}", status))
+                } else {
+                    ListConfigurationSetsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -11582,11 +11786,17 @@ impl ListCustomVerificationEmailTemplatesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListCustomVerificationEmailTemplatesError::Unknown(String::from(body)),
             },
-            Err(_) => ListCustomVerificationEmailTemplatesError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    ListCustomVerificationEmailTemplatesError::Unknown(format!("{}", status))
+                } else {
+                    ListCustomVerificationEmailTemplatesError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -11659,7 +11869,13 @@ impl ListIdentitiesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListIdentitiesError::Unknown(String::from(body)),
             },
-            Err(_) => ListIdentitiesError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ListIdentitiesError::Unknown(format!("{}", status))
+                } else {
+                    ListIdentitiesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -11731,7 +11947,11 @@ impl ListIdentityPoliciesError {
                 _ => ListIdentityPoliciesError::Unknown(String::from(body)),
             },
             Err(_) => {
-                ListIdentityPoliciesError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    ListIdentityPoliciesError::Unknown(format!("{}", status))
+                } else {
+                    ListIdentityPoliciesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -11805,7 +12025,13 @@ impl ListReceiptFiltersError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListReceiptFiltersError::Unknown(String::from(body)),
             },
-            Err(_) => ListReceiptFiltersError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ListReceiptFiltersError::Unknown(format!("{}", status))
+                } else {
+                    ListReceiptFiltersError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -11878,7 +12104,13 @@ impl ListReceiptRuleSetsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListReceiptRuleSetsError::Unknown(String::from(body)),
             },
-            Err(_) => ListReceiptRuleSetsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ListReceiptRuleSetsError::Unknown(format!("{}", status))
+                } else {
+                    ListReceiptRuleSetsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -11951,7 +12183,13 @@ impl ListTemplatesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListTemplatesError::Unknown(String::from(body)),
             },
-            Err(_) => ListTemplatesError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ListTemplatesError::Unknown(format!("{}", status))
+                } else {
+                    ListTemplatesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -12023,7 +12261,15 @@ impl ListVerifiedEmailAddressesError {
                 _ => ListVerifiedEmailAddressesError::Unknown(String::from(body)),
             },
             Err(_) => {
-                ListVerifiedEmailAddressesError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    ListVerifiedEmailAddressesError::Unknown(format!("{}", status))
+                } else {
+                    ListVerifiedEmailAddressesError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -12102,7 +12348,13 @@ impl PutIdentityPolicyError {
                 }
                 _ => PutIdentityPolicyError::Unknown(String::from(body)),
             },
-            Err(_) => PutIdentityPolicyError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    PutIdentityPolicyError::Unknown(format!("{}", status))
+                } else {
+                    PutIdentityPolicyError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -12187,7 +12439,11 @@ impl ReorderReceiptRuleSetError {
                 _ => ReorderReceiptRuleSetError::Unknown(String::from(body)),
             },
             Err(_) => {
-                ReorderReceiptRuleSetError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    ReorderReceiptRuleSetError::Unknown(format!("{}", status))
+                } else {
+                    ReorderReceiptRuleSetError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -12268,7 +12524,13 @@ impl SendBounceError {
                 }
                 _ => SendBounceError::Unknown(String::from(body)),
             },
-            Err(_) => SendBounceError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    SendBounceError::Unknown(format!("{}", status))
+                } else {
+                    SendBounceError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -12379,7 +12641,11 @@ impl SendBulkTemplatedEmailError {
                 _ => SendBulkTemplatedEmailError::Unknown(String::from(body)),
             },
             Err(_) => {
-                SendBulkTemplatedEmailError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    SendBulkTemplatedEmailError::Unknown(format!("{}", status))
+                } else {
+                    SendBulkTemplatedEmailError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -12492,11 +12758,17 @@ impl SendCustomVerificationEmailError {
                 }
                 _ => SendCustomVerificationEmailError::Unknown(String::from(body)),
             },
-            Err(_) => SendCustomVerificationEmailError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    SendCustomVerificationEmailError::Unknown(format!("{}", status))
+                } else {
+                    SendCustomVerificationEmailError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -12603,7 +12875,13 @@ impl SendEmailError {
                 }
                 _ => SendEmailError::Unknown(String::from(body)),
             },
-            Err(_) => SendEmailError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    SendEmailError::Unknown(format!("{}", status))
+                } else {
+                    SendEmailError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -12706,7 +12984,13 @@ impl SendRawEmailError {
                 }
                 _ => SendRawEmailError::Unknown(String::from(body)),
             },
-            Err(_) => SendRawEmailError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    SendRawEmailError::Unknown(format!("{}", status))
+                } else {
+                    SendRawEmailError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -12818,7 +13102,13 @@ impl SendTemplatedEmailError {
                 ),
                 _ => SendTemplatedEmailError::Unknown(String::from(body)),
             },
-            Err(_) => SendTemplatedEmailError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    SendTemplatedEmailError::Unknown(format!("{}", status))
+                } else {
+                    SendTemplatedEmailError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -12903,7 +13193,15 @@ impl SetActiveReceiptRuleSetError {
                 _ => SetActiveReceiptRuleSetError::Unknown(String::from(body)),
             },
             Err(_) => {
-                SetActiveReceiptRuleSetError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    SetActiveReceiptRuleSetError::Unknown(format!("{}", status))
+                } else {
+                    SetActiveReceiptRuleSetError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -12979,7 +13277,11 @@ impl SetIdentityDkimEnabledError {
                 _ => SetIdentityDkimEnabledError::Unknown(String::from(body)),
             },
             Err(_) => {
-                SetIdentityDkimEnabledError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    SetIdentityDkimEnabledError::Unknown(format!("{}", status))
+                } else {
+                    SetIdentityDkimEnabledError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -13053,11 +13355,17 @@ impl SetIdentityFeedbackForwardingEnabledError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => SetIdentityFeedbackForwardingEnabledError::Unknown(String::from(body)),
             },
-            Err(_) => SetIdentityFeedbackForwardingEnabledError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    SetIdentityFeedbackForwardingEnabledError::Unknown(format!("{}", status))
+                } else {
+                    SetIdentityFeedbackForwardingEnabledError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -13130,11 +13438,17 @@ impl SetIdentityHeadersInNotificationsEnabledError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => SetIdentityHeadersInNotificationsEnabledError::Unknown(String::from(body)),
             },
-            Err(_) => SetIdentityHeadersInNotificationsEnabledError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    SetIdentityHeadersInNotificationsEnabledError::Unknown(format!("{}", status))
+                } else {
+                    SetIdentityHeadersInNotificationsEnabledError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -13210,7 +13524,15 @@ impl SetIdentityMailFromDomainError {
                 _ => SetIdentityMailFromDomainError::Unknown(String::from(body)),
             },
             Err(_) => {
-                SetIdentityMailFromDomainError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    SetIdentityMailFromDomainError::Unknown(format!("{}", status))
+                } else {
+                    SetIdentityMailFromDomainError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -13284,11 +13606,17 @@ impl SetIdentityNotificationTopicError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => SetIdentityNotificationTopicError::Unknown(String::from(body)),
             },
-            Err(_) => SetIdentityNotificationTopicError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    SetIdentityNotificationTopicError::Unknown(format!("{}", status))
+                } else {
+                    SetIdentityNotificationTopicError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -13372,7 +13700,11 @@ impl SetReceiptRulePositionError {
                 _ => SetReceiptRulePositionError::Unknown(String::from(body)),
             },
             Err(_) => {
-                SetReceiptRulePositionError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    SetReceiptRulePositionError::Unknown(format!("{}", status))
+                } else {
+                    SetReceiptRulePositionError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -13463,7 +13795,13 @@ impl TestRenderTemplateError {
                 ),
                 _ => TestRenderTemplateError::Unknown(String::from(body)),
             },
-            Err(_) => TestRenderTemplateError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    TestRenderTemplateError::Unknown(format!("{}", status))
+                } else {
+                    TestRenderTemplateError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -13539,11 +13877,17 @@ impl UpdateAccountSendingEnabledError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => UpdateAccountSendingEnabledError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateAccountSendingEnabledError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    UpdateAccountSendingEnabledError::Unknown(format!("{}", status))
+                } else {
+                    UpdateAccountSendingEnabledError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -13651,11 +13995,17 @@ impl UpdateConfigurationSetEventDestinationError {
                 }
                 _ => UpdateConfigurationSetEventDestinationError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateConfigurationSetEventDestinationError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    UpdateConfigurationSetEventDestinationError::Unknown(format!("{}", status))
+                } else {
+                    UpdateConfigurationSetEventDestinationError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -13748,7 +14098,13 @@ impl UpdateConfigurationSetReputationMetricsEnabledError {
                                     "ConfigurationSetDoesNotExist" => UpdateConfigurationSetReputationMetricsEnabledError::ConfigurationSetDoesNotExist(String::from(parsed_error.message)),_ => UpdateConfigurationSetReputationMetricsEnabledError::Unknown(String::from(body))
                                 }
                            },
-                           Err(_) => UpdateConfigurationSetReputationMetricsEnabledError::Unknown(format!("{}:{}", body.to_string(), status))
+                           Err(_) => {
+                               if body.len() == 0 {
+                                   UpdateConfigurationSetReputationMetricsEnabledError::Unknown(format!("{}", status))
+                               } else {
+                                   UpdateConfigurationSetReputationMetricsEnabledError::Unknown(format!("{}:{}", body.to_string(), status))
+                               }
+                            }
                        }
     }
 
@@ -13835,11 +14191,17 @@ impl UpdateConfigurationSetSendingEnabledError {
                 }
                 _ => UpdateConfigurationSetSendingEnabledError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateConfigurationSetSendingEnabledError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    UpdateConfigurationSetSendingEnabledError::Unknown(format!("{}", status))
+                } else {
+                    UpdateConfigurationSetSendingEnabledError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -13936,11 +14298,17 @@ impl UpdateConfigurationSetTrackingOptionsError {
                 }
                 _ => UpdateConfigurationSetTrackingOptionsError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateConfigurationSetTrackingOptionsError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    UpdateConfigurationSetTrackingOptionsError::Unknown(format!("{}", status))
+                } else {
+                    UpdateConfigurationSetTrackingOptionsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -14028,7 +14396,13 @@ impl UpdateCustomVerificationEmailTemplateError {
                                     "CustomVerificationEmailInvalidContent" => UpdateCustomVerificationEmailTemplateError::CustomVerificationEmailInvalidContent(String::from(parsed_error.message)),"CustomVerificationEmailTemplateDoesNotExist" => UpdateCustomVerificationEmailTemplateError::CustomVerificationEmailTemplateDoesNotExist(String::from(parsed_error.message)),"FromEmailAddressNotVerified" => UpdateCustomVerificationEmailTemplateError::FromEmailAddressNotVerified(String::from(parsed_error.message)),_ => UpdateCustomVerificationEmailTemplateError::Unknown(String::from(body))
                                 }
                            },
-                           Err(_) => UpdateCustomVerificationEmailTemplateError::Unknown(format!("{}:{}", body.to_string(), status))
+                           Err(_) => {
+                               if body.len() == 0 {
+                                   UpdateCustomVerificationEmailTemplateError::Unknown(format!("{}", status))
+                               } else {
+                                   UpdateCustomVerificationEmailTemplateError::Unknown(format!("{}:{}", body.to_string(), status))
+                               }
+                            }
                        }
     }
 
@@ -14132,7 +14506,13 @@ impl UpdateReceiptRuleError {
                 }
                 _ => UpdateReceiptRuleError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateReceiptRuleError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    UpdateReceiptRuleError::Unknown(format!("{}", status))
+                } else {
+                    UpdateReceiptRuleError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -14221,7 +14601,13 @@ impl UpdateTemplateError {
                 }
                 _ => UpdateTemplateError::Unknown(String::from(body)),
             },
-            Err(_) => UpdateTemplateError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    UpdateTemplateError::Unknown(format!("{}", status))
+                } else {
+                    UpdateTemplateError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -14294,7 +14680,13 @@ impl VerifyDomainDkimError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => VerifyDomainDkimError::Unknown(String::from(body)),
             },
-            Err(_) => VerifyDomainDkimError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    VerifyDomainDkimError::Unknown(format!("{}", status))
+                } else {
+                    VerifyDomainDkimError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -14366,7 +14758,11 @@ impl VerifyDomainIdentityError {
                 _ => VerifyDomainIdentityError::Unknown(String::from(body)),
             },
             Err(_) => {
-                VerifyDomainIdentityError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    VerifyDomainIdentityError::Unknown(format!("{}", status))
+                } else {
+                    VerifyDomainIdentityError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -14440,7 +14836,13 @@ impl VerifyEmailAddressError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => VerifyEmailAddressError::Unknown(String::from(body)),
             },
-            Err(_) => VerifyEmailAddressError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    VerifyEmailAddressError::Unknown(format!("{}", status))
+                } else {
+                    VerifyEmailAddressError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -14513,7 +14915,13 @@ impl VerifyEmailIdentityError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => VerifyEmailIdentityError::Unknown(String::from(body)),
             },
-            Err(_) => VerifyEmailIdentityError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    VerifyEmailIdentityError::Unknown(format!("{}", status))
+                } else {
+                    VerifyEmailIdentityError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 

--- a/rusoto/services/sns/src/generated.rs
+++ b/rusoto/services/sns/src/generated.rs
@@ -2567,7 +2567,13 @@ impl AddPermissionError {
                 "NotFound" => AddPermissionError::NotFound(String::from(parsed_error.message)),
                 _ => AddPermissionError::Unknown(String::from(body)),
             },
-            Err(_) => AddPermissionError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    AddPermissionError::Unknown(format!("{}", status))
+                } else {
+                    AddPermissionError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -2662,11 +2668,17 @@ impl CheckIfPhoneNumberIsOptedOutError {
                 }
                 _ => CheckIfPhoneNumberIsOptedOutError::Unknown(String::from(body)),
             },
-            Err(_) => CheckIfPhoneNumberIsOptedOutError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    CheckIfPhoneNumberIsOptedOutError::Unknown(format!("{}", status))
+                } else {
+                    CheckIfPhoneNumberIsOptedOutError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -2768,7 +2780,13 @@ impl ConfirmSubscriptionError {
                 ),
                 _ => ConfirmSubscriptionError::Unknown(String::from(body)),
             },
-            Err(_) => ConfirmSubscriptionError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ConfirmSubscriptionError::Unknown(format!("{}", status))
+                } else {
+                    ConfirmSubscriptionError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -2862,7 +2880,15 @@ impl CreatePlatformApplicationError {
                 _ => CreatePlatformApplicationError::Unknown(String::from(body)),
             },
             Err(_) => {
-                CreatePlatformApplicationError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    CreatePlatformApplicationError::Unknown(format!("{}", status))
+                } else {
+                    CreatePlatformApplicationError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -2960,7 +2986,11 @@ impl CreatePlatformEndpointError {
                 _ => CreatePlatformEndpointError::Unknown(String::from(body)),
             },
             Err(_) => {
-                CreatePlatformEndpointError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    CreatePlatformEndpointError::Unknown(format!("{}", status))
+                } else {
+                    CreatePlatformEndpointError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -3058,7 +3088,13 @@ impl CreateTopicError {
                 }
                 _ => CreateTopicError::Unknown(String::from(body)),
             },
-            Err(_) => CreateTopicError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateTopicError::Unknown(format!("{}", status))
+                } else {
+                    CreateTopicError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -3148,7 +3184,13 @@ impl DeleteEndpointError {
                 }
                 _ => DeleteEndpointError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteEndpointError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteEndpointError::Unknown(format!("{}", status))
+                } else {
+                    DeleteEndpointError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -3238,7 +3280,15 @@ impl DeletePlatformApplicationError {
                 _ => DeletePlatformApplicationError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DeletePlatformApplicationError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DeletePlatformApplicationError::Unknown(format!("{}", status))
+                } else {
+                    DeletePlatformApplicationError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -3333,7 +3383,13 @@ impl DeleteTopicError {
                 "NotFound" => DeleteTopicError::NotFound(String::from(parsed_error.message)),
                 _ => DeleteTopicError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteTopicError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteTopicError::Unknown(format!("{}", status))
+                } else {
+                    DeleteTopicError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -3429,7 +3485,11 @@ impl GetEndpointAttributesError {
                 _ => GetEndpointAttributesError::Unknown(String::from(body)),
             },
             Err(_) => {
-                GetEndpointAttributesError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    GetEndpointAttributesError::Unknown(format!("{}", status))
+                } else {
+                    GetEndpointAttributesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -3527,11 +3587,17 @@ impl GetPlatformApplicationAttributesError {
                 )),
                 _ => GetPlatformApplicationAttributesError::Unknown(String::from(body)),
             },
-            Err(_) => GetPlatformApplicationAttributesError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetPlatformApplicationAttributesError::Unknown(format!("{}", status))
+                } else {
+                    GetPlatformApplicationAttributesError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -3626,7 +3692,13 @@ impl GetSMSAttributesError {
                 "Throttled" => GetSMSAttributesError::Throttled(String::from(parsed_error.message)),
                 _ => GetSMSAttributesError::Unknown(String::from(body)),
             },
-            Err(_) => GetSMSAttributesError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetSMSAttributesError::Unknown(format!("{}", status))
+                } else {
+                    GetSMSAttributesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -3722,7 +3794,15 @@ impl GetSubscriptionAttributesError {
                 _ => GetSubscriptionAttributesError::Unknown(String::from(body)),
             },
             Err(_) => {
-                GetSubscriptionAttributesError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    GetSubscriptionAttributesError::Unknown(format!("{}", status))
+                } else {
+                    GetSubscriptionAttributesError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -3818,7 +3898,13 @@ impl GetTopicAttributesError {
                 "NotFound" => GetTopicAttributesError::NotFound(String::from(parsed_error.message)),
                 _ => GetTopicAttributesError::Unknown(String::from(body)),
             },
-            Err(_) => GetTopicAttributesError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetTopicAttributesError::Unknown(format!("{}", status))
+                } else {
+                    GetTopicAttributesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -3917,11 +4003,17 @@ impl ListEndpointsByPlatformApplicationError {
                 )),
                 _ => ListEndpointsByPlatformApplicationError::Unknown(String::from(body)),
             },
-            Err(_) => ListEndpointsByPlatformApplicationError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    ListEndpointsByPlatformApplicationError::Unknown(format!("{}", status))
+                } else {
+                    ListEndpointsByPlatformApplicationError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -4019,7 +4111,15 @@ impl ListPhoneNumbersOptedOutError {
                 _ => ListPhoneNumbersOptedOutError::Unknown(String::from(body)),
             },
             Err(_) => {
-                ListPhoneNumbersOptedOutError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    ListPhoneNumbersOptedOutError::Unknown(format!("{}", status))
+                } else {
+                    ListPhoneNumbersOptedOutError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -4113,7 +4213,15 @@ impl ListPlatformApplicationsError {
                 _ => ListPlatformApplicationsError::Unknown(String::from(body)),
             },
             Err(_) => {
-                ListPlatformApplicationsError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    ListPlatformApplicationsError::Unknown(format!("{}", status))
+                } else {
+                    ListPlatformApplicationsError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -4205,7 +4313,13 @@ impl ListSubscriptionsError {
                 }
                 _ => ListSubscriptionsError::Unknown(String::from(body)),
             },
-            Err(_) => ListSubscriptionsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ListSubscriptionsError::Unknown(format!("{}", status))
+                } else {
+                    ListSubscriptionsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -4302,7 +4416,15 @@ impl ListSubscriptionsByTopicError {
                 _ => ListSubscriptionsByTopicError::Unknown(String::from(body)),
             },
             Err(_) => {
-                ListSubscriptionsByTopicError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    ListSubscriptionsByTopicError::Unknown(format!("{}", status))
+                } else {
+                    ListSubscriptionsByTopicError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -4395,7 +4517,13 @@ impl ListTopicsError {
                 }
                 _ => ListTopicsError::Unknown(String::from(body)),
             },
-            Err(_) => ListTopicsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ListTopicsError::Unknown(format!("{}", status))
+                } else {
+                    ListTopicsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -4487,7 +4615,13 @@ impl OptInPhoneNumberError {
                 "Throttled" => OptInPhoneNumberError::Throttled(String::from(parsed_error.message)),
                 _ => OptInPhoneNumberError::Unknown(String::from(body)),
             },
-            Err(_) => OptInPhoneNumberError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    OptInPhoneNumberError::Unknown(format!("{}", status))
+                } else {
+                    OptInPhoneNumberError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -4593,7 +4727,13 @@ impl PublishError {
                 }
                 _ => PublishError::Unknown(String::from(body)),
             },
-            Err(_) => PublishError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    PublishError::Unknown(format!("{}", status))
+                } else {
+                    PublishError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -4689,7 +4829,13 @@ impl RemovePermissionError {
                 "NotFound" => RemovePermissionError::NotFound(String::from(parsed_error.message)),
                 _ => RemovePermissionError::Unknown(String::from(body)),
             },
-            Err(_) => RemovePermissionError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    RemovePermissionError::Unknown(format!("{}", status))
+                } else {
+                    RemovePermissionError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -4785,7 +4931,11 @@ impl SetEndpointAttributesError {
                 _ => SetEndpointAttributesError::Unknown(String::from(body)),
             },
             Err(_) => {
-                SetEndpointAttributesError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    SetEndpointAttributesError::Unknown(format!("{}", status))
+                } else {
+                    SetEndpointAttributesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
             }
         }
     }
@@ -4883,11 +5033,17 @@ impl SetPlatformApplicationAttributesError {
                 )),
                 _ => SetPlatformApplicationAttributesError::Unknown(String::from(body)),
             },
-            Err(_) => SetPlatformApplicationAttributesError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    SetPlatformApplicationAttributesError::Unknown(format!("{}", status))
+                } else {
+                    SetPlatformApplicationAttributesError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -4982,7 +5138,13 @@ impl SetSMSAttributesError {
                 "Throttled" => SetSMSAttributesError::Throttled(String::from(parsed_error.message)),
                 _ => SetSMSAttributesError::Unknown(String::from(body)),
             },
-            Err(_) => SetSMSAttributesError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    SetSMSAttributesError::Unknown(format!("{}", status))
+                } else {
+                    SetSMSAttributesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -5085,7 +5247,15 @@ impl SetSubscriptionAttributesError {
                 _ => SetSubscriptionAttributesError::Unknown(String::from(body)),
             },
             Err(_) => {
-                SetSubscriptionAttributesError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    SetSubscriptionAttributesError::Unknown(format!("{}", status))
+                } else {
+                    SetSubscriptionAttributesError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -5182,7 +5352,13 @@ impl SetTopicAttributesError {
                 "NotFound" => SetTopicAttributesError::NotFound(String::from(parsed_error.message)),
                 _ => SetTopicAttributesError::Unknown(String::from(body)),
             },
-            Err(_) => SetTopicAttributesError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    SetTopicAttributesError::Unknown(format!("{}", status))
+                } else {
+                    SetTopicAttributesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -5287,7 +5463,13 @@ impl SubscribeError {
                 }
                 _ => SubscribeError::Unknown(String::from(body)),
             },
-            Err(_) => SubscribeError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    SubscribeError::Unknown(format!("{}", status))
+                } else {
+                    SubscribeError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -5382,7 +5564,13 @@ impl UnsubscribeError {
                 "NotFound" => UnsubscribeError::NotFound(String::from(parsed_error.message)),
                 _ => UnsubscribeError::Unknown(String::from(body)),
             },
-            Err(_) => UnsubscribeError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    UnsubscribeError::Unknown(format!("{}", status))
+                } else {
+                    UnsubscribeError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 

--- a/rusoto/services/sns/src/generated.rs
+++ b/rusoto/services/sns/src/generated.rs
@@ -2549,7 +2549,7 @@ pub enum AddPermissionError {
 }
 
 impl AddPermissionError {
-    pub fn from_body(body: &str) -> AddPermissionError {
+    pub fn from_body(body: &str, status: u16) -> AddPermissionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -2567,7 +2567,7 @@ impl AddPermissionError {
                 "NotFound" => AddPermissionError::NotFound(String::from(parsed_error.message)),
                 _ => AddPermissionError::Unknown(String::from(body)),
             },
-            Err(_) => AddPermissionError::Unknown(body.to_string()),
+            Err(_) => AddPermissionError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -2642,7 +2642,7 @@ pub enum CheckIfPhoneNumberIsOptedOutError {
 }
 
 impl CheckIfPhoneNumberIsOptedOutError {
-    pub fn from_body(body: &str) -> CheckIfPhoneNumberIsOptedOutError {
+    pub fn from_body(body: &str, status: u16) -> CheckIfPhoneNumberIsOptedOutError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -2662,7 +2662,11 @@ impl CheckIfPhoneNumberIsOptedOutError {
                 }
                 _ => CheckIfPhoneNumberIsOptedOutError::Unknown(String::from(body)),
             },
-            Err(_) => CheckIfPhoneNumberIsOptedOutError::Unknown(body.to_string()),
+            Err(_) => CheckIfPhoneNumberIsOptedOutError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -2741,7 +2745,7 @@ pub enum ConfirmSubscriptionError {
 }
 
 impl ConfirmSubscriptionError {
-    pub fn from_body(body: &str) -> ConfirmSubscriptionError {
+    pub fn from_body(body: &str, status: u16) -> ConfirmSubscriptionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -2764,7 +2768,7 @@ impl ConfirmSubscriptionError {
                 ),
                 _ => ConfirmSubscriptionError::Unknown(String::from(body)),
             },
-            Err(_) => ConfirmSubscriptionError::Unknown(body.to_string()),
+            Err(_) => ConfirmSubscriptionError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -2840,7 +2844,7 @@ pub enum CreatePlatformApplicationError {
 }
 
 impl CreatePlatformApplicationError {
-    pub fn from_body(body: &str) -> CreatePlatformApplicationError {
+    pub fn from_body(body: &str, status: u16) -> CreatePlatformApplicationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -2857,7 +2861,9 @@ impl CreatePlatformApplicationError {
                 ),
                 _ => CreatePlatformApplicationError::Unknown(String::from(body)),
             },
-            Err(_) => CreatePlatformApplicationError::Unknown(body.to_string()),
+            Err(_) => {
+                CreatePlatformApplicationError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -2933,7 +2939,7 @@ pub enum CreatePlatformEndpointError {
 }
 
 impl CreatePlatformEndpointError {
-    pub fn from_body(body: &str) -> CreatePlatformEndpointError {
+    pub fn from_body(body: &str, status: u16) -> CreatePlatformEndpointError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -2953,7 +2959,9 @@ impl CreatePlatformEndpointError {
                 }
                 _ => CreatePlatformEndpointError::Unknown(String::from(body)),
             },
-            Err(_) => CreatePlatformEndpointError::Unknown(body.to_string()),
+            Err(_) => {
+                CreatePlatformEndpointError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -3030,7 +3038,7 @@ pub enum CreateTopicError {
 }
 
 impl CreateTopicError {
-    pub fn from_body(body: &str) -> CreateTopicError {
+    pub fn from_body(body: &str, status: u16) -> CreateTopicError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -3050,7 +3058,7 @@ impl CreateTopicError {
                 }
                 _ => CreateTopicError::Unknown(String::from(body)),
             },
-            Err(_) => CreateTopicError::Unknown(body.to_string()),
+            Err(_) => CreateTopicError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -3123,7 +3131,7 @@ pub enum DeleteEndpointError {
 }
 
 impl DeleteEndpointError {
-    pub fn from_body(body: &str) -> DeleteEndpointError {
+    pub fn from_body(body: &str, status: u16) -> DeleteEndpointError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -3140,7 +3148,7 @@ impl DeleteEndpointError {
                 }
                 _ => DeleteEndpointError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteEndpointError::Unknown(body.to_string()),
+            Err(_) => DeleteEndpointError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -3212,7 +3220,7 @@ pub enum DeletePlatformApplicationError {
 }
 
 impl DeletePlatformApplicationError {
-    pub fn from_body(body: &str) -> DeletePlatformApplicationError {
+    pub fn from_body(body: &str, status: u16) -> DeletePlatformApplicationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -3229,7 +3237,9 @@ impl DeletePlatformApplicationError {
                 ),
                 _ => DeletePlatformApplicationError::Unknown(String::from(body)),
             },
-            Err(_) => DeletePlatformApplicationError::Unknown(body.to_string()),
+            Err(_) => {
+                DeletePlatformApplicationError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -3305,7 +3315,7 @@ pub enum DeleteTopicError {
 }
 
 impl DeleteTopicError {
-    pub fn from_body(body: &str) -> DeleteTopicError {
+    pub fn from_body(body: &str, status: u16) -> DeleteTopicError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -3323,7 +3333,7 @@ impl DeleteTopicError {
                 "NotFound" => DeleteTopicError::NotFound(String::from(parsed_error.message)),
                 _ => DeleteTopicError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteTopicError::Unknown(body.to_string()),
+            Err(_) => DeleteTopicError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -3398,7 +3408,7 @@ pub enum GetEndpointAttributesError {
 }
 
 impl GetEndpointAttributesError {
-    pub fn from_body(body: &str) -> GetEndpointAttributesError {
+    pub fn from_body(body: &str, status: u16) -> GetEndpointAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -3418,7 +3428,9 @@ impl GetEndpointAttributesError {
                 }
                 _ => GetEndpointAttributesError::Unknown(String::from(body)),
             },
-            Err(_) => GetEndpointAttributesError::Unknown(body.to_string()),
+            Err(_) => {
+                GetEndpointAttributesError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -3495,7 +3507,7 @@ pub enum GetPlatformApplicationAttributesError {
 }
 
 impl GetPlatformApplicationAttributesError {
-    pub fn from_body(body: &str) -> GetPlatformApplicationAttributesError {
+    pub fn from_body(body: &str, status: u16) -> GetPlatformApplicationAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -3515,7 +3527,11 @@ impl GetPlatformApplicationAttributesError {
                 )),
                 _ => GetPlatformApplicationAttributesError::Unknown(String::from(body)),
             },
-            Err(_) => GetPlatformApplicationAttributesError::Unknown(body.to_string()),
+            Err(_) => GetPlatformApplicationAttributesError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -3592,7 +3608,7 @@ pub enum GetSMSAttributesError {
 }
 
 impl GetSMSAttributesError {
-    pub fn from_body(body: &str) -> GetSMSAttributesError {
+    pub fn from_body(body: &str, status: u16) -> GetSMSAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -3610,7 +3626,7 @@ impl GetSMSAttributesError {
                 "Throttled" => GetSMSAttributesError::Throttled(String::from(parsed_error.message)),
                 _ => GetSMSAttributesError::Unknown(String::from(body)),
             },
-            Err(_) => GetSMSAttributesError::Unknown(body.to_string()),
+            Err(_) => GetSMSAttributesError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -3685,7 +3701,7 @@ pub enum GetSubscriptionAttributesError {
 }
 
 impl GetSubscriptionAttributesError {
-    pub fn from_body(body: &str) -> GetSubscriptionAttributesError {
+    pub fn from_body(body: &str, status: u16) -> GetSubscriptionAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -3705,7 +3721,9 @@ impl GetSubscriptionAttributesError {
                 }
                 _ => GetSubscriptionAttributesError::Unknown(String::from(body)),
             },
-            Err(_) => GetSubscriptionAttributesError::Unknown(body.to_string()),
+            Err(_) => {
+                GetSubscriptionAttributesError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -3782,7 +3800,7 @@ pub enum GetTopicAttributesError {
 }
 
 impl GetTopicAttributesError {
-    pub fn from_body(body: &str) -> GetTopicAttributesError {
+    pub fn from_body(body: &str, status: u16) -> GetTopicAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -3800,7 +3818,7 @@ impl GetTopicAttributesError {
                 "NotFound" => GetTopicAttributesError::NotFound(String::from(parsed_error.message)),
                 _ => GetTopicAttributesError::Unknown(String::from(body)),
             },
-            Err(_) => GetTopicAttributesError::Unknown(body.to_string()),
+            Err(_) => GetTopicAttributesError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -3877,7 +3895,7 @@ pub enum ListEndpointsByPlatformApplicationError {
 }
 
 impl ListEndpointsByPlatformApplicationError {
-    pub fn from_body(body: &str) -> ListEndpointsByPlatformApplicationError {
+    pub fn from_body(body: &str, status: u16) -> ListEndpointsByPlatformApplicationError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -3899,7 +3917,11 @@ impl ListEndpointsByPlatformApplicationError {
                 )),
                 _ => ListEndpointsByPlatformApplicationError::Unknown(String::from(body)),
             },
-            Err(_) => ListEndpointsByPlatformApplicationError::Unknown(body.to_string()),
+            Err(_) => ListEndpointsByPlatformApplicationError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -3976,7 +3998,7 @@ pub enum ListPhoneNumbersOptedOutError {
 }
 
 impl ListPhoneNumbersOptedOutError {
-    pub fn from_body(body: &str) -> ListPhoneNumbersOptedOutError {
+    pub fn from_body(body: &str, status: u16) -> ListPhoneNumbersOptedOutError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -3996,7 +4018,9 @@ impl ListPhoneNumbersOptedOutError {
                 }
                 _ => ListPhoneNumbersOptedOutError::Unknown(String::from(body)),
             },
-            Err(_) => ListPhoneNumbersOptedOutError::Unknown(body.to_string()),
+            Err(_) => {
+                ListPhoneNumbersOptedOutError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -4071,7 +4095,7 @@ pub enum ListPlatformApplicationsError {
 }
 
 impl ListPlatformApplicationsError {
-    pub fn from_body(body: &str) -> ListPlatformApplicationsError {
+    pub fn from_body(body: &str, status: u16) -> ListPlatformApplicationsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -4088,7 +4112,9 @@ impl ListPlatformApplicationsError {
                 ),
                 _ => ListPlatformApplicationsError::Unknown(String::from(body)),
             },
-            Err(_) => ListPlatformApplicationsError::Unknown(body.to_string()),
+            Err(_) => {
+                ListPlatformApplicationsError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -4162,7 +4188,7 @@ pub enum ListSubscriptionsError {
 }
 
 impl ListSubscriptionsError {
-    pub fn from_body(body: &str) -> ListSubscriptionsError {
+    pub fn from_body(body: &str, status: u16) -> ListSubscriptionsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -4179,7 +4205,7 @@ impl ListSubscriptionsError {
                 }
                 _ => ListSubscriptionsError::Unknown(String::from(body)),
             },
-            Err(_) => ListSubscriptionsError::Unknown(body.to_string()),
+            Err(_) => ListSubscriptionsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -4255,7 +4281,7 @@ pub enum ListSubscriptionsByTopicError {
 }
 
 impl ListSubscriptionsByTopicError {
-    pub fn from_body(body: &str) -> ListSubscriptionsByTopicError {
+    pub fn from_body(body: &str, status: u16) -> ListSubscriptionsByTopicError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -4275,7 +4301,9 @@ impl ListSubscriptionsByTopicError {
                 }
                 _ => ListSubscriptionsByTopicError::Unknown(String::from(body)),
             },
-            Err(_) => ListSubscriptionsByTopicError::Unknown(body.to_string()),
+            Err(_) => {
+                ListSubscriptionsByTopicError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -4350,7 +4378,7 @@ pub enum ListTopicsError {
 }
 
 impl ListTopicsError {
-    pub fn from_body(body: &str) -> ListTopicsError {
+    pub fn from_body(body: &str, status: u16) -> ListTopicsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -4367,7 +4395,7 @@ impl ListTopicsError {
                 }
                 _ => ListTopicsError::Unknown(String::from(body)),
             },
-            Err(_) => ListTopicsError::Unknown(body.to_string()),
+            Err(_) => ListTopicsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -4441,7 +4469,7 @@ pub enum OptInPhoneNumberError {
 }
 
 impl OptInPhoneNumberError {
-    pub fn from_body(body: &str) -> OptInPhoneNumberError {
+    pub fn from_body(body: &str, status: u16) -> OptInPhoneNumberError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -4459,7 +4487,7 @@ impl OptInPhoneNumberError {
                 "Throttled" => OptInPhoneNumberError::Throttled(String::from(parsed_error.message)),
                 _ => OptInPhoneNumberError::Unknown(String::from(body)),
             },
-            Err(_) => OptInPhoneNumberError::Unknown(body.to_string()),
+            Err(_) => OptInPhoneNumberError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -4540,7 +4568,7 @@ pub enum PublishError {
 }
 
 impl PublishError {
-    pub fn from_body(body: &str) -> PublishError {
+    pub fn from_body(body: &str, status: u16) -> PublishError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -4565,7 +4593,7 @@ impl PublishError {
                 }
                 _ => PublishError::Unknown(String::from(body)),
             },
-            Err(_) => PublishError::Unknown(body.to_string()),
+            Err(_) => PublishError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -4643,7 +4671,7 @@ pub enum RemovePermissionError {
 }
 
 impl RemovePermissionError {
-    pub fn from_body(body: &str) -> RemovePermissionError {
+    pub fn from_body(body: &str, status: u16) -> RemovePermissionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -4661,7 +4689,7 @@ impl RemovePermissionError {
                 "NotFound" => RemovePermissionError::NotFound(String::from(parsed_error.message)),
                 _ => RemovePermissionError::Unknown(String::from(body)),
             },
-            Err(_) => RemovePermissionError::Unknown(body.to_string()),
+            Err(_) => RemovePermissionError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -4736,7 +4764,7 @@ pub enum SetEndpointAttributesError {
 }
 
 impl SetEndpointAttributesError {
-    pub fn from_body(body: &str) -> SetEndpointAttributesError {
+    pub fn from_body(body: &str, status: u16) -> SetEndpointAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -4756,7 +4784,9 @@ impl SetEndpointAttributesError {
                 }
                 _ => SetEndpointAttributesError::Unknown(String::from(body)),
             },
-            Err(_) => SetEndpointAttributesError::Unknown(body.to_string()),
+            Err(_) => {
+                SetEndpointAttributesError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -4833,7 +4863,7 @@ pub enum SetPlatformApplicationAttributesError {
 }
 
 impl SetPlatformApplicationAttributesError {
-    pub fn from_body(body: &str) -> SetPlatformApplicationAttributesError {
+    pub fn from_body(body: &str, status: u16) -> SetPlatformApplicationAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -4853,7 +4883,11 @@ impl SetPlatformApplicationAttributesError {
                 )),
                 _ => SetPlatformApplicationAttributesError::Unknown(String::from(body)),
             },
-            Err(_) => SetPlatformApplicationAttributesError::Unknown(body.to_string()),
+            Err(_) => SetPlatformApplicationAttributesError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -4930,7 +4964,7 @@ pub enum SetSMSAttributesError {
 }
 
 impl SetSMSAttributesError {
-    pub fn from_body(body: &str) -> SetSMSAttributesError {
+    pub fn from_body(body: &str, status: u16) -> SetSMSAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -4948,7 +4982,7 @@ impl SetSMSAttributesError {
                 "Throttled" => SetSMSAttributesError::Throttled(String::from(parsed_error.message)),
                 _ => SetSMSAttributesError::Unknown(String::from(body)),
             },
-            Err(_) => SetSMSAttributesError::Unknown(body.to_string()),
+            Err(_) => SetSMSAttributesError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -5025,7 +5059,7 @@ pub enum SetSubscriptionAttributesError {
 }
 
 impl SetSubscriptionAttributesError {
-    pub fn from_body(body: &str) -> SetSubscriptionAttributesError {
+    pub fn from_body(body: &str, status: u16) -> SetSubscriptionAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -5050,7 +5084,9 @@ impl SetSubscriptionAttributesError {
                 }
                 _ => SetSubscriptionAttributesError::Unknown(String::from(body)),
             },
-            Err(_) => SetSubscriptionAttributesError::Unknown(body.to_string()),
+            Err(_) => {
+                SetSubscriptionAttributesError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -5128,7 +5164,7 @@ pub enum SetTopicAttributesError {
 }
 
 impl SetTopicAttributesError {
-    pub fn from_body(body: &str) -> SetTopicAttributesError {
+    pub fn from_body(body: &str, status: u16) -> SetTopicAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -5146,7 +5182,7 @@ impl SetTopicAttributesError {
                 "NotFound" => SetTopicAttributesError::NotFound(String::from(parsed_error.message)),
                 _ => SetTopicAttributesError::Unknown(String::from(body)),
             },
-            Err(_) => SetTopicAttributesError::Unknown(body.to_string()),
+            Err(_) => SetTopicAttributesError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -5227,7 +5263,7 @@ pub enum SubscribeError {
 }
 
 impl SubscribeError {
-    pub fn from_body(body: &str) -> SubscribeError {
+    pub fn from_body(body: &str, status: u16) -> SubscribeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -5251,7 +5287,7 @@ impl SubscribeError {
                 }
                 _ => SubscribeError::Unknown(String::from(body)),
             },
-            Err(_) => SubscribeError::Unknown(body.to_string()),
+            Err(_) => SubscribeError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -5328,7 +5364,7 @@ pub enum UnsubscribeError {
 }
 
 impl UnsubscribeError {
-    pub fn from_body(body: &str) -> UnsubscribeError {
+    pub fn from_body(body: &str, status: u16) -> UnsubscribeError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -5346,7 +5382,7 @@ impl UnsubscribeError {
                 "NotFound" => UnsubscribeError::NotFound(String::from(parsed_error.message)),
                 _ => UnsubscribeError::Unknown(String::from(body)),
             },
-            Err(_) => UnsubscribeError::Unknown(body.to_string()),
+            Err(_) => UnsubscribeError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 

--- a/rusoto/services/sqs/src/generated.rs
+++ b/rusoto/services/sqs/src/generated.rs
@@ -2350,7 +2350,7 @@ pub enum AddPermissionError {
 }
 
 impl AddPermissionError {
-    pub fn from_body(body: &str) -> AddPermissionError {
+    pub fn from_body(body: &str, status: u16) -> AddPermissionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -2359,7 +2359,7 @@ impl AddPermissionError {
                 "OverLimit" => AddPermissionError::OverLimit(String::from(parsed_error.message)),
                 _ => AddPermissionError::Unknown(String::from(body)),
             },
-            Err(_) => AddPermissionError::Unknown(body.to_string()),
+            Err(_) => AddPermissionError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -2427,7 +2427,7 @@ pub enum ChangeMessageVisibilityError {
 }
 
 impl ChangeMessageVisibilityError {
-    pub fn from_body(body: &str) -> ChangeMessageVisibilityError {
+    pub fn from_body(body: &str, status: u16) -> ChangeMessageVisibilityError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -2443,7 +2443,9 @@ impl ChangeMessageVisibilityError {
                 ),
                 _ => ChangeMessageVisibilityError::Unknown(String::from(body)),
             },
-            Err(_) => ChangeMessageVisibilityError::Unknown(body.to_string()),
+            Err(_) => {
+                ChangeMessageVisibilityError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -2518,7 +2520,7 @@ pub enum ChangeMessageVisibilityBatchError {
 }
 
 impl ChangeMessageVisibilityBatchError {
-    pub fn from_body(body: &str) -> ChangeMessageVisibilityBatchError {
+    pub fn from_body(body: &str, status: u16) -> ChangeMessageVisibilityBatchError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -2546,7 +2548,11 @@ impl ChangeMessageVisibilityBatchError {
                 }
                 _ => ChangeMessageVisibilityBatchError::Unknown(String::from(body)),
             },
-            Err(_) => ChangeMessageVisibilityBatchError::Unknown(body.to_string()),
+            Err(_) => ChangeMessageVisibilityBatchError::Unknown(format!(
+                "{}:{}",
+                body.to_string(),
+                status
+            )),
         }
     }
 
@@ -2619,7 +2625,7 @@ pub enum CreateQueueError {
 }
 
 impl CreateQueueError {
-    pub fn from_body(body: &str) -> CreateQueueError {
+    pub fn from_body(body: &str, status: u16) -> CreateQueueError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -2633,7 +2639,7 @@ impl CreateQueueError {
                 }
                 _ => CreateQueueError::Unknown(String::from(body)),
             },
-            Err(_) => CreateQueueError::Unknown(body.to_string()),
+            Err(_) => CreateQueueError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -2702,7 +2708,7 @@ pub enum DeleteMessageError {
 }
 
 impl DeleteMessageError {
-    pub fn from_body(body: &str) -> DeleteMessageError {
+    pub fn from_body(body: &str, status: u16) -> DeleteMessageError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -2716,7 +2722,7 @@ impl DeleteMessageError {
                 }
                 _ => DeleteMessageError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteMessageError::Unknown(body.to_string()),
+            Err(_) => DeleteMessageError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -2789,7 +2795,7 @@ pub enum DeleteMessageBatchError {
 }
 
 impl DeleteMessageBatchError {
-    pub fn from_body(body: &str) -> DeleteMessageBatchError {
+    pub fn from_body(body: &str, status: u16) -> DeleteMessageBatchError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -2813,7 +2819,7 @@ impl DeleteMessageBatchError {
                 }
                 _ => DeleteMessageBatchError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteMessageBatchError::Unknown(body.to_string()),
+            Err(_) => DeleteMessageBatchError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -2882,7 +2888,7 @@ pub enum DeleteQueueError {
 }
 
 impl DeleteQueueError {
-    pub fn from_body(body: &str) -> DeleteQueueError {
+    pub fn from_body(body: &str, status: u16) -> DeleteQueueError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -2890,7 +2896,7 @@ impl DeleteQueueError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteQueueError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteQueueError::Unknown(body.to_string()),
+            Err(_) => DeleteQueueError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -2955,7 +2961,7 @@ pub enum GetQueueAttributesError {
 }
 
 impl GetQueueAttributesError {
-    pub fn from_body(body: &str) -> GetQueueAttributesError {
+    pub fn from_body(body: &str, status: u16) -> GetQueueAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -2966,7 +2972,7 @@ impl GetQueueAttributesError {
                 ),
                 _ => GetQueueAttributesError::Unknown(String::from(body)),
             },
-            Err(_) => GetQueueAttributesError::Unknown(body.to_string()),
+            Err(_) => GetQueueAttributesError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -3034,7 +3040,7 @@ pub enum GetQueueUrlError {
 }
 
 impl GetQueueUrlError {
-    pub fn from_body(body: &str) -> GetQueueUrlError {
+    pub fn from_body(body: &str, status: u16) -> GetQueueUrlError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -3045,7 +3051,7 @@ impl GetQueueUrlError {
                 }
                 _ => GetQueueUrlError::Unknown(String::from(body)),
             },
-            Err(_) => GetQueueUrlError::Unknown(body.to_string()),
+            Err(_) => GetQueueUrlError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -3111,7 +3117,7 @@ pub enum ListDeadLetterSourceQueuesError {
 }
 
 impl ListDeadLetterSourceQueuesError {
-    pub fn from_body(body: &str) -> ListDeadLetterSourceQueuesError {
+    pub fn from_body(body: &str, status: u16) -> ListDeadLetterSourceQueuesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -3124,7 +3130,9 @@ impl ListDeadLetterSourceQueuesError {
                 }
                 _ => ListDeadLetterSourceQueuesError::Unknown(String::from(body)),
             },
-            Err(_) => ListDeadLetterSourceQueuesError::Unknown(body.to_string()),
+            Err(_) => {
+                ListDeadLetterSourceQueuesError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -3190,7 +3198,7 @@ pub enum ListQueueTagsError {
 }
 
 impl ListQueueTagsError {
-    pub fn from_body(body: &str) -> ListQueueTagsError {
+    pub fn from_body(body: &str, status: u16) -> ListQueueTagsError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -3198,7 +3206,7 @@ impl ListQueueTagsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListQueueTagsError::Unknown(String::from(body)),
             },
-            Err(_) => ListQueueTagsError::Unknown(body.to_string()),
+            Err(_) => ListQueueTagsError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -3261,7 +3269,7 @@ pub enum ListQueuesError {
 }
 
 impl ListQueuesError {
-    pub fn from_body(body: &str) -> ListQueuesError {
+    pub fn from_body(body: &str, status: u16) -> ListQueuesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -3269,7 +3277,7 @@ impl ListQueuesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListQueuesError::Unknown(String::from(body)),
             },
-            Err(_) => ListQueuesError::Unknown(body.to_string()),
+            Err(_) => ListQueuesError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -3336,7 +3344,7 @@ pub enum PurgeQueueError {
 }
 
 impl PurgeQueueError {
-    pub fn from_body(body: &str) -> PurgeQueueError {
+    pub fn from_body(body: &str, status: u16) -> PurgeQueueError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -3350,7 +3358,7 @@ impl PurgeQueueError {
                 }
                 _ => PurgeQueueError::Unknown(String::from(body)),
             },
-            Err(_) => PurgeQueueError::Unknown(body.to_string()),
+            Err(_) => PurgeQueueError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -3417,7 +3425,7 @@ pub enum ReceiveMessageError {
 }
 
 impl ReceiveMessageError {
-    pub fn from_body(body: &str) -> ReceiveMessageError {
+    pub fn from_body(body: &str, status: u16) -> ReceiveMessageError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -3426,7 +3434,7 @@ impl ReceiveMessageError {
                 "OverLimit" => ReceiveMessageError::OverLimit(String::from(parsed_error.message)),
                 _ => ReceiveMessageError::Unknown(String::from(body)),
             },
-            Err(_) => ReceiveMessageError::Unknown(body.to_string()),
+            Err(_) => ReceiveMessageError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -3490,7 +3498,7 @@ pub enum RemovePermissionError {
 }
 
 impl RemovePermissionError {
-    pub fn from_body(body: &str) -> RemovePermissionError {
+    pub fn from_body(body: &str, status: u16) -> RemovePermissionError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -3498,7 +3506,7 @@ impl RemovePermissionError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => RemovePermissionError::Unknown(String::from(body)),
             },
-            Err(_) => RemovePermissionError::Unknown(body.to_string()),
+            Err(_) => RemovePermissionError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -3565,7 +3573,7 @@ pub enum SendMessageError {
 }
 
 impl SendMessageError {
-    pub fn from_body(body: &str) -> SendMessageError {
+    pub fn from_body(body: &str, status: u16) -> SendMessageError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -3579,7 +3587,7 @@ impl SendMessageError {
                 }
                 _ => SendMessageError::Unknown(String::from(body)),
             },
-            Err(_) => SendMessageError::Unknown(body.to_string()),
+            Err(_) => SendMessageError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -3656,7 +3664,7 @@ pub enum SendMessageBatchError {
 }
 
 impl SendMessageBatchError {
-    pub fn from_body(body: &str) -> SendMessageBatchError {
+    pub fn from_body(body: &str, status: u16) -> SendMessageBatchError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -3686,7 +3694,7 @@ impl SendMessageBatchError {
                 }
                 _ => SendMessageBatchError::Unknown(String::from(body)),
             },
-            Err(_) => SendMessageBatchError::Unknown(body.to_string()),
+            Err(_) => SendMessageBatchError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -3757,7 +3765,7 @@ pub enum SetQueueAttributesError {
 }
 
 impl SetQueueAttributesError {
-    pub fn from_body(body: &str) -> SetQueueAttributesError {
+    pub fn from_body(body: &str, status: u16) -> SetQueueAttributesError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -3768,7 +3776,7 @@ impl SetQueueAttributesError {
                 ),
                 _ => SetQueueAttributesError::Unknown(String::from(body)),
             },
-            Err(_) => SetQueueAttributesError::Unknown(body.to_string()),
+            Err(_) => SetQueueAttributesError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -3834,7 +3842,7 @@ pub enum TagQueueError {
 }
 
 impl TagQueueError {
-    pub fn from_body(body: &str) -> TagQueueError {
+    pub fn from_body(body: &str, status: u16) -> TagQueueError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -3842,7 +3850,7 @@ impl TagQueueError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => TagQueueError::Unknown(String::from(body)),
             },
-            Err(_) => TagQueueError::Unknown(body.to_string()),
+            Err(_) => TagQueueError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -3905,7 +3913,7 @@ pub enum UntagQueueError {
 }
 
 impl UntagQueueError {
-    pub fn from_body(body: &str) -> UntagQueueError {
+    pub fn from_body(body: &str, status: u16) -> UntagQueueError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -3913,7 +3921,7 @@ impl UntagQueueError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => UntagQueueError::Unknown(String::from(body)),
             },
-            Err(_) => UntagQueueError::Unknown(body.to_string()),
+            Err(_) => UntagQueueError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 

--- a/rusoto/services/sqs/src/generated.rs
+++ b/rusoto/services/sqs/src/generated.rs
@@ -2359,7 +2359,13 @@ impl AddPermissionError {
                 "OverLimit" => AddPermissionError::OverLimit(String::from(parsed_error.message)),
                 _ => AddPermissionError::Unknown(String::from(body)),
             },
-            Err(_) => AddPermissionError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    AddPermissionError::Unknown(format!("{}", status))
+                } else {
+                    AddPermissionError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -2444,7 +2450,15 @@ impl ChangeMessageVisibilityError {
                 _ => ChangeMessageVisibilityError::Unknown(String::from(body)),
             },
             Err(_) => {
-                ChangeMessageVisibilityError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    ChangeMessageVisibilityError::Unknown(format!("{}", status))
+                } else {
+                    ChangeMessageVisibilityError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -2548,11 +2562,17 @@ impl ChangeMessageVisibilityBatchError {
                 }
                 _ => ChangeMessageVisibilityBatchError::Unknown(String::from(body)),
             },
-            Err(_) => ChangeMessageVisibilityBatchError::Unknown(format!(
-                "{}:{}",
-                body.to_string(),
-                status
-            )),
+            Err(_) => {
+                if body.len() == 0 {
+                    ChangeMessageVisibilityBatchError::Unknown(format!("{}", status))
+                } else {
+                    ChangeMessageVisibilityBatchError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
+            }
         }
     }
 
@@ -2639,7 +2659,13 @@ impl CreateQueueError {
                 }
                 _ => CreateQueueError::Unknown(String::from(body)),
             },
-            Err(_) => CreateQueueError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    CreateQueueError::Unknown(format!("{}", status))
+                } else {
+                    CreateQueueError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -2722,7 +2748,13 @@ impl DeleteMessageError {
                 }
                 _ => DeleteMessageError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteMessageError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteMessageError::Unknown(format!("{}", status))
+                } else {
+                    DeleteMessageError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -2819,7 +2851,13 @@ impl DeleteMessageBatchError {
                 }
                 _ => DeleteMessageBatchError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteMessageBatchError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteMessageBatchError::Unknown(format!("{}", status))
+                } else {
+                    DeleteMessageBatchError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -2896,7 +2934,13 @@ impl DeleteQueueError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => DeleteQueueError::Unknown(String::from(body)),
             },
-            Err(_) => DeleteQueueError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    DeleteQueueError::Unknown(format!("{}", status))
+                } else {
+                    DeleteQueueError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -2972,7 +3016,13 @@ impl GetQueueAttributesError {
                 ),
                 _ => GetQueueAttributesError::Unknown(String::from(body)),
             },
-            Err(_) => GetQueueAttributesError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetQueueAttributesError::Unknown(format!("{}", status))
+                } else {
+                    GetQueueAttributesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -3051,7 +3101,13 @@ impl GetQueueUrlError {
                 }
                 _ => GetQueueUrlError::Unknown(String::from(body)),
             },
-            Err(_) => GetQueueUrlError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetQueueUrlError::Unknown(format!("{}", status))
+                } else {
+                    GetQueueUrlError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -3131,7 +3187,15 @@ impl ListDeadLetterSourceQueuesError {
                 _ => ListDeadLetterSourceQueuesError::Unknown(String::from(body)),
             },
             Err(_) => {
-                ListDeadLetterSourceQueuesError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    ListDeadLetterSourceQueuesError::Unknown(format!("{}", status))
+                } else {
+                    ListDeadLetterSourceQueuesError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -3206,7 +3270,13 @@ impl ListQueueTagsError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListQueueTagsError::Unknown(String::from(body)),
             },
-            Err(_) => ListQueueTagsError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ListQueueTagsError::Unknown(format!("{}", status))
+                } else {
+                    ListQueueTagsError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -3277,7 +3347,13 @@ impl ListQueuesError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => ListQueuesError::Unknown(String::from(body)),
             },
-            Err(_) => ListQueuesError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ListQueuesError::Unknown(format!("{}", status))
+                } else {
+                    ListQueuesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -3358,7 +3434,13 @@ impl PurgeQueueError {
                 }
                 _ => PurgeQueueError::Unknown(String::from(body)),
             },
-            Err(_) => PurgeQueueError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    PurgeQueueError::Unknown(format!("{}", status))
+                } else {
+                    PurgeQueueError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -3434,7 +3516,13 @@ impl ReceiveMessageError {
                 "OverLimit" => ReceiveMessageError::OverLimit(String::from(parsed_error.message)),
                 _ => ReceiveMessageError::Unknown(String::from(body)),
             },
-            Err(_) => ReceiveMessageError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    ReceiveMessageError::Unknown(format!("{}", status))
+                } else {
+                    ReceiveMessageError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -3506,7 +3594,13 @@ impl RemovePermissionError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => RemovePermissionError::Unknown(String::from(body)),
             },
-            Err(_) => RemovePermissionError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    RemovePermissionError::Unknown(format!("{}", status))
+                } else {
+                    RemovePermissionError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -3587,7 +3681,13 @@ impl SendMessageError {
                 }
                 _ => SendMessageError::Unknown(String::from(body)),
             },
-            Err(_) => SendMessageError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    SendMessageError::Unknown(format!("{}", status))
+                } else {
+                    SendMessageError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -3694,7 +3794,13 @@ impl SendMessageBatchError {
                 }
                 _ => SendMessageBatchError::Unknown(String::from(body)),
             },
-            Err(_) => SendMessageBatchError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    SendMessageBatchError::Unknown(format!("{}", status))
+                } else {
+                    SendMessageBatchError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -3776,7 +3882,13 @@ impl SetQueueAttributesError {
                 ),
                 _ => SetQueueAttributesError::Unknown(String::from(body)),
             },
-            Err(_) => SetQueueAttributesError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    SetQueueAttributesError::Unknown(format!("{}", status))
+                } else {
+                    SetQueueAttributesError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -3850,7 +3962,13 @@ impl TagQueueError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => TagQueueError::Unknown(String::from(body)),
             },
-            Err(_) => TagQueueError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    TagQueueError::Unknown(format!("{}", status))
+                } else {
+                    TagQueueError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -3921,7 +4039,13 @@ impl UntagQueueError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => UntagQueueError::Unknown(String::from(body)),
             },
-            Err(_) => UntagQueueError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    UntagQueueError::Unknown(format!("{}", status))
+                } else {
+                    UntagQueueError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 

--- a/rusoto/services/sts/src/generated.rs
+++ b/rusoto/services/sts/src/generated.rs
@@ -1192,7 +1192,7 @@ pub enum AssumeRoleError {
 }
 
 impl AssumeRoleError {
-    pub fn from_body(body: &str) -> AssumeRoleError {
+    pub fn from_body(body: &str, status: u16) -> AssumeRoleError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -1209,7 +1209,7 @@ impl AssumeRoleError {
                 }
                 _ => AssumeRoleError::Unknown(String::from(body)),
             },
-            Err(_) => AssumeRoleError::Unknown(body.to_string()),
+            Err(_) => AssumeRoleError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -1287,7 +1287,7 @@ pub enum AssumeRoleWithSAMLError {
 }
 
 impl AssumeRoleWithSAMLError {
-    pub fn from_body(body: &str) -> AssumeRoleWithSAMLError {
+    pub fn from_body(body: &str, status: u16) -> AssumeRoleWithSAMLError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -1313,7 +1313,7 @@ impl AssumeRoleWithSAMLError {
                 }
                 _ => AssumeRoleWithSAMLError::Unknown(String::from(body)),
             },
-            Err(_) => AssumeRoleWithSAMLError::Unknown(body.to_string()),
+            Err(_) => AssumeRoleWithSAMLError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -1398,7 +1398,7 @@ pub enum AssumeRoleWithWebIdentityError {
 }
 
 impl AssumeRoleWithWebIdentityError {
-    pub fn from_body(body: &str) -> AssumeRoleWithWebIdentityError {
+    pub fn from_body(body: &str, status: u16) -> AssumeRoleWithWebIdentityError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -1429,7 +1429,9 @@ impl AssumeRoleWithWebIdentityError {
                 ),
                 _ => AssumeRoleWithWebIdentityError::Unknown(String::from(body)),
             },
-            Err(_) => AssumeRoleWithWebIdentityError::Unknown(body.to_string()),
+            Err(_) => {
+                AssumeRoleWithWebIdentityError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -1503,7 +1505,7 @@ pub enum DecodeAuthorizationMessageError {
 }
 
 impl DecodeAuthorizationMessageError {
-    pub fn from_body(body: &str) -> DecodeAuthorizationMessageError {
+    pub fn from_body(body: &str, status: u16) -> DecodeAuthorizationMessageError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -1516,7 +1518,9 @@ impl DecodeAuthorizationMessageError {
                 }
                 _ => DecodeAuthorizationMessageError::Unknown(String::from(body)),
             },
-            Err(_) => DecodeAuthorizationMessageError::Unknown(body.to_string()),
+            Err(_) => {
+                DecodeAuthorizationMessageError::Unknown(format!("{}:{}", body.to_string(), status))
+            }
         }
     }
 
@@ -1582,7 +1586,7 @@ pub enum GetCallerIdentityError {
 }
 
 impl GetCallerIdentityError {
-    pub fn from_body(body: &str) -> GetCallerIdentityError {
+    pub fn from_body(body: &str, status: u16) -> GetCallerIdentityError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -1590,7 +1594,7 @@ impl GetCallerIdentityError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetCallerIdentityError::Unknown(String::from(body)),
             },
-            Err(_) => GetCallerIdentityError::Unknown(body.to_string()),
+            Err(_) => GetCallerIdentityError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -1661,7 +1665,7 @@ pub enum GetFederationTokenError {
 }
 
 impl GetFederationTokenError {
-    pub fn from_body(body: &str) -> GetFederationTokenError {
+    pub fn from_body(body: &str, status: u16) -> GetFederationTokenError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -1678,7 +1682,7 @@ impl GetFederationTokenError {
                 }
                 _ => GetFederationTokenError::Unknown(String::from(body)),
             },
-            Err(_) => GetFederationTokenError::Unknown(body.to_string()),
+            Err(_) => GetFederationTokenError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 
@@ -1748,7 +1752,7 @@ pub enum GetSessionTokenError {
 }
 
 impl GetSessionTokenError {
-    pub fn from_body(body: &str) -> GetSessionTokenError {
+    pub fn from_body(body: &str, status: u16) -> GetSessionTokenError {
         let reader = EventReader::new(body.as_bytes());
         let mut stack = XmlResponse::new(reader.into_iter().peekable());
         find_start_element(&mut stack);
@@ -1759,7 +1763,7 @@ impl GetSessionTokenError {
                 }
                 _ => GetSessionTokenError::Unknown(String::from(body)),
             },
-            Err(_) => GetSessionTokenError::Unknown(body.to_string()),
+            Err(_) => GetSessionTokenError::Unknown(format!("{}:{}", body.to_string(), status)),
         }
     }
 

--- a/rusoto/services/sts/src/generated.rs
+++ b/rusoto/services/sts/src/generated.rs
@@ -1209,7 +1209,13 @@ impl AssumeRoleError {
                 }
                 _ => AssumeRoleError::Unknown(String::from(body)),
             },
-            Err(_) => AssumeRoleError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    AssumeRoleError::Unknown(format!("{}", status))
+                } else {
+                    AssumeRoleError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -1313,7 +1319,13 @@ impl AssumeRoleWithSAMLError {
                 }
                 _ => AssumeRoleWithSAMLError::Unknown(String::from(body)),
             },
-            Err(_) => AssumeRoleWithSAMLError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    AssumeRoleWithSAMLError::Unknown(format!("{}", status))
+                } else {
+                    AssumeRoleWithSAMLError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -1430,7 +1442,15 @@ impl AssumeRoleWithWebIdentityError {
                 _ => AssumeRoleWithWebIdentityError::Unknown(String::from(body)),
             },
             Err(_) => {
-                AssumeRoleWithWebIdentityError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    AssumeRoleWithWebIdentityError::Unknown(format!("{}", status))
+                } else {
+                    AssumeRoleWithWebIdentityError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -1519,7 +1539,15 @@ impl DecodeAuthorizationMessageError {
                 _ => DecodeAuthorizationMessageError::Unknown(String::from(body)),
             },
             Err(_) => {
-                DecodeAuthorizationMessageError::Unknown(format!("{}:{}", body.to_string(), status))
+                if body.len() == 0 {
+                    DecodeAuthorizationMessageError::Unknown(format!("{}", status))
+                } else {
+                    DecodeAuthorizationMessageError::Unknown(format!(
+                        "{}:{}",
+                        body.to_string(),
+                        status
+                    ))
+                }
             }
         }
     }
@@ -1594,7 +1622,13 @@ impl GetCallerIdentityError {
             Ok(parsed_error) => match &parsed_error.code[..] {
                 _ => GetCallerIdentityError::Unknown(String::from(body)),
             },
-            Err(_) => GetCallerIdentityError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetCallerIdentityError::Unknown(format!("{}", status))
+                } else {
+                    GetCallerIdentityError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -1682,7 +1716,13 @@ impl GetFederationTokenError {
                 }
                 _ => GetFederationTokenError::Unknown(String::from(body)),
             },
-            Err(_) => GetFederationTokenError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetFederationTokenError::Unknown(format!("{}", status))
+                } else {
+                    GetFederationTokenError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 
@@ -1763,7 +1803,13 @@ impl GetSessionTokenError {
                 }
                 _ => GetSessionTokenError::Unknown(String::from(body)),
             },
-            Err(_) => GetSessionTokenError::Unknown(format!("{}:{}", body.to_string(), status)),
+            Err(_) => {
+                if body.len() == 0 {
+                    GetSessionTokenError::Unknown(format!("{}", status))
+                } else {
+                    GetSessionTokenError::Unknown(format!("{}:{}", body.to_string(), status))
+                }
+            }
         }
     }
 

--- a/service_crategen/src/commands/generate/codegen/error_types.rs
+++ b/service_crategen/src/commands/generate/codegen/error_types.rs
@@ -165,8 +165,13 @@ impl GenerateErrorTypes for XmlErrorTypes {
                                     {type_matchers}
                                 }}
                            }},
-                           // In here let's see if we have *anything* in the body: if not, return just the status code
-                           Err(_) => {type_name}::Unknown(format!(\"{{}}:{{}}\", body.to_string(), status))
+                           Err(_) => {{
+                               if body.len() == 0 {{
+                                   {type_name}::Unknown(format!(\"{{}}\", status))
+                               }} else {{
+                                   {type_name}::Unknown(format!(\"{{}}:{{}}\", body.to_string(), status))
+                               }}
+                            }}
                        }}
                     }}
 

--- a/service_crategen/src/commands/generate/codegen/error_types.rs
+++ b/service_crategen/src/commands/generate/codegen/error_types.rs
@@ -155,7 +155,7 @@ impl GenerateErrorTypes for XmlErrorTypes {
     fn generate_error_from_body_impl(&self, operation_name: &str, operation: &Operation, service: &Service) -> String {
         format!("
                 impl {type_name} {{
-                    pub fn from_body(body: &str) -> {type_name} {{
+                    pub fn from_body(body: &str, status: u16) -> {type_name} {{
                         let reader = EventReader::new(body.as_bytes());
                         let mut stack = XmlResponse::new(reader.into_iter().peekable());
                         find_start_element(&mut stack);
@@ -165,7 +165,8 @@ impl GenerateErrorTypes for XmlErrorTypes {
                                     {type_matchers}
                                 }}
                            }},
-                           Err(_) => {type_name}::Unknown(body.to_string())
+                           // In here let's see if we have *anything* in the body: if not, return just the status code
+                           Err(_) => {type_name}::Unknown(format!(\"{{}}:{{}}\", body.to_string(), status))
                        }}
                     }}
 

--- a/service_crategen/src/commands/generate/codegen/rest_xml.rs
+++ b/service_crategen/src/commands/generate/codegen/rest_xml.rs
@@ -48,7 +48,7 @@ impl GenerateProtocol for RestXmlGenerator {
                         self.client.sign_and_dispatch(request, |response| {{
                             if !response.status.is_success() {{
                                 return Box::new(response.buffer().from_err().and_then(|response| {{
-                                    Err({error_type}::from_body(String::from_utf8_lossy(response.body.as_ref()).as_ref()))
+                                    Err({error_type}::from_body(String::from_utf8_lossy(response.body.as_ref()).as_ref(), response.status.as_u16()))
                                 }}));
                             }}
 


### PR DESCRIPTION
Love some feedback on this. It surfaces the status code to users when we can't figure out what the response should be. A stopgap until we implement all S3 errors since it doesn't follow its API definitions or documentation, as discussed in https://github.com/rusoto/rusoto/issues/716 .

Test output:

```
thread 'test_head_object_404' panicked at 'Got this error: Unknown("404")', tests/s3.rs:55:13
```

@bluejekyll can you weigh in on this potential solution? Thanks!