### PR TITLE
Feat/streaming body async read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 - Add Connect service
 - Add MediaTailor support
+- Add ByteStream struct to core
 
 ## [0.35.0] - 2018-10-31
 

--- a/integration_tests/tests/s3.rs
+++ b/integration_tests/tests/s3.rs
@@ -107,6 +107,7 @@ fn test_all_the_things() {
                                   &binary_filename,
                                   &"tests/sample-data/binary-file");
     test_get_object(&client, &test_bucket, &binary_filename);
+    test_get_object_blocking_read(&client, &test_bucket, &binary_filename);
 
     // PUT an object via stream
     let another_filename = format!("streaming{}", filename);
@@ -316,6 +317,23 @@ fn test_get_object(client: &TestClient, bucket: &str, filename: &str) {
 
     let stream = result.body.unwrap();
     let body = stream.concat2().wait().unwrap();
+
+    assert!(body.len() > 0);
+}
+
+fn test_get_object_blocking_read(client: &TestClient, bucket: &str, filename: &str) {
+    let get_req = GetObjectRequest {
+        bucket: bucket.to_owned(),
+        key: filename.to_owned(),
+        ..Default::default()
+    };
+
+    let result = client.get_object(get_req).sync().expect("Couldn't GET object");
+    println!("get object result: {:#?}", result);
+
+    let mut stream = result.body.unwrap().into_blocking_read();
+    let mut body = Vec::new();
+    stream.read_to_end(&mut body).unwrap();
 
     assert!(body.len() > 0);
 }

--- a/mock/src/lib.rs
+++ b/mock/src/lib.rs
@@ -44,13 +44,12 @@ use std::fs::File;
 use std::io::Read;
 use std::time::Duration;
 
-use futures::future::{ok, FutureResult};
-use futures::stream::once;
-use http::{HttpTryFrom, StatusCode};
-use rusoto_core::credential::{AwsCredentials, CredentialsError, ProvideAwsCredentials};
+use rusoto_core::{DispatchSignedRequest, HttpDispatchError, ByteStream};
+use rusoto_core::credential::{ProvideAwsCredentials, CredentialsError, AwsCredentials};
 use rusoto_core::request::{Headers, HttpResponse};
 use rusoto_core::signature::SignedRequest;
-use rusoto_core::{DispatchSignedRequest, HttpDispatchError};
+use futures::future::{FutureResult, ok};
+use http::{HttpTryFrom, StatusCode};
 use serde::Serialize;
 
 /// Provides a set of credentials that always resolve
@@ -131,7 +130,7 @@ impl DispatchSignedRequest for MockRequestDispatcher {
         }
         ok(HttpResponse {
             status: self.status,
-            body: Box::new(once(Ok(self.body.clone()))),
+            body: ByteStream::from(self.body.clone()),
             headers: Headers::new(self.headers.iter().map(|(k, v)| (k.as_ref(), v.to_owned()))),
         })
     }

--- a/rusoto/core/src/lib.rs
+++ b/rusoto/core/src/lib.rs
@@ -35,6 +35,7 @@ extern crate xml;
 
 mod future;
 mod client;
+mod stream;
 
 pub mod param;
 pub mod region;
@@ -54,3 +55,4 @@ pub use credential::{ProvideAwsCredentials, DefaultCredentialsProvider, Credenti
 pub use request::{DispatchSignedRequest, HttpClient, HttpDispatchError};
 pub use region::Region;
 pub use future::RusotoFuture;
+pub use stream::ByteStream;

--- a/rusoto/core/src/stream.rs
+++ b/rusoto/core/src/stream.rs
@@ -1,0 +1,113 @@
+use std::io;
+use std::fmt;
+
+use tokio::io::AsyncRead;
+use futures::{Stream, stream, Async, Poll};
+
+/// Stream of bytes.
+pub struct ByteStream {
+    size_hint: Option<usize>,
+    inner: Box<Stream<Item = Vec<u8>, Error = io::Error> + Send>,
+}
+
+impl ByteStream {
+    /// Create a new `ByteStreamy` by wrapping a `futures` stream.
+    pub fn new<S>(stream: S) -> ByteStream
+    where
+        S: Stream<Item = Vec<u8>, Error = io::Error> + Send + 'static,
+    {
+        ByteStream {
+            size_hint: None,
+            inner: Box::new(stream),
+        }
+    }
+
+    pub(crate) fn size_hint(&self) -> Option<usize> {
+        self.size_hint
+    }
+
+    /// Return an implementation of `AsyncRead` that uses async i/o to consume the stream.
+    pub fn into_async_read(self) -> impl AsyncRead + Send {
+        ImplAsyncRead {
+            buffer: io::Cursor::new(Vec::new()),
+            stream: self.inner.fuse(),
+        }
+    }
+}
+
+impl From<Vec<u8>> for ByteStream {
+    fn from(buf: Vec<u8>) -> ByteStream {
+        ByteStream {
+            size_hint: Some(buf.len()),
+            inner: Box::new(stream::once(Ok(buf))),
+        }
+    }
+}
+
+impl fmt::Debug for ByteStream {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "<ByteStream size_hint={:?}>", self.size_hint)
+    }
+}
+
+impl Stream for ByteStream {
+    type Item = Vec<u8>;
+    type Error = io::Error;
+
+    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+        self.inner.poll()
+    }
+}
+
+struct ImplAsyncRead {
+    buffer: io::Cursor<Vec<u8>>,
+    stream: stream::Fuse<Box<Stream<Item = Vec<u8>, Error = io::Error> + Send>>,
+}
+
+impl io::Read for ImplAsyncRead {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        if buf.len() == 0 {
+            return Ok(0);
+        }
+        loop {
+            let n = self.buffer.read(buf)?;
+            if n > 0 {
+                return Ok(n);
+            }
+            match self.stream.poll()? {
+                Async::NotReady => {
+                    return Err(io::ErrorKind::WouldBlock.into());
+                },
+                Async::Ready(Some(buffer)) => {
+                    self.buffer = io::Cursor::new(buffer);
+                    continue;
+                },
+                Async::Ready(None) => {
+                    return Ok(0);
+                }
+            }
+        }
+    }
+}
+
+impl AsyncRead for ImplAsyncRead {}
+
+#[test]
+fn test_async_read() {
+    use std::io::Read;
+
+    let chunks = vec![b"1234".to_vec(), b"5678".to_vec()];
+    let stream = ByteStream::new(stream::iter_ok(chunks));
+    let mut async_read = stream.into_async_read();
+
+    let mut buf = [0u8; 3];
+    assert_eq!(async_read.read(&mut buf).unwrap(), 3);
+    assert_eq!(&buf[..3], b"123");
+    assert_eq!(async_read.read(&mut buf).unwrap(), 1);
+    assert_eq!(&buf[..1], b"4");
+    assert_eq!(async_read.read(&mut buf).unwrap(), 3);
+    assert_eq!(&buf[..3], b"567");
+    assert_eq!(async_read.read(&mut buf).unwrap(), 1);
+    assert_eq!(&buf[..1], b"8");
+    assert_eq!(async_read.read(&mut buf).unwrap(), 0);
+}

--- a/service_crategen/src/commands/generate/codegen/mod.rs
+++ b/service_crategen/src/commands/generate/codegen/mod.rs
@@ -333,48 +333,8 @@ fn generate_types<P>(writer: &mut FileWriter, service: &Service, protocol_genera
 
         if streaming {
             // Add a second type for streaming blobs, which are the only streaming type we can have
-            writeln!(writer,
-                     "pub struct {streaming_name} {{
-                         len: Option<usize>,
-                         inner: Box<::futures::Stream<Item=Vec<u8>, Error=::std::io::Error> + Send>
-                     }}
-
-                     impl {streaming_name} {{
-                         pub fn new<S>(stream: S) -> {streaming_name}
-                             where S: ::futures::Stream<Item=Vec<u8>, Error=::std::io::Error> + Send + 'static
-                         {{
-                             {streaming_name} {{
-                                 len: None,
-                                 inner: Box::new(stream)
-                             }}
-                         }}
-                     }}
-
-                     impl From<Vec<u8>> for {streaming_name} {{
-                         fn from(buf: Vec<u8>) -> {streaming_name} {{
-                             {streaming_name} {{
-                                 len: Some(buf.len()),
-                                 inner: Box::new(::futures::stream::once(Ok(buf)))
-                             }}
-                         }}
-                     }}
-
-                     impl fmt::Debug for {streaming_name} {{
-                         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {{
-                             write!(f, \"<{name}: streaming content, len = {{:?}}>\", self.len)
-                         }}
-                     }}
-
-                     impl ::futures::Stream for {streaming_name} {{
-                         type Item = Vec<u8>;
-                         type Error = ::std::io::Error;
-
-                         fn poll(&mut self) -> ::futures::Poll<Option<Self::Item>, Self::Error> {{
-                             self.inner.poll()
-                         }}
-                     }}",
-                     name = type_name,
-                     streaming_name = mutate_type_name_for_streaming(&type_name))?;
+            writeln!(writer, "pub type {} = ::rusoto_core::ByteStream;",
+                mutate_type_name_for_streaming(&type_name))?;
         }
 
         if deserialized {

--- a/service_crategen/src/commands/generate/codegen/rest_xml.rs
+++ b/service_crategen/src/commands/generate/codegen/rest_xml.rs
@@ -208,7 +208,7 @@ fn generate_payload_member_serialization(shape: &Shape) -> String {
     // if the member is 'streaming', it's a boxed stream that should just be delivered as the body
     if payload_member.streaming() {
         format!("if let Some(__body) = input.{} {{
-                     request.set_payload_stream(__body.len, __body.inner);
+                     request.set_payload_stream(__body);
                  }}", payload_field.to_snake_case())
     }
     // otherwise serialize the object to XML and use that as the payload

--- a/service_crategen/src/commands/generate/codegen/xml_payload_parser.rs
+++ b/service_crategen/src/commands/generate/codegen/xml_payload_parser.rs
@@ -2,7 +2,7 @@ use inflector::Inflector;
 
 use ::Service;
 use botocore::{Member, Operation, Shape, ShapeType};
-use super::{generate_field_name, mutate_type_name, mutate_type_name_for_streaming};
+use super::{generate_field_name, mutate_type_name};
 
 pub fn generate_deserializer(name: &str, ty: &str, shape: &Shape, service: &Service) -> String {
     format!("struct {name}Deserializer;
@@ -94,13 +94,12 @@ fn payload_body_parser(payload_type: ShapeType,
         ShapeType::Blob if streaming => {
             format!("
                 let mut result = {output_shape}::default();
-                result.{payload_member} = Some({streaming_constructor} {{ len: None, inner: response.body }});
+                result.{payload_member} = Some(response.body);
                 {parse_non_payload}
                 Box::new(future::ok(result))
                 ",
                     output_shape = output_shape,
                     payload_member = payload_member.to_snake_case(),
-                    streaming_constructor = mutate_type_name_for_streaming(payload_member),
                     parse_non_payload = parse_non_payload)
         },
         _ => {


### PR DESCRIPTION
Addresses #1070 in part by providing an implementation of `Read` and `AsyncRead` that uses non-blocking I/O.

To do this, I've moved the `StreamingBody` struct into core and renamed it to `ByteStream`. Rationale for this was to not generate this code over and over again, but have a central place for it.

Eventually we should be able to use the upcoming `BufStream` trait in `tokio` for this (see https://github.com/tokio-rs/tokio/pull/611), but in the meantime I think it's okay to roll our own.

Also yay `impl Trait` is now available due to us bumping the minimum Rust version 🎉 