### PR TITLE
Switch to Mimic release of Ceph for testing.

### DIFF
--- a/.semaphoreci/test_10_ceph.sh
+++ b/.semaphoreci/test_10_ceph.sh
@@ -12,7 +12,7 @@ cd "$GIT_ROOT/integration_tests"
 # http://docs.ceph.com/docs/master/releases/schedule/
 
 ./docker_test_run.py \
-    --docker-image "ceph/daemon:latest-luminous" \
+    --docker-image "ceph/daemon:latest-mimic" \
     --docker-image "ceph/daemon" \
     --port=9000 \
     --run-opt=-p=9000:8080 \

--- a/.semaphoreci/test_10_ceph.sh
+++ b/.semaphoreci/test_10_ceph.sh
@@ -12,7 +12,6 @@ cd "$GIT_ROOT/integration_tests"
 # http://docs.ceph.com/docs/master/releases/schedule/
 
 ./docker_test_run.py \
-    --docker-image "ceph/daemon:latest-mimic" \
     --docker-image "ceph/daemon" \
     --port=9000 \
     --run-opt=-p=9000:8080 \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 - rusoto_credential uses Serde derives for credentials instead of hand written code
 - Add MediaStore support
 - Expose raw BufferedHttpResponse on ::Unknown error variants
-- Switch Ceph test to use the `Mimic` release instead of `Luminous`
+- Removed Ceph test for `Luminous`
 
 ## [0.34.0] - 2018-09-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - rusoto_credential uses Serde derives for credentials instead of hand written code
 - Add MediaStore support
 - Expose raw BufferedHttpResponse on ::Unknown error variants
+- Switch Ceph test to use the `Mimic` release instead of `Luminous`
 
 ## [0.34.0] - 2018-09-05
 


### PR DESCRIPTION
Fixes https://github.com/rusoto/rusoto/issues/1158 on my machine. 😉 

Per http://docs.ceph.com/docs/master/releases/schedule/ the `Mimic` release is the latest release, from June 2018.

I did a lot of digging around the Ceph bug tracker and scouring the internet but couldn't figure out why the latest Luminous release kept trying to bind on a port twice. 🤷‍♀️ 