### PR TITLE
fix canonical path probrem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Add MediaStore support
 - Expose raw BufferedHttpResponse on ::Unknown error variants
 - Removed Ceph test for `Luminous`
+* Fix bug that could not authenticate ARN with colon
 
 ## [0.34.0] - 2018-09-05
 

--- a/integration_tests/tests/lambda.rs
+++ b/integration_tests/tests/lambda.rs
@@ -3,7 +3,7 @@
 extern crate rusoto_core;
 extern crate rusoto_lambda;
 
-use rusoto_lambda::{Lambda, LambdaClient, ListFunctionsRequest};
+use rusoto_lambda::{Lambda, LambdaClient, ListFunctionsRequest, InvocationRequest, InvokeError};
 use rusoto_core::Region;
 
 #[test]
@@ -13,4 +13,41 @@ fn should_list_functions() {
 
     let result = client.list_functions(request).sync().unwrap();
     println!("{:#?}", result);
+}
+
+#[test]
+fn should_function_not_found() {
+    let client = LambdaClient::new(Region::UsEast1);
+    {
+        let request = InvocationRequest{
+            function_name: "no-such-a-function".to_string(),
+            invocation_type: Some("RequestResponse".to_string()),
+            ..Default::default()
+        };
+
+        let result = client.invoke(request).sync();
+
+        assert!(result.is_err());
+        if let Err(InvokeError::Unknown(resp)) = result {
+            assert_eq!(resp.status, 404);
+        }else{
+            assert!(false, format!("expect Err(InvokeError::Unknown(_), found {:?}", result));
+        }
+    }
+    {
+        // ARN with colons
+        let request = InvocationRequest{
+            function_name: "function:no-such-a-function".to_string(),
+            ..Default::default()
+        };
+
+        let result = client.invoke(request).sync();
+
+        assert!(result.is_err());
+        if let Err(InvokeError::Unknown(resp)) = result {
+            assert_eq!(resp.status, 404);
+        }else{
+            assert!(false, format!("expect Err(InvokeError::Unknown(_), found {:?}", result));
+        }
+    }
 }

--- a/rusoto/core/src/request.rs
+++ b/rusoto/core/src/request.rs
@@ -379,7 +379,7 @@ impl<C> DispatchSignedRequest for HttpClient<C>
             hyper_headers.insert("user-agent", DEFAULT_USER_AGENT.parse().unwrap());
         }
 
-        let mut final_uri = format!("{}://{}{}", request.scheme(), request.hostname(), request.canonical_path());
+        let mut final_uri = format!("{}://{}{}", request.scheme(), request.hostname(), request.path);
         if !request.canonical_query_string().is_empty() {
             final_uri = final_uri + &format!("?{}", request.canonical_query_string());
         }

--- a/rusoto/core/src/request.rs
+++ b/rusoto/core/src/request.rs
@@ -379,7 +379,7 @@ impl<C> DispatchSignedRequest for HttpClient<C>
             hyper_headers.insert("user-agent", DEFAULT_USER_AGENT.parse().unwrap());
         }
 
-        let mut final_uri = format!("{}://{}{}", request.scheme(), request.hostname(), request.path);
+        let mut final_uri = format!("{}://{}{}", request.scheme(), request.hostname(), request.canonical_path());
         if !request.canonical_query_string().is_empty() {
             final_uri = final_uri + &format!("?{}", request.canonical_query_string());
         }

--- a/rusoto/core/src/signature.rs
+++ b/rusoto/core/src/signature.rs
@@ -360,6 +360,13 @@ impl SignedRequest {
         // build the canonical request
         let signed_headers = signed_headers(&self.headers);
         self.canonical_uri = canonical_uri(&self.path);
+        // Normalize URI paths according to RFC 3986. Remove redundant and relative path components. Each path segment must be URI-encoded twice (except for Amazon S3 which only gets URI-encoded once).
+        // see https://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html
+        let canonical_uri = if &self.service != "s3" {
+            utf8_percent_encode(&self.canonical_uri, StrictPathEncodeSet).collect::<String>()
+        }else{
+            self.canonical_uri.clone()
+        };
         let canonical_headers = canonical_headers(&self.headers);
 
         let canonical_request: String;
@@ -368,7 +375,7 @@ impl SignedRequest {
             None => {
                 canonical_request = format!("{}\n{}\n{}\n{}\n{}\n{}",
                                             &self.method,
-                                            utf8_percent_encode(&self.canonical_uri, StrictPathEncodeSet).collect::<String>(),
+                                            canonical_uri,
                                             self.canonical_query_string,
                                             canonical_headers,
                                             signed_headers,
@@ -379,7 +386,7 @@ impl SignedRequest {
                 let (digest, len) = digest_payload(&payload);
                 canonical_request = format!("{}\n{}\n{}\n{}\n{}\n{}",
                                             &self.method,
-                                            utf8_percent_encode(&self.canonical_uri, StrictPathEncodeSet).collect::<String>(),
+                                            canonical_uri,
                                             self.canonical_query_string,
                                             canonical_headers,
                                             signed_headers,
@@ -389,7 +396,7 @@ impl SignedRequest {
             Some(SignedRequestPayload::Stream(len, _)) => {
                 canonical_request = format!("{}\n{}\n{}\n{}\n{}\n{}",
                                             &self.method,
-                                            utf8_percent_encode(&self.canonical_uri, StrictPathEncodeSet).collect::<String>(),
+                                            canonical_uri,
                                             self.canonical_query_string,
                                             canonical_headers,
                                             signed_headers,

--- a/rusoto/core/src/signature.rs
+++ b/rusoto/core/src/signature.rs
@@ -368,7 +368,7 @@ impl SignedRequest {
             None => {
                 canonical_request = format!("{}\n{}\n{}\n{}\n{}\n{}",
                                             &self.method,
-                                            self.canonical_uri,
+                                            utf8_percent_encode(&self.canonical_uri, StrictPathEncodeSet).collect::<String>(),
                                             self.canonical_query_string,
                                             canonical_headers,
                                             signed_headers,
@@ -379,7 +379,7 @@ impl SignedRequest {
                 let (digest, len) = digest_payload(&payload);
                 canonical_request = format!("{}\n{}\n{}\n{}\n{}\n{}",
                                             &self.method,
-                                            self.canonical_uri,
+                                            utf8_percent_encode(&self.canonical_uri, StrictPathEncodeSet).collect::<String>(),
                                             self.canonical_query_string,
                                             canonical_headers,
                                             signed_headers,
@@ -389,7 +389,7 @@ impl SignedRequest {
             Some(SignedRequestPayload::Stream(len, _)) => {
                 canonical_request = format!("{}\n{}\n{}\n{}\n{}\n{}",
                                             &self.method,
-                                            self.canonical_uri,
+                                            utf8_percent_encode(&self.canonical_uri, StrictPathEncodeSet).collect::<String>(),
                                             self.canonical_query_string,
                                             canonical_headers,
                                             signed_headers,


### PR DESCRIPTION
#1035

```rust
let json = json!({});
let json_str = ::serde_json::to_string(&json).unwrap();
let json_bytes: &[u8] = json_str.as_ref();
let client = LambdaClient::new(Region::ApNortheast1)
let fut = client.invoke(InvocationRequest{
        client_context: None,
        function_name: "arn:aws:lambda:ap-northeast-1:xxxxxxxxxxxx:function:my-function".to_string(),
        invocation_type: Some("RequestResponse".to_string()),
        log_type: None,
        payload: Some(json_bytes.to_vec()),
        qualifier: None,
    });
```

## before this PR

request url

```
https://lambda.ap-northeast-1.amazonaws.com/2015-03-31/functions/arn%3Aaws%3Alambda%3Aap-northeast-1%3Axxxxxxxxxxxx%3Afunction%3Amy-function/invocations
```

[canonical_request](https://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html)

```
POST
/2015-03-31/functions/arn%3Aaws%3Alambda%3Aap-northeast-1%3Axxxxxxxxxxxx%3Afunction%3Amy-function/invocations

host:lambda.ap-northeast-1.amazonaws.com
x-amz-content-sha256:xxxxxxxxxxxx
x-amz-date:20181016T111857Z
x-amz-invocation-type:RequestResponse

host;x-amz-content-sha256;x-amz-date;x-amz-invocation-type
c3f2deac49d75e5c848f509b1ab0807736b121c3ea7f34f2b5fb94ba327d2290
```

This causes  403 `The request signature we calculated does not match the signature you provided. Check your AWS Secret Access Key and signing method. Consult the service documentation for details.`

Because the canonical request MUST be "canonical" to the path.

## after this PR

request url

```
https://lambda.ap-northeast-1.amazonaws.com/2015-03-31/functions/arn%3Aaws%3Alambda%3Aap-northeast-1%3Axxxxxxxxxxxx%3Afunction%3Amy-function/invocations
```

[canonical_request](https://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html)

```
POST
/2015-03-31/functions/arn%253Aaws%253Alambda%253Aap-northeast-1%253Axxxxxxxxxxxx%253Afunction%253Amy-function/invocations

host:lambda.ap-northeast-1.amazonaws.com
x-amz-content-sha256:xxxxxxxxxxxx
x-amz-date:20181016T111857Z
x-amz-invocation-type:RequestResponse

host;x-amz-content-sha256;x-amz-date;x-amz-invocation-type
c3f2deac49d75e5c848f509b1ab0807736b121c3ea7f34f2b5fb94ba327d2290
```

it works.