### PR TITLE
consider profile.region in default region impl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Add MediaStore support
 - Expose raw BufferedHttpResponse on ::Unknown error variants
 - Removed Ceph test for `Luminous`
+- Honor profile region in `Default` implementation of `Region`
 
 ## [0.34.0] - 2018-09-05
 

--- a/rusoto/core/src/region.rs
+++ b/rusoto/core/src/region.rs
@@ -247,12 +247,12 @@ impl Display for ParseRegionError {
 
 impl Default for Region {
     fn default() -> Region {
-        match std::env::var("AWS_DEFAULT_REGION").or_else(|| std::env::var("AWS_REGION")) {
+        match std::env::var("AWS_DEFAULT_REGION").or_else(|_| std::env::var("AWS_REGION")) {
             Ok(ref v) =>
                 Region::from_str(v).unwrap_or(Region::UsEast1),
             Err(_) => {
                 match ProfileProvider::region() {
-                    Some(region) => Region::from_str(region).unwrap_or(Region::UsEast1),
+                    Ok(Some(region)) => Region::from_str(&region).unwrap_or(Region::UsEast1),
                     _ => Region::UsEast1,
                 }
             }

--- a/rusoto/core/src/region.rs
+++ b/rusoto/core/src/region.rs
@@ -8,6 +8,7 @@ use std;
 use std::error::Error;
 use std::str::FromStr;
 use std::fmt::{self, Display, Error as FmtError, Formatter};
+use credential::ProfileProvider;
 use serde::{de, Serialize, Serializer, Deserialize, Deserializer};
 use serde::ser::SerializeTuple;
 
@@ -16,7 +17,9 @@ use serde::ser::SerializeTuple;
 /// # Default
 ///
 /// `Region` implements the `Default` trait. Calling `Region::default()` will attempt to read the
-/// `AWS_DEFAULT_REGION` environment variable. If it is not set or malformed, it will fall back to `Region::UsEast1`.
+/// `AWS_DEFAULT_REGION` or `AWS_REGION` environment variable. If it is malformed, it will fall back to `Region::UsEast1`.
+/// If it is not present it will fallback on the value associated with the current profile in `~/.aws/config` or the file
+/// specified by the `AWS_CONFIG_FILE` environment variable. If that is malformed of absent it will fall back on `Region::UsEast1`
 ///
 /// # AWS-compatible services
 ///
@@ -244,10 +247,15 @@ impl Display for ParseRegionError {
 
 impl Default for Region {
     fn default() -> Region {
-        match std::env::var("AWS_DEFAULT_REGION") {
+        match std::env::var("AWS_DEFAULT_REGION").or_else(|| std::env::var("AWS_REGION")) {
             Ok(ref v) =>
                 Region::from_str(v).unwrap_or(Region::UsEast1),
-            Err(_) => Region::UsEast1,
+            Err(_) => {
+                match ProfileProvider::region() {
+                    Some(region) => Region::from_str(region).unwrap_or(Region::UsEast1),
+                    _ => Region::UsEast1,
+                }
+            }
         }
     }
 }

--- a/rusoto/credential/src/profile.rs
+++ b/rusoto/credential/src/profile.rs
@@ -210,7 +210,7 @@ fn parse_config_file(file_path: &Path) -> Option<HashMap<String, HashMap<String,
             .filter_map(|line| {
                 line.ok()
                     .map(|l| l.trim_matches(' ').to_owned())
-                    .filter(|l| !l.starts_with('#') || !l.is_empty())
+                    .into_iter().find(|l| !l.starts_with('#') || !l.is_empty())
             })
             .fold(
                 Default::default(), |(mut result, profile), line| {

--- a/rusoto/credential/tests/sample-data/default_config
+++ b/rusoto/credential/tests/sample-data/default_config
@@ -1,0 +1,3 @@
+[default]
+output = json
+region = us-east-2

--- a/rusoto/credential/tests/sample-data/multiple_profile_config
+++ b/rusoto/credential/tests/sample-data/multiple_profile_config
@@ -1,0 +1,9 @@
+[default]
+output = json
+region = us-east-2
+[profile foo]
+region = us-east-3
+output = json
+[profile bar]
+region = us-east-4
+output = json


### PR DESCRIPTION
this addresses https://github.com/rusoto/rusoto/issues/957  /cc @matthewkmayer

notes for changelog

Default impl for Region now honors `AWS_PROFILE` env variable in addition to currently supported `AWS_DEFAULT_PROFILE` to line up with behavior of existing sdks.  The default impl also now considers the current profiles region where defined `~/.aws/config`

Implementation notes. 

I wanted to keep this pull as small as possible so I was thrifty in reusing the ini parsing bits from `ProfileProvider` if that's a long time good idea I'm not sure. I feel like we may want to use a proper `ini` parsing crate. Parsing is simple enough but I'm not sure if the current could be more efficient. Also not sure if it needs to be for rusoto's very simple case.

I'm not sure of `ProfileProfiler` is the right place for this or if there should be a `ConfigProvider` . Technically the config only exists to serve additional profile fields so maybe this is okay as is.

I wasn't sure how to unit test the change of the Default impl but I was able to unit test the bits that the Default impl calls into. Mostly because cargo runs tests in parallel at setting env variables in tests feel's wrong so I'm open to suggestions. I'm also open to iterate on this. I'm a fan of small and fast changes over larger and slow changes. 

